### PR TITLE
Compute dataRegs on demand

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
@@ -16,14 +16,12 @@ public class RMW extends MemEvent implements RegWriter, RegReaderData {
 
     private final Register resultRegister;
     private final IExpr value;
-    private ImmutableSet<Register> dataRegs;
     
 
     public RMW(IExpr address, Register register, IExpr value, String mo) {
         super(address, mo);
 		this.resultRegister = register;
         this.value = value;
-        this.dataRegs = value.getRegs();
         addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, RMW, REG_WRITER, REG_READER);
     }
 
@@ -31,7 +29,6 @@ public class RMW extends MemEvent implements RegWriter, RegReaderData {
         super(other);
 		this.resultRegister = other.resultRegister;
         this.value = other.value;
-        this.dataRegs = other.dataRegs;
     }
 
     @Override
@@ -45,7 +42,7 @@ public class RMW extends MemEvent implements RegWriter, RegReaderData {
 
 	@Override
 	public ImmutableSet<Register> getDataRegs() {
-		return dataRegs;
+		return value.getRegs();
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -2,8 +2,6 @@ package com.dat3m.dartagnan.program.event.arch.tso;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
-import static com.dat3m.dartagnan.program.event.Tag.*;
-
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
@@ -12,22 +10,21 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.collect.ImmutableSet;
 
+import static com.dat3m.dartagnan.program.event.Tag.*;
+
 public class Xchg extends MemEvent implements RegWriter, RegReaderData {
 
     private final Register resultRegister;
-    private final ImmutableSet<Register> dataRegs;
 
     public Xchg(MemoryObject address, Register register) {
         super(address, null);
         this.resultRegister = register;
-        this.dataRegs = ImmutableSet.of(resultRegister);
         addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, Tag.TSO.ATOM, REG_WRITER, REG_READER);
     }
 
     private Xchg(Xchg other){
         super(other);
         this.resultRegister = other.resultRegister;
-        this.dataRegs = other.dataRegs;
     }
 
     @Override
@@ -37,7 +34,7 @@ public class Xchg extends MemEvent implements RegWriter, RegReaderData {
 
     @Override
     public ImmutableSet<Register> getDataRegs(){
-        return dataRegs;
+        return ImmutableSet.of(resultRegister);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
@@ -13,19 +13,16 @@ import org.sosy_lab.java_smt.api.SolverContext;
 public class Assume extends Event implements RegReaderData {
 
 	protected final ExprInterface expr;
-	private final ImmutableSet<Register> dataRegs;
 
 	public Assume(ExprInterface expr) {
 		super();
 		this.expr = expr;
-		this.dataRegs = expr.getRegs();
 		addFilters(Tag.ANY, Tag.LOCAL, Tag.REG_READER);
 	}
 
 	protected Assume(Assume other){
 		super(other);
 		this.expr = other.expr;
-		this.dataRegs = other.dataRegs;
 	}
 
 
@@ -36,7 +33,7 @@ public class Assume extends Event implements RegReaderData {
 
 	@Override
 	public ImmutableSet<Register> getDataRegs(){
-		return dataRegs;
+		return expr.getRegs();
 	}
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
@@ -16,7 +16,6 @@ public class CondJump extends Event implements RegReaderData {
     private Label label;
     private Label label4Copy;
     private BExpr expr;
-    private ImmutableSet<Register> dataRegs;
 
     public CondJump(BExpr expr, Label label){
     	Preconditions.checkNotNull(label, "CondJump event requires non null label event");
@@ -25,7 +24,6 @@ public class CondJump extends Event implements RegReaderData {
         this.label.addListener(this);
         this.thread = label.getThread();
         this.expr = expr;
-        dataRegs = expr.getRegs();
         addFilters(Tag.ANY, Tag.JUMP, Tag.REG_READER);
     }
 
@@ -33,7 +31,6 @@ public class CondJump extends Event implements RegReaderData {
 		super(other);
 		this.label = other.label4Copy;
 		this.expr = other.expr;
-		this.dataRegs = other.dataRegs;
 		Event notifier = label != null ? label : other.label;
 		notifier.addListener(this);
     }
@@ -56,7 +53,6 @@ public class CondJump extends Event implements RegReaderData {
 
     public void setGuard(BExpr guard){
         this.expr = guard;
-        this.dataRegs = expr.getRegs();
     }
 
     @Override
@@ -68,7 +64,7 @@ public class CondJump extends Event implements RegReaderData {
 
     @Override
     public ImmutableSet<Register> getDataRegs(){
-        return dataRegs;
+        return expr.getRegs();
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
@@ -16,13 +16,11 @@ public class Local extends Event implements RegWriter, RegReaderData {
 	
 	protected final Register register;
 	protected ExprInterface expr;
-	private ImmutableSet<Register> dataRegs;
 	private Formula regResultExpr;
 	
 	public Local(Register register, ExprInterface expr) {
 		this.register = register;
 		this.expr = expr;
-		this.dataRegs = expr.getRegs();
 		addFilters(Tag.ANY, Tag.LOCAL, Tag.REG_WRITER, Tag.REG_READER);
 	}
 	
@@ -30,7 +28,6 @@ public class Local extends Event implements RegWriter, RegReaderData {
 		super(other);
 		this.register = other.register;
 		this.expr = other.expr;
-		this.dataRegs = other.dataRegs;
 		this.regResultExpr = other.regResultExpr;
 	}
 
@@ -46,7 +43,6 @@ public class Local extends Event implements RegWriter, RegReaderData {
 
 	public void setExpr(ExprInterface expr){
 		this.expr = expr;
-		this.dataRegs = expr.getRegs();
 	}
 
 	@Override
@@ -61,7 +57,7 @@ public class Local extends Event implements RegWriter, RegReaderData {
 
 	@Override
 	public ImmutableSet<Register> getDataRegs(){
-		return dataRegs;
+		return expr.getRegs();
 	}
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -12,19 +12,16 @@ import org.sosy_lab.java_smt.api.SolverContext;
 public class Store extends MemEvent implements RegReaderData {
 
     protected ExprInterface value;
-    private ImmutableSet<Register> dataRegs;
 
     public Store(IExpr address, ExprInterface value, String mo){
     	super(address, mo);
         this.value = value;
-        dataRegs = value.getRegs();
         addFilters(Tag.ANY, Tag.VISIBLE, Tag.MEMORY, Tag.WRITE, Tag.REG_READER);
     }
     
     protected Store(Store other){
         super(other);
         this.value = other.value;
-        dataRegs = other.dataRegs;
     }
 
     @Override
@@ -35,7 +32,7 @@ public class Store extends MemEvent implements RegReaderData {
 
     @Override
     public ImmutableSet<Register> getDataRegs(){
-        return dataRegs;
+        return value.getRegs();
     }
 
     @Override
@@ -51,7 +48,6 @@ public class Store extends MemEvent implements RegReaderData {
     @Override
     public void setMemValue(ExprInterface value){
         this.value = value;
-        this.dataRegs = value.getRegs();
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -15,13 +15,11 @@ public abstract class AtomicAbstract extends MemEvent implements RegWriter, RegR
 
     protected final Register resultRegister;
     protected ExprInterface value;
-    protected ImmutableSet<Register> dataRegs;
 
     AtomicAbstract(IExpr address, Register register, IExpr value, String mo) {
         super(address, mo);
         this.resultRegister = register;
         this.value = value;
-        this.dataRegs = value.getRegs();
         addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, RMW, REG_WRITER, REG_READER);
     }
 
@@ -29,7 +27,6 @@ public abstract class AtomicAbstract extends MemEvent implements RegWriter, RegR
         super(other);
         this.resultRegister = other.resultRegister;
         this.value = other.value;
-        this.dataRegs = other.dataRegs;
     }
 
     @Override
@@ -39,7 +36,7 @@ public abstract class AtomicAbstract extends MemEvent implements RegWriter, RegR
 
     @Override
     public ImmutableSet<Register> getDataRegs() {
-        return dataRegs;
+        return value.getRegs();
     }
 
     @Override
@@ -50,7 +47,6 @@ public abstract class AtomicAbstract extends MemEvent implements RegWriter, RegR
     @Override
     public void setMemValue(ExprInterface value){
         this.value = value;
-        this.dataRegs = value.getRegs();
     }
 
 	// Visitor

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -15,26 +15,23 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.*;
 public class AtomicStore extends MemEvent implements RegReaderData {
 
     private ExprInterface value;
-    private ImmutableSet<Register> dataRegs;
 
     public AtomicStore(IExpr address, ExprInterface value, String mo){
         super(address, mo);
         Preconditions.checkArgument(!mo.equals(MO_ACQUIRE) && !mo.equals(MO_ACQUIRE_RELEASE),
         		getClass().getName() + " can not have memory order: " + mo);
         this.value = value;
-        this.dataRegs = value.getRegs();
         addFilters(Tag.ANY, Tag.VISIBLE, Tag.MEMORY, Tag.WRITE, Tag.REG_READER);
     }
 
     private AtomicStore(AtomicStore other){
         super(other);
         this.value = other.value;
-        this.dataRegs = other.dataRegs;
     }
 
     @Override
     public ImmutableSet<Register> getDataRegs(){
-        return dataRegs;
+        return value.getRegs();
     }
 
     @Override
@@ -51,7 +48,6 @@ public class AtomicStore extends MemEvent implements RegReaderData {
     @Override
     public void setMemValue(ExprInterface value){
         this.value = value;
-        this.dataRegs = value.getRegs();
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -15,13 +15,11 @@ public abstract class RMWAbstract extends MemEvent implements RegWriter, RegRead
 
     protected final Register resultRegister;
     protected ExprInterface value;
-    protected ImmutableSet<Register> dataRegs;
 
     RMWAbstract(IExpr address, Register register, ExprInterface value, String mo) {
         super(address, mo);
         this.resultRegister = register;
         this.value = value;
-        this.dataRegs = value.getRegs();
         addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, RMW, REG_WRITER, REG_READER);
     }
 
@@ -29,7 +27,6 @@ public abstract class RMWAbstract extends MemEvent implements RegWriter, RegRead
         super(other);
         this.resultRegister = other.resultRegister;
         this.value = other.value;
-        this.dataRegs = other.dataRegs;
     }
 
     @Override
@@ -39,7 +36,7 @@ public abstract class RMWAbstract extends MemEvent implements RegWriter, RegRead
 
     @Override
     public ImmutableSet<Register> getDataRegs(){
-        return dataRegs;
+        return value.getRegs();
     }
 
     @Override
@@ -50,7 +47,6 @@ public abstract class RMWAbstract extends MemEvent implements RegWriter, RegRead
     @Override
     public void setMemValue(ExprInterface value){
         this.value = value;
-        this.dataRegs = value.getRegs();
     }
 
 	// Visitor

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAddUnless.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAddUnless.java
@@ -15,7 +15,6 @@ public class RMWAddUnless extends RMWAbstract implements RegWriter, RegReaderDat
 
     public RMWAddUnless(IExpr address, Register register, ExprInterface cmp, IExpr value) {
         super(address, register, value, Tag.Linux.MO_MB);
-        dataRegs = new ImmutableSet.Builder<Register>().addAll(value.getRegs()).addAll(cmp.getRegs()).build();
         this.cmp = cmp;
     }
 
@@ -33,6 +32,11 @@ public class RMWAddUnless extends RMWAbstract implements RegWriter, RegReaderDat
     	return cmp;
     }
     
+    @Override
+    public ImmutableSet<Register> getDataRegs(){
+        return new ImmutableSet.Builder<Register>().addAll(value.getRegs()).addAll(cmp.getRegs()).build();
+    }
+
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWCmpXchg.java
@@ -15,7 +15,6 @@ public class RMWCmpXchg extends RMWAbstract implements RegWriter, RegReaderData 
 
     public RMWCmpXchg(IExpr address, Register register, ExprInterface cmp, IExpr value, String mo) {
         super(address, register, value, mo);
-        this.dataRegs = new ImmutableSet.Builder<Register>().addAll(value.getRegs()).addAll(cmp.getRegs()).build();
         this.cmp = cmp;
     }
 
@@ -33,6 +32,11 @@ public class RMWCmpXchg extends RMWAbstract implements RegWriter, RegReaderData 
     	return cmp;
     }
     
+    @Override
+    public ImmutableSet<Register> getDataRegs(){
+        return new ImmutableSet.Builder<Register>().addAll(value.getRegs()).addAll(cmp.getRegs()).build();
+    }
+
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/cond/RMWReadCond.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/cond/RMWReadCond.java
@@ -23,13 +23,11 @@ import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
 public abstract class RMWReadCond extends Load implements RegWriter, RegReaderData {
 
     protected ExprInterface cmp;
-    private final ImmutableSet<Register> dataRegs;
     protected BooleanFormula formulaCond;
 
     RMWReadCond(Register reg, ExprInterface cmp, IExpr address, String atomic) {
         super(reg, address, atomic);
         this.cmp = cmp;
-        this.dataRegs = cmp.getRegs();
         addFilters(Tag.RMW, Tag.REG_READER);
     }
 
@@ -46,7 +44,7 @@ public abstract class RMWReadCond extends Load implements RegWriter, RegReaderDa
 
     @Override
     public ImmutableSet<Register> getDataRegs(){
-        return dataRegs;
+        return cmp.getRegs();
     }
 
     public abstract String condToString();


### PR DESCRIPTION
As suggested in #215, this PR computes `dataRegs` information on demand instead than when building the object.