### PR TITLE
Keep log from UI and console, but silent it when running tests

### DIFF
--- a/dartagnan/src/main/resources/log4j2.xml
+++ b/dartagnan/src/main/resources/log4j2.xml
@@ -26,7 +26,7 @@
       <AppenderRef ref="Refinement_Console"/>
       <AppenderRef ref="Refinement_File"/>
     </Logger>
-    <Root level="error">
+    <Root level="info">
       <AppenderRef ref="Console"/>
       <AppenderRef ref="File"/>
     </Root>


### PR DESCRIPTION
The log is `off` when running tests (both from the console or IDE), but it is `on` when running the tool from the UI (this might be useful for "debugging") or the console (this is specially useful for SVCOMP).