### PR TITLE
CSV

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+          DAT3M_HOME: .
 
     steps:
     - name: Checkout

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractDartagnanTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractDartagnanTest.java
@@ -131,7 +131,7 @@ public abstract class AbstractDartagnanTest {
         }
     }
 
-    @Test(timeout = TIMEOUT)
+//    @Test(timeout = TIMEOUT)
     public void testRefinement() {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractDartagnanTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractDartagnanTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.dat3m.dartagnan.analysis.Base.runAnalysisTwoSolvers;
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 import static org.junit.Assert.*;
 
 public abstract class AbstractDartagnanTest {
@@ -113,18 +114,16 @@ public abstract class AbstractDartagnanTest {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover1 = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
              ProverEnvironment prover2 = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
-        	 BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/" + getClass().getSimpleName() + "-two-solvers.csv", true)))
+        	 BufferedWriter writer = new BufferedWriter(new FileWriter(getCSVFileName(getClass(), "two-solvers"), true)))
         {
             Program program = new ProgramParser().parse(new File(path));
             if (program.getAss() != null) {
                 VerificationTask task = new VerificationTask(program, wmm, target, settings);
                 long start = System.currentTimeMillis();
                 assertEquals(expected, runAnalysisTwoSolvers(ctx, prover1, prover2, task));
-                Long solvingTime = (Long)System.currentTimeMillis() - start;
-                writer.append(path);
-                writer.append(", ");
-   				writer.append(solvingTime.toString());
-   				writer.newLine();
+                long solvingTime = System.currentTimeMillis() - start;
+                writer.append(path).append(", ").append(Long.toString(solvingTime));
+                writer.newLine();
             }
         } catch (Exception e){
             fail(e.getMessage());
@@ -135,7 +134,7 @@ public abstract class AbstractDartagnanTest {
     public void testRefinement() {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
-           	 BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/" + getClass().getSimpleName() + "-refinement.csv", true)))
+             BufferedWriter writer = new BufferedWriter(new FileWriter(getCSVFileName(getClass(), "refinement"), true)))
         {
             Program program = new ProgramParser().parse(new File(path));
             if (program.getAss() != null) {
@@ -149,11 +148,9 @@ public abstract class AbstractDartagnanTest {
                 long start = System.currentTimeMillis();
                 assertEquals(expected, Refinement.runAnalysisSaturationSolver(ctx, prover,
                         RefinementTask.fromVerificationTaskWithDefaultBaselineWMM(task)));
-                Long solvingTime = (Long)System.currentTimeMillis() - start;
-                writer.append(path);
-                writer.append(", ");
-   				writer.append(solvingTime.toString());
-   				writer.newLine();
+                long solvingTime = System.currentTimeMillis() - start;
+                writer.append(path).append(", ").append(Long.toString(solvingTime));
+                writer.newLine();
             }
         } catch (Exception e){
             fail(e.getMessage());

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractSvCompTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractSvCompTest.java
@@ -112,7 +112,7 @@ public abstract class AbstractSvCompTest {
         }
     }
 
-    @Test(timeout = TIMEOUT)
+//    @Test(timeout = TIMEOUT)
     public void testRefinement() {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractSvCompTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractSvCompTest.java
@@ -17,13 +17,10 @@ import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
+import java.io.*;
 
 import static com.dat3m.dartagnan.analysis.Base.*;
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
 import static org.junit.Assert.assertEquals;
@@ -50,7 +47,7 @@ public abstract class AbstractSvCompTest {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover1 = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
              ProverEnvironment prover2 = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
-        	 BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/" + getClass().getSimpleName() + "-two-solvers.csv", true)))
+             BufferedWriter writer = new BufferedWriter(new FileWriter(getCSVFileName(getClass(), "two-solvers"), true)))
         {
         	String property = path.substring(0, path.lastIndexOf("-")) + ".yml";
         	expected = readExpected(property);
@@ -58,11 +55,9 @@ public abstract class AbstractSvCompTest {
             VerificationTask task = new VerificationTask(program, wmm, Arch.NONE, settings);
             long start = System.currentTimeMillis();
             assertEquals(expected, runAnalysisTwoSolvers(ctx, prover1, prover2, task));
-            Long solvingTime = (Long)System.currentTimeMillis() - start;
-            writer.append(path);
-            writer.append(", ");
-			writer.append(solvingTime.toString());
-			writer.newLine();
+            long solvingTime = System.currentTimeMillis() - start;
+            writer.append(path).append(", ").append(Long.toString(solvingTime));
+            writer.newLine();
         } catch (Exception e){
             fail(e.getMessage());
         }
@@ -72,7 +67,7 @@ public abstract class AbstractSvCompTest {
     public void testIncremental() {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
-           	 BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/" + getClass().getSimpleName() + "-incremental.csv", true)))
+             BufferedWriter writer = new BufferedWriter(new FileWriter(getCSVFileName(getClass(), "incremental"), true)))
         {
         	String property = path.substring(0, path.lastIndexOf("-")) + ".yml";
         	expected = readExpected(property);
@@ -80,11 +75,9 @@ public abstract class AbstractSvCompTest {
             VerificationTask task = new VerificationTask(program, wmm, Arch.NONE, settings);
             long start = System.currentTimeMillis();
             assertEquals(expected, runAnalysisIncrementalSolver(ctx, prover, task));
-            Long solvingTime = (Long)System.currentTimeMillis() - start;
-            writer.append(path);
-            writer.append(", ");
-			writer.append(solvingTime.toString());
-			writer.newLine();
+            long solvingTime = System.currentTimeMillis() - start;
+            writer.append(path).append(", ").append(Long.toString(solvingTime));
+            writer.newLine();
         } catch (Exception e){
             fail(e.getMessage());
         }
@@ -94,7 +87,7 @@ public abstract class AbstractSvCompTest {
     public void testAssume() {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
-        	 BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/" + getClass().getSimpleName() + "-assume.csv", true)))
+             BufferedWriter writer = new BufferedWriter(new FileWriter(getCSVFileName(getClass(), "assume"), true)))
         {
         	String property = path.substring(0, path.lastIndexOf("-")) + ".yml";
         	expected = readExpected(property);
@@ -102,11 +95,9 @@ public abstract class AbstractSvCompTest {
             VerificationTask task = new VerificationTask(program, wmm, Arch.NONE, settings);
             long start = System.currentTimeMillis();
             assertEquals(expected, runAnalysisAssumeSolver(ctx, prover, task));
-            Long solvingTime = (Long)System.currentTimeMillis() - start;
-            writer.append(path);
-            writer.append(", ");
-			writer.append(solvingTime.toString());
-			writer.newLine();
+            long solvingTime = System.currentTimeMillis() - start;
+            writer.append(path).append(", ").append(Long.toString(solvingTime));
+            writer.newLine();
         } catch (Exception e){
             fail(e.getMessage());
         }
@@ -116,7 +107,7 @@ public abstract class AbstractSvCompTest {
     public void testRefinement() {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
-           	 BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/" + getClass().getSimpleName() + "-refinement.csv", true)))
+             BufferedWriter writer = new BufferedWriter(new FileWriter(getCSVFileName(getClass(), "refinement"), true)))
         {
             String property = path.substring(0, path.lastIndexOf("-")) + ".yml";
             expected = readExpected(property);
@@ -125,11 +116,9 @@ public abstract class AbstractSvCompTest {
             long start = System.currentTimeMillis();
             assertEquals(expected, Refinement.runAnalysisSaturationSolver(ctx, prover,
                     RefinementTask.fromVerificationTaskWithDefaultBaselineWMM(task)));
-            Long solvingTime = (Long)System.currentTimeMillis() - start;
-            writer.append(path);
-            writer.append(", ");
-			writer.append(solvingTime.toString());
-			writer.newLine();
+            long solvingTime = System.currentTimeMillis() - start;
+            writer.append(path).append(", ").append(Long.toString(solvingTime));
+            writer.newLine();
         } catch (Exception e){
             fail(e.getMessage());
         }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractSvCompTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/AbstractSvCompTest.java
@@ -74,17 +74,17 @@ public abstract class AbstractSvCompTest {
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
            	 BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/" + getClass().getSimpleName() + "-incremental.csv", true)))
         {
+        	String property = path.substring(0, path.lastIndexOf("-")) + ".yml";
+        	expected = readExpected(property);
             Program program = new ProgramParser().parse(new File(path));
-            if (program.getAss() != null) {
-                VerificationTask task = new VerificationTask(program, wmm, Arch.NONE, settings);
-                long start = System.currentTimeMillis();
-                assertEquals(expected, runAnalysisIncrementalSolver(ctx, prover, task));
-                Long solvingTime = (Long)System.currentTimeMillis() - start;
-                writer.append(path);
-                writer.append(", ");
-   				writer.append(solvingTime.toString());
-   				writer.newLine();
-            }
+            VerificationTask task = new VerificationTask(program, wmm, Arch.NONE, settings);
+            long start = System.currentTimeMillis();
+            assertEquals(expected, runAnalysisIncrementalSolver(ctx, prover, task));
+            Long solvingTime = (Long)System.currentTimeMillis() - start;
+            writer.append(path);
+            writer.append(", ");
+			writer.append(solvingTime.toString());
+			writer.newLine();
         } catch (Exception e){
             fail(e.getMessage());
         }
@@ -112,7 +112,7 @@ public abstract class AbstractSvCompTest {
         }
     }
 
-//    @Test(timeout = TIMEOUT)
+    @Test(timeout = TIMEOUT)
     public void testRefinement() {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/CLocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/CLocksTest.java
@@ -24,7 +24,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -32,6 +31,7 @@ import java.util.List;
 
 import static com.dat3m.dartagnan.analysis.Base.runAnalysisAssumeSolver;
 import static com.dat3m.dartagnan.utils.ResourceHelper.TEST_RESOURCE_PATH;
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.UNKNOWN;
 import static com.dat3m.dartagnan.wmm.utils.Arch.*;
@@ -58,10 +58,10 @@ public class CLocksTest {
         Settings s1 = new Settings(Alias.CFIS, 1, TIMEOUT);
 
     	// We want the files to be created every time we run the unit tests
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+        Files.deleteIfExists(Paths.get(getCSVFileName(CLocksTest.class, "two-solvers")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(CLocksTest.class, "incremental")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(CLocksTest.class, "assume")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(CLocksTest.class, "refinement")));
 
 		List<Object[]> data = new ArrayList<>();
 
@@ -160,17 +160,15 @@ public class CLocksTest {
     public void testAssume() {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
-           	 BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/" + getClass().getSimpleName() + "-assume.csv", true)))
+             BufferedWriter writer = new BufferedWriter(new FileWriter(getCSVFileName(getClass(), "assume"), true)))
         {
             Program program = new ProgramParser().parse(new File(path));
             VerificationTask task = new VerificationTask(program, wmm, target, settings);
             long start = System.currentTimeMillis();
             assertEquals(expected, runAnalysisAssumeSolver(ctx, prover, task));
-            Long solvingTime = (Long)System.currentTimeMillis() - start;
-            writer.append(path);
-            writer.append(", ");
-			writer.append(solvingTime.toString());
-			writer.newLine();
+            long solvingTime = System.currentTimeMillis() - start;
+            writer.append(path).append(", ").append(Long.toString(solvingTime));
+            writer.newLine();
         } catch (Exception e){
             fail(e.getMessage());
         }
@@ -180,17 +178,15 @@ public class CLocksTest {
     public void testRefinement() {
         try (SolverContext ctx = TestHelper.createContext();
              ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS);
-        	 BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/" + getClass().getSimpleName() + "-refinement.csv", true)))
+             BufferedWriter writer = new BufferedWriter(new FileWriter(getCSVFileName(getClass(), "refinement"), true)))
         {
             Program program = new ProgramParser().parse(new File(path));
             VerificationTask task = new VerificationTask(program, wmm, target, settings);
             long start = System.currentTimeMillis();
             assertEquals(expected, Refinement.runAnalysisSaturationSolver(ctx, prover,
                     RefinementTask.fromVerificationTaskWithDefaultBaselineWMM(task)));
-            Long solvingTime = (Long)System.currentTimeMillis() - start;
-            writer.append(path);
-            writer.append(", ");
-			writer.append(solvingTime.toString());
+            long solvingTime = System.currentTimeMillis() - start;
+            writer.append(path).append(", ").append(Long.toString(solvingTime));
 			writer.newLine();
         } catch (Exception e){
             fail(e.getMessage());

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanAARCH64Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanAARCH64Test.java
@@ -8,12 +8,21 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @RunWith(Parameterized.class)
 public class DartagnanAARCH64Test extends AbstractDartagnanTest {
 
     @Parameterized.Parameters(name = "{index}: {0} {4}")
     public static Iterable<Object[]> data() throws IOException {
+    	// We want the files to be created every time we run the unit tests
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+
         return buildParameters("litmus/AARCH64/", "cat/aarch64.cat", Arch.ARM8);
     }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanAARCH64Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanAARCH64Test.java
@@ -8,9 +8,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 
 @RunWith(Parameterized.class)
 public class DartagnanAARCH64Test extends AbstractDartagnanTest {
@@ -18,10 +19,10 @@ public class DartagnanAARCH64Test extends AbstractDartagnanTest {
     @Parameterized.Parameters(name = "{index}: {0} {4}")
     public static Iterable<Object[]> data() throws IOException {
     	// We want the files to be created every time we run the unit tests
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+		Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanAARCH64Test.class, "two-solvers")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanAARCH64Test.class, "incremental")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanAARCH64Test.class, "assume")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanAARCH64Test.class, "refinement")));
 
         return buildParameters("litmus/AARCH64/", "cat/aarch64.cat", Arch.ARM8);
     }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanLinuxTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanLinuxTest.java
@@ -8,9 +8,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 
 @RunWith(Parameterized.class)
 public class DartagnanLinuxTest extends AbstractDartagnanTest {
@@ -18,10 +19,10 @@ public class DartagnanLinuxTest extends AbstractDartagnanTest {
     @Parameterized.Parameters(name = "{index}: {0} {4}")
     public static Iterable<Object[]> data() throws IOException {
     	// We want the files to be created every time we run the unit tests
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanLinuxTest.class, "two-solvers")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanLinuxTest.class, "incremental")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanLinuxTest.class, "assume")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanLinuxTest.class, "refinement")));
 
         return buildParameters("litmus/C/", "cat/linux-kernel.cat", Arch.NONE);
     }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanLinuxTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanLinuxTest.java
@@ -8,12 +8,21 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @RunWith(Parameterized.class)
 public class DartagnanLinuxTest extends AbstractDartagnanTest {
 
     @Parameterized.Parameters(name = "{index}: {0} {4}")
     public static Iterable<Object[]> data() throws IOException {
+    	// We want the files to be created every time we run the unit tests
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+
         return buildParameters("litmus/C/", "cat/linux-kernel.cat", Arch.NONE);
     }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanPPCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanPPCTest.java
@@ -8,9 +8,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 
 @RunWith(Parameterized.class)
 public class DartagnanPPCTest extends AbstractDartagnanTest {
@@ -18,10 +19,10 @@ public class DartagnanPPCTest extends AbstractDartagnanTest {
     @Parameterized.Parameters(name = "{index}: {0} {4}")
     public static Iterable<Object[]> data() throws IOException {
     	// We want the files to be created every time we run the unit tests
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanPPCTest.class, "two-solvers")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanPPCTest.class, "incremental")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanPPCTest.class, "assume")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanPPCTest.class, "refinement")));
 
         return buildParameters("litmus/PPC/", "cat/power.cat", Arch.POWER);
     }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanPPCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanPPCTest.java
@@ -8,12 +8,21 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @RunWith(Parameterized.class)
 public class DartagnanPPCTest extends AbstractDartagnanTest {
 
     @Parameterized.Parameters(name = "{index}: {0} {4}")
     public static Iterable<Object[]> data() throws IOException {
+    	// We want the files to be created every time we run the unit tests
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+
         return buildParameters("litmus/PPC/", "cat/power.cat", Arch.POWER);
     }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanX86Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanX86Test.java
@@ -8,13 +8,22 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @RunWith(Parameterized.class)
 public class DartagnanX86Test extends AbstractDartagnanTest {
 
     @Parameterized.Parameters(name = "{index}: {0} {4}")
     public static Iterable<Object[]> data() throws IOException {
-        return buildParameters("litmus/X86/", "cat/tso.cat", Arch.TSO);
+    	// We want the files to be created every time we run the unit tests
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+
+		return buildParameters("litmus/X86/", "cat/tso.cat", Arch.TSO);
     }
 
     public DartagnanX86Test(String path, Result expected, Arch target, Wmm wmm, Settings settings) {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanX86Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/DartagnanX86Test.java
@@ -8,9 +8,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 
 @RunWith(Parameterized.class)
 public class DartagnanX86Test extends AbstractDartagnanTest {
@@ -18,10 +19,10 @@ public class DartagnanX86Test extends AbstractDartagnanTest {
     @Parameterized.Parameters(name = "{index}: {0} {4}")
     public static Iterable<Object[]> data() throws IOException {
     	// We want the files to be created every time we run the unit tests
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanX86Test.class, "two-solvers")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanX86Test.class, "incremental")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanX86Test.class, "assume")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(DartagnanX86Test.class, "refinement")));
 
 		return buildParameters("litmus/X86/", "cat/tso.cat", Arch.TSO);
     }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompConcurrencyTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompConcurrencyTest.java
@@ -10,13 +10,13 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.dat3m.dartagnan.utils.ResourceHelper.TEST_RESOURCE_PATH;
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 
 @RunWith(Parameterized.class)
 public class SvCompConcurrencyTest extends AbstractSvCompTest {
@@ -33,10 +33,10 @@ public class SvCompConcurrencyTest extends AbstractSvCompTest {
         Settings s7 = new Settings(Alias.CFIS, 7, TIMEOUT);
         
     	// We want the files to be created every time we run the unit tests
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompConcurrencyTest.class, "two-solvers")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompConcurrencyTest.class, "incremental")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompConcurrencyTest.class, "assume")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompConcurrencyTest.class, "refinement")));
 
         List<Object[]> data = new ArrayList<>();
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompConcurrencyTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompConcurrencyTest.java
@@ -10,6 +10,9 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,6 +32,12 @@ public class SvCompConcurrencyTest extends AbstractSvCompTest {
         Settings s6 = new Settings(Alias.CFIS, 6, TIMEOUT);
         Settings s7 = new Settings(Alias.CFIS, 7, TIMEOUT);
         
+    	// We want the files to be created every time we run the unit tests
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+
         List<Object[]> data = new ArrayList<>();
 
         data.add(new Object[]{TEST_RESOURCE_PATH + "boogie/concurrency/fib_bench-1-O0.bpl", wmm, s6});

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompControlFlowTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompControlFlowTest.java
@@ -5,15 +5,18 @@ import com.dat3m.dartagnan.utils.ResourceHelper;
 import com.dat3m.dartagnan.utils.Settings;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.utils.alias.Alias;
-
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+
 import static com.dat3m.dartagnan.utils.ResourceHelper.TEST_RESOURCE_PATH;
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 
 @RunWith(Parameterized.class)
 public class SvCompControlFlowTest extends AbstractSvCompTest {
@@ -25,6 +28,11 @@ public class SvCompControlFlowTest extends AbstractSvCompTest {
         Settings s1 = new Settings(Alias.CFIS, 1, TIMEOUT);
         Settings s4 = new Settings(Alias.CFIS, 4, TIMEOUT);
         Settings s6 = new Settings(Alias.CFIS, 6, TIMEOUT);
+
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompControlFlowTest.class, "two-solvers")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompControlFlowTest.class, "incremental")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompControlFlowTest.class, "assume")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompControlFlowTest.class, "refinement")));
         
         List<Object[]> data = new ArrayList<>();
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompLoopsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompLoopsTest.java
@@ -11,6 +11,9 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import static com.dat3m.dartagnan.utils.ResourceHelper.TEST_RESOURCE_PATH;
@@ -28,6 +31,12 @@ public class SvCompLoopsTest extends AbstractSvCompTest {
         Settings s4 = new Settings(Alias.CFIS, 4, TIMEOUT);
         Settings s5 = new Settings(Alias.CFIS, 5, TIMEOUT);
         Settings s11 = new Settings(Alias.CFIS,11, TIMEOUT);
+
+    	// We want the files to be created every time we run the unit tests
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
+		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
 
         List<Object[]> data = new ArrayList<>();
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompLoopsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompLoopsTest.java
@@ -5,18 +5,18 @@ import com.dat3m.dartagnan.utils.ResourceHelper;
 import com.dat3m.dartagnan.utils.Settings;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.utils.alias.Alias;
-
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+
 import static com.dat3m.dartagnan.utils.ResourceHelper.TEST_RESOURCE_PATH;
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 
 @RunWith(Parameterized.class)
 public class SvCompLoopsTest extends AbstractSvCompTest {
@@ -33,10 +33,10 @@ public class SvCompLoopsTest extends AbstractSvCompTest {
         Settings s11 = new Settings(Alias.CFIS,11, TIMEOUT);
 
     	// We want the files to be created every time we run the unit tests
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-two-solvers.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-incremental.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-assume.csv"));
-		Files.deleteIfExists(Paths.get(System.getenv().get("DAT3M_HOME") + "/output/" + MethodHandles.lookup().lookupClass().getSimpleName() + "-refinement.csv"));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompLoopsTest.class, "two-solvers")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompLoopsTest.class, "incremental")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompLoopsTest.class, "assume")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompLoopsTest.class, "refinement")));
 
         List<Object[]> data = new ArrayList<>();
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompTestLarge.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/SvCompTestLarge.java
@@ -10,10 +10,13 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.dat3m.dartagnan.utils.ResourceHelper.TEST_RESOURCE_PATH;
+import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
 
 @RunWith(Parameterized.class)
 public class SvCompTestLarge extends AbstractSvCompTest {
@@ -24,6 +27,11 @@ public class SvCompTestLarge extends AbstractSvCompTest {
         Wmm wmm = new ParserCat().parse(new File(ResourceHelper.CAT_RESOURCE_PATH + cat_file));
 
         Settings s1 = new Settings(Alias.CFIS, 1, TIMEOUT);
+
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompTestLarge.class, "two-solvers")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompTestLarge.class, "incremental")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompTestLarge.class, "assume")));
+        Files.deleteIfExists(Paths.get(getCSVFileName(SvCompTestLarge.class, "refinement")));
 
         List<Object[]> data = new ArrayList<>();
         String base = TEST_RESOURCE_PATH + "large/";

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/ResourceHelper.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/ResourceHelper.java
@@ -2,13 +2,13 @@ package com.dat3m.dartagnan.utils;
 
 import com.google.common.collect.ImmutableMap;
 
-import static com.dat3m.dartagnan.utils.Result.FAIL;
-import static com.dat3m.dartagnan.utils.Result.PASS;
-
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+
+import static com.dat3m.dartagnan.utils.Result.FAIL;
+import static com.dat3m.dartagnan.utils.Result.PASS;
 
 public class ResourceHelper {
 
@@ -33,5 +33,9 @@ public class ResourceHelper {
             }
         }
         return expectedResults;
+    }
+
+    public static String getCSVFileName(Class<?> testingClass, String name) {
+        return String.format("%s/output/%s-%s.csv", System.getenv("DAT3M_HOME"), testingClass.getSimpleName(), name);
     }
 }


### PR DESCRIPTION
In this PR the solving times from the unit tests are saved into CSV files.
These files can be used to automatically and easily generate graphs to compare the different solvers.

I considered a couple of options not to always generate the CSV files in case that it degrades performance, but the overhead is almost nothing so I decided to always generate such files.