### PR TITLE
Eventfactory

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -1,16 +1,20 @@
 package com.dat3m.dartagnan.parsers.program.utils;
 
-import com.dat3m.dartagnan.program.Thread;
-import com.dat3m.dartagnan.program.event.*;
-import com.google.common.collect.ImmutableSet;
 import com.dat3m.dartagnan.asserts.AbstractAssert;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.event.CondJump;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Label;
+import com.dat3m.dartagnan.program.event.Skip;
 import com.dat3m.dartagnan.program.memory.Address;
 import com.dat3m.dartagnan.program.memory.Location;
 import com.dat3m.dartagnan.program.memory.Memory;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.*;
 
@@ -94,17 +98,17 @@ public class ProgramBuilder {
     public void initRegEqLocPtr(int regThread, String regName, String locName, int precision){
         Location loc = getOrCreateLocation(locName, precision);
         Register reg = getOrCreateRegister(regThread, regName, precision);
-        addChild(regThread, new Local(reg, loc.getAddress()));
+        addChild(regThread, Events.newLocal(reg, loc.getAddress()));
     }
 
     public void initRegEqLocVal(int regThread, String regName, String locName, int precision){
         Location loc = getOrCreateLocation(locName, precision);
         Register reg = getOrCreateRegister(regThread, regName, precision);
-        addChild(regThread, new Local(reg, iValueMap.get(loc.getAddress())));
+        addChild(regThread, Events.newLocal(reg, iValueMap.get(loc.getAddress())));
     }
 
     public void initRegEqConst(int regThread, String regName, IConst iValue){
-        addChild(regThread, new Local(getOrCreateRegister(regThread, regName, iValue.getPrecision()), iValue));
+        addChild(regThread, Events.newLocal(getOrCreateRegister(regThread, regName, iValue.getPrecision()), iValue));
     }
 
     public void addDeclarationArray(String name, List<IConst> values, int precision){
@@ -208,7 +212,7 @@ public class ProgramBuilder {
     private void buildInitThreads(){
         int nextThreadId = nextThreadId();
         for (Map.Entry<IExpr, IConst> entry : iValueMap.entrySet()) {
-            Event e = new Init(entry.getKey(), entry.getValue());
+            Event e = Events.newInit(entry.getKey(), entry.getValue());
             Thread thread = new Thread(nextThreadId, e);
             threads.put(nextThreadId, thread);
             nextThreadId++;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -1,6 +1,9 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
-import com.dat3m.dartagnan.expression.*;
+import com.dat3m.dartagnan.expression.Atom;
+import com.dat3m.dartagnan.expression.IConst;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.IExprBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.parsers.LitmusAArch64BaseVisitor;
 import com.dat3m.dartagnan.parsers.LitmusAArch64Parser;
@@ -8,14 +11,16 @@ import com.dat3m.dartagnan.parsers.LitmusAArch64Visitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ParsingException;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.arch.aarch64.event.RMWLoadExclusive;
 import com.dat3m.dartagnan.program.arch.aarch64.event.StoreExclusive;
-import com.dat3m.dartagnan.program.event.*;
+import com.dat3m.dartagnan.program.event.Cmp;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Label;
+import com.dat3m.dartagnan.program.event.rmw.RMWLoadExclusive;
+import org.antlr.v4.runtime.misc.Interval;
 
 import java.math.BigInteger;
-
-import org.antlr.v4.runtime.misc.Interval;
 
 public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
         implements LitmusAArch64Visitor<Object> {
@@ -109,14 +114,14 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
     public Object visitMov(LitmusAArch64Parser.MovContext ctx) {
         Register register = programBuilder.getOrCreateRegister(mainThread, ctx.rD, -1);
         IExpr expr = ctx.expr32() != null ? (IExpr)ctx.expr32().accept(this) : (IExpr)ctx.expr64().accept(this);
-        return programBuilder.addChild(mainThread, new Local(register, expr));
+        return programBuilder.addChild(mainThread, Events.newLocal(register, expr));
     }
 
     @Override
     public Object visitCmp(LitmusAArch64Parser.CmpContext ctx) {
         Register register = programBuilder.getOrCreateRegister(mainThread, ctx.rD, -1);
         IExpr expr = ctx.expr32() != null ? (IExpr)ctx.expr32().accept(this) : (IExpr)ctx.expr64().accept(this);
-        return programBuilder.addChild(mainThread, new Cmp(register, expr));
+        return programBuilder.addChild(mainThread, Events.newCompare(register, expr));
     }
 
     @Override
@@ -124,7 +129,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
         Register rD = programBuilder.getOrCreateRegister(mainThread, ctx.rD, -1);
         Register r1 = programBuilder.getOrErrorRegister(mainThread, ctx.rV);
         IExpr expr = ctx.expr32() != null ? (IExpr)ctx.expr32().accept(this) : (IExpr)ctx.expr64().accept(this);
-        return programBuilder.addChild(mainThread, new Local(rD, new IExprBin(r1, ctx.arithmeticInstruction().op, expr)));
+        return programBuilder.addChild(mainThread, Events.newLocal(rD, new IExprBin(r1, ctx.arithmeticInstruction().op, expr)));
     }
 
     @Override
@@ -134,7 +139,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
         if(ctx.offset() != null){
             address = visitOffset(ctx.offset(), address);
         }
-        return programBuilder.addChild(mainThread, new Load(register, address, ctx.loadInstruction().mo));
+        return programBuilder.addChild(mainThread, Events.newLoad(register, address, ctx.loadInstruction().mo));
     }
 
     @Override
@@ -144,7 +149,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
         if(ctx.offset() != null){
             address = visitOffset(ctx.offset(), address);
         }
-        RMWLoadExclusive load = new RMWLoadExclusive(register, address, ctx.loadExclusiveInstruction().mo);
+        RMWLoadExclusive load = Events.newRMWLoadExclusive(register, address, ctx.loadExclusiveInstruction().mo);
         return programBuilder.addChild(mainThread, load);
     }
 
@@ -155,7 +160,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
         if(ctx.offset() != null){
             address = visitOffset(ctx.offset(), address);
         }
-        return programBuilder.addChild(mainThread, new Store(address, register, ctx.storeInstruction().mo));
+        return programBuilder.addChild(mainThread, Events.newStore(address, register, ctx.storeInstruction().mo));
     }
 
     @Override
@@ -166,7 +171,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
         if(ctx.offset() != null){
             address = visitOffset(ctx.offset(), address);
         }
-        StoreExclusive event = new StoreExclusive(statusReg, address, register, ctx.storeExclusiveInstruction().mo);
+        StoreExclusive event = Events.Arm8.newExclusiveStore(statusReg, address, register, ctx.storeExclusiveInstruction().mo);
         return programBuilder.addChild(mainThread, event);
     }
 
@@ -174,7 +179,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
     public Object visitBranch(LitmusAArch64Parser.BranchContext ctx) {
         Label label = programBuilder.getOrCreateLabel(ctx.label().getText());
         if(ctx.branchCondition() == null){
-            return programBuilder.addChild(mainThread, new CondJump(new BConst(true), label));
+            return programBuilder.addChild(mainThread, Events.newGoto(label));
         }
         Event lastEvent = programBuilder.getLastEvent(mainThread);
         if(!(lastEvent instanceof Cmp)){
@@ -182,7 +187,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
         }
         Cmp cmp = (Cmp)lastEvent;
         Atom expr = new Atom(cmp.getLeft(), ctx.branchCondition().op, cmp.getRight());
-        return programBuilder.addChild(mainThread, new CondJump(expr, label));
+        return programBuilder.addChild(mainThread, Events.newJump(expr, label));
     }
 
     @Override
@@ -190,7 +195,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
         Register register = programBuilder.getOrErrorRegister(mainThread, ctx.rV);
         Atom expr = new Atom(register, ctx.branchRegInstruction().op, new IConst(BigInteger.ZERO, -1));
         Label label = programBuilder.getOrCreateLabel(ctx.label().getText());
-        return programBuilder.addChild(mainThread, new CondJump(expr, label));
+        return programBuilder.addChild(mainThread, Events.newJump(expr, label));
     }
 
     @Override
@@ -200,7 +205,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
 
     @Override
     public Object visitFence(LitmusAArch64Parser.FenceContext ctx) {
-        return programBuilder.addChild(mainThread, new FenceOpt(ctx.Fence().getText(), ctx.opt));
+        return programBuilder.addChild(mainThread, Events.newFenceOpt(ctx.Fence().getText(), ctx.opt));
     }
 
     @Override
@@ -244,7 +249,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
         IExpr expr = ctx.immediate() == null
                 ? programBuilder.getOrErrorRegister(mainThread, ctx.expressionConversion().register32().id)
                 : new IConst(new BigInteger(ctx.immediate().constant().getText()), -1);
-        programBuilder.addChild(mainThread, new Local(result, new IExprBin(register, IOpBin.PLUS, expr)));
+        programBuilder.addChild(mainThread, Events.newLocal(result, new IExprBin(register, IOpBin.PLUS, expr)));
         return result;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -10,13 +10,15 @@ import com.dat3m.dartagnan.parsers.LitmusPPCVisitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ParsingException;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.*;
+import com.dat3m.dartagnan.program.event.Cmp;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Label;
 import com.google.common.collect.ImmutableSet;
+import org.antlr.v4.runtime.misc.Interval;
 
 import java.math.BigInteger;
-
-import org.antlr.v4.runtime.misc.Interval;
 
 public class VisitorLitmusPPC
         extends LitmusPPCBaseVisitor<Object>
@@ -113,14 +115,14 @@ public class VisitorLitmusPPC
     public Object visitLi(LitmusPPCParser.LiContext ctx) {
         Register register = programBuilder.getOrCreateRegister(mainThread, ctx.register().getText(), -1);
         IConst constant = new IConst(new BigInteger(ctx.constant().getText()), -1);
-        return programBuilder.addChild(mainThread, new Local(register, constant));
+        return programBuilder.addChild(mainThread, Events.newLocal(register, constant));
     }
 
     @Override
     public Object visitLwz(LitmusPPCParser.LwzContext ctx) {
         Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), -1);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, new Load(r1, ra, "_rx"));
+        return programBuilder.addChild(mainThread, Events.newLoad(r1, ra, "_rx"));
     }
 
     @Override
@@ -133,7 +135,7 @@ public class VisitorLitmusPPC
     public Object visitStw(LitmusPPCParser.StwContext ctx) {
         Register r1 = programBuilder.getOrErrorRegister(mainThread, ctx.register(0).getText());
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, new Store(ra, r1, "_rx"));
+        return programBuilder.addChild(mainThread, Events.newStore(ra, r1, "_rx"));
     }
 
     @Override
