### PR TITLE
174

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ export DAT3M_HOME=<Dat3M's root>
 export PATH=$DAT3M_HOME/:$PATH
 ```
 
+At least the following compiler flag needs to be set, further can be added  
+```
+export CFLAGS="-I$DAT3M_HOME/include"
+```
+
 If you are verifying C code, be sure both `clang` and `smack` are in your `PATH`.
 
 To build the tool run

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
@@ -22,7 +22,7 @@ public class ProgramParser {
             compileWithClang(file);
             compileWithSmack(file);
             String name = file.getName().substring(0, file.getName().lastIndexOf('.'));
-            return new ProgramParser().parse(new File(System.getenv().get("DAT3M_HOME") + "/output/" + name + ".bpl"));    		
+            return new ProgramParser().parse(new File(System.getenv("DAT3M_HOME") + "/output/" + name + ".bpl"));    		
     	}
 
         Program program;
@@ -47,7 +47,7 @@ public class ProgramParser {
                 }
                 compileWithClang(CFile);
 	            compileWithSmack(CFile);
-	            File BplFile = new File(System.getenv().get("DAT3M_HOME") + "/output/" + name + ".bpl");
+	            File BplFile = new File(System.getenv("DAT3M_HOME") + "/output/" + name + ".bpl");
 	            BplFile.deleteOnExit();
 	            Program p = new ProgramParser().parse(BplFile);
 	            CFile.delete();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -21,8 +21,8 @@ public class Compilation {
 		
     	ArrayList<String> cmd = new ArrayList<String>();
     	cmd.addAll(asList("smack", "-q", "-t", "--no-memory-splitting"));
-        cmd.add("--clang-options=-I" + System.getenv().get("DAT3M_HOME") + "/include/ " + clangFlags);
-    	cmd.addAll(asList("-bpl", System.getenv().get("DAT3M_HOME") + "/output/" + name + ".bpl"));
+        cmd.add("--clang-options=-I" + System.getenv("DAT3M_HOME") + "/include/ " + clangFlags);
+    	cmd.addAll(asList("-bpl", System.getenv("DAT3M_HOME") + "/output/" + name + ".bpl"));
     	cmd.add(file.getAbsolutePath());
     	
     	ProcessBuilder processBuilder = new ProcessBuilder(cmd); 
@@ -44,11 +44,11 @@ public class Compilation {
 	}	
 
 	public static void compileWithClang(File file) throws Exception {
-		String clangFlags = System.getenv().get("CFLAGS") != null ? System.getenv().get("CFLAGS") : "";
+		String clangFlags = System.getenv("CFLAGS") != null ? System.getenv("CFLAGS") : "";
 		
     	ArrayList<String> cmd = new ArrayList<String>();
     	cmd.addAll(asList("clang", "-S", clangFlags, "-o"));
-    	cmd.add(System.getenv().get("DAT3M_HOME") + "/output/test.s");
+    	cmd.add(System.getenv("DAT3M_HOME") + "/output/test.s");
     	cmd.add(file.getAbsolutePath());
     	ProcessBuilder processBuilder = new ProcessBuilder(cmd);
     	logger.info("Compiling with clang");
@@ -58,7 +58,7 @@ public class Compilation {
     		String errorString = CharStreams.toString(new InputStreamReader(proc.getErrorStream(), Charsets.UTF_8));
 			throw new Exception(errorString);
     	}
-    	File testFile = new File(System.getenv().get("DAT3M_HOME") + "/output/test.s");
+    	File testFile = new File(System.getenv("DAT3M_HOME") + "/output/test.s");
     	testFile.delete();
 	}	
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -17,11 +17,10 @@ public class Compilation {
 	
 	public static void compileWithSmack(File file) throws Exception {
 		String name = file.getName().substring(0, file.getName().lastIndexOf('.'));
-		String clangFlags = System.getenv().get("CFLAGS") != null ? System.getenv().get("CFLAGS") : "";
 		
     	ArrayList<String> cmd = new ArrayList<String>();
     	cmd.addAll(asList("smack", "-q", "-t", "--no-memory-splitting"));
-        cmd.add("--clang-options=-I" + System.getenv("DAT3M_HOME") + "/include/ " + clangFlags);
+        cmd.add("--clang-options=-I" + System.getenv("DAT3M_HOME") + "/include/ " + System.getenv().getOrDefault("CFLAGS", ""));
     	cmd.addAll(asList("-bpl", System.getenv("DAT3M_HOME") + "/output/" + name + ".bpl"));
     	cmd.add(file.getAbsolutePath());
     	
@@ -44,10 +43,8 @@ public class Compilation {
 	}	
 
 	public static void compileWithClang(File file) throws Exception {
-		String clangFlags = System.getenv("CFLAGS") != null ? System.getenv("CFLAGS") : "";
-		
     	ArrayList<String> cmd = new ArrayList<String>();
-    	cmd.addAll(asList("clang", "-S", clangFlags, "-o"));
+    	cmd.addAll(asList("clang", "-S", System.getenv().getOrDefault("CFLAGS", ""), "-o"));
     	cmd.add(System.getenv("DAT3M_HOME") + "/output/test.s");
     	cmd.add(file.getAbsolutePath());
     	ProcessBuilder processBuilder = new ProcessBuilder(cmd);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -20,7 +20,7 @@ public class Compilation {
 
     	ArrayList<String> cmd = new ArrayList<String>();
     	cmd.addAll(asList("smack", "-q", "-t", "--no-memory-splitting"));
-        cmd.add("--clang-options=-DCUSTOM_VERIFIER_ASSERT -fno-vectorize -fno-slp-vectorize -I" + System.getenv().get("DAT3M_HOME") + "/include/");    		    		
+        cmd.add("--clang-options=" + System.getenv().get("CFLAGS"));
     	cmd.addAll(asList("-bpl", System.getenv().get("DAT3M_HOME") + "/output/" + name + ".bpl"));
     	cmd.add(file.getAbsolutePath());
     	
@@ -44,7 +44,7 @@ public class Compilation {
 
 	public static void compileWithClang(File file) throws Exception {
     	ArrayList<String> cmd = new ArrayList<String>();
-    	cmd.addAll(asList("clang", "-S", "-o"));
+    	cmd.addAll(asList("clang", "-S", System.getenv().get("CFLAGS"), "-o"));
     	cmd.add(System.getenv().get("DAT3M_HOME") + "/output/test.s");
     	cmd.add(file.getAbsolutePath());
     	ProcessBuilder processBuilder = new ProcessBuilder(cmd);
@@ -55,7 +55,6 @@ public class Compilation {
     		String errorString = CharStreams.toString(new InputStreamReader(proc.getErrorStream(), Charsets.UTF_8));
 			throw new Exception(errorString);
     	}
-    	// TODO(HP): Can this be removed?
     	File testFile = new File(System.getenv().get("DAT3M_HOME") + "/output/test.s");
     	testFile.delete();
 	}	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -17,10 +17,11 @@ public class Compilation {
 	
 	public static void compileWithSmack(File file) throws Exception {
 		String name = file.getName().substring(0, file.getName().lastIndexOf('.'));
-
+		String clangFlags = System.getenv().get("CFLAGS") != null ? System.getenv().get("CFLAGS") : "";
+		
     	ArrayList<String> cmd = new ArrayList<String>();
     	cmd.addAll(asList("smack", "-q", "-t", "--no-memory-splitting"));
-        cmd.add("--clang-options=" + System.getenv().get("CFLAGS"));
+        cmd.add("--clang-options=-I" + System.getenv().get("DAT3M_HOME") + "/include/ " + clangFlags);
     	cmd.addAll(asList("-bpl", System.getenv().get("DAT3M_HOME") + "/output/" + name + ".bpl"));
     	cmd.add(file.getAbsolutePath());
     	
@@ -43,8 +44,10 @@ public class Compilation {
 	}	
 
 	public static void compileWithClang(File file) throws Exception {
+		String clangFlags = System.getenv().get("CFLAGS") != null ? System.getenv().get("CFLAGS") : "";
+		
     	ArrayList<String> cmd = new ArrayList<String>();
-    	cmd.addAll(asList("clang", "-S", System.getenv().get("CFLAGS"), "-o"));
+    	cmd.addAll(asList("clang", "-S", clangFlags, "-o"));
     	cmd.add(System.getenv().get("DAT3M_HOME") + "/output/test.s");
     	cmd.add(file.getAbsolutePath());
     	ProcessBuilder processBuilder = new ProcessBuilder(cmd);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
@@ -60,7 +60,7 @@ public class WitnessBuilder {
 	}
 	
 	public void write() {
-		try (FileWriter fw = new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/witness.graphml")) {
+		try (FileWriter fw = new FileWriter(System.getenv("DAT3M_HOME") + "/output/witness.graphml")) {
 			fw.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
 			fw.write("<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n");
 			for(GraphAttributes attr : GraphAttributes.values()) {fw.write("<key attr.name=\"" + attr.toString() + "\" attr.type=\"string\" for=\"graph\" id=\"" + attr + "\"/>\n");}

--- a/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
@@ -64,7 +64,7 @@ public class SVCOMPRunner {
 	        // (it not the original C file) and we already created the Boogie file
 	        tmp.delete();
 
-	        String boogieName = System.getenv().get("DAT3M_HOME") + "/output/" +
+	        String boogieName = System.getenv("DAT3M_HOME") + "/output/" +
 					file.getName().substring(0, file.getName().lastIndexOf('.')) +
 					"-" + options.getOptimization() + ".bpl";
 	        
@@ -74,9 +74,9 @@ public class SVCOMPRunner {
 	        
 	    	ArrayList<String> cmd = new ArrayList<String>();
 	    	cmd.add("java");
-	    	cmd.add("-Dlog4j.configurationFile=" + System.getenv().get("DAT3M_HOME") + "/dartagnan/src/main/resources/log4j2.xml");
+	    	cmd.add("-Dlog4j.configurationFile=" + System.getenv("DAT3M_HOME") + "/dartagnan/src/main/resources/log4j2.xml");
 	    	cmd.add("-DLOGNAME=" + file.getName());
-	    	cmd.addAll(asList("-jar", System.getenv().get("DAT3M_HOME") + "/dartagnan/target/dartagnan-3.0.0.jar"));
+	    	cmd.addAll(asList("-jar", System.getenv("DAT3M_HOME") + "/dartagnan/target/dartagnan-3.0.0.jar"));
 	    	cmd.addAll(asList("-i", boogieName));
 	    	cmd.addAll(asList("-cat", options.getTargetModelFilePath()));
 	    	cmd.addAll(asList("-t", options.getTarget().asStringOption()));

--- a/svcomp/src/main/java/com/dat3m/svcomp/utils/BoogieSan.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/utils/BoogieSan.java
@@ -11,7 +11,7 @@ public class BoogieSan {
 
     public static void write(String boogieFileName) {
     	try {
-            BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv().get("DAT3M_HOME") + "/output/boogiesan.bpl"));
+            BufferedWriter writer = new BufferedWriter(new FileWriter(System.getenv("DAT3M_HOME") + "/output/boogiesan.bpl"));
             try (Stream<String> stream = Files.lines(Paths.get(boogieFileName))) {
                 stream.filter(s -> !skip(s)).forEach(s -> {
     					try {

--- a/svcomp/src/main/java/com/dat3m/svcomp/utils/Compilation.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/utils/Compilation.java
@@ -26,12 +26,12 @@ public class Compilation {
     	cmd.addAll(asList("--integer-encoding", opt.getEncoding()));
     	if(ownAtomics) {
         	cmd.add("--clang-options=-DCUSTOM_VERIFIER_ASSERT -" + opt.getOptimization() + 
-        			" -fno-vectorize -fno-slp-vectorize -I" + System.getenv().get("DAT3M_HOME") + "/include/");    		    		
+        			" -fno-vectorize -fno-slp-vectorize -I" + System.getenv("DAT3M_HOME") + "/include/");    		    		
     	} else {
         	cmd.add("--clang-options=-DCUSTOM_VERIFIER_ASSERT -" + opt.getOptimization() + 
         			" -fno-vectorize -fno-slp-vectorize");    		
     	}
-    	cmd.addAll(asList("-bpl", System.getenv().get("DAT3M_HOME") + "/output/" + name + "-" + opt.getOptimization() + ".bpl"));
+    	cmd.addAll(asList("-bpl", System.getenv("DAT3M_HOME") + "/output/" + name + "-" + opt.getOptimization() + ".bpl"));
     	cmd.add(file.getAbsolutePath());
     	
     	ProcessBuilder processBuilder = new ProcessBuilder(cmd); 

--- a/svcomp/src/main/java/com/dat3m/svcomp/utils/SVCOMPSanitizer.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/utils/SVCOMPSanitizer.java
@@ -20,7 +20,7 @@ public class SVCOMPSanitizer {
 	}
 
 	public File run(int bound) throws ParsingException {
-		File tmp = new File(System.getenv().get("DAT3M_HOME") + "/output/" + file.getName().substring(0, file.getName().lastIndexOf('.')) + "_tmp.c");
+		File tmp = new File(System.getenv("DAT3M_HOME") + "/output/" + file.getName().substring(0, file.getName().lastIndexOf('.')) + "_tmp.c");
 		try {
 			BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file.getAbsolutePath())));
 			PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(tmp)));		


### PR DESCRIPTION
This PR gives the user more control over `clang` (both directly when checking that the code compiles and when the flags are passed to `smack`).

Notice that we could do the same for the compilation in the `svcomp` module. However for the competition the flags are pretty much fixed (all tasks are preprocessed anyway), thus I chose not to change those.

The CI will trivially because this change only affects the behavior when `*.c` files are passed as input (the CI uses the `*.bpl` ones), so please test that it works from the console (you need to set `CFLAGS`, see the updated `README`).