### PR TITLE
Change in ARM8 Cat

### DIFF
--- a/cat/aarch64.cat
+++ b/cat/aarch64.cat
@@ -104,13 +104,13 @@ let bob = po; [dmb.full]; po
 	| po; [L]; coi
 
 (* Ordered-before *)
-let ob = (obs | dob | aob | bob)^+
+let ob = obs | dob | aob | bob
 
 (* Internal visibility requirement *)
 acyclic po-loc | ca | rf as internal
 
 (* External visibility requirement *)
-irreflexive ob as external
+acyclic ob as external
 
 (* Atomic: Basic LDXR/STXR constraint to forbid intervening writes. *)
 empty rmw & (fre; coe) as atomic


### PR DESCRIPTION
We still use `irreflexive ob+` instead of `acyclic ob` in our .cat for Aaarch64. This PR fixes this issue.