### PR TITLE
Interface Event

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
@@ -1,0 +1,12 @@
+package com.dat3m.dartagnan.program.event;
+
+public abstract class AbstractEvent extends Event {
+
+    protected AbstractEvent() {
+        super();
+    }
+
+    protected AbstractEvent(AbstractEvent other) {
+        super(other);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
@@ -1,12 +1,144 @@
 package com.dat3m.dartagnan.program.event;
 
-public abstract class AbstractEvent extends Event {
+import com.dat3m.dartagnan.program.Thread;
+import com.google.common.base.Preconditions;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+
+import java.util.*;
+
+public abstract class AbstractEvent implements Event {
+
+    // ID after parsing (original)
+    protected int oId = -1;
+    // ID after unrolling
+    protected int uId = -1;
+    // ID after compilation
+    protected int cId = -1;
+    // ID within a function
+    protected int fId = -1;
+    // line in the original C program
+    protected int cLine = -1;
+    // The thread this event belongs to
+    protected Thread thread;
+
+    protected final Set<String> filter;
+
+    protected transient Event successor;
+
+    protected transient BooleanFormula cfVar;
+
+    protected Set<Event> listeners = new HashSet<>();
+
+    private transient String repr;
 
     protected AbstractEvent() {
-        super();
+        filter = new HashSet<>();
     }
 
     protected AbstractEvent(AbstractEvent other) {
-        super(other);
+        this.oId = other.oId;
+        this.uId = other.uId;
+        this.cId = other.cId;
+        this.fId = other.fId;
+        this.cLine = other.cLine;
+        this.filter = other.filter;
+        this.thread = other.thread;
+        this.listeners = other.listeners;
+    }
+
+    @Override public int getOId() { return oId; }
+    @Override public void setOId(int id) { oId = id; }
+
+    @Override public int getUId(){ return uId; }
+    @Override public void setUId(int id) { uId = id; }
+
+    @Override public int getCId() { return cId; }
+    @Override public void setCId(int id) { cId = id; }
+
+    // TODO: This should be called "LId" (localId) and be set once after all processing is done.
+    @Override public int getFId() { return fId; }
+    @Override public void setFId(int id) { fId = id; }
+
+    @Override public int getCLine() { return cLine; }
+    @Override public void setCLine(int line) { cLine = line; }
+
+    @Override public BooleanFormula cf(){ return cfVar; }
+    @Override public void setCfVar(BooleanFormula cfVar) { this.cfVar = cfVar; }
+
+    @Override
+    public Event getSuccessor(){
+        return successor;
+    }
+
+    @Override
+    public void setSuccessor(Event event){
+        successor = event;
+        if(successor != null) {
+            successor.setThread(thread);
+        }
+    }
+
+    @Override
+    public Thread getThread() {
+        return thread;
+    }
+
+    @Override
+    public void setThread(Thread t) {
+        Preconditions.checkNotNull(t);
+        thread = t;
+    }
+
+    @Override
+    public boolean is(String param){
+        return param != null && (filter.contains(param));
+    }
+
+    @Override
+    public void addFilters(String... params){
+        filter.addAll(Arrays.asList(params));
+    }
+
+    @Override
+    public boolean hasFilter(String f) {
+        return filter.contains(f);
+    }
+
+    @Override
+    public int compareTo(Event e){
+        int result = Integer.compare(cId,e.getCId());
+        if(result == 0){
+            result = Integer.compare(uId,e.getUId());
+            if(result == 0){
+                result = Integer.compare(oId,e.getOId());
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void addListener(Event e) {
+        listeners.add(e);
+    }
+
+    @Override
+    public Set<Event> getListeners() {
+        return listeners;
+    }
+
+    // Encoding
+    // -----------------------------------------------------------------------------------------------------------------
+
+    public String repr() {
+        if (cId == -1) {
+            // We have not yet compiled
+            return "E" + oId;
+        }
+        if (repr == null) {
+            // We cache the result, because this saves string concatenations
+            // for every(!) single edge encoded in the program
+            repr = "E" + cId;
+        }
+        return repr;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Assume.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Assume.java
@@ -9,7 +9,7 @@ import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
 
-public class Assume extends Event implements RegReaderData {
+public class Assume extends AbstractEvent implements RegReaderData {
 
 	protected final ExprInterface expr;
 	private final ImmutableSet<Register> dataRegs;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/CondJump.java
@@ -14,7 +14,7 @@ import java.util.List;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.SolverContext;
 
-public class CondJump extends Event implements RegReaderData {
+public class CondJump extends AbstractEvent implements RegReaderData {
 
     private Label label;
     private Label label4Copy;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/ExecutionStatus.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/ExecutionStatus.java
@@ -14,7 +14,7 @@ import java.math.BigInteger;
 
 import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
 
-public class ExecutionStatus extends Event implements RegWriter {
+public class ExecutionStatus extends AbstractEvent implements RegWriter {
 
     private final Register register;
     private final Event event;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Fence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Fence.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.event;
 
 import com.dat3m.dartagnan.program.utils.EType;
 
-public class Fence extends Event {
+public class Fence extends AbstractEvent {
 
 	protected final String name;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/FunCall.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/FunCall.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.event;
 
 import com.dat3m.dartagnan.program.utils.EType;
 
-public class FunCall extends Event {
+public class FunCall extends AbstractEvent {
 
 	private final String funName;
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/FunRet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/FunRet.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.event;
 
 import com.dat3m.dartagnan.program.utils.EType;
 
-public class FunRet extends Event {
+public class FunRet extends AbstractEvent {
 
 	private final String funName;
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/IfAsJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/IfAsJump.java
@@ -30,7 +30,7 @@ public class IfAsJump extends CondJump {
 		List<Event> events = new ArrayList<>();
 		Event next = successor;
 		// For IfAsJump events, getLabel() returns the label representing the else branch
-		while(next != null && next.successor != getLabel()) {
+		while(next != null && next.getSuccessor() != getLabel()) {
 			events.add(next);
 			next = next.getSuccessor();
 		}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Label.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Label.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.event;
 
 import com.dat3m.dartagnan.program.utils.EType;
 
-public class Label extends Event {
+public class Label extends AbstractEvent {
 
     private final String name;
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Local.java
@@ -11,7 +11,7 @@ import org.sosy_lab.java_smt.api.*;
 
 import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
 
-public class Local extends Event implements RegWriter, RegReaderData {
+public class Local extends AbstractEvent implements RegWriter, RegReaderData {
 	
 	protected final Register register;
 	protected final ExprInterface expr;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemEvent.java
@@ -6,7 +6,7 @@ import com.google.common.base.Preconditions;
 import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.SolverContext;
 
-public abstract class MemEvent extends Event {
+public abstract class MemEvent extends AbstractEvent {
 
     protected final IExpr address;
     protected final String mo;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Skip.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Skip.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.event;
 
 import com.dat3m.dartagnan.program.utils.EType;
 
-public class Skip extends Event {
+public class Skip extends AbstractEvent {
 	
 	public Skip() {
 		addFilters(EType.ANY);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/svcomp/event/BeginAtomic.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/svcomp/event/BeginAtomic.java
@@ -1,9 +1,10 @@
 package com.dat3m.dartagnan.program.svcomp.event;
 
+import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.utils.EType;
 
-public class BeginAtomic extends Event {
+public class BeginAtomic extends AbstractEvent {
 	
     public BeginAtomic() {
         addFilters(EType.RMW);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/svcomp/event/EndAtomic.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/svcomp/event/EndAtomic.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.svcomp.event;
 
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.analysis.BranchEquivalence;
+import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.verification.Context;
 import com.google.common.base.Preconditions;
@@ -17,7 +18,7 @@ import java.util.stream.Collectors;
 import static com.dat3m.dartagnan.program.utils.EType.RMW;
 import static com.dat3m.dartagnan.program.utils.EType.SVCOMPATOMIC;
 
-public class EndAtomic extends Event {
+public class EndAtomic extends AbstractEvent {
 
 	private static final Logger logger = LogManager.getLogger(EndAtomic.class);
 


### PR DESCRIPTION
Restructures `com.dat3m.dartagnan.program.event.Event` as an interface.  This enables the separation of parsed, unrolled and compiled events, etc. in a stepwise manner, due to diamond-shaped inheritance.  `RegWriter` and `RegReaderData` may now extend `Event`.