### PR TITLE
Reduce encodeSets of acyclicity axiom

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
@@ -33,6 +33,7 @@ public class GlobalSettings {
     public static final boolean PERFORM_REORDERING = true;
     public static final boolean DETERMINISTIC_REORDERING = true;
     public static final boolean ENABLE_SYMMETRY_REDUCTION = true;
+    public static final boolean REDUCE_ACYCLICITY_ENCODE_SETS = true;
 
     // ==== Refinement ====
     public static final boolean REFINEMENT_USE_LOCALLY_CONSISTENT_BASELINE_WMM = true; // Uses acyclic(po-loc + rf) as baseline

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Acyclic.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Acyclic.java
@@ -1,5 +1,6 @@
 package com.dat3m.dartagnan.wmm.axiom;
 
+import com.dat3m.dartagnan.GlobalSettings;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.utils.equivalence.BranchEquivalence;
@@ -50,8 +51,10 @@ public class Acyclic extends Axiom {
         }
 
         logger.info("encodeTupleSet size " + result.size());
-        reduceWithMinSets(result);
-        logger.info("reduced encodeTupleSet size " + result.size());
+        if (GlobalSettings.REDUCE_ACYCLICITY_ENCODE_SETS) {
+            reduceWithMinSets(result);
+            logger.info("reduced encodeTupleSet size " + result.size());
+        }
         return result;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Acyclic.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Acyclic.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.wmm.axiom;
 
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
+import com.dat3m.dartagnan.utils.equivalence.BranchEquivalence;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
@@ -49,7 +50,61 @@ public class Acyclic extends Axiom {
         }
 
         logger.info("encodeTupleSet size " + result.size());
+        reduceWithMinSets(result);
+        logger.info("reduced encodeTupleSet size " + result.size());
         return result;
+    }
+
+    private void reduceWithMinSets(TupleSet encodeSet) {
+        /*
+            Assumption: MinSet is acyclic!
+            Overall idea:
+                (1) We compute a (must) transitive reduction of must(rel) per thread.
+                    - For this, we assume that must(rel) is mostly transitive per thread.
+                      If it is not, we won't get a full reduction but still a good one
+                    - For any pair (a, c) in must(rel) mod thread, we look for some b such that
+                      (a, b) and (b, c) is in must(rel) and c is implied by either a or b
+                (2) We compute the (must) transitive closure of must(rel) (not of the reduction!!!)
+                    - Any edge in "must(rel)+ \ red(must(rel))" can be removed from the encodeSet
+                    - We might want to optimize this by finding the cross-thread must edges
+                      and only compute reachability wrt to those, as we assume that must(rel) is already
+                      transitive within threads.
+
+         */
+        BranchEquivalence eq = task.getBranchEquivalence();
+        TupleSet minSet = rel.getMinTupleSet();
+        // (1) Reduction
+        TupleSet reduct = new TupleSet();
+        Map<Event, Collection<Event>> predMap = new HashMap<>();
+        for (Tuple t : minSet) {
+            predMap.computeIfAbsent(t.getSecond(), key -> new ArrayList<>()).add(t.getFirst());
+        }
+        DependencyGraph<Event> depGraph = DependencyGraph.from(predMap.keySet(), predMap);
+        for (DependencyGraph<Event>.Node start : depGraph.getNodes()) {
+            Event e1 = start.getContent();
+            List<DependencyGraph<Event>.Node> deps = start.getDependents();
+            for (int i = deps.size() - 1; i >= 0; i--) {
+                DependencyGraph<Event>.Node end = deps.get(i);
+                Event e3 = end.getContent();
+                boolean redundant = false;
+                for (DependencyGraph<Event>.Node mid : deps.subList(0, i)) {
+                    Event e2 = mid.getContent();
+                    if (e2.cfImpliesExec() && (eq.isImplied(e1, e2) || eq.isImplied(e3, e2))) {
+                        if (minSet.contains(new Tuple(e2, e3))) {
+                            redundant = true;
+                            break;
+                        }
+                    }
+                }
+                if (!redundant) {
+                    reduct.add(new Tuple(e1, e3));
+                }
+            }
+        }
+
+        //TODO (2): Will only be relevant once we have cross-thread must-edges
+
+        encodeSet.removeIf(t -> minSet.contains(t) && !reduct.contains(t));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Acyclic.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Acyclic.java
@@ -66,7 +66,7 @@ public class Acyclic extends Axiom {
                     - For this, we assume that must(rel) is mostly transitive per thread.
                       If it is not, we won't get a full reduction but still a good one
                     - For any pair (a, c) in must(rel) mod thread, we look for some b such that
-                      (a, b) and (b, c) is in must(rel) and c is implied by either a or b
+                      (a, b) and (b, c) is in must(rel) and b is implied by either a or c
                 (2) We compute the (must) transitive closure of must(rel) (not of the reduction!!!)
                     - Any edge in "must(rel)+ \ red(must(rel))" can be removed from the encodeSet
                     - We might want to optimize this by finding the cross-thread must edges


### PR DESCRIPTION
This PR targets issue #150 but not completey solves it.
We reduce the `encodeTupleSet` (active set) that gets computed for acyclicity axioms by computing a transitive reduction(*) on the minSet of the relation. Every minSet-edge that is not part of the reduction, can safely be removed from the encoding.

TODO: In the presence of cross-thread min-edges, we can do further reductions. These are not accounted for right now, as we have no case that produces cross-thread min-edges.

(*) We approximate the reduction right now. Also, it is formally no standard transitive reduction because min-edges have this extra condition about when they can get composed (cf-implication) that affects the notion of reachability.