### PR TITLE
Computing isGoto()

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Atom.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Atom.java
@@ -84,38 +84,36 @@ public class Atom extends BExpr implements ExprInterface {
     }
 
     @Override
-	public ExprInterface reduce() {
-    	ExprInterface e1 = lhs.reduce();
-    	ExprInterface e2 = rhs.reduce();
+	public BConst reduce() {
     	// Reduction for IExpr
-    	if(e1 instanceof IConst && e2 instanceof IConst) {
-        	BigInteger v1 = ((IConst)e1).getIntValue();
-        	BigInteger v2 = ((IConst)e2).getIntValue();
+    	if(lhs instanceof IExpr && rhs instanceof IExpr) {
+        	BigInteger v1 = ((IExpr)lhs).reduce().getIntValue();
+        	BigInteger v2 = ((IExpr)lhs).reduce().getIntValue();
             switch(op) {
             	case EQ:
-            		return new IConst(v1.compareTo(v2) == 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+            		return new BConst(v1.compareTo(v2) == 0);
             	case NEQ:
-            		return new IConst(v1.compareTo(v2) != 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+            		return new BConst(v1.compareTo(v2) != 0);
 	            case LT:
 	            case ULT:
-	                return new IConst(v1.compareTo(v2) < 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+	                return new BConst(v1.compareTo(v2) < 0);
 	            case LTE:
 	            case ULTE:
-	                return new IConst(v1.compareTo(v2) <= 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+	                return new BConst(v1.compareTo(v2) <= 0);
 	            case GT:
 	            case UGT:
-	                return new IConst(v1.compareTo(v2) > 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+	                return new BConst(v1.compareTo(v2) > 0);
 	            case GTE:
 	            case UGTE:
-	                return new IConst(v1.compareTo(v2) >= 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+	                return new BConst(v1.compareTo(v2) >= 0);
 	            default:
 	                throw new UnsupportedOperationException("Reduce not supported for " + this);
             }            
     	}
     	// Reduction for BExpr
-    	if(e1 instanceof BConst && e2 instanceof BConst) {
-        	boolean v1 = ((BConst)e1).getValue();
-        	boolean v2 = ((BConst)e2).getValue();
+    	if(lhs instanceof BConst && rhs instanceof BConst) {
+    		boolean v1 = ((BConst)lhs).reduce().getValue();
+    		boolean v2 = ((BConst)lhs).reduce().getValue();
             switch(op) {
 	            case EQ:
 	            	return new BConst(v1 == v2);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Atom.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Atom.java
@@ -84,27 +84,47 @@ public class Atom extends BExpr implements ExprInterface {
     }
 
     @Override
-	public IConst reduce() {
-    	BigInteger v1 = lhs.reduce().getIntValue();
-    	BigInteger v2 = rhs.reduce().getIntValue();
-        switch(op) {
-        case EQ:
-            return new IConst(v1.compareTo(v2) == 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
-        case NEQ:
-            return new IConst(v1.compareTo(v2) != 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
-        case LT:
-        case ULT:
-            return new IConst(v1.compareTo(v2) < 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
-        case LTE:
-        case ULTE:
-            return new IConst(v1.compareTo(v2) <= 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
-        case GT:
-        case UGT:
-            return new IConst(v1.compareTo(v2) > 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
-        case GTE:
-        case UGTE:
-            return new IConst(v1.compareTo(v2) >= 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
-        }
+	public ExprInterface reduce() {
+    	ExprInterface e1 = lhs.reduce();
+    	ExprInterface e2 = rhs.reduce();
+    	// Reduction for IExpr
+    	if(e1 instanceof IConst && e2 instanceof IConst) {
+        	BigInteger v1 = ((IConst)e1).getIntValue();
+        	BigInteger v2 = ((IConst)e2).getIntValue();
+            switch(op) {
+            	case EQ:
+            		return new IConst(v1.compareTo(v2) == 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+            	case NEQ:
+            		return new IConst(v1.compareTo(v2) != 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+	            case LT:
+	            case ULT:
+	                return new IConst(v1.compareTo(v2) < 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+	            case LTE:
+	            case ULTE:
+	                return new IConst(v1.compareTo(v2) <= 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+	            case GT:
+	            case UGT:
+	                return new IConst(v1.compareTo(v2) > 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+	            case GTE:
+	            case UGTE:
+	                return new IConst(v1.compareTo(v2) >= 0 ? BigInteger.ONE : BigInteger.ZERO, lhs.getPrecision());
+	            default:
+	                throw new UnsupportedOperationException("Reduce not supported for " + this);
+            }            
+    	}
+    	// Reduction for BExpr
+    	if(e1 instanceof BConst && e2 instanceof BConst) {
+        	boolean v1 = ((BConst)e1).getValue();
+        	boolean v2 = ((BConst)e2).getValue();
+            switch(op) {
+	            case EQ:
+	            	return new BConst(v1 == v2);
+	            case NEQ:
+	            	return new BConst(v1 != v2);
+	            default:
+	                throw new UnsupportedOperationException("Reduce not supported for " + this);
+            }
+    	}
         throw new UnsupportedOperationException("Reduce not supported for " + this);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BConst.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BConst.java
@@ -54,8 +54,8 @@ public class BConst extends BExpr implements ExprInterface {
 	}
 
 	@Override
-	public IConst reduce() {
-		return value ? IConst.ONE : IConst.ZERO;
+	public ExprInterface reduce() {
+		return new BConst(value);
 	}
 	
 	public boolean getValue() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BConst.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BConst.java
@@ -54,7 +54,7 @@ public class BConst extends BExpr implements ExprInterface {
 	}
 
 	@Override
-	public ExprInterface reduce() {
+	public BConst reduce() {
 		return this;
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BConst.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BConst.java
@@ -55,7 +55,7 @@ public class BConst extends BExpr implements ExprInterface {
 
 	@Override
 	public ExprInterface reduce() {
-		return new BConst(value);
+		return this;
 	}
 	
 	public boolean getValue() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExpr.java
@@ -36,6 +36,11 @@ public abstract class BExpr implements ExprInterface {
 		return null;
 	}
 
+	@Override
+	public BConst reduce() {
+        throw new UnsupportedOperationException("Reduce not supported for " + this);
+	}
+
 	public boolean isTrue() {
 		return this.equals(BConst.TRUE);
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprBin.java
@@ -85,14 +85,14 @@ public class BExprBin extends BExpr {
     }
 
     @Override
-	public IConst reduce() {
-    	BigInteger v1 = b1.reduce().getIntValue();
-    	BigInteger v2 = b2.reduce().getIntValue();
+	public ExprInterface reduce() {
+    	boolean v1 = ((BConst)b1.reduce()).getValue();
+    	boolean v2 = ((BConst)b2.reduce()).getValue();
 		switch(op) {
         case AND:
-        	return new IConst(v1.compareTo(BigInteger.ONE) == 0 ? v2 : BigInteger.ZERO, -1);
+        	return new BConst(v1 && v2);
         case OR:
-        	return new IConst(v1.compareTo(BigInteger.ONE) == 0 ? BigInteger.ONE : v2, -1);
+        	return new BConst(v1 || v2);
         }
         throw new UnsupportedOperationException("Reduce not supported for " + this);
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprBin.java
@@ -85,7 +85,7 @@ public class BExprBin extends BExpr {
     }
 
     @Override
-	public ExprInterface reduce() {
+	public BConst reduce() {
     	boolean v1 = ((BConst)b1.reduce()).getValue();
     	boolean v2 = ((BConst)b2.reduce()).getValue();
 		switch(op) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprUn.java
@@ -75,8 +75,8 @@ public class BExprUn extends BExpr {
     }
 
 	@Override
-	public IConst reduce() {
-		return new IConst(b.reduce().getIntValue(), -1);
+	public ExprInterface reduce() {
+		return new BConst(!((BConst)b.reduce()).getValue());
 	}
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprUn.java
@@ -75,7 +75,7 @@ public class BExprUn extends BExpr {
     }
 
 	@Override
-	public ExprInterface reduce() {
+	public BConst reduce() {
 		return new BConst(!((BConst)b.reduce()).getValue());
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BNonDet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BNonDet.java
@@ -18,11 +18,6 @@ public class BNonDet extends BExpr implements ExprInterface {
 		this.precision = precision;
 	}
 	
-	@Override
-	public ExprInterface reduce() {
-        throw new UnsupportedOperationException("Reduce not supported for " + this);
-	}
-
     @Override
     public Formula toIntFormula(Event e, SolverContext ctx) {
     	FormulaManager fmgr = ctx.getFormulaManager();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BNonDet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BNonDet.java
@@ -19,7 +19,7 @@ public class BNonDet extends BExpr implements ExprInterface {
 	}
 	
 	@Override
-	public IConst reduce() {
+	public ExprInterface reduce() {
         throw new UnsupportedOperationException("Reduce not supported for " + this);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExprInterface.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExprInterface.java
@@ -15,7 +15,7 @@ import com.dat3m.dartagnan.program.event.Event;
 
 public interface ExprInterface {
 
-	IConst reduce();
+	ExprInterface reduce();
 	
     Formula toIntFormula(Event e, SolverContext ctx);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IConst.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IConst.java
@@ -79,7 +79,7 @@ public class IConst extends IExpr implements ExprInterface {
     }
 
 	@Override
-	public ExprInterface reduce() {
+	public IConst reduce() {
 		return this;
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IConst.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IConst.java
@@ -79,7 +79,7 @@ public class IConst extends IExpr implements ExprInterface {
     }
 
 	@Override
-	public IConst reduce() {
+	public ExprInterface reduce() {
 		return this;
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
@@ -31,6 +31,11 @@ public abstract class IExpr implements ExprInterface {
 		return this;
 	}
 	
+	@Override
+	public IConst reduce() {
+		throw new UnsupportedOperationException("Reduce not supported for " + this);
+	}
+
 	public IExpr simplify() {
 		return this;
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
@@ -58,8 +58,8 @@ public class IExprBin extends IExpr implements ExprInterface {
     
     @Override
 	public IConst reduce() {
-    	BigInteger v1 = lhs.reduce().getIntValue();
-    	BigInteger v2 = rhs.reduce().getIntValue();
+    	BigInteger v1 = ((IConst)lhs.reduce()).getIntValue();
+    	BigInteger v2 = ((IConst)rhs.reduce()).getIntValue();
 		return new IConst(op.combine(v1, v2), lhs.getPrecision());
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
@@ -62,16 +62,17 @@ public class IExprUn extends IExpr {
     }
 
     @Override
-	public ExprInterface reduce() {
+	public IConst reduce() {
+		IConst inner = (IConst)b.reduce();
         switch(op){
 			case MINUS:
-				return new IConst(((IConst)b.reduce()).getIntValue().negate(), b.getPrecision());
+			return new IConst(inner.getIntValue().negate(), b.getPrecision());
 			case BV2UINT:
 			case INT2BV1: case INT2BV8: case INT2BV16: case INT2BV32: case INT2BV64: 
 			case TRUNC6432: case TRUNC6416: case TRUNC648: case TRUNC641: case TRUNC3216: case TRUNC328: case TRUNC321: case TRUNC168: case TRUNC161: case TRUNC81:
 			case ZEXT18: case ZEXT116: case ZEXT132: case ZEXT164: case ZEXT816: case ZEXT832: case ZEXT864: case ZEXT1632: case ZEXT1664: case ZEXT3264: 
 			case SEXT18: case SEXT116: case SEXT132: case SEXT164: case SEXT816: case SEXT832: case SEXT864: case SEXT1632: case SEXT1664: case SEXT3264:
-				return b.reduce();
+				return inner;
 			default:
 		        throw new UnsupportedOperationException("Reduce not supported for " + this);				
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
@@ -62,10 +62,10 @@ public class IExprUn extends IExpr {
     }
 
     @Override
-	public IConst reduce() {
+	public ExprInterface reduce() {
         switch(op){
 			case MINUS:
-				return new IConst(b.reduce().getIntValue().negate(), b.getPrecision());
+				return new IConst(((IConst)b.reduce()).getIntValue().negate(), b.getPrecision());
 			case BV2UINT:
 			case INT2BV1: case INT2BV8: case INT2BV16: case INT2BV32: case INT2BV64: 
 			case TRUNC6432: case TRUNC6416: case TRUNC648: case TRUNC641: case TRUNC3216: case TRUNC328: case TRUNC321: case TRUNC168: case TRUNC161: case TRUNC81:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
@@ -44,7 +44,7 @@ public class INonDet extends IExpr implements ExprInterface {
 	}
 	
 	@Override
-	public IConst reduce() {
+	public ExprInterface reduce() {
         throw new UnsupportedOperationException("Reduce not supported for " + this);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
@@ -44,11 +44,6 @@ public class INonDet extends IExpr implements ExprInterface {
 	}
 	
 	@Override
-	public ExprInterface reduce() {
-        throw new UnsupportedOperationException("Reduce not supported for " + this);
-	}
-
-	@Override
 	public Formula toIntFormula(Event e, SolverContext ctx) {
 		String name = Integer.toString(hashCode());
 		FormulaManager fmgr = ctx.getFormulaManager();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
@@ -71,7 +71,7 @@ public class IfExpr implements ExprInterface {
 
 	@Override
 	public ExprInterface reduce() {
-		return ((BConst)guard.reduce()).getValue() ? tbranch.reduce() : fbranch.reduce();
+		return guard.reduce().getValue() ? tbranch.reduce() : fbranch.reduce();
 	}
 	
 	public BExpr getGuard() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
@@ -70,8 +70,8 @@ public class IfExpr implements ExprInterface {
     }
 
 	@Override
-	public IConst reduce() {
-		return guard.reduce().getIntValue().signum() == 1 ? tbranch.reduce() : fbranch.reduce();
+	public ExprInterface reduce() {
+		return ((BConst)guard.reduce()).getValue() ? tbranch.reduce() : fbranch.reduce();
 	}
 	
 	public BExpr getGuard() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/StdProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/StdProcedures.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.parsers.program.visitors.boogie;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IConst;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.parsers.BoogieParser.Call_cmdContext;
 import com.dat3m.dartagnan.parsers.program.utils.ParsingException;
 import com.dat3m.dartagnan.program.EventFactory;
@@ -19,8 +18,6 @@ import java.util.List;
 public class StdProcedures {
 	
 	public static List<String> STDPROCEDURES = Arrays.asList(
-			"WRITE_ONCE",
-			"READ_ONCE",
 			"external_alloc",
 			"$alloc",
 			"__assert_rtn",
@@ -45,19 +42,6 @@ public class StdProcedures {
 	
 	public static void handleStdFunction(VisitorBoogie visitor, Call_cmdContext ctx) {
 		String name = ctx.call_params().Define() == null ? ctx.call_params().Ident(0).getText() : ctx.call_params().Ident(1).getText();
-		if(name.startsWith("WRITE_ONCE")) {
-			IExpr address = (IExpr)ctx.call_params().exprs().expr(0).accept(visitor);
-			ExprInterface value = (ExprInterface)ctx.call_params().exprs().expr(1).accept(visitor);
-			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newStore(address, value, "NA"));
-			return;
-		}
-//		if(name.startsWith("READ_ONCE")) {
-//			System.out.println(ctx.getText());
-//			IExpr address = (IExpr)ctx.call_params().exprs().expr(0).accept(visitor);
-//			ExprInterface value = (ExprInterface)ctx.call_params().exprs().expr(1).accept(visitor);
-//			visitor.programBuilder.addChild(visitor.threadCount, new Store(address, value, "NA"));
-//			return;
-//		}
 		if(name.equals("$alloc") || name.equals("$malloc") || name.equals("calloc") || name.equals("malloc") || name.equals("external_alloc") ) {
 			alloc(visitor, ctx);
 			return;
@@ -116,7 +100,7 @@ public class StdProcedures {
 	private static void alloc(VisitorBoogie visitor, Call_cmdContext ctx) {
 		int size;
 		try {
-			size = ((ExprInterface)ctx.call_params().exprs().expr(0).accept(visitor)).reduce().getIntValue().intValue();
+			size = ((IConst)((ExprInterface)ctx.call_params().exprs().expr(0).accept(visitor)).reduce()).getIntValue().intValue();
 		} catch (Exception e) {
 			String tmp = ctx.call_params().getText();
 			tmp = tmp.contains(",") ? tmp.substring(0, tmp.indexOf(',')) : tmp.substring(0, tmp.indexOf(')')); 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -159,7 +159,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 		if(exp instanceof Atom && ((Atom)exp).getLHS() instanceof Address && ((Atom)exp).getOp().equals(EQ)) {
  			Address add = (Address)((Atom)exp).getLHS();
  			ExprInterface def = ((Atom)exp).getRHS();
- 			add.setConstantValue(def.reduce().getValue());
+ 			add.setConstantValue(((IConst)def.reduce()).getValue());
  		}
 		return null;
 	}
@@ -431,7 +431,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 				throw new ParsingException("Constants cannot be assigned: " + ctx.getText());
 			}
 			if(initMode) {
-				programBuilder.initLocEqConst(name, value.reduce());
+				programBuilder.initLocEqConst(name, (IConst)value.reduce());
 				continue;
 			}
 			Register register = programBuilder.getRegister(threadCount, currentScope.getID() + ":" + name);
@@ -682,7 +682,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 				ExprInterface lhs = address;
 				BigInteger rhs = BigInteger.ZERO;
 				while(lhs instanceof IExprBin) {
-					rhs = rhs.add(((IExprBin)lhs).getRHS().reduce().getIntValue());
+					rhs = rhs.add(((IConst)((IExprBin)lhs).getRHS().reduce()).getIntValue());
 					lhs = ((IExprBin)lhs).getLHS();
 				}
 				String text = ctx.expr(1).getText();				
@@ -694,7 +694,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 				if(!rhs.equals(BigInteger.ZERO)) {
 					text += "(" + rhs + ")";
 				}
-				programBuilder.initLocEqConst(text, value.reduce());
+				programBuilder.initLocEqConst(text, (IConst)value.reduce());
 				return null;
 			}
 			Store child = EventFactory.newStore(address, value, null, currentLine);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
@@ -108,11 +108,6 @@ public class Register extends IExpr implements ExprInterface {
 	}
 
 	@Override
-	public ExprInterface reduce() {
-		throw new UnsupportedOperationException("Reduce not supported for " + this);
-	}
-
-	@Override
 	public int getPrecision() {
     	return precision;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
 import com.dat3m.dartagnan.program.event.Event;
@@ -109,7 +108,7 @@ public class Register extends IExpr implements ExprInterface {
 	}
 
 	@Override
-	public IConst reduce() {
+	public ExprInterface reduce() {
 		throw new UnsupportedOperationException("Reduce not supported for " + this);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/CondJump.java
@@ -8,7 +8,6 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.utils.RegReaderData;
 import com.dat3m.dartagnan.program.utils.EType;
-import com.dat3m.dartagnan.program.utils.Utils;
 import com.dat3m.dartagnan.utils.recursion.RecursiveAction;
 import com.dat3m.dartagnan.utils.recursion.RecursiveFunction;
 import com.dat3m.dartagnan.wmm.utils.Arch;
@@ -50,8 +49,15 @@ public class CondJump extends Event implements RegReaderData {
     }
     
     public boolean isGoto() {
-    	SolverContext defaultCtx = Utils.getDefaultCtx();
-        return defaultCtx.getFormulaManager().getBooleanFormulaManager().isTrue(expr.toBoolFormula(this, defaultCtx));
+    	// This is an under-approximation
+    	// We do not detect cases like CondJump(2*x==x+x,label) as jumps
+    	// However treating those (unusual) as jumps should not break anything
+    	try {
+    		return ((BConst)expr.reduce()).getValue();	
+    	} catch (Exception e) {
+    		// "Complex" expressions cannot be reduced and thus they are trivially not true.
+    		return false;
+		}
     }
     
     public Label getLabel(){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/utils/Utils.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/utils/Utils.java
@@ -1,32 +1,9 @@
 package com.dat3m.dartagnan.program.utils;
 
-import org.sosy_lab.common.ShutdownManager;
-import org.sosy_lab.common.configuration.Configuration;
-import org.sosy_lab.common.log.BasicLogManager;
-import org.sosy_lab.java_smt.SolverContextFactory;
 import org.sosy_lab.java_smt.api.*;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 
 public class Utils {
-
-	private static SolverContext defaultCtx;
-
-	public static SolverContext getDefaultCtx() {
-		if (defaultCtx == null) {
-				try {
-					Configuration config = Configuration.defaultConfiguration();
-					defaultCtx = SolverContextFactory.createSolverContext(
-							config,
-							BasicLogManager.create(config),
-							ShutdownManager.create().getNotifier(),
-							SolverContextFactory.Solvers.Z3);
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
-		}
-		return defaultCtx;
-	}
-
 
 	public static BooleanFormula generalEqual(Formula f1, Formula f2, SolverContext ctx) {
 		FormulaManager fmgr = ctx.getFormulaManager();


### PR DESCRIPTION
This PR targets #108.

I improved the typing of the reduce method (I can return `BConst` or `IConst` now) and I use this to implement `isGoto()` instead of having to make a call to the solver.