@@ -146,7 +148,7 @@ public class VisitorLitmusPPC
     public Object visitMr(LitmusPPCParser.MrContext ctx) {
         Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), -1);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, new Local(r1, r2));
+        return programBuilder.addChild(mainThread, Events.newLocal(r1, r2));
     }
 
     @Override
@@ -154,7 +156,7 @@ public class VisitorLitmusPPC
         Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), -1);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IConst constant = new IConst(new BigInteger(ctx.constant().getText()), -1);
-        return programBuilder.addChild(mainThread, new Local(r1, new IExprBin(r2, IOpBin.PLUS, constant)));
+        return programBuilder.addChild(mainThread, Events.newLocal(r1, new IExprBin(r2, IOpBin.PLUS, constant)));
     }
 
     @Override
@@ -162,14 +164,14 @@ public class VisitorLitmusPPC
         Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), -1);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, new Local(r1, new IExprBin(r2, IOpBin.XOR, r3)));
+        return programBuilder.addChild(mainThread, Events.newLocal(r1, new IExprBin(r2, IOpBin.XOR, r3)));
     }
 
     @Override
     public Object visitCmpw(LitmusPPCParser.CmpwContext ctx) {
         Register r1 = programBuilder.getOrErrorRegister(mainThread, ctx.register(0).getText());
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, new Cmp(r1, r2));
+        return programBuilder.addChild(mainThread, Events.newCompare(r1, r2));
     }
 
     @Override
@@ -181,7 +183,7 @@ public class VisitorLitmusPPC
         }
         Cmp cmp = (Cmp)lastEvent;
         Atom expr = new Atom(cmp.getLeft(), ctx.cond().op, cmp.getRight());
-        return programBuilder.addChild(mainThread, new CondJump(expr, label));
+        return programBuilder.addChild(mainThread, Events.newJump(expr, label));
     }
 
     @Override
@@ -194,7 +196,7 @@ public class VisitorLitmusPPC
         String name = ctx.getText().toLowerCase();
         name = name.substring(0, 1).toUpperCase() + name.substring(1);
         if(fences.contains(name)){
-            return programBuilder.addChild(mainThread, new Fence(name));
+            return programBuilder.addChild(mainThread, Events.newFence(name));
         }
         throw new ParsingException("Unrecognised fence " + name);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
@@ -7,18 +7,13 @@ import com.dat3m.dartagnan.parsers.LitmusX86Visitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ParsingException;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.Fence;
-import com.dat3m.dartagnan.program.event.Load;
-import com.dat3m.dartagnan.program.event.Local;
-import com.dat3m.dartagnan.program.event.Store;
-import com.dat3m.dartagnan.program.arch.tso.event.Xchg;
 import com.dat3m.dartagnan.program.memory.Location;
 import com.google.common.collect.ImmutableSet;
+import org.antlr.v4.runtime.misc.Interval;
 
 import java.math.BigInteger;
-
-import org.antlr.v4.runtime.misc.Interval;
 
 public class VisitorLitmusX86
         extends LitmusX86BaseVisitor<Object>
@@ -115,35 +110,35 @@ public class VisitorLitmusX86
     public Object visitLoadValueToRegister(LitmusX86Parser.LoadValueToRegisterContext ctx) {
         Register register = programBuilder.getOrCreateRegister(mainThread, ctx.register().getText(), -1);
         IConst constant = new IConst(new BigInteger(ctx.constant().getText()), -1);
-        return programBuilder.addChild(mainThread, new Local(register, constant));
+        return programBuilder.addChild(mainThread, Events.newLocal(register, constant));
     }
 
     @Override
     public Object visitLoadLocationToRegister(LitmusX86Parser.LoadLocationToRegisterContext ctx) {
         Register register = programBuilder.getOrCreateRegister(mainThread, ctx.register().getText(), -1);
         Location location = programBuilder.getOrCreateLocation(ctx.location().getText(), -1);
-        return programBuilder.addChild(mainThread, new Load(register, location.getAddress(), "_rx"));
+        return programBuilder.addChild(mainThread, Events.newLoad(register, location.getAddress(), "_rx"));
     }
 
     @Override
     public Object visitStoreValueToLocation(LitmusX86Parser.StoreValueToLocationContext ctx) {
         Location location = programBuilder.getOrCreateLocation(ctx.location().getText(), -1);
         IConst constant = new IConst(new BigInteger(ctx.constant().getText()), -1);
-        return programBuilder.addChild(mainThread, new Store(location.getAddress(), constant, "_rx"));
+        return programBuilder.addChild(mainThread, Events.newStore(location.getAddress(), constant, "_rx"));
     }
 
     @Override
     public Object visitStoreRegisterToLocation(LitmusX86Parser.StoreRegisterToLocationContext ctx) {
         Register register = programBuilder.getOrErrorRegister(mainThread, ctx.register().getText());
         Location location = programBuilder.getOrCreateLocation(ctx.location().getText(), -1);
-        return programBuilder.addChild(mainThread, new Store(location.getAddress(), register, "_rx"));
+        return programBuilder.addChild(mainThread, Events.newStore(location.getAddress(), register, "_rx"));
     }
 
     @Override
     public Object visitExchangeRegisterLocation(LitmusX86Parser.ExchangeRegisterLocationContext ctx) {
         Register register = programBuilder.getOrErrorRegister(mainThread, ctx.register().getText());
         Location location = programBuilder.getOrCreateLocation(ctx.location().getText(), -1);
-        return programBuilder.addChild(mainThread, new Xchg(location.getAddress(), register));
+        return programBuilder.addChild(mainThread, Events.X86.newExchange(location.getAddress(), register));
     }
 
     @Override
@@ -181,7 +176,7 @@ public class VisitorLitmusX86
         String name = ctx.getText().toLowerCase();
         name = name.substring(0, 1).toUpperCase() + name.substring(1);
         if(fences.contains(name)){
-            return programBuilder.addChild(mainThread, new Fence(name));
+            return programBuilder.addChild(mainThread, Events.newFence(name));
         }
         throw new ParsingException("Unrecognised fence " + name);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/AtomicProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/AtomicProcedures.java
@@ -1,20 +1,18 @@
 package com.dat3m.dartagnan.parsers.program.visitors.boogie;
 
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.intToMo;
-
-import java.util.Arrays;
-import java.util.List;
-
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.parsers.BoogieParser;
 import com.dat3m.dartagnan.parsers.BoogieParser.Call_cmdContext;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.atomic.event.*;
-import com.dat3m.dartagnan.program.event.Load;
-import com.dat3m.dartagnan.program.event.Store;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.dat3m.dartagnan.program.atomic.utils.Mo.intToMo;
 
 public class AtomicProcedures {
 
@@ -71,7 +69,7 @@ public class AtomicProcedures {
 	private static void atomicInit(VisitorBoogie visitor, Call_cmdContext ctx) {
 		IExpr add = (IExpr)ctx.call_params().exprs().expr().get(0).accept(visitor);
 		ExprInterface value = (ExprInterface)ctx.call_params().exprs().expr().get(1).accept(visitor);
-		visitor.programBuilder.addChild(visitor.threadCount, new Store(add, value, null, visitor.currentLine));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.newStore(add, value, null, visitor.currentLine));
 	}
 
 	private static void atomicStore(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -81,7 +79,7 @@ public class AtomicProcedures {
 		if(ctx.call_params().exprs().expr().size() > 2) {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getIntValue().intValue());
 		}
-		visitor.programBuilder.addChild(visitor.threadCount, new AtomicStore(add, value, mo));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.Atomic.newStore(add, value, mo));
 	}
 
 	private static void atomicLoad(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -91,7 +89,7 @@ public class AtomicProcedures {
 		if(ctx.call_params().exprs().expr().size() > 1) {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(1).accept(visitor)).getIntValue().intValue());
 		}
-		visitor.programBuilder.addChild(visitor.threadCount, new AtomicLoad(reg, add, mo));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.Atomic.newLoad(reg, add, mo));
 	}
 
 	private static void atomicFetchOp(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -116,7 +114,7 @@ public class AtomicProcedures {
 		if(ctx.call_params().exprs().expr().size() > 2) {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getIntValue().intValue());
 		}
-		visitor.programBuilder.addChild(visitor.threadCount, new AtomicFetchOp(reg, add, value, op, mo));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.Atomic.newFetchOp(reg, add, value, op, mo));
 	}
 
 	private static void atomicXchg(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -127,7 +125,7 @@ public class AtomicProcedures {
 		if(ctx.call_params().exprs().expr().size() > 2) {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getIntValue().intValue());
 		}
-		visitor.programBuilder.addChild(visitor.threadCount, new AtomicXchg(reg, add, value, mo));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.Atomic.newExchange(reg, add, value, mo));
 	}
 
 	private static void DAT3M_CAS(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -140,12 +138,12 @@ public class AtomicProcedures {
 		if(params.size() > 3) {
 			mo = intToMo(((IConst) params.get(3).accept(visitor)).getIntValue().intValue());
 		}
-		visitor.programBuilder.addChild(visitor.threadCount, new Dat3mCAS(reg, add, expected, desired, mo));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.Atomic.newDat3mCAS(reg, add, expected, desired, mo));
 	}
 
 	private static void atomicThreadFence(VisitorBoogie visitor, Call_cmdContext ctx) {
 		String mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(0).accept(visitor)).getIntValue().intValue());
-		visitor.programBuilder.addChild(visitor.threadCount, new AtomicThreadFence(mo));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.Atomic.newFence(mo));
 	}
 	
 	private static void atomicCmpXchg(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -161,7 +159,7 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst) params.get(3).accept(visitor)).getIntValue().intValue());
 			// NOTE: We forget about the 5th parameter (MO on fail) for now!
 		}
-		visitor.programBuilder.addChild(visitor.threadCount, new Load(expected, expectedAdd, mo));
-		visitor.programBuilder.addChild(visitor.threadCount, new AtomicCmpXchg(reg, add, expected, desired, mo, strong));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.newLoad(expected, expectedAdd, mo));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.Atomic.newCompareExchange(reg, add, expected, desired, mo, strong));
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
@@ -1,10 +1,5 @@
 package com.dat3m.dartagnan.parsers.program.visitors.boogie;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
@@ -12,15 +7,15 @@ import com.dat3m.dartagnan.parsers.BoogieParser.Call_cmdContext;
 import com.dat3m.dartagnan.parsers.BoogieParser.ExprContext;
 import com.dat3m.dartagnan.parsers.BoogieParser.ExprsContext;
 import com.dat3m.dartagnan.parsers.program.utils.ParsingException;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Label;
