### PR TITLE
Replace duplicated bound option

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
@@ -21,7 +21,7 @@ public class Program {
 	private final Memory memory;
 	private Arch arch;
     private EventCache cache;
-    private boolean isUnrolled;
+    private int unrollingBound = 0;
     private boolean isCompiled;
 
     public Program(Memory memory){
@@ -39,7 +39,11 @@ public class Program {
     }
 
     public boolean isUnrolled(){
-        return isUnrolled;
+        return unrollingBound > 0;
+    }
+
+    public int getUnrollingBound(){
+        return unrollingBound;
     }
 
 	public String getName(){
@@ -114,11 +118,11 @@ public class Program {
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
-    public boolean markAsUnrolled() {
-        if (isUnrolled) {
+    public boolean markAsUnrolled(int bound) {
+        if (unrollingBound > 0) {
             return false;
         }
-        isUnrolled = true;
+        unrollingBound = bound;
         return true;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -78,7 +78,7 @@ public class LoopUnrolling implements ProgramProcessor {
             nextId = unrollThread(thread, bound, nextId);
         }
         program.clearCache(false);
-        program.markAsUnrolled();
+        program.markAsUnrolled(bound);
 
         updateAssertions(program);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
@@ -31,7 +31,6 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.dat3m.dartagnan.configuration.OptionNames.BOUND;
 import static com.dat3m.dartagnan.configuration.OptionNames.WITNESS_ORIGINAL_PROGRAM_PATH;
 import static com.dat3m.dartagnan.program.event.Tag.C11.PTHREAD;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
@@ -59,12 +58,6 @@ public class WitnessBuilder {
 
     public boolean canBeBuilt() { return originalProgramFilePath != null; }
 
-	@Option(
-			name=BOUND,
-			description = "Unrolling bound used in the verification.",
-			secure=true)
-	private String bound;
-
     // =====================================================================
 
 	private final Map<Event, Integer> eventThreadMap = new HashMap<>();
@@ -87,7 +80,7 @@ public class WitnessBuilder {
 		}
 
 		WitnessGraph graph = new WitnessGraph();
-		graph.addAttribute(UNROLLBOUND.toString(), valueOf(bound));
+		graph.addAttribute(UNROLLBOUND.toString(), valueOf(task.getProgram().getUnrollingBound()));
 		graph.addAttribute(WITNESSTYPE.toString(), type + "_witness");
 		graph.addAttribute(SOURCECODELANG.toString(), "C");
 		graph.addAttribute(PRODUCER.toString(), "Dartagnan");


### PR DESCRIPTION
This PR removed the duplicated bound option (once in the LoopUnrolling pass and once in the svcomp witness builder) by storing the bound as program metadata after unrolling