### PR TITLE
Jump forwarding

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
@@ -42,6 +42,9 @@ public class ExprSimplifier extends ExprTransformer {
                 return lhs;
             }
         }
+        if (lhs.equals(rhs) && atom.getOp() == COpBin.NEQ) {
+            return BConst.FALSE;
+        }
         return new Atom(lhs, atom.getOp(), rhs);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
@@ -49,6 +49,13 @@ public class CondJump extends Event implements RegReaderData {
     public Label getLabel(){
         return label;
     }
+    public void setLabel(Label newLabel) {
+        Preconditions.checkNotNull(newLabel);
+        newLabel.addListener(this);
+        this.label.getListeners().remove(this.label);
+        this.label = newLabel;
+        this.label4Copy = null;
+    }
 
     public BExpr getGuard(){
         return expr;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/JumpForwarding.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/JumpForwarding.java
@@ -1,0 +1,110 @@
+package com.dat3m.dartagnan.program.processing;
+
+import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.event.core.CondJump;
+import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.Label;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class JumpForwarding implements ProgramProcessor {
+
+    private static final Logger logger = LogManager.getLogger(JumpForwarding.class);
+
+    private JumpForwarding() { }
+
+    public static JumpForwarding newInstance() {
+        return new JumpForwarding();
+    }
+
+    public static JumpForwarding fromConfig(Configuration config) throws InvalidConfigurationException {
+        return newInstance();
+    }
+
+    @Override
+    public void run(Program program) {
+        Preconditions.checkArgument(program.isUnrolled(), "Jump forwarding should be performed after unrolling.");
+
+        logger.info("#Events before jump forwarding: " + program.getEvents().size());
+
+        int numForwardedJumps = 0;
+        for (Thread t : program.getThreads()) {
+            numForwardedJumps += run(t);
+            t.clearCache();
+        }
+        program.clearCache(false);
+
+        logger.info("#Jumps forwarded: " + numForwardedJumps);
+        logger.info("#Events after jump forwarding: " + program.getEvents().size());
+    }
+
+    private int run(Thread thread) {
+        Map<Label, Label> forwardingMap = new HashMap<>();
+        Set<Event> toBeRemoved = new HashSet<>();
+
+        int numForwardedJumps = 0;
+        Label forwardTo = null;
+        Event next = null;
+        boolean nextIsGoto = false;
+
+        for (Event cur : Lists.reverse(thread.getEvents())) {
+            if (cur instanceof Label) {
+                Label l = (Label) cur;
+                if (forwardTo != null) {
+                    // We have a label whose jumps can can get forwarded
+                    forwardingMap.put(l, forwardingMap.get(forwardTo));
+                    toBeRemoved.add(l);
+                } else {
+                    // We have a label that cannot get forwarded, but it itself can be a target for forwarding
+                    forwardTo = l;
+                    forwardingMap.put(l, l);
+                }
+            } else if (cur instanceof CondJump) {
+                CondJump jump = (CondJump)cur;
+                // We forward the jump if possible
+                jump.setLabel(forwardingMap.getOrDefault(jump.getLabel(), jump.getLabel()));
+                numForwardedJumps++;
+                if (jump.isGoto()) {
+                    // If we have a goto, we can possibly forward directly to its target label
+                    forwardTo = jump.getLabel();
+                    if (nextIsGoto) {
+                        // We have 2 gotos in sequence... the latter cannot be reached
+                        toBeRemoved.add(next);
+                    }
+                } else {
+                    // We have a conditional jump, there is no clear forwarding doable
+                    forwardTo = null;
+                }
+            } else {
+                forwardTo = null;
+            }
+
+            nextIsGoto = (cur instanceof CondJump && (((CondJump) cur).isGoto()));
+            next = cur;
+        }
+
+        // Here is the actual removal
+        Event pred = null;
+        Event cur = thread.getEntry();
+        while (cur != null) {
+            if (toBeRemoved.contains(cur)) {
+                cur.delete(pred);
+                cur = pred;
+            }
+            pred = cur;
+            cur = cur.getSuccessor();
+        }
+
+        return numForwardedJumps;
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/JumpForwarding.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/JumpForwarding.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing;
 
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Label;
@@ -74,8 +75,10 @@ public class JumpForwarding implements ProgramProcessor {
                 // We forward the jump if possible
                 jump.setLabel(forwardingMap.getOrDefault(jump.getLabel(), jump.getLabel()));
                 numForwardedJumps++;
-                if (jump.isGoto()) {
+                if (jump.isGoto() && !jump.is(Tag.BOUND)) {
                     // If we have a goto, we can possibly forward directly to its target label
+                    // NOTE: We cannot forward past a bound jump, because that can make bound events
+                    // unreachable.
                     forwardTo = jump.getLabel();
                     if (nextIsGoto) {
                         // We have 2 gotos in sequence... the latter cannot be reached

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.program.processing;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.processing.compilation.Compilation;
-
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
@@ -53,6 +52,8 @@ public class ProcessingManager implements ProgramProcessor {
                 constantPropagation ? ConstantPropagation.fromConfig(config) : null,
                 DeadAssignmentElimination.fromConfig(config),
                 RemoveDeadCondJumps.fromConfig(config),
+                JumpForwarding.fromConfig(config),
+                // We should use DCE and/or Simplifier, but right now this causes problems
                 Compilation.fromConfig(config),
                 reduceSymmetry ? SymmetryReduction.fromConfig(config) : null
         ));


### PR DESCRIPTION
This PR adds a pass that simplifies the following types of code
```
lbl1; // Any jump to lbl1 can get forwarded to jump directly to lbl2
lbl2;
```
and
```
lbl; // Any jump to lbl can get forwarded to jump directly to X
goto X;
```

While this pass already deletes labels whose jumps can get forwarded, it still produces redundant code with e.g. multiple subsequent gotos.
It would be good to run DCE (Dead Code Elimination) afterwards, but this has currently 2 problems:
- DCE is assumed to run before unrolling and it will update the `oId` of events.
- DCE can remove assertions (cause e.g. the last loop iteration is unreachable and it contains an assertion). Removing assertions causes a lot of problems right now, because `Program` stores state about the assertions which needs to get updated properly. But updating the assertion requires knowing whether we have litmus code or boogie code.

After DCE, `Simplifier` can also remove code of the form of `goto lbl; lbl;`.
Running all these passes repeatedly also causes a lot of logging output which might be better summarized in a single logging message.
