### PR TITLE
174

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ export DAT3M_HOME=<Dat3M's root>
 export PATH=$DAT3M_HOME/:$PATH
 ```
 
+At least the following compiler flag needs to be set, further can be added  
+```
+export CFLAGS="-I$DAT3M_HOME/include"
+```
+
 If you are verifying C code, be sure both `clang` and `smack` are in your `PATH`.
 
 To build the tool run

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -20,7 +20,7 @@ public class Compilation {
 
     	ArrayList<String> cmd = new ArrayList<String>();
     	cmd.addAll(asList("smack", "-q", "-t", "--no-memory-splitting"));
-        cmd.add("--clang-options=-DCUSTOM_VERIFIER_ASSERT -fno-vectorize -fno-slp-vectorize -I" + System.getenv().get("DAT3M_HOME") + "/include/");    		    		
+        cmd.add("--clang-options=" + System.getenv().get("CFLAGS"));
     	cmd.addAll(asList("-bpl", System.getenv().get("DAT3M_HOME") + "/output/" + name + ".bpl"));
     	cmd.add(file.getAbsolutePath());
     	
@@ -44,7 +44,7 @@ public class Compilation {
 
 	public static void compileWithClang(File file) throws Exception {
     	ArrayList<String> cmd = new ArrayList<String>();
-    	cmd.addAll(asList("clang", "-S", "-o"));
+    	cmd.addAll(asList("clang", "-S", System.getenv().get("CFLAGS"), "-o"));
     	cmd.add(System.getenv().get("DAT3M_HOME") + "/output/test.s");
     	cmd.add(file.getAbsolutePath());
     	ProcessBuilder processBuilder = new ProcessBuilder(cmd);
@@ -55,7 +55,6 @@ public class Compilation {
     		String errorString = CharStreams.toString(new InputStreamReader(proc.getErrorStream(), Charsets.UTF_8));
 			throw new Exception(errorString);
     	}
-    	// TODO(HP): Can this be removed?
     	File testFile = new File(System.getenv().get("DAT3M_HOME") + "/output/test.s");
     	testFile.delete();
 	}	


### PR DESCRIPTION
This PR gives the user more control over `clang` (both directly when checking that the code compiles and when the flags are passed to `smack`).

Notice that we could do the same for the compilation in the `svcomp` module. However for the competition the flags are pretty much fixed (all tasks are preprocessed anyway), thus I chose not to change those.

The CI will trivially because this change only affects the behavior when `*.c` files are passed as input (the CI uses the `*.bpl` ones), so please test that it works from the console (you need to set `CFLAGS`, see the updated `README`).