### PR TITLE
Do not simplify atoms using signed comparisons

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/COpBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/COpBin.java
@@ -58,6 +58,18 @@ public enum COpBin {
         }
     }
 
+    public boolean isSigned() {
+        switch(this){
+            case EQ: case NEQ:
+            case GTE: case LTE: case GT: case LT:
+            	return true;
+            case UGTE: case ULTE: case UGT: case ULT:
+            	return false;
+            default:
+                throw new UnsupportedOperationException(this + " cannot be inverted");
+        }
+    }
+
     public BooleanFormula encode(Formula e1, Formula e2, SolverContext ctx) {
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
         if(e1 instanceof BooleanFormula && e2 instanceof BooleanFormula) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ConstantPropagation.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing;
 
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.BOpUn;
+import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.expression.op.IOpUn;
 import com.dat3m.dartagnan.expression.processing.ExprSimplifier;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
@@ -169,7 +170,8 @@ public class ConstantPropagation implements ProgramProcessor {
     		Atom atom = (Atom)input;
     		ExprInterface lhs = evaluate(atom.getLHS(), map);
     		ExprInterface rhs = evaluate(atom.getRHS(), map);
-			return (lhs == TOP | rhs == TOP) ? TOP : new Atom(lhs, atom.getOp(), rhs).visit(simplifier);
+			COpBin op = atom.getOp();
+			return (lhs == TOP | rhs == TOP || op.isSigned()) ? TOP : new Atom(lhs, op, rhs).visit(simplifier);
     	}
     	if(input instanceof BExprUn) {
     		BExprUn un = (BExprUn)input;


### PR DESCRIPTION
The simplifications done by constant propagation are unsound (when using `ARCH_PRECISION != -1`, i.e. bit-vectors) for `Atom`s if the comparison is signed. 

This was causing problems with `linuxrwlock` if `ARCH_PRECISION == 64`.

This PR fixes this issue.