### PR TITLE
Use BigInteger.reminder() instead of BigInteger.mod() in

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpBin.java
@@ -173,9 +173,10 @@ public enum IOpBin {
             case UDIV:
                 return a.divide(b);
             case MOD:
+                return a.mod(b);
             case SREM:
             case UREM:
-                return a.mod(b);
+                return a.remainder(b);
             case AND:
                 return a.and(b);
             case OR:

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/LFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/LFDSTest.java
@@ -69,16 +69,12 @@ public class LFDSTest extends AbstractCTest {
             {"treiber-3-CAS-relaxed", NONE, FAIL},
             {"chase-lev-5", TSO, PASS},
             {"chase-lev-5", ARM8, PASS},
-            {"chase-lev-5", POWER, PASS},
-            // TODO chase-lev currently has a problem which results in a null pointer.
-            // It seems to be a problem with model extraction. However this does not always happen.
-            // For the moment we don't run these two tests to avoid the CI potentially failing.
-//            {"chase-lev-5", NONE, PASS},
+            {"chase-lev-5", NONE, PASS},
             // These ones have an extra thief that violate the assertion
             {"chase-lev-6", TSO, FAIL},
             {"chase-lev-6", ARM8, FAIL},
             {"chase-lev-6", POWER, FAIL},
-//            {"chase-lev-6", NONE, FAIL},
+            {"chase-lev-6", NONE, FAIL},
         });
     }
 


### PR DESCRIPTION
`Chase-lev` under `RC11` used to failed sporadically. The reason was probable that we were using the wrong `BigInteger` method when combining values. I tested that benchmarks several (>20) times now and it does not fail. Without the changes of this PR it failed 1 out of ~5 times I tried. Thus it seems the problem is actually fixed.

@ThomasHaas the other day you managed to add a break point somewhere and detected that we had a rf-edge for two events not having the same address. I did not find the way of doing this. Can you please check if this does not happen anymore with the proposed changes?