### PR TITLE
Format as program metadata

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -4,6 +4,7 @@ import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.parsers.witness.ParserWitness;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.verification.RefinementTask;
@@ -147,7 +148,7 @@ public class Dartagnan extends BaseOptions {
                 // Verification ended, we can interrupt the timeout Thread
                 t.interrupt();
 
-                if (fileProgram.getName().endsWith(".litmus")) {
+                if (p.getFormat().equals(Format.LITMUS)) {
                     if (p.getAssFilter() != null) {
                         System.out.println("Filter " + (p.getAssFilter()));
                     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.parsers.witness.ParserWitness;
 import com.dat3m.dartagnan.program.Program;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.verification.RefinementTask;
@@ -148,7 +148,7 @@ public class Dartagnan extends BaseOptions {
                 // Verification ended, we can interrupt the timeout Thread
                 t.interrupt();
 
-                if (p.getFormat().equals(Format.LITMUS)) {
+                if (p.getFormat().equals(SourceLanguage.LITMUS)) {
                     if (p.getAssFilter() != null) {
                         System.out.println("Filter " + (p.getAssFilter()));
                     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -4,6 +4,7 @@ import com.dat3m.dartagnan.asserts.AbstractAssert;
 import com.dat3m.dartagnan.exception.MalformedProgramException;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.EventFactory;
@@ -33,8 +34,8 @@ public class ProgramBuilder {
 
     private int lastOrigId = 0;
 
-    public Program build(){
-        Program program = new Program(memory);
+    public Program build(Format format){
+        Program program = new Program(memory, format);
         buildInitThreads();
         for(Thread thread : threads.values()){
         	addChild(thread.getId(), getOrCreateLabel("END_OF_T" + thread.getId()));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.asserts.AbstractAssert;
 import com.dat3m.dartagnan.exception.MalformedProgramException;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.program.Program;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.EventFactory;
@@ -34,7 +34,7 @@ public class ProgramBuilder {
 
     private int lastOrigId = 0;
 
-    public Program build(Format format){
+    public Program build(SourceLanguage format){
         Program program = new Program(memory, format);
         buildInitThreads();
         for(Thread thread : threads.values()){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -11,8 +11,8 @@ import com.dat3m.dartagnan.parsers.LitmusAArch64Parser;
 import com.dat3m.dartagnan.parsers.LitmusAArch64Visitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.arch.aarch64.StoreExclusive;
 import com.dat3m.dartagnan.program.event.core.Cmp;
@@ -57,7 +57,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(Format.LITMUS);
+        return programBuilder.build(SourceLanguage.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -12,6 +12,7 @@ import com.dat3m.dartagnan.parsers.LitmusAArch64Visitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.arch.aarch64.StoreExclusive;
 import com.dat3m.dartagnan.program.event.core.Cmp;
@@ -56,7 +57,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build();
+        return programBuilder.build(Format.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -10,7 +10,7 @@ import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
@@ -59,7 +59,7 @@ public class VisitorLitmusC
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(Format.LITMUS);
+        return programBuilder.build(SourceLanguage.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -10,6 +10,7 @@ import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
@@ -58,7 +59,7 @@ public class VisitorLitmusC
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build();
+        return programBuilder.build(Format.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
@@ -9,7 +9,7 @@ import com.dat3m.dartagnan.parsers.LitmusLISAVisitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -52,7 +52,7 @@ public class VisitorLitmusLISA
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(Format.LITMUS);
+        return programBuilder.build(SourceLanguage.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
@@ -9,6 +9,7 @@ import com.dat3m.dartagnan.parsers.LitmusLISAVisitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -51,7 +52,7 @@ public class VisitorLitmusLISA
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build();
+        return programBuilder.build(Format.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -11,6 +11,7 @@ import com.dat3m.dartagnan.parsers.LitmusPPCVisitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.Cmp;
 import com.dat3m.dartagnan.program.event.core.Event;
@@ -57,7 +58,7 @@ public class VisitorLitmusPPC
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build();
+        return programBuilder.build(Format.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -11,7 +11,7 @@ import com.dat3m.dartagnan.parsers.LitmusPPCVisitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.Cmp;
 import com.dat3m.dartagnan.program.event.core.Event;
@@ -58,7 +58,7 @@ public class VisitorLitmusPPC
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(Format.LITMUS);
+        return programBuilder.build(SourceLanguage.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
@@ -8,7 +8,7 @@ import com.dat3m.dartagnan.parsers.LitmusX86Visitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.collect.ImmutableSet;
@@ -53,7 +53,7 @@ public class VisitorLitmusX86
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(Format.LITMUS);
+        return programBuilder.build(SourceLanguage.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
@@ -8,6 +8,7 @@ import com.dat3m.dartagnan.parsers.LitmusX86Visitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.collect.ImmutableSet;
@@ -52,7 +53,7 @@ public class VisitorLitmusX86
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build();
+        return programBuilder.build(Format.LITMUS);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -16,6 +16,7 @@ import com.dat3m.dartagnan.parsers.program.boogie.PthreadPool;
 import com.dat3m.dartagnan.parsers.program.boogie.Scope;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
@@ -130,7 +131,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
     		pool.addIntPtr(threadCount + 1, next);
     		visitProc_decl(procedures.get(nextName), true, threadCallingValues.get(threadCount));	
     	}
-    	return programBuilder.build();
+    	return programBuilder.build(Format.BOOGIE);
     }
 
 	private void preProc_decl(Proc_declContext ctx) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -16,7 +16,7 @@ import com.dat3m.dartagnan.parsers.program.boogie.PthreadPool;
 import com.dat3m.dartagnan.parsers.program.boogie.Scope;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
@@ -131,7 +131,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
     		pool.addIntPtr(threadCount + 1, next);
     		visitProc_decl(procedures.get(nextName), true, threadCallingValues.get(threadCount));	
     	}
-    	return programBuilder.build(Format.BOOGIE);
+    	return programBuilder.build(SourceLanguage.BOOGIE);
     }
 
 	private void preProc_decl(Proc_declContext ctx) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
@@ -23,20 +23,20 @@ public class Program {
     private EventCache cache;
     private int unrollingBound = 0;
     private boolean isCompiled;
-    private Format format;
+    private SourceLanguage format;
 
-    public Program(Memory memory, Format format){
+    public Program(Memory memory, SourceLanguage format){
         this("", memory, format);
     }
 
-	public Program (String name, Memory memory, Format format) {
+	public Program (String name, Memory memory, SourceLanguage format) {
 		this.name = name;
 		this.memory = memory;
 		this.threads = new ArrayList<>();
 		this.format = format;
 	}
 
-	public Format getFormat(){
+	public SourceLanguage getFormat(){
         return format;
     }
 
@@ -143,5 +143,5 @@ public class Program {
         return true;
     }
     
-    public enum Format {LITMUS, BOOGIE;}
+    public enum SourceLanguage {LITMUS, BOOGIE;}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
@@ -23,16 +23,22 @@ public class Program {
     private EventCache cache;
     private int unrollingBound = 0;
     private boolean isCompiled;
+    private Format format;
 
-    public Program(Memory memory){
-        this("", memory);
+    public Program(Memory memory, Format format){
+        this("", memory, format);
     }
 
-	public Program (String name, Memory memory) {
+	public Program (String name, Memory memory, Format format) {
 		this.name = name;
 		this.memory = memory;
 		this.threads = new ArrayList<>();
+		this.format = format;
 	}
+
+	public Format getFormat(){
+        return format;
+    }
 
 	public boolean isCompiled(){
         return isCompiled;
@@ -136,4 +142,6 @@ public class Program {
         isCompiled = true;
         return true;
     }
+    
+    public enum Format {LITMUS, BOOGIE;}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.asserts.AssertInline;
 import com.dat3m.dartagnan.asserts.AssertTrue;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
@@ -80,7 +81,11 @@ public class LoopUnrolling implements ProgramProcessor {
         program.clearCache(false);
         program.markAsUnrolled(bound);
 
-        updateAssertions(program);
+    	// For litmus tests, assertions are not part of the program and thus this pass
+    	// must be avoid otherwise the real assertion is replaced by "true"
+        if(!program.getFormat().equals(Format.LITMUS)) {
+            updateAssertions(program);        	
+        }
 
         logger.info("Program unrolled {} times", bound);
         if(print) {
@@ -162,12 +167,6 @@ public class LoopUnrolling implements ProgramProcessor {
     }
     
     private void updateAssertions(Program program) {
-    	// For litmus tests, assertions are not part of the program and thus this pass
-    	// must be avoid otherwise the real assertion is replaced by "true"
-        if (program.getAss() != null) {
-            return;
-        }
-
         List<Event> assertions = new ArrayList<>();
         for(Thread t : program.getThreads()){
             assertions.addAll(t.getCache().getEvents(FilterBasic.get(Tag.ASSERTION)));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -6,7 +6,7 @@ import com.dat3m.dartagnan.asserts.AssertInline;
 import com.dat3m.dartagnan.asserts.AssertTrue;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
@@ -83,7 +83,7 @@ public class LoopUnrolling implements ProgramProcessor {
 
     	// For litmus tests, assertions are not part of the program and thus this pass
     	// must be avoid otherwise the real assertion is replaced by "true"
-        if(!program.getFormat().equals(Format.LITMUS)) {
+        if(!program.getFormat().equals(SourceLanguage.LITMUS)) {
             updateAssertions(program);        	
         }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
@@ -10,7 +10,7 @@ import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Skip;
@@ -45,7 +45,7 @@ public class ExceptionsTest {
     public void RegisterAlreadyExist() throws Exception {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
-    	Thread t = pb.build(Format.LITMUS).getThreads().get(0);
+    	Thread t = pb.build(SourceLanguage.LITMUS).getThreads().get(0);
     	t.addRegister("r1", -1);
     	// Adding same register a second time
     	t.addRegister("r1", -1);
@@ -57,14 +57,14 @@ public class ExceptionsTest {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
     	// Program must be unrolled first
-    	Compilation.newInstance().run(pb.build(Format.LITMUS));
+    	Compilation.newInstance().run(pb.build(SourceLanguage.LITMUS));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void unrollBeforeReorderException() throws Exception {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
-    	Program p = pb.build(Format.LITMUS);
+    	Program p = pb.build(SourceLanguage.LITMUS);
     	LoopUnrolling.newInstance().run(p);
     	// Reordering cannot be called after unrolling
     	BranchReordering.newInstance().run(p);
@@ -74,7 +74,7 @@ public class ExceptionsTest {
     public void initializedBeforeCompileException() throws Exception {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
-    	Program p = pb.build(Format.LITMUS);
+    	Program p = pb.build(SourceLanguage.LITMUS);
 		Wmm cat = new ParserCat().parse(new File(ResourceHelper.CAT_RESOURCE_PATH+ "cat/tso.cat"));
 		Configuration config = Configuration.defaultConfiguration();
 		VerificationTask task = VerificationTask.builder()
@@ -88,7 +88,7 @@ public class ExceptionsTest {
     public void unrollBeforeDCEException() throws Exception {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
-    	Program p = pb.build(Format.LITMUS);
+    	Program p = pb.build(SourceLanguage.LITMUS);
     	LoopUnrolling.newInstance().run(p);
     	// DCE cannot be called after unrolling
     	DeadCodeElimination.newInstance().run(p);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
@@ -10,6 +10,7 @@ import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Skip;
@@ -44,7 +45,7 @@ public class ExceptionsTest {
     public void RegisterAlreadyExist() throws Exception {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
-    	Thread t = pb.build().getThreads().get(0);
+    	Thread t = pb.build(Format.LITMUS).getThreads().get(0);
     	t.addRegister("r1", -1);
     	// Adding same register a second time
     	t.addRegister("r1", -1);
@@ -56,14 +57,14 @@ public class ExceptionsTest {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
     	// Program must be unrolled first
-    	Compilation.newInstance().run(pb.build());
+    	Compilation.newInstance().run(pb.build(Format.LITMUS));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void unrollBeforeReorderException() throws Exception {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
-    	Program p = pb.build();
+    	Program p = pb.build(Format.LITMUS);
     	LoopUnrolling.newInstance().run(p);
     	// Reordering cannot be called after unrolling
     	BranchReordering.newInstance().run(p);
@@ -73,7 +74,7 @@ public class ExceptionsTest {
     public void initializedBeforeCompileException() throws Exception {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
-    	Program p = pb.build();
+    	Program p = pb.build(Format.LITMUS);
 		Wmm cat = new ParserCat().parse(new File(ResourceHelper.CAT_RESOURCE_PATH+ "cat/tso.cat"));
 		Configuration config = Configuration.defaultConfiguration();
 		VerificationTask task = VerificationTask.builder()
@@ -87,7 +88,7 @@ public class ExceptionsTest {
     public void unrollBeforeDCEException() throws Exception {
     	ProgramBuilder pb = new ProgramBuilder();
     	pb.initThread(0);
-    	Program p = pb.build();
+    	Program p = pb.build(Format.LITMUS);
     	LoopUnrolling.newInstance().run(p);
     	// DCE cannot be called after unrolling
     	DeadCodeElimination.newInstance().run(p);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.exception.ProgramProcessingException;
 import com.dat3m.dartagnan.expression.BConst;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.EventFactory.Linux;
 import com.dat3m.dartagnan.program.event.core.Load;
@@ -29,7 +29,7 @@ public class UnrollExceptionsTest {
         pb.addChild(0, EventFactory.newRMWStore(load, object, IValue.ONE, null));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(Format.LITMUS));
+		processor.run(pb.build(SourceLanguage.LITMUS));
     }
 
     @Test(expected = ProgramProcessingException.class)
@@ -41,7 +41,7 @@ public class UnrollExceptionsTest {
         pb.addChild(0, Linux.newRMWStoreCond(load, object, IValue.ONE, null));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(Format.LITMUS));
+		processor.run(pb.build(SourceLanguage.LITMUS));
     }
 
     @Test(expected = ProgramProcessingException.class)
@@ -51,7 +51,7 @@ public class UnrollExceptionsTest {
     	pb.addChild(0, EventFactory.newRMWStoreExclusive(pb.getOrNewObject("X"), IValue.ONE, null, true));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(Format.LITMUS));
+		processor.run(pb.build(SourceLanguage.LITMUS));
     }
 
     @Test(expected = ProgramProcessingException.class)
@@ -63,7 +63,7 @@ public class UnrollExceptionsTest {
 		pb.addChild(0, Linux.newConditionalBarrier(load, null));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(Format.LITMUS));
+		processor.run(pb.build(SourceLanguage.LITMUS));
     }
 
     @Test(expected = ProgramProcessingException.class)
@@ -75,6 +75,6 @@ public class UnrollExceptionsTest {
 		pb.addChild(0, EventFactory.newExecutionStatus(pb.getOrCreateRegister(0, "r1", 32), store));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(Format.LITMUS));
+		processor.run(pb.build(SourceLanguage.LITMUS));
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
@@ -4,6 +4,7 @@ import com.dat3m.dartagnan.exception.ProgramProcessingException;
 import com.dat3m.dartagnan.expression.BConst;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.EventFactory.Linux;
 import com.dat3m.dartagnan.program.event.core.Load;
@@ -28,7 +29,7 @@ public class UnrollExceptionsTest {
         pb.addChild(0, EventFactory.newRMWStore(load, object, IValue.ONE, null));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build());
+		processor.run(pb.build(Format.LITMUS));
     }
 
     @Test(expected = ProgramProcessingException.class)
@@ -40,7 +41,7 @@ public class UnrollExceptionsTest {
         pb.addChild(0, Linux.newRMWStoreCond(load, object, IValue.ONE, null));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build());
+		processor.run(pb.build(Format.LITMUS));
     }
 
     @Test(expected = ProgramProcessingException.class)
@@ -50,7 +51,7 @@ public class UnrollExceptionsTest {
     	pb.addChild(0, EventFactory.newRMWStoreExclusive(pb.getOrNewObject("X"), IValue.ONE, null, true));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build());
+		processor.run(pb.build(Format.LITMUS));
     }
 
     @Test(expected = ProgramProcessingException.class)
@@ -62,7 +63,7 @@ public class UnrollExceptionsTest {
 		pb.addChild(0, Linux.newConditionalBarrier(load, null));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build());
+		processor.run(pb.build(Format.LITMUS));
     }
 
     @Test(expected = ProgramProcessingException.class)
@@ -74,6 +75,6 @@ public class UnrollExceptionsTest {
 		pb.addChild(0, EventFactory.newExecutionStatus(pb.getOrCreateRegister(0, "r1", 32), store));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build());
+		processor.run(pb.build(Format.LITMUS));
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AliasAnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AliasAnalysisTest.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.expression.op.BOpBin;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.Program.Format;
 import com.dat3m.dartagnan.program.analysis.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.*;
@@ -280,7 +281,7 @@ public class AliasAnalysisTest {
     }
 
     private AliasAnalysis analyze(ProgramBuilder builder, Alias method) throws InvalidConfigurationException {
-        Program program = builder.build();
+        Program program = builder.build(Format.LITMUS);
         LoopUnrolling.newInstance().run(program);
         Compilation.newInstance().run(program);
         return AliasAnalysis.fromConfig(program,Configuration.builder().setOption(ALIAS_METHOD,method.asStringOption()).build());

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AliasAnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AliasAnalysisTest.java
@@ -6,7 +6,7 @@ import com.dat3m.dartagnan.expression.op.BOpBin;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.Format;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.analysis.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.*;
@@ -281,7 +281,7 @@ public class AliasAnalysisTest {
     }
 
     private AliasAnalysis analyze(ProgramBuilder builder, Alias method) throws InvalidConfigurationException {
-        Program program = builder.build(Format.LITMUS);
+        Program program = builder.build(SourceLanguage.LITMUS);
         LoopUnrolling.newInstance().run(program);
         Compilation.newInstance().run(program);
         return AliasAnalysis.fromConfig(program,Configuration.builder().setOption(ALIAS_METHOD,method.asStringOption()).build());


### PR DESCRIPTION
This PR adds the format (litmus or bpl) as program metadata and provides a reliable and stable way of checking the format. Currently we are checking if the program has a "global" assertion to decide that the format is litmus, but this does not work anymore once we update inline assertions.