-import com.dat3m.dartagnan.program.event.Local;
-import com.dat3m.dartagnan.program.event.pthread.Create;
-import com.dat3m.dartagnan.program.event.pthread.Join;
-import com.dat3m.dartagnan.program.event.pthread.Lock;
-import com.dat3m.dartagnan.program.event.pthread.InitLock;
-import com.dat3m.dartagnan.program.event.pthread.Unlock;
 import com.dat3m.dartagnan.program.memory.Location;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class PthreadsProcedures {
 	
@@ -82,9 +77,9 @@ public class PthreadsProcedures {
 		visitor.pool.add(threadPtr, threadName);
 		Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText(), -1);
 		// We assume pthread_create always succeeds
-		visitor.programBuilder.addChild(visitor.threadCount, new Local(reg, new IConst(BigInteger.ZERO, -1)));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.newLocal(reg, new IConst(BigInteger.ZERO, -1)));
 		Location loc = visitor.programBuilder.getOrCreateLocation(threadPtr + "_active", -1);
-		visitor.programBuilder.addChild(visitor.threadCount, new Create(threadPtr, threadName, loc.getAddress(), visitor.currentLine));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.Pthread.newCreate(threadPtr, threadName, loc.getAddress(), visitor.currentLine));
 	}
 	
 	private static void pthread_join(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -97,7 +92,7 @@ public class PthreadsProcedures {
 		Location loc = visitor.programBuilder.getOrCreateLocation(visitor.pool.getPtrFromReg(callReg) + "_active", -1);
 		Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, null, -1);
        	Label label = visitor.programBuilder.getOrCreateLabel("END_OF_T" + visitor.threadCount);
-       	visitor.programBuilder.addChild(visitor.threadCount, new Join(visitor.pool.getPtrFromReg(callReg), reg, loc.getAddress(), label));
+       	visitor.programBuilder.addChild(visitor.threadCount, Events.Pthread.newJoin(visitor.pool.getPtrFromReg(callReg), reg, loc.getAddress(), label));
 	}
 
 	private static void mutexInit(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -105,7 +100,7 @@ public class PthreadsProcedures {
 		IExpr lockAddress = (IExpr)lock.accept(visitor);
 		IExpr value = (IExpr)ctx.call_params().exprs().expr(1).accept(visitor);
 		if(lockAddress != null) {
-			visitor.programBuilder.addChild(visitor.threadCount, new InitLock(lock.getText(), lockAddress, value));	
+			visitor.programBuilder.addChild(visitor.threadCount, Events.Pthread.newInitLock(lock.getText(), lockAddress, value));
 		}
 	}
 	
@@ -115,7 +110,7 @@ public class PthreadsProcedures {
 		IExpr lockAddress = (IExpr)lock.accept(visitor);
        	Label label = visitor.programBuilder.getOrCreateLabel("END_OF_T" + visitor.threadCount);
 		if(lockAddress != null) {
-			visitor.programBuilder.addChild(visitor.threadCount, new Lock(lock.getText(), lockAddress, register, label));
+			visitor.programBuilder.addChild(visitor.threadCount, Events.Pthread.newLock(lock.getText(), lockAddress, register, label));
 		}
 	}
 	
@@ -125,7 +120,7 @@ public class PthreadsProcedures {
 		IExpr lockAddress = (IExpr)lock.accept(visitor);
        	Label label = visitor.programBuilder.getOrCreateLabel("END_OF_T" + visitor.threadCount);
 		if(lockAddress != null) {
-			visitor.programBuilder.addChild(visitor.threadCount, new Unlock(lock.getText(), lockAddress, register, label));
+			visitor.programBuilder.addChild(visitor.threadCount, Events.Pthread.newUnlock(lock.getText(), lockAddress, register, label));
 		}
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/StdProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/StdProcedures.java
@@ -1,20 +1,20 @@
 package com.dat3m.dartagnan.parsers.program.visitors.boogie;
 
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.parsers.BoogieParser.Call_cmdContext;
 import com.dat3m.dartagnan.parsers.program.utils.ParsingException;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Local;
-import com.dat3m.dartagnan.program.event.Store;
 import com.dat3m.dartagnan.program.memory.Address;
 import com.dat3m.dartagnan.program.utils.EType;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class StdProcedures {
 	
@@ -48,7 +48,7 @@ public class StdProcedures {
 		if(name.startsWith("WRITE_ONCE")) {
 			IExpr address = (IExpr)ctx.call_params().exprs().expr(0).accept(visitor);
 			ExprInterface value = (ExprInterface)ctx.call_params().exprs().expr(1).accept(visitor);
-			visitor.programBuilder.addChild(visitor.threadCount, new Store(address, value, "NA"));
+			visitor.programBuilder.addChild(visitor.threadCount, Events.newStore(address, value, "NA"));
 			return;
 		}
 //		if(name.startsWith("READ_ONCE")) {
@@ -130,7 +130,7 @@ public class StdProcedures {
 		// the name should be unique, thus we add the process identifier.
 		visitor.programBuilder.addDeclarationArray(visitor.currentScope.getID() + ":" + ptr, values, start.getPrecision());
 		Address adds = visitor.programBuilder.getPointer(visitor.currentScope.getID() + ":" + ptr);
-		visitor.programBuilder.addChild(visitor.threadCount, new Local(start, adds));
+		visitor.programBuilder.addChild(visitor.threadCount, Events.newLocal(start, adds));
 		visitor.allocationRegs.add(start);
 	}
 	
@@ -141,7 +141,7 @@ public class StdProcedures {
     	if(expr instanceof IConst && ((IConst)expr).getIntValue().compareTo(BigInteger.ONE) == 0) {
     		return;
     	}
-    	Local event = new Local(ass, expr);
+    	Local event = Events.newLocal(ass, expr);
 		event.addFilters(EType.ASSERTION);
 		visitor.programBuilder.addChild(visitor.threadCount, event);
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Events.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Events.java
@@ -1,0 +1,355 @@
+package com.dat3m.dartagnan.program;
+
+import com.dat3m.dartagnan.expression.*;
+import com.dat3m.dartagnan.expression.op.BOpUn;
+import com.dat3m.dartagnan.expression.op.COpBin;
+import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.program.arch.aarch64.event.StoreExclusive;
+import com.dat3m.dartagnan.program.arch.linux.event.*;
+import com.dat3m.dartagnan.program.arch.linux.event.cond.*;
+import com.dat3m.dartagnan.program.arch.tso.event.Xchg;
+import com.dat3m.dartagnan.program.atomic.event.*;
+import com.dat3m.dartagnan.program.event.*;
+import com.dat3m.dartagnan.program.event.pthread.*;
+import com.dat3m.dartagnan.program.event.rmw.*;
+import com.dat3m.dartagnan.program.memory.Address;
+import com.dat3m.dartagnan.program.svcomp.event.BeginAtomic;
+import com.dat3m.dartagnan.program.svcomp.event.EndAtomic;
+
+import java.math.BigInteger;
+
+public class Events {
+
+    // Static class
+    private Events() {}
+
+
+    public static Local newLocal(Register register, ExprInterface expr, int cLine) {
+        return new Local(register, expr, cLine);
+    }
+
+    public static Local newLocal(Register register, ExprInterface expr) {
+        return newLocal(register, expr, -1);
+    }
+
+    public static CondJump newJump(BExpr cond, Label target) {
+        return new CondJump(cond, target);
+    }
+
+    public static CondJump newJumpUnless(ExprInterface cond, Label target) { return newJump(new BExprUn(BOpUn.NOT, cond), target); }
+
+    public static IfAsJump newIfJump(BExpr expr, Label label, Label end) {
+        return new IfAsJump(expr, label, end);
+    }
+
+    public static IfAsJump newIfJumpUnless(ExprInterface expr, Label label, Label end) {
+        return newIfJump(new BExprUn(BOpUn.NOT, expr), label, end);
+    }
+
+    public static CondJump newGoto(Label target) {
+        return newJump(BConst.TRUE, target);
+    }
+
+    public static CondJump newFakeCtrlDep(Register reg, Label target) { return newJump(new Atom(reg, COpBin.EQ, reg), target); }
+
+    public static Fence newFence(String name) {
+        return new Fence(name);
+    }
+
+    public static FenceOpt newFenceOpt(String name, String opt) {
+        return new FenceOpt(name, opt);
+    }
+
+    public static Init newInit(IExpr address, IConst value) {
+        return new Init(address, value);
+    }
+
+    public static Label newLabel(String name) {
+        return new Label(name);
+    }
+
+    public static Load newLoad(Register register, IExpr address, String mo, int cLine) {
+        return new Load(register, address, mo, cLine);
+    }
+
+    public static Load newLoad(Register register, IExpr address, String mo) {
+        return newLoad(register, address, mo, -1);
+    }
+
+    public static Store newStore(IExpr address, ExprInterface value, String mo, int cLine) {
+        return new Store(address, value, mo, cLine);
+    }
+
+    public static Store newStore(IExpr address, ExprInterface value, String mo) {
+        return newStore(address, value, mo, -1);
+    }
+
+    public static Cmp newCompare(IExpr left, IExpr right) {
+        return new Cmp(left, right);
+    }
+
+    public static Skip newSkip() {
+        return new Skip();
+    }
+
+    public static FunCall newFunctionCall(String funName, int cLine) {
+        return new FunCall(funName, cLine);
+    }
+
+    public static FunRet newFunctionReturn(String funName, int cLine) {
+        return new FunRet(funName, cLine);
+    }
+
+    public static RMWLoad newRMWLoad(Register reg, IExpr address, String mo) {
+        return new RMWLoad(reg, address, mo);
+    }
+
+    public static RMWStore newRMWStore(RMWLoad loadEvent, IExpr address, ExprInterface value, String mo) {
+        return new RMWStore(loadEvent, address, value, mo);
+    }
+
+    public static RMWLoadExclusive newRMWLoadExclusive(Register reg, IExpr address, String mo) {
+        return new RMWLoadExclusive(reg, address, mo);
+    }
+
+    public static RMWStoreExclusive newRMWStoreExclusive(IExpr address, ExprInterface value, String mo) {
+        return new RMWStoreExclusive(address, value, mo);
+    }
+
+    public static RMWStoreExclusive newRMWStoreExclusive(IExpr address, ExprInterface value, String mo, boolean isStrong) {
+        return new RMWStoreExclusive(address, value, mo, isStrong);
+    }
+
+    public static RMWStoreExclusiveStatus newRMWStoreExclusiveStatus(Register register, RMWStoreExclusive storeEvent) {
+        return new RMWStoreExclusiveStatus(register, storeEvent);
+    }
+
+
+    public static class Pthread {
+        private Pthread() {}
+
+        public static Create newCreate(Register pthread_t, String routine, Address address, int cLine) {
+            return new Create(pthread_t, routine, address, cLine);
+        }
+
+        public static End newEnd(Address address){
+            return new End(address);
+        }
+
+        public static InitLock newInitLock(String name, IExpr address, IExpr value) {
+            return new InitLock(name, address, value);
+        }
+
+        public static Join newJoin(Register pthread_t, Register reg, Address address, Label label) {
+            return new Join(pthread_t, reg, address, label);
+        }
+
+        public static Lock newLock(String name, IExpr address, Register reg, Label label) {
+            return new Lock(name, address, reg, label);
+        }
+
+        public static Start newStart(Register reg, Address address, Label label) {
+            return new Start(reg, address, label);
+        }
+
+        public static Unlock newUnlock(String name, IExpr address, Register reg, Label label) {
+            return new Unlock(name, address, reg, label);
+        }
+    }
+
+    public static class Atomic {
+        private Atomic() {}
+
+        public static AtomicCmpXchg newCompareExchange(Register register, IExpr address, Register expected, ExprInterface value, String mo, boolean isStrong) {
+            return new AtomicCmpXchg(register, address, expected, value, mo, isStrong);
+        }
+
+        public static AtomicCmpXchg newCompareExchange(Register register, IExpr address, Register expected, ExprInterface value, String mo) {
+            return newCompareExchange(register, address, expected, value, mo, false);
+        }
+
+        public static AtomicFetchOp newFetchOp(Register register, IExpr address, ExprInterface value, IOpBin op, String mo) {
+            return new AtomicFetchOp(register, address, value, op, mo);
+        }
+
+        public static AtomicFetchOp newFADD(Register register, IExpr address, ExprInterface value, String mo) {
+            return newFetchOp(register, address, value, IOpBin.PLUS, mo);
+        }
+
+        public static AtomicFetchOp newIncrement(Register register, IExpr address, String mo) {
+            return newFetchOp(register, address, new IConst(BigInteger.ONE, -1), IOpBin.PLUS, mo);
+        }
+
+        public static AtomicLoad newLoad(Register register, IExpr address, String mo) {
+            return new AtomicLoad(register, address, mo);
+        }
+
+        public static AtomicStore newStore(IExpr address, ExprInterface value, String mo) {
+            return new AtomicStore(address, value, mo);
+        }
+
+        public static AtomicThreadFence newFence(String mo) {
+            return new AtomicThreadFence(mo);
+        }
+
+        public static AtomicXchg newExchange(Register register, IExpr address, ExprInterface value, String mo) {
+            return new AtomicXchg(register, address, value, mo);
+        }
+
+        public static Dat3mCAS newDat3mCAS(Register register, IExpr address, IExpr expected, ExprInterface value, String mo) {
+            return new Dat3mCAS(register, address, expected, value, mo);
+        }
+    }
+
+    public static class Svcomp {
+        private Svcomp() {}
+
+        public static BeginAtomic newBeginAtomic() {
+            return new BeginAtomic();
+        }
+
+        public static EndAtomic newEndAtomic(BeginAtomic begin) {
+            return new EndAtomic(begin);
+        }
+    }
+
+
+    private static class ArmCommon {
+        private ArmCommon() {}
+
+        public static StoreExclusive newExclusiveStore(Register register, IExpr address, ExprInterface value, String mo) {
+            return new StoreExclusive(register, address, value, mo);
+        }
+    }
+
+    public static class Arm extends ArmCommon {
+        private Arm() {}
+
+        public static Fence newISHBarrier() {
+            return new Fence("Ish");
+        }
+    }
+
+    public static class Arm8 extends ArmCommon {
+        private Arm8() {}
+
+        public static class DMB {
+            private DMB() {}
+
+            public static Fence newBarrier() {
+                return newSYBarrier(); // Default barrier
+            }
+
+            public static Fence newSYBarrier() {
+                return new Fence("DMB.SY");
+            }
+
+            public static Fence newISHBarrier() {
+                return new Fence("DMB.ISH");
+            }
+        }
+
+        public static class DSB {
+            private DSB() {}
+
+            public static Fence newBarrier() {
+                return newSYBarrier(); // Default barrier
+            }
+
+            public static Fence newSYBarrier() {
+                return new Fence("DSB.SY");
+            }
+
+            public static Fence newISHBarrier() {
+                return new Fence("DSB.ISH");
+            }
+
+            public static Fence newISHLDBarrier() {
+                return new Fence ("DSB.ISHLD");
+            }
+        }
+
+    }
+
+    public static class Linux {
+        private Linux() {}
+
+        public static FenceCond newConditionalFence(RMWReadCond loadEvent, String name) {
+            return new FenceCond(loadEvent, name);
+        }
+
+        public static RMWReadCondCmp newRMWReadCondCmp(Register reg, ExprInterface cmp, IExpr address, String atomic) {
+            return new RMWReadCondCmp(reg, cmp, address, atomic);
+        }
+
+        public static RMWReadCondUnless newRMWReadCondUnless(Register reg, ExprInterface cmp, IExpr address, String mo) {
+            return new RMWReadCondUnless(reg, cmp, address, mo);
+        }
+
+        public static RMWStoreCond newRMWStoreCond(RMWReadCond loadEvent, IExpr address, ExprInterface value, String mo) {
+            return new RMWStoreCond(loadEvent, address, value, mo);
+        }
+
+        public static RMWAddUnless newRMWAddUnless(IExpr address, Register register, ExprInterface cmp, ExprInterface value) {
+            return new RMWAddUnless(address, register, cmp, value);
+        }
+
+        public static RMWCmpXchg newRMWCompareExchange(IExpr address, Register register, ExprInterface cmp, ExprInterface value, String mo) {
+            return new RMWCmpXchg(address, register, cmp, value, mo);
+        }
+
+        public static RMWFetchOp newRMWFetchOp(IExpr address, Register register, ExprInterface value, IOpBin op, String mo) {
+            return new RMWFetchOp(address, register, value, op, mo);
+        }
+
+        public static RMWOp newRMWOp(IExpr address, Register register, ExprInterface value, IOpBin op) {
+            return new RMWOp(address, register, value, op);
+        }
+
+        public static RMWOpAndTest newRMWOpAndTest(IExpr address, Register register, ExprInterface value, IOpBin op) {
+            return new RMWOpAndTest(address, register, value, op);
+        }
+
+        public static RMWOpReturn newRMWOpReturn(IExpr address, Register register, ExprInterface value, IOpBin op, String mo) {
+            return new RMWOpReturn(address, register, value, op, mo);
+        }
+
+        public static RMWXchg newRMWExchange(IExpr address, Register register, ExprInterface value, String mo) {
+            return new RMWXchg(address, register, value, mo);
+        }
+
+        public static Fence newMemoryBarrier() {
+            return newFence("Mb");
+        }
+
+    }
+
+    public static class X86 {
+        private X86() {}
+
+        public static Xchg newExchange(Address address, Register register) {
+            return new Xchg(address, register);
+        }
+
+        public static Fence newMFence() {
+            return newFence("Mfence");
+        }
+    }
+
+    public static class Power {
+        private Power() {}
+
+        public static Fence newISyncBarrier() {
+            return newFence("ISync");
+        }
+
+        public static Fence newSyncBarrier() {
+            return newFence("Sync");
+        }
+
+        public static Fence newLwSyncBarrier() {
+            return newFence("Lwsync");
+        }
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
@@ -1,23 +1,17 @@
 package com.dat3m.dartagnan.program;
 
-import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
-import com.google.common.collect.ImmutableSet;
-
-import static org.sosy_lab.java_smt.api.FormulaType.IntegerType;
-import static org.sosy_lab.java_smt.api.FormulaType.getBitvectorTypeWithSize;
-
-import java.math.BigInteger;
-
-import org.sosy_lab.java_smt.api.Formula;
-import org.sosy_lab.java_smt.api.FormulaManager;
-import org.sosy_lab.java_smt.api.FormulaType;
-import org.sosy_lab.java_smt.api.Model;
-import org.sosy_lab.java_smt.api.SolverContext;
-
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
 import com.dat3m.dartagnan.program.event.Event;
+import com.google.common.collect.ImmutableSet;
+import org.sosy_lab.java_smt.api.*;
+
+import java.math.BigInteger;
+
+import static org.sosy_lab.java_smt.api.FormulaType.IntegerType;
+import static org.sosy_lab.java_smt.api.FormulaType.getBitvectorTypeWithSize;
 
 public class Register extends IExpr implements ExprInterface {
 
@@ -98,8 +92,8 @@ public class Register extends IExpr implements ExprInterface {
 
 	@Override
 	public Formula getLastValueExpr(SolverContext ctx){
-		FormulaManager fmgr = ctx.getFormulaManager();
 		String name = getName() + "_" + threadId + "_final";
+		FormulaManager fmgr = ctx.getFormulaManager();
 		FormulaType<?> type = precision > 0 ? getBitvectorTypeWithSize(precision) : IntegerType;
 		return fmgr.makeVariable(type, name);
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/aarch64/event/StoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/aarch64/event/StoreExclusive.java
@@ -2,20 +2,22 @@ package com.dat3m.dartagnan.program.arch.aarch64.event;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.Store;
 import com.dat3m.dartagnan.program.arch.aarch64.utils.EType;
 import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Store;
+import com.dat3m.dartagnan.program.event.rmw.RMWStoreExclusive;
+import com.dat3m.dartagnan.program.event.rmw.RMWStoreExclusiveStatus;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
 import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
 import com.dat3m.dartagnan.wmm.utils.Arch;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.Arrays;
 import java.util.LinkedList;
-
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 public class StoreExclusive extends Store implements RegWriter, RegReaderData {
 
@@ -57,8 +59,8 @@ public class StoreExclusive extends Store implements RegWriter, RegReaderData {
     @Override
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         if(target == Arch.ARM || target == Arch.ARM8) {
-            RMWStoreExclusive store = new RMWStoreExclusive(address, value, mo);
-            RMWStoreExclusiveStatus status = new RMWStoreExclusiveStatus(register, store);
+            RMWStoreExclusive store = Events.newRMWStoreExclusive(address, value, mo);
+            RMWStoreExclusiveStatus status = Events.newRMWStoreExclusiveStatus(register, store);
             LinkedList<Event> events = new LinkedList<>(Arrays.asList(store, status));
             return compileSequenceRecursive(target, nextId, predecessor, events, depth + 1);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWAddUnless.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWAddUnless.java
@@ -1,11 +1,5 @@
 package com.dat3m.dartagnan.program.arch.linux.event;
 
-import com.dat3m.dartagnan.program.arch.linux.utils.Mo;
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.rmw.cond.FenceCond;
-import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
-import com.dat3m.dartagnan.wmm.utils.Arch;
-import com.google.common.collect.ImmutableSet;
 import com.dat3m.dartagnan.expression.Atom;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
@@ -13,11 +7,17 @@ import com.dat3m.dartagnan.expression.IExprBin;
 import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.arch.linux.event.cond.FenceCond;
+import com.dat3m.dartagnan.program.arch.linux.event.cond.RMWReadCondUnless;
+import com.dat3m.dartagnan.program.arch.linux.event.cond.RMWStoreCond;
+import com.dat3m.dartagnan.program.arch.linux.utils.Mo;
+import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.Local;
-import com.dat3m.dartagnan.program.event.rmw.cond.RMWReadCondUnless;
-import com.dat3m.dartagnan.program.event.rmw.cond.RMWStoreCond;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
+import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
+import com.dat3m.dartagnan.wmm.utils.Arch;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Arrays;
 import java.util.LinkedList;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWAddUnless.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWAddUnless.java
@@ -6,8 +6,8 @@ import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IExprBin;
 import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.arch.linux.event.cond.FenceCond;
 import com.dat3m.dartagnan.program.arch.linux.event.cond.RMWReadCondUnless;
 import com.dat3m.dartagnan.program.arch.linux.event.cond.RMWStoreCond;
 import com.dat3m.dartagnan.program.arch.linux.utils.Mo;
@@ -58,13 +58,13 @@ public class RMWAddUnless extends RMWAbstract implements RegWriter, RegReaderDat
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         if(target == Arch.NONE) {
             Register dummy = new Register(null, resultRegister.getThreadId(), resultRegister.getPrecision());
-            RMWReadCondUnless load = new RMWReadCondUnless(dummy, cmp, address, Mo.RELAXED);
-            RMWStoreCond store = new RMWStoreCond(load, address, new IExprBin(dummy, IOpBin.PLUS, value), Mo.RELAXED);
-            Local local = new Local(resultRegister, new Atom(dummy, COpBin.NEQ, cmp));
+            RMWReadCondUnless load = Events.Linux.newRMWReadCondUnless(dummy, cmp, address, Mo.RELAXED);
+            RMWStoreCond store = Events.Linux.newRMWStoreCond(load, address, new IExprBin(dummy, IOpBin.PLUS, value), Mo.RELAXED);
+            Local local = Events.newLocal(resultRegister, new Atom(dummy, COpBin.NEQ, cmp));
 
             LinkedList<Event> events = new LinkedList<>(Arrays.asList(load, store, local));
-            events.addFirst(new FenceCond(load, "Mb"));
-            events.addLast(new FenceCond(load, "Mb"));
+            events.addFirst(Events.Linux.newMemoryBarrier());
+            events.addLast(Events.Linux.newMemoryBarrier());
 
             return compileSequenceRecursive(target, nextId, predecessor, events, depth + 1);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWCmpXchg.java
@@ -1,19 +1,19 @@
 package com.dat3m.dartagnan.program.arch.linux.event;
 
-import com.dat3m.dartagnan.program.arch.linux.utils.Mo;
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Local;
-import com.dat3m.dartagnan.program.event.rmw.cond.FenceCond;
-import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
-import com.dat3m.dartagnan.wmm.utils.Arch;
-import com.google.common.collect.ImmutableSet;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.rmw.cond.RMWReadCondCmp;
-import com.dat3m.dartagnan.program.event.rmw.cond.RMWStoreCond;
+import com.dat3m.dartagnan.program.arch.linux.event.cond.FenceCond;
+import com.dat3m.dartagnan.program.arch.linux.event.cond.RMWReadCondCmp;
+import com.dat3m.dartagnan.program.arch.linux.event.cond.RMWStoreCond;
+import com.dat3m.dartagnan.program.arch.linux.utils.Mo;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Local;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
+import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
+import com.dat3m.dartagnan.wmm.utils.Arch;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Arrays;
 import java.util.LinkedList;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWFetchOp.java
@@ -4,11 +4,10 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IExprBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.arch.linux.utils.Mo;
 import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Fence;
-import com.dat3m.dartagnan.program.event.Local;
 import com.dat3m.dartagnan.program.event.rmw.RMWLoad;
 import com.dat3m.dartagnan.program.event.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
@@ -59,16 +58,16 @@ public class RMWFetchOp extends RMWAbstract implements RegWriter, RegReaderData 
                 dummy = new Register(null, resultRegister.getThreadId(), resultRegister.getPrecision());
             }
 
-            RMWLoad load = new RMWLoad(dummy, address, Mo.loadMO(mo));
-            RMWStore store = new RMWStore(load, address, new IExprBin(dummy, op, value), Mo.storeMO(mo));
+            RMWLoad load = Events.newRMWLoad(dummy, address, Mo.loadMO(mo));
+            RMWStore store = Events.newRMWStore(load, address, new IExprBin(dummy, op, value), Mo.storeMO(mo));
 
             LinkedList<Event> events = new LinkedList<>(Arrays.asList(load, store));
             if (dummy != resultRegister) {
-                events.addLast(new Local(resultRegister, dummy));
+                events.addLast(Events.newLocal(resultRegister, dummy));
             }
             if (Mo.MB.equals(mo)) {
-                events.addFirst(new Fence("Mb"));
-                events.addLast(new Fence("Mb"));
+                events.addFirst(Events.Linux.newMemoryBarrier());
+                events.addLast(Events.Linux.newMemoryBarrier());
             }
             return compileSequenceRecursive(target, nextId, predecessor, events, depth + 1);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWOp.java
@@ -4,14 +4,15 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IExprBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.arch.linux.utils.EType;
 import com.dat3m.dartagnan.program.arch.linux.utils.Mo;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.rmw.RMWLoad;
 import com.dat3m.dartagnan.program.event.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
-import com.dat3m.dartagnan.program.arch.linux.utils.EType;
 import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
 import com.dat3m.dartagnan.wmm.utils.Arch;
 
@@ -53,8 +54,8 @@ public class RMWOp extends RMWAbstract implements RegWriter, RegReaderData {
     @Override
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         if(target == Arch.NONE) {
-            RMWLoad load = new RMWLoad(resultRegister, address, Mo.RELAXED);
-            RMWStore store = new RMWStore(load, address, new IExprBin(resultRegister, op, value), Mo.RELAXED);
+            RMWLoad load = Events.newRMWLoad(resultRegister, address, Mo.RELAXED);
+            RMWStore store = Events.newRMWStore(load, address, new IExprBin(resultRegister, op, value), Mo.RELAXED);
             load.addFilters(EType.NORETURN);
             LinkedList<Event> events = new LinkedList<>(Arrays.asList(load, store));
             return compileSequenceRecursive(target, nextId, predecessor, events, depth + 1);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWOpReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWOpReturn.java
@@ -4,10 +4,10 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IExprBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.arch.linux.utils.Mo;
 import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Fence;
 import com.dat3m.dartagnan.program.event.Local;
 import com.dat3m.dartagnan.program.event.rmw.RMWLoad;
 import com.dat3m.dartagnan.program.event.rmw.RMWStore;
@@ -54,14 +54,14 @@ public class RMWOpReturn extends RMWAbstract implements RegWriter, RegReaderData
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         if(target == Arch.NONE) {
             Register dummy = new Register(null, resultRegister.getThreadId(), resultRegister.getPrecision());
-            RMWLoad load = new RMWLoad(dummy, address, Mo.loadMO(mo));
-            Local local = new Local(resultRegister, new IExprBin(dummy, op, value));
-            RMWStore store = new RMWStore(load, address, resultRegister, Mo.storeMO(mo));
+            RMWLoad load = Events.newRMWLoad(dummy, address, Mo.loadMO(mo));
+            Local local = Events.newLocal(resultRegister, new IExprBin(dummy, op, value));
+            RMWStore store = Events.newRMWStore(load, address, resultRegister, Mo.storeMO(mo));
 
             LinkedList<Event> events = new LinkedList<>(Arrays.asList(load, local, store));
             if (Mo.MB.equals(mo)) {
-                events.addFirst(new Fence("Mb"));
-                events.addLast(new Fence("Mb"));
+                events.addFirst(Events.Linux.newMemoryBarrier());
+                events.addLast(Events.Linux.newMemoryBarrier());
             }
             return compileSequenceRecursive(target, nextId, predecessor, events, depth + 1);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/RMWXchg.java
@@ -2,11 +2,10 @@ package com.dat3m.dartagnan.program.arch.linux.event;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.arch.linux.utils.Mo;
 import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Fence;
-import com.dat3m.dartagnan.program.event.Local;
 import com.dat3m.dartagnan.program.event.rmw.RMWLoad;
 import com.dat3m.dartagnan.program.event.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
@@ -52,16 +51,16 @@ public class RMWXchg extends RMWAbstract implements RegWriter, RegReaderData {
                 dummy = new Register(null, resultRegister.getThreadId(), resultRegister.getPrecision());
             }
 
-            RMWLoad load = new RMWLoad(dummy, address, Mo.loadMO(mo));
-            RMWStore store = new RMWStore(load, address, value, Mo.storeMO(mo));
+            RMWLoad load = Events.newRMWLoad(dummy, address, Mo.loadMO(mo));
+            RMWStore store = Events.newRMWStore(load, address, value, Mo.storeMO(mo));
 
             LinkedList<Event> events = new LinkedList<>(Arrays.asList(load, store));
             if (dummy != resultRegister) {
-                events.addLast(new Local(resultRegister, dummy));
+                events.addLast(Events.newLocal(resultRegister, dummy));
             }
             if (Mo.MB.equals(mo)) {
-                events.addFirst(new Fence("Mb"));
-                events.addLast(new Fence("Mb"));
+                events.addFirst(Events.Linux.newMemoryBarrier());
+                events.addLast(Events.Linux.newMemoryBarrier());
             }
             return compileSequenceRecursive(target, nextId, predecessor, events, depth + 1);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/FenceCond.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/FenceCond.java
@@ -1,24 +1,21 @@
-package com.dat3m.dartagnan.program.event.rmw.cond;
+package com.dat3m.dartagnan.program.arch.linux.event.cond;
 
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Fence;
 import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
 import com.dat3m.dartagnan.verification.VerificationTask;
-
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.rmw.RMWStore;
-import com.dat3m.dartagnan.program.event.utils.RegReaderData;
+public class FenceCond extends Fence {
 
-public class RMWStoreCond extends RMWStore implements RegReaderData {
-
+    private final RMWReadCond loadEvent;
     protected transient BooleanFormula execVar;
 
-    public RMWStoreCond(RMWReadCond loadEvent, IExpr address, ExprInterface value, String mo) {
-        super(loadEvent, address, value, mo);
+    public FenceCond (RMWReadCond loadEvent, String name){
+        super(name);
+        this.loadEvent = loadEvent;
     }
 
     @Override
@@ -34,20 +31,21 @@ public class RMWStoreCond extends RMWStore implements RegReaderData {
 
     @Override
     public String toString(){
-        return String.format("%1$-" + Event.PRINT_PAD_EXTRA + "s", super.toString()) + ((RMWReadCond)loadEvent).condToString();
+        return String.format("%1$-" + Event.PRINT_PAD_EXTRA + "s", super.toString()) + loadEvent.condToString();
     }
 
     @Override
     protected BooleanFormula encodeExec(SolverContext ctx){
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		return bmgr.equivalence(execVar, bmgr.and(cfVar, ((RMWReadCond)loadEvent).getCond()));
+		return bmgr.equivalence(execVar, bmgr.and(cfVar, loadEvent.getCond()));
     }
 
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
+
     @Override
     public RecursiveAction unrollRecursive(int bound, Event predecessor, int depth) {
-        throw new RuntimeException("RMWStoreCond cannot be unrolled: event must be generated during compilation");
+        throw new RuntimeException("FenceCond cannot be unrolled: event must be generated during compilation");
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWReadCond.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWReadCond.java
@@ -1,22 +1,20 @@
-package com.dat3m.dartagnan.program.event.rmw.cond;
-
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.utils.EType;
-import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
-import com.dat3m.dartagnan.verification.VerificationTask;
-import com.google.common.collect.ImmutableSet;
-
-import static com.dat3m.dartagnan.program.utils.Utils.generalEqual;
-
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.SolverContext;
+package com.dat3m.dartagnan.program.arch.linux.event.cond;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.rmw.RMWLoad;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
+import com.dat3m.dartagnan.program.utils.EType;
+import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
+import com.dat3m.dartagnan.verification.VerificationTask;
+import com.google.common.collect.ImmutableSet;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.SolverContext;
+
+import static com.dat3m.dartagnan.program.utils.Utils.generalEqual;
 
 public abstract class RMWReadCond extends RMWLoad implements RegWriter, RegReaderData {
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWReadCondCmp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWReadCondCmp.java
@@ -1,4 +1,4 @@
-package com.dat3m.dartagnan.program.event.rmw.cond;
+package com.dat3m.dartagnan.program.arch.linux.event.cond;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWReadCondUnless.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWReadCondUnless.java
@@ -1,6 +1,4 @@
-package com.dat3m.dartagnan.program.event.rmw.cond;
-
-import org.sosy_lab.java_smt.api.SolverContext;
+package com.dat3m.dartagnan.program.arch.linux.event.cond;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
@@ -8,6 +6,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
 import com.dat3m.dartagnan.verification.VerificationTask;
+import org.sosy_lab.java_smt.api.SolverContext;
 
 public class RMWReadCondUnless extends RMWReadCond implements RegWriter, RegReaderData {
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWStoreCond.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWStoreCond.java
@@ -1,23 +1,22 @@
-package com.dat3m.dartagnan.program.event.rmw.cond;
+package com.dat3m.dartagnan.program.arch.linux.event.cond;
 
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.rmw.RMWStore;
+import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
 import com.dat3m.dartagnan.verification.VerificationTask;
-
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
 
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Fence;
+public class RMWStoreCond extends RMWStore implements RegReaderData {
 
-public class FenceCond extends Fence {
-
-    private final RMWReadCond loadEvent;
     protected transient BooleanFormula execVar;
 
-    public FenceCond (RMWReadCond loadEvent, String name){
-        super(name);
-        this.loadEvent = loadEvent;
+    public RMWStoreCond(RMWReadCond loadEvent, IExpr address, ExprInterface value, String mo) {
+        super(loadEvent, address, value, mo);
     }
 
     @Override
@@ -33,21 +32,20 @@ public class FenceCond extends Fence {
 
     @Override
     public String toString(){
-        return String.format("%1$-" + Event.PRINT_PAD_EXTRA + "s", super.toString()) + loadEvent.condToString();
+        return String.format("%1$-" + Event.PRINT_PAD_EXTRA + "s", super.toString()) + ((RMWReadCond)loadEvent).condToString();
     }
 
     @Override
     protected BooleanFormula encodeExec(SolverContext ctx){
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		return bmgr.equivalence(execVar, bmgr.and(cfVar, loadEvent.getCond()));
+		return bmgr.equivalence(execVar, bmgr.and(cfVar, ((RMWReadCond)loadEvent).getCond()));
     }
 
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
-
     @Override
     public RecursiveAction unrollRecursive(int bound, Event predecessor, int depth) {
-        throw new RuntimeException("FenceCond cannot be unrolled: event must be generated during compilation");
+        throw new RuntimeException("RMWStoreCond cannot be unrolled: event must be generated during compilation");
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWStoreCond.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/linux/event/cond/RMWStoreCond.java
@@ -1,20 +1,17 @@
 package com.dat3m.dartagnan.program.arch.linux.event.cond;
-package com.dat3m.dartagnan.program.event.rmw.cond;
-
-import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
-import com.dat3m.dartagnan.verification.VerificationTask;
-
-import static org.sosy_lab.java_smt.api.FormulaType.BooleanType;
-
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
+import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
+import com.dat3m.dartagnan.verification.VerificationTask;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.SolverContext;
+
+import static org.sosy_lab.java_smt.api.FormulaType.BooleanType;
 
 
 public class RMWStoreCond extends RMWStore implements RegReaderData {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/tso/event/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/arch/tso/event/Xchg.java
@@ -1,10 +1,9 @@
 package com.dat3m.dartagnan.program.arch.tso.event;
 
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
-import com.dat3m.dartagnan.wmm.utils.Arch;
-import com.google.common.collect.ImmutableSet;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.arch.tso.utils.EType;
+import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.Local;
 import com.dat3m.dartagnan.program.event.MemEvent;
 import com.dat3m.dartagnan.program.event.rmw.RMWLoad;
@@ -12,7 +11,9 @@ import com.dat3m.dartagnan.program.event.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
 import com.dat3m.dartagnan.program.memory.Address;
-import com.dat3m.dartagnan.program.arch.tso.utils.EType;
+import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
+import com.dat3m.dartagnan.wmm.utils.Arch;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -66,13 +67,13 @@ public class Xchg extends MemEvent implements RegWriter, RegReaderData {
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         if(target == Arch.TSO) {
             Register dummyReg = new Register(null, resultRegister.getThreadId(), resultRegister.getPrecision());
-            RMWLoad load = new RMWLoad(dummyReg, address, null);
+            RMWLoad load = Events.newRMWLoad(dummyReg, address, null);
             load.addFilters(EType.ATOM);
 
-            RMWStore store = new RMWStore(load, address, resultRegister, null);
+            RMWStore store = Events.newRMWStore(load, address, resultRegister, null);
             store.addFilters(EType.ATOM);
 
-            Local local = new Local(resultRegister, dummyReg);
+            Local local = Events.newLocal(resultRegister, dummyReg);
 
             LinkedList<Event> events = new LinkedList<>(Arrays.asList(load, store, local));
             return compileSequenceRecursive(target, nextId, predecessor, events, depth + 1);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/atomic/event/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/atomic/event/AtomicAbstract.java
@@ -1,16 +1,16 @@
 package com.dat3m.dartagnan.program.atomic.event;
 
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
-import com.dat3m.dartagnan.wmm.utils.Arch;
-import com.google.common.collect.ImmutableSet;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.arch.linux.utils.EType;
+import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.MemEvent;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
-import com.dat3m.dartagnan.program.arch.linux.utils.EType;
+import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
+import com.dat3m.dartagnan.wmm.utils.Arch;
+import com.google.common.collect.ImmutableSet;
 
 public abstract class AtomicAbstract extends MemEvent implements RegWriter, RegReaderData {
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/atomic/event/AtomicCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/atomic/event/AtomicCmpXchg.java
@@ -1,13 +1,15 @@
 package com.dat3m.dartagnan.program.atomic.event;
 
-import com.dat3m.dartagnan.expression.*;
+import com.dat3m.dartagnan.expression.Atom;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.IConst;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.arch.aarch64.event.RMWLoadExclusive;
-import com.dat3m.dartagnan.program.arch.aarch64.event.RMWStoreExclusive;
-import com.dat3m.dartagnan.program.arch.aarch64.event.RMWStoreExclusiveStatus;
 import com.dat3m.dartagnan.program.event.*;
 import com.dat3m.dartagnan.program.event.rmw.RMWLoad;
-import com.dat3m.dartagnan.program.event.rmw.RMWStore;
+import com.dat3m.dartagnan.program.event.rmw.RMWStoreExclusive;
+import com.dat3m.dartagnan.program.event.rmw.RMWStoreExclusiveStatus;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
 import com.dat3m.dartagnan.program.utils.EType;
@@ -75,14 +77,14 @@ public class AtomicCmpXchg extends AtomicAbstract implements RegWriter, RegReade
             case NONE:
             case TSO: {
                 Register dummy = new Register(null, resultRegister.getThreadId(), resultRegister.getPrecision());
-                load = new RMWLoad(dummy, address, mo);
-                Local casResult = new Local(resultRegister, new Atom(dummy, EQ, expected));
-                Label fail = new Label("CAS_fail");
-                Label endCas = new Label("CAS_end");
-                CondJump branch = new CondJump(new Atom(resultRegister, NEQ, IConst.ONE), fail);
-                store = new RMWStore((RMWLoad)load, address, value, mo);
-                CondJump jumpToEnd = new CondJump(BConst.TRUE, endCas);
-                Local updateReg = new Local(expected, dummy);
+                load = Events.newRMWLoad(dummy, address, mo);
+                Local casResult = Events.newLocal(resultRegister, new Atom(dummy, EQ, expected));
+                Label fail = Events.newLabel("CAS_fail");
+                Label endCas = Events.newLabel("CAS_end");
+                CondJump branch = Events.newJump(new Atom(resultRegister, NEQ, IConst.ONE), fail);
+                store = Events.newRMWStore((RMWLoad)load, address, value, mo);
+                CondJump jumpToEnd = Events.newGoto(endCas);
+                Local updateReg = Events.newLocal(expected, dummy);
                 events.addAll(Arrays.asList(load, casResult, branch, store, jumpToEnd, fail, updateReg, endCas));
                 break;
             }
@@ -113,35 +115,35 @@ public class AtomicCmpXchg extends AtomicAbstract implements RegWriter, RegReade
                 }
 
                 Register dummy = new Register(null, resultRegister.getThreadId(), resultRegister.getPrecision());
-                load = new RMWLoadExclusive(dummy, address, loadMo);
-                Local casResult = new Local(resultRegister, new Atom(dummy, EQ, expected));
-                Label fail = new Label("CAS_fail");
-                Label endCas = new Label("CAS_end");
-                CondJump branch = new CondJump(new Atom(resultRegister, NEQ, IConst.ONE), fail);
+                load = Events.newRMWLoadExclusive(dummy, address, loadMo);
+                Local casResult = Events.newLocal(resultRegister, new Atom(dummy, EQ, expected));
+                Label fail = Events.newLabel("CAS_fail");
+                Label endCas = Events.newLabel("CAS_end");
+                CondJump branch = Events.newJump(new Atom(resultRegister, NEQ, IConst.ONE), fail);
                 // ---- CAS success ----
-                store = new RMWStoreExclusive(address, value, storeMo, is(STRONG));
+                store = Events.newRMWStoreExclusive(address, value, storeMo, is(STRONG));
                 Register statusReg = new Register("status(" + getOId() + ")", resultRegister.getThreadId(), resultRegister.getPrecision());
-                RMWStoreExclusiveStatus status = new RMWStoreExclusiveStatus(statusReg, (RMWStoreExclusive)store);
-                Event jumpStoreFail = new CondJump(new Atom(statusReg, EQ, IConst.ONE), (Label) getThread().getExit());
+                RMWStoreExclusiveStatus status = Events.newRMWStoreExclusiveStatus(statusReg, (RMWStoreExclusive)store);
+                Event jumpStoreFail = Events.newJump(new Atom(statusReg, EQ, IConst.ONE), (Label) getThread().getExit());
                 jumpStoreFail.addFilters(EType.BOUND);
-                CondJump jumpToEndCas = new CondJump(BConst.TRUE, endCas);
+                CondJump jumpToEndCas = Events.newGoto(endCas);
                 // ---------------------
                 // ---- CAS Fail ----
-                Local updateReg = new Local(expected, dummy);
+                Local updateReg = Events.newLocal(expected, dummy);
                
                 // --- Add Fence before under POWER ---
                 if(target.equals(POWER)) {
                     if (mo.equals(SC)) {
-                        events.addFirst(new Fence("Sync"));
+                        events.addFirst(Events.Power.newSyncBarrier());
                     } else if (storeMo.equals(REL)) {
-                        events.addFirst(new Fence("Lwsync"));
+                        events.addFirst(Events.Power.newLwSyncBarrier());
                     }                	
                 }
                 // --- Add success events ---
                 events.addAll(Arrays.asList(load, casResult, branch, store, status, jumpStoreFail));
                 // --- Add Fence after success under POWER ---
                 if (target.equals(POWER) && loadMo.equals(ACQ)) {
-                    events.addLast(new Fence("Isync"));
+                    events.addLast(Events.Power.newISyncBarrier());
                 }
                 // --- Add fail events + exit ---
                 events.addAll(Arrays.asList(jumpToEndCas, fail, updateReg, endCas));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/atomic/event/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/atomic/event/AtomicLoad.java
@@ -1,28 +1,19 @@
 package com.dat3m.dartagnan.program.atomic.event;
 
-import com.dat3m.dartagnan.expression.Atom;
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.CondJump;
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Fence;
-import com.dat3m.dartagnan.program.event.Label;
-import com.dat3m.dartagnan.program.event.Load;
-import com.dat3m.dartagnan.program.event.MemEvent;
+import com.dat3m.dartagnan.program.event.*;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
 import com.dat3m.dartagnan.program.utils.EType;
 import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
 import com.dat3m.dartagnan.wmm.utils.Arch;
 
-import static com.dat3m.dartagnan.expression.op.COpBin.EQ;
+import java.util.LinkedList;
+
 import static com.dat3m.dartagnan.program.arch.aarch64.utils.Mo.ACQ;
 import static com.dat3m.dartagnan.program.arch.aarch64.utils.Mo.RX;
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.ACQUIRE;
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.CONSUME;
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.RELAXED;
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
-
-import java.util.LinkedList;
+import static com.dat3m.dartagnan.program.atomic.utils.Mo.*;
 
 public class AtomicLoad extends MemEvent implements RegWriter {
 
@@ -66,7 +57,7 @@ public class AtomicLoad extends MemEvent implements RegWriter {
     @Override
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         LinkedList<Event> events = new LinkedList<>();
-        Load load = new Load(resultRegister, address, mo);
+        Load load = Events.newLoad(resultRegister, address, mo);
         events.add(load);
 
         switch (target) {
@@ -75,19 +66,19 @@ public class AtomicLoad extends MemEvent implements RegWriter {
                 break;
             case POWER:
                 if(SC.equals(mo) || ACQUIRE.equals(mo) || CONSUME.equals(mo)){
-                    Label label = new Label("Jump_" + oId);
-                    CondJump jump = new CondJump(new Atom(resultRegister, EQ, resultRegister), label);
-                    events.addLast(jump);
+                    Label label = Events.newLabel("Jump_" + oId);
+                    CondJump fakeDep = Events.newFakeCtrlDep(resultRegister, label);
+                    events.addLast(fakeDep);
                     events.addLast(label);
-                    events.addLast(new Fence("Isync"));
+                    events.addLast(Events.Power.newISyncBarrier());
                     if(SC.equals(mo)){
-                        events.addFirst(new Fence("Sync"));
+                        events.addFirst(Events.Power.newSyncBarrier());
                     }
                 }
                 break;
             case ARM:
                 if(SC.equals(mo) || ACQUIRE.equals(mo) || CONSUME.equals(mo)) {
-                    events.addLast(new Fence("Ish"));
+                    events.addLast(Events.Arm.newISHBarrier());
                 }
                 break;
             case ARM8:
@@ -104,7 +95,7 @@ public class AtomicLoad extends MemEvent implements RegWriter {
 		                throw new UnsupportedOperationException("Compilation to " + target + " is not supported for " + this);
 					}
 		        events = new LinkedList<>();
-		        load = new Load(resultRegister, address, loadMo);
+		        load = Events.newLoad(resultRegister, address, loadMo);
 		        events.add(load);
                 break;
             default:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/atomic/event/AtomicThreadFence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/atomic/event/AtomicThreadFence.java
@@ -1,16 +1,14 @@
 package com.dat3m.dartagnan.program.atomic.event;
 
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.Fence;
 import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
 import com.dat3m.dartagnan.wmm.utils.Arch;
 
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.ACQUIRE;
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.ACQ_REL;
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.RELEASE;
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
-
 import java.util.LinkedList;
+
+import static com.dat3m.dartagnan.program.atomic.utils.Mo.*;
 
 public class AtomicThreadFence extends Fence {
 
@@ -52,25 +50,25 @@ public class AtomicThreadFence extends Fence {
                 break;
             case TSO:
                 if(SC.equals(mo)){
-                    events.add(new Fence("Mfence"));
+                    events.add(Events.X86.newMFence());
                 }
                 break;
             case POWER:
                 if(ACQUIRE.equals(mo) || RELEASE.equals(mo) || ACQ_REL.equals(mo) || SC.equals(mo)){
-                    events.add(new Fence("Lwsync"));
+                    events.add(Events.Power.newLwSyncBarrier());
                 }
                 break;
             case ARM:
                 if(ACQUIRE.equals(mo) || RELEASE.equals(mo) || ACQ_REL.equals(mo) || SC.equals(mo)){
-                    events.addLast(new Fence("Ish"));
+                    events.addLast(Events.Arm.newISHBarrier());
                 }
                 break;
             case ARM8:
                 if(RELEASE.equals(mo) || ACQ_REL.equals(mo) || SC.equals(mo)){
-                	events.addLast(new Fence("DMB.ISH"));
+                	events.addLast(Events.Arm8.DMB.newISHBarrier());
                 }
                 if(ACQUIRE.equals(mo)){
-                	events.addLast(new Fence("DSB.ISHLD"));
+                	events.addLast(Events.Arm8.DSB.newISHLDBarrier());
                 }                
                 break;
             default:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/CondJump.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan.program.event;
 import com.dat3m.dartagnan.GlobalSettings;
 import com.dat3m.dartagnan.expression.BConst;
 import com.dat3m.dartagnan.expression.BExpr;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
@@ -140,7 +141,7 @@ public class CondJump extends Event implements RegReaderData {
             Event next = predecessor;
             if(bound == 1) {
                 Label target = (Label)getThread().getExit();
-                next = new CondJump(BConst.TRUE, target);
+                next = Events.newGoto(target);
                 next.addFilters(EType.BOUND);
                 predecessor.setSuccessor(next);
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/Create.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/Create.java
@@ -1,19 +1,19 @@
 package com.dat3m.dartagnan.program.event.pthread;
 
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
-import static com.dat3m.dartagnan.program.utils.EType.PTHREAD;
-
-import java.math.BigInteger;
-import java.util.LinkedList;
-
 import com.dat3m.dartagnan.expression.IConst;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Fence;
 import com.dat3m.dartagnan.program.event.Store;
 import com.dat3m.dartagnan.program.memory.Address;
 import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
 import com.dat3m.dartagnan.wmm.utils.Arch;
+
+import java.math.BigInteger;
+import java.util.LinkedList;
+
+import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
+import static com.dat3m.dartagnan.program.utils.EType.PTHREAD;
 
 public class Create extends Event {
 
@@ -55,7 +55,7 @@ public class Create extends Event {
     @Override
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         LinkedList<Event> events = new LinkedList<>();
-        Store store = new Store(address, new IConst(BigInteger.ONE, -1), SC, cLine);
+        Store store = Events.newStore(address, new IConst(BigInteger.ONE, -1), SC, cLine);
         store.addFilters(PTHREAD);
         events.add(store);
 
@@ -63,18 +63,18 @@ public class Create extends Event {
             case NONE:
                 break;
             case TSO:
-                events.addLast(new Fence("Mfence"));
+                events.addLast(Events.X86.newMFence());
                 break;
             case POWER:
-                events.addFirst(new Fence("Sync"));
+                events.addFirst(Events.Power.newSyncBarrier());
                 break;
             case ARM:
-                events.addFirst(new Fence("Ish"));
-                events.addLast(new Fence("Ish"));
+                events.addFirst(Events.Arm.newISHBarrier());
+                events.addLast(Events.Arm.newISHBarrier());
                 break;
             case ARM8:
-                events.addFirst(new Fence("DMB.ISH"));
-                events.addLast(new Fence("DMB.ISH"));
+                events.addFirst(Events.Arm8.DMB.newISHBarrier());
+                events.addLast(Events.Arm8.DMB.newISHBarrier());
                 break;
             default:
                 throw new UnsupportedOperationException("Compilation to " + target + " is not supported for " + this);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/End.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/End.java
@@ -1,17 +1,17 @@
 package com.dat3m.dartagnan.program.event.pthread;
 
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
-
-import java.math.BigInteger;
-import java.util.LinkedList;
-
 import com.dat3m.dartagnan.expression.IConst;
+import com.dat3m.dartagnan.program.Events;
 import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Fence;
 import com.dat3m.dartagnan.program.event.Store;
 import com.dat3m.dartagnan.program.memory.Address;
 import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
 import com.dat3m.dartagnan.wmm.utils.Arch;
+
+import java.math.BigInteger;
+import java.util.LinkedList;
+
+import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
 
 public class End extends Event {
 
@@ -45,25 +45,25 @@ public class End extends Event {
     @Override
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         LinkedList<Event> events = new LinkedList<>();
-        Store store = new Store(address, new IConst(BigInteger.ZERO, -1), SC);
+        Store store = Events.newStore(address, new IConst(BigInteger.ZERO, -1), SC);
         events.add(store);
 
         switch (target){
             case NONE:
                 break;
             case TSO:
-                events.addLast(new Fence("Mfence"));
+                events.addLast(Events.X86.newMFence());
                 break;
             case POWER:
-                events.addFirst(new Fence("Sync"));
+                events.addFirst(Events.Power.newSyncBarrier());
                 break;
             case ARM:
-                events.addFirst(new Fence("Ish"));
-                events.addLast(new Fence("Ish"));
+                events.addFirst(Events.Arm.newISHBarrier());
+                events.addLast(Events.Arm.newISHBarrier());
                 break;
             case ARM8:
-                events.addFirst(new Fence("DMB.ISH"));
-                events.addLast(new Fence("DMB.ISH"));
+                events.addFirst(Events.Arm8.DMB.newISHBarrier());
+                events.addLast(Events.Arm8.DMB.newISHBarrier());
                 break;
             default:
                 throw new UnsupportedOperationException("Compilation to " + target + " is not supported for " + this);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/InitLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/InitLock.java
@@ -1,14 +1,14 @@
 package com.dat3m.dartagnan.program.event.pthread;
 
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Events;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
+import com.dat3m.dartagnan.wmm.utils.Arch;
 
 import java.util.LinkedList;
 
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Store;
-import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
-import com.dat3m.dartagnan.wmm.utils.Arch;
+import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
 
 public class InitLock extends Event {
 	
@@ -48,7 +48,7 @@ public class InitLock extends Event {
     @Override
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         LinkedList<Event> events = new LinkedList<>();
-        events.add(new Store(address, value, SC));
+        events.add(Events.newStore(address, value, SC));
         return compileSequenceRecursive(target, nextId, predecessor, events, depth + 1);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/Lock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/Lock.java
@@ -1,24 +1,22 @@
 package com.dat3m.dartagnan.program.event.pthread;
 
-import static com.dat3m.dartagnan.expression.op.COpBin.NEQ;
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
-import static com.dat3m.dartagnan.program.utils.EType.LOCK;
-import static com.dat3m.dartagnan.program.utils.EType.RMW;
+import com.dat3m.dartagnan.expression.Atom;
+import com.dat3m.dartagnan.expression.IConst;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Events;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Label;
+import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
+import com.dat3m.dartagnan.wmm.utils.Arch;
 
 import java.math.BigInteger;
 import java.util.LinkedList;
 
-import com.dat3m.dartagnan.expression.Atom;
-import com.dat3m.dartagnan.expression.IConst;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.CondJump;
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Label;
-import com.dat3m.dartagnan.program.event.Load;
-import com.dat3m.dartagnan.program.event.Store;
-import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
-import com.dat3m.dartagnan.wmm.utils.Arch;
+import static com.dat3m.dartagnan.expression.op.COpBin.NEQ;
+import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
+import static com.dat3m.dartagnan.program.utils.EType.LOCK;
+import static com.dat3m.dartagnan.program.utils.EType.RMW;
 
 public class Lock extends Event {
 	
@@ -72,9 +70,9 @@ public class Lock extends Event {
 
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         LinkedList<Event> events = new LinkedList<>();
-        events.add(new Load(reg, address, SC));
-        events.add(new CondJump(new Atom(reg, NEQ, new IConst(BigInteger.ZERO, -1)),label));
-        events.add(new Store(address, new IConst(BigInteger.ONE, -1), SC));
+        events.add(Events.newLoad(reg, address, SC));
+        events.add(Events.newJump(new Atom(reg, NEQ, new IConst(BigInteger.ZERO, -1)),label));
+        events.add(Events.newStore(address, new IConst(BigInteger.ONE, -1), SC));
         for(Event e : events) {
             e.addFilters(LOCK, RMW);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/Unlock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/pthread/Unlock.java
@@ -1,24 +1,22 @@
 package com.dat3m.dartagnan.program.event.pthread;
 
-import static com.dat3m.dartagnan.expression.op.COpBin.NEQ;
-import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
-import static com.dat3m.dartagnan.program.utils.EType.LOCK;
-import static com.dat3m.dartagnan.program.utils.EType.RMW;
+import com.dat3m.dartagnan.expression.Atom;
+import com.dat3m.dartagnan.expression.IConst;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Events;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Label;
+import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
+import com.dat3m.dartagnan.wmm.utils.Arch;
 
 import java.math.BigInteger;
 import java.util.LinkedList;
 
-import com.dat3m.dartagnan.expression.Atom;
-import com.dat3m.dartagnan.expression.IConst;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.CondJump;
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Label;
-import com.dat3m.dartagnan.program.event.Load;
-import com.dat3m.dartagnan.program.event.Store;
-import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
-import com.dat3m.dartagnan.wmm.utils.Arch;
+import static com.dat3m.dartagnan.expression.op.COpBin.NEQ;
+import static com.dat3m.dartagnan.program.atomic.utils.Mo.SC;
+import static com.dat3m.dartagnan.program.utils.EType.LOCK;
+import static com.dat3m.dartagnan.program.utils.EType.RMW;
 
 public class Unlock extends Event {
 	
@@ -73,9 +71,9 @@ public class Unlock extends Event {
     @Override
     protected RecursiveFunction<Integer> compileRecursive(Arch target, int nextId, Event predecessor, int depth) {
         LinkedList<Event> events = new LinkedList<>();
-        events.add(new Load(reg, address, SC));
-        events.add(new CondJump(new Atom(reg, NEQ, new IConst(BigInteger.ONE, -1)),label));
-        events.add(new Store(address, new IConst(BigInteger.ZERO, -1), SC));
+        events.add(Events.newLoad(reg, address, SC));
+        events.add(Events.newJump(new Atom(reg, NEQ, new IConst(BigInteger.ONE, -1)), label));
+        events.add(Events.newStore(address, new IConst(BigInteger.ZERO, -1), SC));
         for(Event e : events) {
             e.addFilters(LOCK, RMW);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/rmw/RMWLoadExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/rmw/RMWLoadExclusive.java
@@ -1,10 +1,10 @@
-package com.dat3m.dartagnan.program.arch.aarch64.event;
+package com.dat3m.dartagnan.program.event.rmw;
 
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.arch.aarch64.utils.EType;
 import com.dat3m.dartagnan.program.event.Load;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
-import com.dat3m.dartagnan.program.arch.aarch64.utils.EType;
 
 public class RMWLoadExclusive extends Load implements RegWriter {
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/rmw/RMWStoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/rmw/RMWStoreExclusive.java
@@ -1,19 +1,17 @@
-package com.dat3m.dartagnan.program.arch.aarch64.event;
-
-import com.dat3m.dartagnan.program.arch.aarch64.utils.EType;
-import com.dat3m.dartagnan.program.event.Store;
-import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
-import com.dat3m.dartagnan.verification.VerificationTask;
-
-import static org.sosy_lab.java_smt.api.FormulaType.BooleanType;
-
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.SolverContext;
+package com.dat3m.dartagnan.program.event.rmw;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.arch.aarch64.utils.EType;
 import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Store;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
+import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
+import com.dat3m.dartagnan.verification.VerificationTask;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.SolverContext;
+
+import static org.sosy_lab.java_smt.api.FormulaType.BooleanType;
 
 public class RMWStoreExclusive extends Store implements RegReaderData {
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/rmw/RMWStoreExclusiveStatus.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/rmw/RMWStoreExclusiveStatus.java
@@ -1,22 +1,20 @@
-package com.dat3m.dartagnan.program.arch.aarch64.event;
-
-import com.dat3m.dartagnan.program.utils.EType;
-import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
-import com.dat3m.dartagnan.verification.VerificationTask;
-
-import static com.dat3m.dartagnan.program.utils.Utils.generalEqual;
-
-import java.math.BigInteger;
-
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.Formula;
-import org.sosy_lab.java_smt.api.SolverContext;
+package com.dat3m.dartagnan.program.event.rmw;
 
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.utils.RegWriter;
+import com.dat3m.dartagnan.program.utils.EType;
+import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
+import com.dat3m.dartagnan.verification.VerificationTask;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.Formula;
+import org.sosy_lab.java_smt.api.SolverContext;
+
+import java.math.BigInteger;
+
+import static com.dat3m.dartagnan.program.utils.Utils.generalEqual;
 
 public class RMWStoreExclusiveStatus extends Event implements RegWriter {
 


### PR DESCRIPTION
This PR addresses #89. The major changes are as follows:
- A new static factory class ```Events``` is used to create events.
- Linux specific events are moved to the Linux directory (rmw.cond was only used for CLitmus tests and nowhere else)
- RMW exclusive events where moved from AArch64 to the rmw directory (we use those events not only for Arm but also for Power!)
- ```Events``` also contains new convenience functions for creating fake ctrl dependencies, unconditional jumps (gotos) and jumps with negated conditions.

The structure of the new ```Events``` class mirrors the directory structure of our ```events``` folder (with some changes). It has various inner classes to achieve this structure. 