### PR TITLE
Alias method as OptionInterface

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/Alias.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/Alias.java
@@ -1,0 +1,27 @@
+package com.dat3m.dartagnan.configuration;
+
+import java.util.Arrays;
+
+import com.dat3m.dartagnan.configuration.OptionInterface;
+
+public enum Alias implements OptionInterface {
+	// For comparison reasons, we might want to add a NONE method with may = true, must = false
+	FIELD_SENSITIVE, FIELD_INSENSITIVE;
+
+	// Used for options in the console
+	public String asStringOption() {
+		return this.toString().toLowerCase();
+	}
+
+	public static Alias getDefault() {
+		return FIELD_SENSITIVE;
+	}
+	
+	// Used to decide the order shown by the selector in the UI
+	public static Alias[] orderedValues() {
+		Alias[] order = { FIELD_SENSITIVE, FIELD_INSENSITIVE };
+		// Be sure no element is missing
+		assert(Arrays.asList(order).containsAll(Arrays.asList(values())));
+		return order;
+	}
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/AliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/AliasAnalysis.java
@@ -1,7 +1,11 @@
 package com.dat3m.dartagnan.program.analysis;
 
+import com.dat3m.dartagnan.configuration.Alias;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
@@ -11,29 +15,29 @@ import static com.dat3m.dartagnan.configuration.OptionNames.ALIAS_METHOD;
 
 public interface AliasAnalysis {
 
+    static final Logger logger = LogManager.getLogger(AliasAnalysis.class);
+
     boolean mustAlias(MemEvent a, MemEvent b);
     boolean mayAlias(MemEvent a, MemEvent b);
 
     static AliasAnalysis fromConfig(Program program, Configuration config) throws InvalidConfigurationException {
         InjectionTarget o = new InjectionTarget();
         config.inject(o);
-        try {
-            return (AliasAnalysis)o.method
-            .getDeclaredMethod("fromConfig",Program.class,Configuration.class)
-            .invoke(null,program,config);
-        } catch(ReflectiveOperationException x) {
-            throw new InvalidConfigurationException(String.format("invalid %s#fromConfig(%s,%s)",
-                    o.method.getName(),
-                    Program.class.getSimpleName(),
-                    Configuration.class.getSimpleName()),
-                x);
-        }
+		logger.info("Selected Alias Analysis: " + o.method);
+    	switch (o.method) {
+		case FIELD_SENSITIVE:
+			return FieldSensitiveAndersen.fromConfig(program, config);
+		case FIELD_INSENSITIVE:
+			return AndersenAliasAnalysis.fromConfig(program, config);
+		default:
+			throw new UnsupportedOperationException("Alias method not recognized");
+		}
     }
 
     @Options
     final class InjectionTarget {
         @Option(name = ALIAS_METHOD,
                 description = "General type of analysis that approximates the 'loc' relationship between memory events.")
-        private Class<?extends AliasAnalysis> method = FieldSensitiveAndersen.class;
+        private Alias method = Alias.FIELD_SENSITIVE;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/AliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/AliasAnalysis.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.program.analysis;
 import com.dat3m.dartagnan.configuration.Alias;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
@@ -15,29 +14,33 @@ import static com.dat3m.dartagnan.configuration.OptionNames.ALIAS_METHOD;
 
 public interface AliasAnalysis {
 
-    static final Logger logger = LogManager.getLogger(AliasAnalysis.class);
+    Logger logger = LogManager.getLogger(AliasAnalysis.class);
 
     boolean mustAlias(MemEvent a, MemEvent b);
     boolean mayAlias(MemEvent a, MemEvent b);
 
     static AliasAnalysis fromConfig(Program program, Configuration config) throws InvalidConfigurationException {
-        InjectionTarget o = new InjectionTarget();
-        config.inject(o);
-		logger.info("Selected Alias Analysis: " + o.method);
-    	switch (o.method) {
-		case FIELD_SENSITIVE:
-			return FieldSensitiveAndersen.fromConfig(program, config);
-		case FIELD_INSENSITIVE:
-			return AndersenAliasAnalysis.fromConfig(program, config);
-		default:
-			throw new UnsupportedOperationException("Alias method not recognized");
-		}
+        Config c = new Config(config);
+		logger.info("Selected Alias Analysis: " + c.method);
+    	switch (c.method) {
+            case FIELD_SENSITIVE:
+                return FieldSensitiveAndersen.fromConfig(program, config);
+            case FIELD_INSENSITIVE:
+                return AndersenAliasAnalysis.fromConfig(program, config);
+            default:
+                throw new UnsupportedOperationException("Alias method not recognized");
+        }
     }
 
     @Options
-    final class InjectionTarget {
+    final class Config {
         @Option(name = ALIAS_METHOD,
                 description = "General type of analysis that approximates the 'loc' relationship between memory events.")
         private Alias method = Alias.FIELD_SENSITIVE;
+
+        private Config(Configuration config) throws InvalidConfigurationException {
+            config.inject(this);
+        }
     }
+
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AliasAnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AliasAnalysisTest.java
@@ -1,13 +1,12 @@
 package com.dat3m.dartagnan.miscellaneous;
 
+import com.dat3m.dartagnan.configuration.Alias;
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.BOpBin;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.analysis.AliasAnalysis;
-import com.dat3m.dartagnan.program.analysis.AndersenAliasAnalysis;
-import com.dat3m.dartagnan.program.analysis.FieldSensitiveAndersen;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -19,6 +18,7 @@ import org.sosy_lab.common.configuration.InvalidConfigurationException;
 
 import java.math.BigInteger;
 
+import static com.dat3m.dartagnan.configuration.Alias.*;
 import static com.dat3m.dartagnan.configuration.OptionNames.ALIAS_METHOD;
 import static com.dat3m.dartagnan.expression.IValue.*;
 import static com.dat3m.dartagnan.expression.op.COpBin.*;
@@ -36,15 +36,15 @@ public class AliasAnalysisTest {
 
     @Test
     public void fieldsensitive0() throws InvalidConfigurationException {
-        program0(FieldSensitiveAndersen.class,MAY,MAY,NONE,NONE,NONE,NONE);
+        program0(FIELD_SENSITIVE,MAY,MAY,NONE,NONE,NONE,NONE);
     }
 
     @Test
     public void fieldinsensitive0() throws InvalidConfigurationException {
-        program0(AndersenAliasAnalysis.class,MAY,NONE,MAY,NONE,MAY,NONE);
+        program0(FIELD_INSENSITIVE,MAY,NONE,MAY,NONE,MAY,NONE);
     }
 
-    private void program0(Class<?extends AliasAnalysis> method, Result... expect) throws InvalidConfigurationException {
+    private void program0(Alias method, Result... expect) throws InvalidConfigurationException {
         ProgramBuilder b = new ProgramBuilder();
 
         MemoryObject x = b.newObject("x",2);
@@ -75,15 +75,15 @@ public class AliasAnalysisTest {
 
     @Test
     public void fieldsensitive1() throws InvalidConfigurationException {
-        program1(FieldSensitiveAndersen.class,NONE,NONE,MUST,MUST,NONE,NONE);
+        program1(FIELD_SENSITIVE,NONE,NONE,MUST,MUST,NONE,NONE);
     }
 
     @Test
     public void fieldinsensitive1() throws InvalidConfigurationException {
-        program1(AndersenAliasAnalysis.class,NONE,NONE,MUST,MAY,MAY,MAY);
+        program1(FIELD_INSENSITIVE,NONE,NONE,MUST,MAY,MAY,MAY);
     }
 
-    private void program1(Class<?extends AliasAnalysis> method, Result... expect) throws InvalidConfigurationException {
+    private void program1(Alias method, Result... expect) throws InvalidConfigurationException {
         ProgramBuilder b = new ProgramBuilder();
         MemoryObject x = b.newObject("x",3);
         x.setInitialValue(0,x);
@@ -110,15 +110,15 @@ public class AliasAnalysisTest {
 
     @Test
     public void fieldsensitive2() throws InvalidConfigurationException {
-        program2(FieldSensitiveAndersen.class,NONE,NONE,NONE,MAY,NONE,MAY);
+        program2(FIELD_SENSITIVE,NONE,NONE,NONE,MAY,NONE,MAY);
     }
 
     @Test
     public void fieldinsensitive2() throws InvalidConfigurationException {
-        program2(AndersenAliasAnalysis.class,NONE,NONE,NONE,MAY,MAY,MAY);
+        program2(FIELD_INSENSITIVE,NONE,NONE,NONE,MAY,MAY,MAY);
     }
 
-    private void program2(Class<?extends AliasAnalysis> method, Result... expect) throws InvalidConfigurationException {
+    private void program2(Alias method, Result... expect) throws InvalidConfigurationException {
         ProgramBuilder b = new ProgramBuilder();
         MemoryObject x = b.newObject("x",3);
 
@@ -150,15 +150,15 @@ public class AliasAnalysisTest {
 
     @Test
     public void fieldsensitive3() throws InvalidConfigurationException {
-        program3(FieldSensitiveAndersen.class,MUST,NONE,NONE,MAY,MAY,MAY);
+        program3(FIELD_SENSITIVE,MUST,NONE,NONE,MAY,MAY,MAY);
     }
 
     @Test
     public void fieldinsensitive3() throws InvalidConfigurationException {
-        program3(AndersenAliasAnalysis.class,MUST,NONE,NONE,MAY,MAY,MAY);
+        program3(FIELD_INSENSITIVE,MUST,NONE,NONE,MAY,MAY,MAY);
     }
 
-    private void program3(Class<?extends AliasAnalysis> method, Result... expect) throws InvalidConfigurationException {
+    private void program3(Alias method, Result... expect) throws InvalidConfigurationException {
         ProgramBuilder b = new ProgramBuilder();
         MemoryObject x = b.newObject("x",3);
         x.setInitialValue(0,x);
@@ -185,15 +185,15 @@ public class AliasAnalysisTest {
 
     @Test
     public void fieldsensitive4() throws InvalidConfigurationException {
-        program4(FieldSensitiveAndersen.class,MAY,MAY,NONE,NONE,NONE,NONE);
+        program4(FIELD_SENSITIVE,MAY,MAY,NONE,NONE,NONE,NONE);
     }
 
     @Test
     public void fieldinsensitive4() throws InvalidConfigurationException {
-        program4(AndersenAliasAnalysis.class,NONE,MUST,NONE,NONE,NONE,NONE);
+        program4(FIELD_INSENSITIVE,NONE,MUST,NONE,NONE,NONE,NONE);
     }
 
-    private void program4(Class<?extends AliasAnalysis> method, Result... expect) throws InvalidConfigurationException {
+    private void program4(Alias method, Result... expect) throws InvalidConfigurationException {
         ProgramBuilder b = new ProgramBuilder();
         MemoryObject x = b.getOrNewObject("x");
         MemoryObject y = b.getOrNewObject("y");
@@ -223,15 +223,15 @@ public class AliasAnalysisTest {
 
     @Test
     public void fieldsensitive5() throws InvalidConfigurationException {
-        program5(FieldSensitiveAndersen.class,MAY,MAY,NONE,NONE,NONE,NONE);
+        program5(FIELD_SENSITIVE,MAY,MAY,NONE,NONE,NONE,NONE);
     }
 
     @Test
     public void fieldinsensitive5() throws InvalidConfigurationException {
-        program5(AndersenAliasAnalysis.class,MUST,NONE,NONE,NONE,NONE,NONE);
+        program5(FIELD_INSENSITIVE,MUST,NONE,NONE,NONE,NONE,NONE);
     }
 
-    private void program5(Class<?extends AliasAnalysis> method, Result... expect) throws InvalidConfigurationException {
+    private void program5(Alias method, Result... expect) throws InvalidConfigurationException {
         ProgramBuilder b = new ProgramBuilder();
         MemoryObject x = b.getOrNewObject("x");
         MemoryObject y = b.getOrNewObject("y");
@@ -279,11 +279,11 @@ public class AliasAnalysisTest {
         return new IExprBin(lhs,MULT,new IValue(BigInteger.valueOf(rhs),-1));
     }
 
-    private AliasAnalysis analyze(ProgramBuilder builder, Class<?extends AliasAnalysis> method) throws InvalidConfigurationException {
+    private AliasAnalysis analyze(ProgramBuilder builder, Alias method) throws InvalidConfigurationException {
         Program program = builder.build();
         LoopUnrolling.newInstance().run(program);
         Compilation.newInstance().run(program);
-        return AliasAnalysis.fromConfig(program,Configuration.builder().setOption(ALIAS_METHOD,method.getName()).build());
+        return AliasAnalysis.fromConfig(program,Configuration.builder().setOption(ALIAS_METHOD,method.asStringOption()).build());
     }
 
     private void assertAlias(Result expect, AliasAnalysis a, MemEvent x, MemEvent y) {


### PR DESCRIPTION
This PR adds a new enum type (similar to Arch, Method, etc) to select between the different alias analysis.

Interestingly, in cases where I expected both analyses to behave (i.e. size of the maxTupleSets) differently like  mutex_musl, they do not.