### PR TITLE
Add symmetry breaking to Assume/Incremental solver

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/analysis/Base.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/analysis/Base.java
@@ -5,12 +5,9 @@ import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
-import org.sosy_lab.java_smt.api.SolverContext;
-import org.sosy_lab.java_smt.api.SolverException;
+import org.sosy_lab.java_smt.api.*;
 
+import static com.dat3m.dartagnan.GlobalSettings.ENABLE_SYMMETRY_BREAKING;
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
 import static java.util.Collections.singletonList;
@@ -38,6 +35,9 @@ public class Base {
         // For validation this contains information.
         // For verification graph.encode() just returns ctx.mkTrue()
         prover.addConstraint(task.encodeWitness(ctx));
+        if (ENABLE_SYMMETRY_BREAKING) {
+            prover.addConstraint(task.encodeSymmetryBreaking(ctx));
+        }
         logger.info("Starting push()");
         prover.push();
         prover.addConstraint(task.encodeAssertions(ctx));
@@ -74,6 +74,9 @@ public class Base {
         // For validation this contains information.
         // For verification graph.encode() just returns ctx.mkTrue()
         prover.addConstraint(task.encodeWitness(ctx));
+        if (ENABLE_SYMMETRY_BREAKING) {
+            prover.addConstraint(task.encodeSymmetryBreaking(ctx));
+        }
         
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
         BooleanFormula assumptionLiteral = bmgr.makeVariable("DAT3M_assertion_assumption");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/analysis/Base.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/analysis/Base.java
@@ -12,8 +12,6 @@ import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
 import static java.util.Collections.singletonList;
 
-
-//TODO: Add symmetry breaking
 public class Base {
 
     private static final Logger logger = LogManager.getLogger(Base.class);
@@ -126,6 +124,11 @@ public class Base {
         BooleanFormula encodeWitness = task.encodeWitness(ctx);
 		prover1.addConstraint(encodeWitness);
         prover2.addConstraint(encodeWitness);
+
+        if (ENABLE_SYMMETRY_BREAKING) {
+            prover1.addConstraint(task.encodeSymmetryBreaking(ctx));
+            prover2.addConstraint(task.encodeSymmetryBreaking(ctx));
+        }
         
         prover1.addConstraint(task.encodeAssertions(ctx));
 


### PR DESCRIPTION
This PR simply adds the symmetry breaking feature to our baseline solvers ```Assume``` and ```Incremental```.
Should I also add it to ```TwoSolvers```? It probably won't do anything for the litmus tests.