### PR TITLE
Build on windows

### DIFF
--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -311,6 +311,78 @@
       </build>
     </profile>
 
+    <profile>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <id>windows</id>
+      <dependencies>
+        <!-- Z3 dependencies (Windows) -->
+        <dependency>
+          <groupId>org.sosy-lab</groupId>
+          <artifactId>javasmt-solver-z3</artifactId>
+          <version>4.8.10</version>
+          <type>dll</type>
+          <classifier>libz3</classifier>
+        </dependency>
+        <dependency>
+          <groupId>org.sosy-lab</groupId>
+          <artifactId>javasmt-solver-z3</artifactId>
+          <version>4.8.10</version>
+          <type>dll</type>
+          <classifier>libz3java</classifier>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.1.1</version>
+            <executions>
+              <execution>
+                <id>copy</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>copy-dependencies</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <outputDirectory>${project.dependency.path}</outputDirectory>
+              <artifactItems>
+                <!-- Z3 native libraries (MacOS) -->
+                <artifactItem>
+                  <groupId>org.sosy-lab</groupId>
+                  <artifactId>javasmt-solver-z3</artifactId>
+                  <type>dll</type>
+                  <classifier>libz3java</classifier>
+                  <destFileName>libz3java.dll</destFileName>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.sosy-lab</groupId>
+                  <artifactId>javasmt-solver-z3</artifactId>
+                  <type>dll</type>
+                  <classifier>libz3</classifier>
+                  <destFileName>libz3.dll</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
 
   <dependencies>

--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -129,59 +129,6 @@
       <build>
         <plugins>
           <plugin>
