### PR TITLE
Debug option

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -48,4 +48,9 @@ public class OptionNames {
 	public static final String SANITIZE = "svcomp.sanitize";
 	public static final String OPTIMIZATION = "svcomp.optimization";
 	public static final String INTEGER_ENCODING = "svcomp.integerEncoding";
+
+	// Debugging Options
+	public static final String PRINT_PROGRAM_AFTER_SIMPLIFICATION = "printer.afterSimplification";
+	public static final String PRINT_PROGRAM_AFTER_UNROLLING = "printer.afterUnrolling";
+	public static final String PRINT_PROGRAM_AFTER_COMPILATION = "printer.afterCompilation";
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -40,12 +40,8 @@ public class ProgramBuilder {
         Program program = new Program(memory, ImmutableSet.copyOf(locations.values()));
         buildInitThreads();
         for(Thread thread : threads.values()){
+        	addChild(thread.getId(), getOrCreateLabel("END_OF_T" + thread.getId()));
             validateLabels(thread);
-            // The boogie visitor creates the label by itself because it need it for EventFactory.Pthread.newStart
-            // thus we check if the label exists to avoid having it twice
-            if(!hasLabel("END_OF_T" + thread.getId())) {
-            	addChild(thread.getId(), getOrCreateLabel("END_OF_T" + thread.getId()));
-            }
             program.add(thread);
         }
         program.setAss(ass);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -294,8 +294,6 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
         		Location loc = programBuilder.getOrCreateLocation(String.format("%s(%s)_active", pool.getPtrFromInt(threadCount), pool.getCreatorFromPtr(pool.getPtrFromInt(threadCount))));
         		programBuilder.addChild(threadCount, EventFactory.Pthread.newEnd(loc.getAddress()));
          	}
-        	label = programBuilder.getOrCreateLabel("END_OF_T" + threadCount);
-         	programBuilder.addChild(threadCount, label);
     	}
     }
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -13,6 +13,7 @@ import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Local;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
+import com.dat3m.dartagnan.utils.printer.Printer;
 import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,7 +22,7 @@ import org.sosy_lab.common.configuration.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.dat3m.dartagnan.configuration.OptionNames.BOUND;
+import static com.dat3m.dartagnan.configuration.OptionNames.*;
 
 @Options
 public class LoopUnrolling implements ProgramProcessor {
@@ -41,6 +42,11 @@ public class LoopUnrolling implements ProgramProcessor {
         Preconditions.checkArgument(bound >= 1, "The unrolling bound must be positive.");
         this.bound = bound;
     }
+
+    @Option(name = PRINT_PROGRAM_AFTER_UNROLLING,
+            description = "Prints the program after unrolling.",
+            secure = true)
+    private boolean print = false;
 
     // =====================================================================
 
@@ -74,10 +80,15 @@ public class LoopUnrolling implements ProgramProcessor {
         program.clearCache(false);
         program.markAsUnrolled();
 
-        logger.info("Program unrolled {} times", bound);
-        
         updateAssertions(program);
-    }
+
+        logger.info("Program unrolled {} times", bound);
+        if(print) {
+        	System.out.println("===== Program after unrolling =====");
+        	System.out.println(new Printer().print(program));
+        	System.out.println("===================================");
+        }
+}
 
     private int unrollThread(Thread t, int bound, int nextId){
         while(bound > 0) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Simplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Simplifier.java
@@ -5,24 +5,45 @@ import com.dat3m.dartagnan.expression.BExpr;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.utils.printer.Printer;
 import com.google.common.base.Preconditions;
+
+import static com.dat3m.dartagnan.configuration.OptionNames.PRINT_PROGRAM_AFTER_SIMPLIFICATION;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.configuration.Option;
+import org.sosy_lab.common.configuration.Options;
 
+@Options
 public class Simplifier implements ProgramProcessor {
 
-    private static final Logger logger = LogManager.getLogger(Simplifier.class);
+    // =========================== Configurables ===========================
+
+	@Option(name = PRINT_PROGRAM_AFTER_SIMPLIFICATION,
+            description = "Prints the program after simplification.",
+            secure = true)
+    private boolean print = false;
+
+    // =====================================================================
+
+	private static final Logger logger = LogManager.getLogger(Simplifier.class);
 
     private Simplifier() { }
+
+    private Simplifier(Configuration config) throws InvalidConfigurationException {
+        this();
+        config.inject(this);
+    }
 
     public static Simplifier newInstance() {
         return new Simplifier();
     }
 
     public static Simplifier fromConfig(Configuration config) throws InvalidConfigurationException {
-        return newInstance(); // There is nothing to configure
+        return new Simplifier(config);
     }
 
     @Override
@@ -38,6 +59,11 @@ public class Simplifier implements ProgramProcessor {
         program.clearCache(false);
 
         logger.info("post-simplification: " + program.getEvents().size() + " events");
+        if(print) {
+        	System.out.println("===== Program after simplification =====");
+        	System.out.println(new Printer().print(program));
+        	System.out.println("========================================");
+        }
     }
 
     private boolean simplify(Thread t) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/Compilation.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.processing.ProgramProcessor;
+import com.dat3m.dartagnan.utils.printer.Printer;
 import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -16,7 +17,7 @@ import org.sosy_lab.common.configuration.Options;
 
 import java.util.List;
 
-import static com.dat3m.dartagnan.configuration.OptionNames.TARGET;
+import static com.dat3m.dartagnan.configuration.OptionNames.*;
 
 @Options
 public class Compilation implements ProgramProcessor {
@@ -34,6 +35,11 @@ public class Compilation implements ProgramProcessor {
 
     public Arch getTarget() { return target; }
     public void setTarget(Arch target) { this.target = target;}
+
+    @Option(name = PRINT_PROGRAM_AFTER_COMPILATION,
+            description = "Prints the program after compilation.",
+            secure = true)
+    private boolean print = false;
 
     // =====================================================================
 
@@ -89,6 +95,11 @@ public class Compilation implements ProgramProcessor {
         program.clearCache(false);
         program.markAsCompiled();
         logger.info("Program compiled to {}", target);
+        if(print) {
+        	System.out.println("===== Program after compilation =====");
+        	System.out.println(new Printer().print(program));
+        	System.out.println("=====================================");
+        }
     }
 
     private int compileThread(Thread thread, int nextId, EventVisitor<List<Event>> visitor) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/printer/Printer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/printer/Printer.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Init;
+import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Skip;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
 
@@ -94,6 +95,9 @@ public class Printer {
                 	throw new RuntimeException("Unrecognized event id type " + idType);
             }
             result.append(idSb);
+            if(!(event instanceof Label)) {
+            	result.append("   ");
+            }
             result.append(padding, idSb.length(), padding.length());
             result.append(event).append("\n");
         }


### PR DESCRIPTION
This PR adds 3 debug options
- `--printer.afterSimplification`: prints the program after running the simplification pass
- `--printer.afterUnrolling`: prints the program after running the unrolling pass
- `--printer.afterCompilation`: prints the program after running the compilation pass

By default all options are off.