### PR TITLE
Compare expected with result in external tools

### DIFF
--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractExternalTool.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractExternalTool.java
@@ -23,7 +23,6 @@ public abstract class AbstractExternalTool {
 
     protected String name;
     protected Result expected;
-    protected String output = "";
 
     public AbstractExternalTool(String name, Result expected) {
         this.name = name;
@@ -36,7 +35,7 @@ public abstract class AbstractExternalTool {
     protected abstract Provider<String> getToolCmdProvider();
     protected abstract Provider<List<String>> getToolOptionsProvider();
     protected abstract long getTimeout();
-    protected abstract Result getResult();
+    protected abstract Result getResult(String output);
 
     protected Provider<Integer> getTimeoutProvider() {
         return Provider.fromSupplier(() -> 0);
@@ -86,9 +85,10 @@ public abstract class AbstractExternalTool {
     	Process proc = processBuilder.start();
 		BufferedReader read = new BufferedReader(new InputStreamReader(proc.getInputStream()));
 		proc.waitFor();
+		String output = "";
 		while(read.ready()) {
 			output += read.readLine();
 		}
-		assertEquals(expected, getResult());
+		assertEquals(expected, getResult(output));
 	}
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractExternalTool.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractExternalTool.java
@@ -4,6 +4,7 @@ import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.rules.CSVLogger;
 import com.dat3m.dartagnan.utils.rules.Provider;
 import com.dat3m.dartagnan.utils.rules.RequestShutdownOnError;
+
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,6 +12,10 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 import org.sosy_lab.common.ShutdownManager;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,6 +23,7 @@ public abstract class AbstractExternalTool {
 
     protected String name;
     protected Result expected;
+    protected String output = "";
 
     public AbstractExternalTool(String name, Result expected) {
         this.name = name;
@@ -30,6 +36,7 @@ public abstract class AbstractExternalTool {
     protected abstract Provider<String> getToolCmdProvider();
     protected abstract Provider<List<String>> getToolOptionsProvider();
     protected abstract long getTimeout();
+    protected abstract Result getResult();
 
     protected Provider<Integer> getTimeoutProvider() {
         return Provider.fromSupplier(() -> 0);
@@ -75,9 +82,13 @@ public abstract class AbstractExternalTool {
     	cmd.addAll(toolOptionsProvider.get());
     	cmd.add(filePathProvider.get());
     	ProcessBuilder processBuilder = new ProcessBuilder(cmd);
-    	processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
     	processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
     	Process proc = processBuilder.start();
+		BufferedReader read = new BufferedReader(new InputStreamReader(proc.getInputStream()));
 		proc.waitFor();
+		while(read.ready()) {
+			output += read.readLine();
+		}
+		assertEquals(expected, getResult());
 	}
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractHerd.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractHerd.java
@@ -56,7 +56,7 @@ public abstract class AbstractHerd extends AbstractExternalTool {
 	}
 
 	@Override
-	protected Result getResult() {
+	protected Result getResult(String output) {
 		return output.contains("Ok") ? FAIL : PASS;
 	}
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractHerd.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractHerd.java
@@ -4,6 +4,9 @@ import com.dat3m.dartagnan.utils.ResourceHelper;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.rules.Provider;
 
+import static com.dat3m.dartagnan.utils.Result.FAIL;
+import static com.dat3m.dartagnan.utils.Result.PASS;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,5 +53,10 @@ public abstract class AbstractHerd extends AbstractExternalTool {
 	@Override
 	protected Provider<String> getToolCmdProvider() {
 		return Provider.fromSupplier(() -> "herd7");
+	}
+
+	@Override
+	protected Result getResult() {
+		return output.contains("Ok") ? FAIL : PASS;
 	}
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Genmc.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Genmc.java
@@ -51,7 +51,7 @@ public class Genmc extends AbstractExternalTool {
             {"lfds/safe_stack-3", FAIL},
             {"lfds/chase-lev-5", PASS},
             {"lfds/dglm-3", PASS},
-            {"lfds/harris_linked_list-3", PASS},
+            {"lfds/harris-3", PASS},
             {"lfds/ms-3", PASS},
             {"lfds/treiber-3", PASS}
 		});

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Genmc.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Genmc.java
@@ -41,19 +41,24 @@ public class Genmc extends AbstractExternalTool {
 	@Parameterized.Parameters(name = "{index}: {0}, target={1}")
     public static Iterable<Object[]> data() throws IOException {
 		return Arrays.asList(new Object[][]{
-            {"locks/ttas-5", UNKNOWN},
+            {"locks/ttas-5", PASS},
             {"locks/ticketlock-6", PASS},
-            {"locks/mutex-4", UNKNOWN},
-            {"locks/spinlock-5", UNKNOWN},
-            {"locks/linuxrwlock-3", UNKNOWN},
-            {"locks/mutex_musl-4", UNKNOWN},
-            {"locks/seqlock-12", UNKNOWN},
+            {"locks/mutex-4", PASS},
+            {"locks/spinlock-5", PASS},
+            {"locks/linuxrwlock-3", PASS},
+            {"locks/mutex_musl-4", PASS},
+            {"locks/seqlock-12", PASS},
             {"lfds/safe_stack-3", FAIL},
             {"lfds/chase-lev-5", PASS},
-            {"lfds/dglm-3", UNKNOWN},
-            {"lfds/harris_linked_list-3", UNKNOWN},
-            {"lfds/ms-3", UNKNOWN},
-            {"lfds/treiber-3", UNKNOWN}
+            {"lfds/dglm-3", PASS},
+            {"lfds/harris_linked_list-3", PASS},
+            {"lfds/ms-3", PASS},
+            {"lfds/treiber-3", PASS}
 		});
     }
+
+	@Override
+	protected Result getResult() {
+		return output.contains("No errors were detected") ? PASS : FAIL;
+	}
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Genmc.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Genmc.java
@@ -58,7 +58,7 @@ public class Genmc extends AbstractExternalTool {
     }
 
 	@Override
-	protected Result getResult() {
+	protected Result getResult(String output) {
 		return output.contains("No errors were detected") ? PASS : FAIL;
 	}
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/HerdLinux.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/HerdLinux.java
@@ -26,7 +26,8 @@ public class HerdLinux extends AbstractHerd {
 	protected Provider<List<String>> getToolOptionsProvider() {
 		return Provider.fromSupplier(() -> {
 			String dat3m = System.getenv("DAT3M_HOME");
-			return Arrays.asList("-model", dat3m + "/cat/linux-kernel.cat", 
+			return Arrays.asList("-model", dat3m + "/cat/linux-kernel.cat",
+								"-I", dat3m + "/cat/",
 								"-macros", dat3m + "/cat/linux-kernel.def", 
 								"-bell", dat3m + "/cat/linux-kernel.bell");
 		});

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Nidhugg.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Nidhugg.java
@@ -59,19 +59,24 @@ public class Nidhugg extends AbstractExternalTool {
 	@Parameterized.Parameters(name = "{index}: {0}, target={1}")
     public static Iterable<Object[]> data() throws IOException {
 		return Arrays.asList(new Object[][]{
-            {"locks/ttas-5", UNKNOWN},
+            {"locks/ttas-5", PASS},
             {"locks/ticketlock-6", PASS},
-            {"locks/mutex-4", UNKNOWN},
-            {"locks/spinlock-5", UNKNOWN},
-            {"locks/linuxrwlock-3", UNKNOWN},
-            {"locks/mutex_musl-4", UNKNOWN},
-            {"locks/seqlock-12", UNKNOWN},
+            {"locks/mutex-4", PASS},
+            {"locks/spinlock-5", PASS},
+            {"locks/linuxrwlock-3", PASS},
+            {"locks/mutex_musl-4", PASS},
+            {"locks/seqlock-12", PASS},
             {"lfds/safestack-3", FAIL},
             {"lfds/chase-lev-5", PASS},
-            {"lfds/dglm-3", UNKNOWN},
-            {"lfds/harris_linked_list-3", UNKNOWN},
-            {"lfds/ms-3", UNKNOWN},
-            {"lfds/treiber-3", UNKNOWN}
+            {"lfds/dglm-3", PASS},
+            {"lfds/harris_linked_list-3", PASS},
+            {"lfds/ms-3", PASS},
+            {"lfds/treiber-3", PASS}
 		});
     }
+
+    @Override
+	protected Result getResult() {
+		return output.contains("No errors were detected") ? PASS : FAIL;
+	}
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Nidhugg.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Nidhugg.java
@@ -69,7 +69,7 @@ public class Nidhugg extends AbstractExternalTool {
             {"lfds/safestack-3", FAIL},
             {"lfds/chase-lev-5", PASS},
             {"lfds/dglm-3", PASS},
-            {"lfds/harris_linked_list-3", PASS},
+            {"lfds/harris-3", PASS},
             {"lfds/ms-3", PASS},
             {"lfds/treiber-3", PASS}
 		});

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Nidhugg.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/Nidhugg.java
@@ -76,7 +76,7 @@ public class Nidhugg extends AbstractExternalTool {
     }
 
     @Override
-	protected Result getResult() {
+	protected Result getResult(String output) {
 		return output.contains("No errors were detected") ? PASS : FAIL;
 	}
 }


### PR DESCRIPTION
The external tool unit tests were executing the corresponding tool, but never actually comparing the obtained result with the generated one. This PR adds this functionality.