-      	    <groupId>org.jacoco</groupId>
-      		<artifactId>jacoco-maven-plugin</artifactId>
-      		<version>0.8.7</version>
-			<configuration>
-        	  <excludes>
-            	<exclude>**/parsers/*Parser.class</exclude>
-            	<exclude>**/parsers/*Lexer.class</exclude>
-            	<exclude>**/parsers/*Visitor.class</exclude>
-            	<exclude>**/parsers/*Context.class</exclude>
-            	<exclude>**/parsers/*Listener.class</exclude>
-        	  </excludes>
-    		</configuration>
-      		<executions>
-        	  <execution>
-          		<goals>
-            	  <goal>prepare-agent</goal>
-          		</goals>
-        	  </execution>
-        	  <execution>
-          		<id>generate-code-coverage-report</id>
-          		<phase>test</phase>
-          		<goals>
-              	  <goal>report</goal>
-          		</goals>
-        	  </execution>
-        	  <execution>
-          		<id>check</id>
-          		<goals>
-              	  <goal>check</goal>
-          		</goals>
-	    		<configuration>
-	        	  <rules>
-				    <rule>
-	            	  <element>BUNDLE</element>
-	            	  <limits>
-	              		<limit>
-	                	  <counter>LINE</counter>
-	                	  <value>COVEREDRATIO</value>
-	                	  <minimum>0.70</minimum>
-	              		</limit>
-	              	    <limit>
-	               		  <counter>BRANCH</counter>
-	                	  <value>COVEREDRATIO</value>
-	                	  <minimum>0.60</minimum>
-	              		</limit>
-	            	  </limits>
-	          		</rule>
-	        	  </rules>
-	    		</configuration>
-        	  </execution>
-      		</executions>
-      	  </plugin>
-          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
             <version>3.1.1</version>
@@ -319,59 +266,6 @@
 
       <build>
         <plugins>
-          <plugin>
-      	    <groupId>org.jacoco</groupId>
-      		<artifactId>jacoco-maven-plugin</artifactId>
-      		<version>0.8.7</version>
-      		<configuration>
-        	  <excludes>
-            	<exclude>**/parsers/*Parser.class</exclude>
-            	<exclude>**/parsers/*Lexer.class</exclude>
-            	<exclude>**/parsers/*Visitor.class</exclude>
-            	<exclude>**/parsers/*Context.class</exclude>
-				<exclude>**/parsers/*Listener.class</exclude>
-        	  </excludes>
-    		</configuration>
-      		<executions>
-        	  <execution>
-          		<goals>
-            	  <goal>prepare-agent</goal>
-          		</goals>
-        	  </execution>
-        	  <execution>
-          		<id>generate-code-coverage-report</id>
-          		<phase>test</phase>
-          		<goals>
-              	  <goal>report</goal>
-          		</goals>
-        	  </execution>
-        	  <execution>
-          		<id>check</id>
-          		<goals>
-              	  <goal>check</goal>
-          		</goals>
-	    		<configuration>
-	        	  <rules>
-				    <rule>
-	            	  <element>BUNDLE</element>
-	            	  <limits>
-	              		<limit>
-	                	  <counter>LINE</counter>
-	                	  <value>COVEREDRATIO</value>
-	                	  <minimum>0.70</minimum>
-	              		</limit>
-	              	    <limit>
-	               		  <counter>BRANCH</counter>
-	                	  <value>COVEREDRATIO</value>
-	                	  <minimum>0.60</minimum>
-	              		</limit>
-	            	  </limits>
-	          		</rule>
-	        	  </rules>
-	    		</configuration>
-        	  </execution>
-      		</executions>
-      	  </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
@@ -551,6 +445,59 @@
           <source>11</source>
           <target>11</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.7</version>
+        <configuration>
+          <excludes>
+            <exclude>**/parsers/*Parser.class</exclude>
+            <exclude>**/parsers/*Lexer.class</exclude>
+            <exclude>**/parsers/*Visitor.class</exclude>
+            <exclude>**/parsers/*Context.class</exclude>
+            <exclude>**/parsers/*Listener.class</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>generate-code-coverage-report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.70</minimum>
+                    </limit>
+                    <limit>
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.60</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -319,7 +319,7 @@
       </activation>
       <id>windows</id>
       <dependencies>
-        <!-- MathSAT5 dependency (Linux) -->
+        <!-- MathSAT5 dependency (Windows) -->
         <dependency>
           <groupId>org.sosy-lab</groupId>
           <artifactId>javasmt-solver-mathsat5</artifactId>

--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -319,6 +319,28 @@
       </activation>
       <id>windows</id>
       <dependencies>
+        <!-- MathSAT5 dependency (Linux) -->
+        <dependency>
+          <groupId>org.sosy-lab</groupId>
+          <artifactId>javasmt-solver-mathsat5</artifactId>
+          <version>5.6.6</version>
+          <classifier>mathsat5j</classifier>
+          <type>dll</type>
+        </dependency>
+        <dependency>
+          <groupId>org.sosy-lab</groupId>
+          <artifactId>javasmt-solver-mathsat5</artifactId>
+          <version>5.6.6</version>
+          <classifier>mathsat</classifier>
+          <type>dll</type>
+        </dependency>
+        <dependency>
+          <groupId>org.sosy-lab</groupId>
+          <artifactId>javasmt-solver-mathsat5</artifactId>
+          <version>5.6.6</version>
+          <classifier>mpir</classifier>
+          <type>dll</type>
+        </dependency>
         <!-- Z3 dependencies (Windows) -->
         <dependency>
           <groupId>org.sosy-lab</groupId>
@@ -361,7 +383,29 @@
             <configuration>
               <outputDirectory>${project.dependency.path}</outputDirectory>
               <artifactItems>
-                <!-- Z3 native libraries (MacOS) -->
+                <!-- MathSAT5 native library (Windows) -->
+                <artifactItem>
+                  <groupId>org.sosy-lab</groupId>
+                  <artifactId>javasmt-solver-mathsat5</artifactId>
+                  <type>dll</type>
+                  <classifier>mathsat5j</classifier>
+                  <destFileName>mathsat5j.dll</destFileName>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.sosy-lab</groupId>
+                  <artifactId>javasmt-solver-mathsat5</artifactId>
+                  <type>dll</type>
+                  <classifier>mathsat</classifier>
+                  <destFileName>mathsat.dll</destFileName>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.sosy-lab</groupId>
+                  <artifactId>javasmt-solver-mathsat5</artifactId>
+                  <type>dll</type>
+                  <classifier>mpir</classifier>
+                  <destFileName>mpir.dll</destFileName>
+                </artifactItem>
+                <!-- Z3 native libraries (Windows) -->
                 <artifactItem>
                   <groupId>org.sosy-lab</groupId>
                   <artifactId>javasmt-solver-z3</artifactId>


### PR DESCRIPTION
Adds the settings profile 'windows'.  While linux builds require the .so files of Z3 to be present and mac-os needs .dylib files, my machine successfully passed the test suites with just the .dll files.  This should improve the platform-independent development.

Tested on:
Edition: Windows 10 Home (64bit)
Version: 21H2
Processor: Intel Core i5 3450 @3.1GHz
Maven Version: 3.8.1

This PR also moves the coverage plugin setting into the purely module-specific section of the POM.  I was not able to find any discussion on why each profile had its own coverage settings, but suspect it may have some function.