### PR TITLE
Improved symmetry breaking

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
@@ -1,5 +1,6 @@
 package com.dat3m.dartagnan;
 
+import com.dat3m.dartagnan.wmm.relation.RelationNameRepository;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,7 +23,11 @@ public class GlobalSettings {
     public static final boolean ALLOW_PARTIAL_MODELS = false;
     public static final boolean MERGE_CF_VARS = true; // ONLY has effect if ALLOW_PARTIAL_MODELS is 'false'
     public static final boolean ANTISYMM_CO = false;
+    // ------ Symm breaking ------
     public static final boolean ENABLE_SYMMETRY_BREAKING = true;
+    public static final boolean BREAK_SYMMETRY_BY_SYNC_DEGREE = true;
+    public static final String BREAK_SYMMETRY_ON_RELATION = RelationNameRepository.RF;
+    public static final int LEX_LEADER_SIZE = 1000;
 
     // === BranchEquivalence ===
     public static final boolean MERGE_BRANCHES = true;
@@ -68,6 +73,11 @@ public class GlobalSettings {
     	logger.info("PERFORM_DEAD_CODE_ELIMINATION: " + PERFORM_DEAD_CODE_ELIMINATION);
     	logger.info("PERFORM_REORDERING: " + PERFORM_REORDERING);
     	logger.info("ENABLE_SYMMETRY_BREAKING: " + ENABLE_SYMMETRY_BREAKING);
+    	if (ENABLE_SYMMETRY_BREAKING) {
+            logger.info("-- Breaking on Relation: " + BREAK_SYMMETRY_ON_RELATION);
+            logger.info("-- Break by sync-degree: " + BREAK_SYMMETRY_BY_SYNC_DEGREE);
+            logger.info("-- Lex leader size: " + LEX_LEADER_SIZE);
+        }
         logger.info("ENABLE_SYMMETRY_REDUCTION: " + ENABLE_SYMMETRY_REDUCTION);
     	logger.info("MAX_RECURSION_DEPTH: " + MAX_RECURSION_DEPTH);
     	logger.info("ENABLE_DEBUG_OUTPUT: " + ENABLE_DEBUG_OUTPUT);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/symmetry/SymmetryBreaking.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/symmetry/SymmetryBreaking.java
@@ -5,31 +5,38 @@ import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.utils.EType;
 import com.dat3m.dartagnan.utils.equivalence.EquivalenceClass;
 import com.dat3m.dartagnan.verification.VerificationTask;
+import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.utils.RelationRepository;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
+import com.dat3m.dartagnan.wmm.utils.TupleSet;
+import com.google.common.base.Preconditions;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
-import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.RF;
+import static com.dat3m.dartagnan.GlobalSettings.*;
 
 
 // A first rough implementation for symmetry breaking
 public class SymmetryBreaking {
 
-    private static final int LEX_LEADER_SIZE = 1000;
-
+    private final VerificationTask task;
     private final ThreadSymmetry symm;
-    private final Relation rf;
+    private final Relation rel;
 
     public SymmetryBreaking(VerificationTask task) {
+        this.task = task;
         this.symm = task.getThreadSymmetry();
-        this.rf = task.getMemoryModel().getRelationRepository().getRelation(RF);
+
+        RelationRepository repo = task.getMemoryModel().getRelationRepository();
+        Preconditions.checkState(repo.containsRelation(BREAK_SYMMETRY_ON_RELATION),
+                "Unknown relation: " + BREAK_SYMMETRY_ON_RELATION);
+        this.rel = repo.getRelation(BREAK_SYMMETRY_ON_RELATION);
 
     }
 
@@ -59,32 +66,72 @@ public class SymmetryBreaking {
         // These need to get skipped!
         Thread t1 = symmThreads.get(0);
         List<Tuple> r1 = new ArrayList<>();
-        for (Tuple t : rf.getMaxTupleSet()) {
+        for (Tuple t : rel.getMaxTupleSet()) {
             Event a = t.getFirst();
             Event b = t.getSecond();
             if (!a.is(EType.PTHREAD) && !b.is(EType.PTHREAD) && a.getThread() == t1) {
                 r1.add(t);
             }
         }
-        r1.sort(Comparator.naturalOrder());
+        sort(r1);
 
         // Construct symmetric rows
         for (int i = 1; i < symmThreads.size(); i++) {
             Thread t2 = symmThreads.get(i);
             Function<Event, Event> p = symm.createTransposition(t1, t2);
-            List<Tuple> r2 = new ArrayList<>();
-            for (Tuple t : r1) {
-                r2.add(mapTuple(t, p));
-                // assert rf.getMaxTupleSet().contains(r2.get(r2.size() - 1));
-            }
-
-
+            List<Tuple> r2 = r1.stream().map(t -> mapTuple(t, p)).collect(Collectors.toList());
             enc = bmgr.and(enc, encodeLexLeader(rep, i, r1, r2, ctx));
             t1 = t2;
             r1 = r2;
         }
 
         return enc;
+    }
+
+    private void sort(List<Tuple> row) {
+        if (!BREAK_SYMMETRY_BY_SYNC_DEGREE) {
+            row.sort(Comparator.naturalOrder());
+            return;
+        }
+
+        // Setup of data structures
+        Map<Axiom, Map<Event, Integer>> inDegrees = new HashMap<>();
+        Map<Axiom, Map<Event, Integer>> outDegrees = new HashMap<>();
+        Set<Event> inEvents = new HashSet<>();
+        Set<Event> outEvents = new HashSet<>();
+        for (Tuple t : row) {
+            inEvents.add(t.getFirst());
+            outEvents.add(t.getSecond());
+        }
+
+        // Compute sync degrees per axiom
+        for (Axiom ax : task.getAxioms()) {
+            TupleSet mustSet = ax.getRelation().getMinTupleSet();
+            Map<Event, Integer> in = inDegrees.computeIfAbsent(ax, key -> new HashMap<>());
+            Map<Event, Integer> out = outDegrees.computeIfAbsent(ax, key -> new HashMap<>());
+
+            for (Event e : inEvents) {
+                in.put(e, mustSet.getBySecond(e).size());
+            }
+            for (Event e : outEvents) {
+                out.put(e, mustSet.getByFirst(e).size());
+            }
+        }
+
+        // Combine sync degrees of axioms
+        Map<Event, Integer> combInDegree = new HashMap<>(inEvents.size());
+        Map<Event, Integer> combOutDegree = new HashMap<>(outEvents.size());
+        for (Axiom ax : task.getAxioms()) {
+            for (Map.Entry<Event, Integer> entry : inDegrees.get(ax).entrySet()) {
+                combInDegree.compute(entry.getKey(), (k, v) -> Math.max(v == null ? -1 : v, entry.getValue()));
+            }
+            for (Map.Entry<Event, Integer> entry : outDegrees.get(ax).entrySet()) {
+                combOutDegree.compute(entry.getKey(), (k, v) -> Math.max(v == null ? -1 : v, entry.getValue()));
+            }
+        }
+
+        // Sort by sync degrees
+        row.sort(Comparator.<Tuple>comparingInt(t -> combInDegree.get(t.getFirst()) * combOutDegree.get(t.getSecond())).reversed());
     }
 
     /*
@@ -102,8 +149,8 @@ public class SymmetryBreaking {
         // From x1 to x(n-1)
         for (int i = 1; i < size; i++) {
             BooleanFormula y = bmgr.makeVariable("y" + i + suffix);
-            BooleanFormula orig = rf.getSMTVar(r1.get(i-1), ctx);
-            BooleanFormula perm = rf.getSMTVar(r2.get(i-1), ctx);
+            BooleanFormula orig = rel.getSMTVar(r1.get(i-1), ctx);
+            BooleanFormula perm = rel.getSMTVar(r2.get(i-1), ctx);
             enc = bmgr.and(
                     enc,
                     bmgr.or(y, bmgr.not(ylast), bmgr.not(orig)),
@@ -113,8 +160,8 @@ public class SymmetryBreaking {
             ylast = y;
         }
         // Final iteration is handled differently
-        BooleanFormula orig = rf.getSMTVar(r1.get(size-1), ctx);
-        BooleanFormula perm = rf.getSMTVar(r2.get(size-1), ctx);
+        BooleanFormula orig = rel.getSMTVar(r1.get(size-1), ctx);
+        BooleanFormula perm = rel.getSMTVar(r2.get(size-1), ctx);
         enc = bmgr.and(enc, bmgr.or(bmgr.not(ylast), bmgr.not(orig), perm));
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/BinaryRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/BinaryRelation.java
@@ -1,16 +1,14 @@
 package com.dat3m.dartagnan.wmm.relation.binary;
 
-import com.dat3m.dartagnan.verification.VerificationTask;
-import com.google.common.collect.Sets;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
-
-import java.util.Arrays;
-import java.util.List;
-
+import com.google.common.collect.Sets;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  *
@@ -20,8 +18,6 @@ public abstract class BinaryRelation extends Relation {
 
     protected Relation r1;
     protected Relation r2;
-
-    int lastEncodedIteration = -1;
 
     BinaryRelation(Relation r1, Relation r2) {
         this.r1 = r1;
@@ -56,12 +52,6 @@ public abstract class BinaryRelation extends Relation {
             recursiveGroupId |= (r1Id | r2Id) & parentId;
         }
         return recursiveGroupId;
-    }
-
-    @Override
-    public void initialise(VerificationTask task, SolverContext ctx){
-        super.initialise(task, ctx);
-        lastEncodedIteration = -1;
     }
 
     @Override


### PR DESCRIPTION
This PR extends the functionatlity of symmetry breaking slightly. `GlobalSettings` has some new options to configure symmetry breaking.

Overall, I didn't see a performance improvement in breaking on e.g. `co` instead of `rf` or in changing the order of breaking variables (based on "synchronisation degree"). But this needs more testing.
