### PR TITLE
Mod vs rem

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
@@ -127,7 +127,16 @@ public enum IOpBin {
             	case UDIV:
             		return bvmgr.divide(bv1, bv2, this.equals(DIV));
             	case MOD:
+            		BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
+            		BitvectorFormula rem = bvmgr.modulo(bv1, bv2, true);
+            		// Check if rem and bv2 have the same sign
+            		BooleanFormula cond = bvmgr.greaterThan(bvmgr.multiply(rem, bv2), bvmgr.makeBitvector(32, 1), true);
+            		// If they have the same sign, return the reminder, otherwise invert it
+            		bmgr.ifThenElse(cond, rem, bvmgr.negate(rem));
+            	case SREM:
             		return bvmgr.modulo(bv1, bv2, true);
+            	case UREM:
+            		return bvmgr.modulo(bv1, bv2, false);
             	case AND:
             		return bvmgr.and(bv1, bv2);
             	case OR:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
@@ -130,8 +130,10 @@ public enum IOpBin {
             		BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
             		BitvectorFormula rem = bvmgr.modulo(bv1, bv2, true);
             		// Check if rem and bv2 have the same sign
-            		BitvectorFormula srem = bvmgr.extract(rem, bvmgr.getLength(rem), bvmgr.getLength(rem), true);
-            		BitvectorFormula sbv2 = bvmgr.extract(rem, bvmgr.getLength(bv2), bvmgr.getLength(bv2), true);
+            		int rem_length = bvmgr.getLength(rem);
+            		int bv2_length = bvmgr.getLength(bv2);
+            		BitvectorFormula srem = bvmgr.extract(rem, rem_length-1, rem_length-1, true);
+            		BitvectorFormula sbv2 = bvmgr.extract(rem, bv2_length-1, bv2_length-1, true);
             		BooleanFormula cond = bvmgr.equal(srem, sbv2);
             		// If they have the same sign, return the reminder, otherwise invert it
             		return bmgr.ifThenElse(cond, rem, bvmgr.negate(rem));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
@@ -130,9 +130,10 @@ public enum IOpBin {
             		BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
             		BitvectorFormula rem = bvmgr.modulo(bv1, bv2, true);
             		// Check if rem and bv2 have the same sign
-            		BooleanFormula cond = bvmgr.greaterThan(bvmgr.multiply(rem, bv2), bvmgr.makeBitvector(32, 1), true);
+            		BooleanFormula cond = bvmgr.greaterThan(bvmgr.multiply(rem, bv2), 
+            												bvmgr.makeBitvector(bvmgr.getLength(bv1), 1), true);
             		// If they have the same sign, return the reminder, otherwise invert it
-            		bmgr.ifThenElse(cond, rem, bvmgr.negate(rem));
+            		return bmgr.ifThenElse(cond, rem, bvmgr.negate(rem));
             	case SREM:
             		return bvmgr.modulo(bv1, bv2, true);
             	case UREM:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
@@ -130,8 +130,9 @@ public enum IOpBin {
             		BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
             		BitvectorFormula rem = bvmgr.modulo(bv1, bv2, true);
             		// Check if rem and bv2 have the same sign
-            		BooleanFormula cond = bvmgr.greaterThan(bvmgr.multiply(rem, bv2), 
-            												bvmgr.makeBitvector(bvmgr.getLength(bv1), 1), true);
+            		BitvectorFormula srem = bvmgr.extract(rem, bvmgr.getLength(rem), bvmgr.getLength(rem), true);
+            		BitvectorFormula sbv2 = bvmgr.extract(rem, bvmgr.getLength(bv2), bvmgr.getLength(bv2), true);
+            		BooleanFormula cond = bvmgr.equal(srem, sbv2);
             		// If they have the same sign, return the reminder, otherwise invert it
             		return bmgr.ifThenElse(cond, rem, bvmgr.negate(rem));
             	case SREM:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
@@ -133,7 +133,7 @@ public enum IOpBin {
             		int rem_length = bvmgr.getLength(rem);
             		int bv2_length = bvmgr.getLength(bv2);
             		BitvectorFormula srem = bvmgr.extract(rem, rem_length-1, rem_length-1, true);
-            		BitvectorFormula sbv2 = bvmgr.extract(rem, bv2_length-1, bv2_length-1, true);
+            		BitvectorFormula sbv2 = bvmgr.extract(bv2, bv2_length-1, bv2_length-1, true);
             		BooleanFormula cond = bvmgr.equal(srem, sbv2);
             		// If they have the same sign, return the reminder, otherwise invert it
             		return bmgr.ifThenElse(cond, rem, bvmgr.negate(rem));


### PR DESCRIPTION
This PR adds encoding implementation to `srem` and `urem` in the case of BVs. As clarified by the java-SMT authors, what their API calls `modulo` is actually the reminder. You can compute `mod` for that one. I used this from [here](https://llvm.org/docs/LangRef.html)
> This instruction returns the remainder of a division (where the result is either zero or has the same sign as the dividend, op1), not the modulo operator (where the result is either zero or has the same sign as the divisor, op2) of a value.

to implement `mod`.