### PR TITLE
No-optimisable tag

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
@@ -18,6 +18,22 @@ public class ExprSimplifier extends ExprTransformer {
     public ExprInterface visit(Atom atom) {
         ExprInterface lhs = atom.getLHS().visit(this);
         ExprInterface rhs = atom.getRHS().visit(this);
+        if (lhs instanceof Register && rhs instanceof Register && lhs.equals(rhs)) {
+        	switch(atom.getOp()) {
+        		case EQ:
+        		case LTE:
+        		case ULTE:
+        		case GTE:
+        		case UGTE:
+        			return BConst.TRUE;
+        		case NEQ:
+        		case LT:
+        		case ULT:
+        		case GT:
+        		case UGT:
+        			return BConst.FALSE;
+        	}
+        }
         if (lhs instanceof IConst && rhs instanceof  IConst) {
             IConst lc = (IConst) lhs;
             IConst rc = (IConst) rhs;
@@ -119,6 +135,15 @@ public class ExprSimplifier extends ExprTransformer {
         IExpr lhs = (IExpr)iBin.getLHS().visit(this);
         IExpr rhs = (IExpr)iBin.getRHS().visit(this);
         IOpBin op = iBin.getOp();
+        if (lhs instanceof Register && rhs instanceof Register && lhs.equals(rhs)) {
+        	switch(op) {
+        		case AND:
+        		case OR:
+        			return lhs;
+        		case XOR:
+        			return IValue.ZERO;
+        	}
+        }
         if (! (lhs instanceof IConst || rhs instanceof IConst)) {
             return new IExprBin(lhs, iBin.getOp(), rhs);
         } else if (lhs instanceof IConst && rhs instanceof IConst) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserBoogie.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.exception.ParserErrorListener;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.parsers.program.visitors.boogie.VisitorBoogie;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 
 import org.antlr.v4.runtime.*;
 
@@ -18,7 +19,7 @@ class ParserBoogie implements ParserInterface{
 
         BoogieParser parser = new BoogieParser(tokenStream);
         parser.addErrorListener(new ParserErrorListener());
-        ProgramBuilder pb = new ProgramBuilder();
+        ProgramBuilder pb = new ProgramBuilder(SourceLanguage.BOOGIE);
         ParserRuleContext parserEntryPoint = parser.main();
         VisitorBoogie visitor = new VisitorBoogie(pb);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusAArch64.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.exception.ParserErrorListener;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.parsers.program.visitors.VisitorLitmusAArch64;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.configuration.Arch;
 
 import org.antlr.v4.runtime.*;
@@ -20,7 +21,7 @@ class ParserLitmusAArch64 implements ParserInterface {
         LitmusAArch64Parser parser = new LitmusAArch64Parser(tokenStream);
         parser.addErrorListener(new DiagnosticErrorListener(true));
         parser.addErrorListener(new ParserErrorListener());
-        ProgramBuilder pb = new ProgramBuilder();
+        ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
         ParserRuleContext parserEntryPoint = parser.main();
         VisitorLitmusAArch64 visitor = new VisitorLitmusAArch64(pb);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusC.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.parsers.LitmusCParser;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.parsers.program.visitors.VisitorLitmusC;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.configuration.Arch;
 
 import org.antlr.v4.runtime.*;
@@ -18,7 +19,7 @@ class ParserLitmusC implements ParserInterface {
 
         LitmusCParser parser = new LitmusCParser(tokenStream);
         parser.setErrorHandler(new BailErrorStrategy());
-        ProgramBuilder pb = new ProgramBuilder();
+        ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
         ParserRuleContext parserEntryPoint = parser.main();
         VisitorLitmusC visitor = new VisitorLitmusC(pb);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusLISA.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusLISA.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.exception.ParserErrorListener;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.parsers.program.visitors.VisitorLitmusLISA;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 
 import org.antlr.v4.runtime.*;
 
@@ -19,7 +20,7 @@ class ParserLitmusLISA implements ParserInterface {
         LitmusLISAParser parser = new LitmusLISAParser(tokenStream);
         parser.addErrorListener(new DiagnosticErrorListener(true));
         parser.addErrorListener(new ParserErrorListener());
-        ProgramBuilder pb = new ProgramBuilder();
+        ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
         ParserRuleContext parserEntryPoint = parser.main();
         VisitorLitmusLISA visitor = new VisitorLitmusLISA(pb);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusPPC.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.exception.ParserErrorListener;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.parsers.program.visitors.VisitorLitmusPPC;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.configuration.Arch;
 
 import org.antlr.v4.runtime.*;
@@ -20,7 +21,7 @@ class ParserLitmusPPC implements ParserInterface {
         LitmusPPCParser parser = new LitmusPPCParser(tokenStream);
         parser.addErrorListener(new DiagnosticErrorListener(true));
         parser.addErrorListener(new ParserErrorListener());
-        ProgramBuilder pb = new ProgramBuilder();
+        ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
         ParserRuleContext parserEntryPoint = parser.main();
         VisitorLitmusPPC visitor = new VisitorLitmusPPC(pb);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusX86.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.exception.ParserErrorListener;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.parsers.program.visitors.VisitorLitmusX86;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.configuration.Arch;
 
 import org.antlr.v4.runtime.*;
@@ -20,7 +21,7 @@ class ParserLitmusX86 implements ParserInterface {
         LitmusX86Parser parser = new LitmusX86Parser(tokenStream);
         parser.addErrorListener(new DiagnosticErrorListener(true));
         parser.addErrorListener(new ParserErrorListener());
-        ProgramBuilder pb = new ProgramBuilder();
+        ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
         ParserRuleContext parserEntryPoint = parser.main();
         VisitorLitmusX86 visitor = new VisitorLitmusX86(pb);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -8,6 +8,7 @@ import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.EventFactory;
+import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Label;
@@ -20,6 +21,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class ProgramBuilder {
@@ -36,8 +38,14 @@ public class ProgramBuilder {
     private AbstractAssert assFilter;
 
     private int lastOrigId = 0;
+    
+    private SourceLanguage format;
 
-    public Program build(SourceLanguage format){
+    public ProgramBuilder(SourceLanguage format) {
+    	this.format = format;
+    }
+    
+    public Program build(){
         Program program = new Program(memory, format);
         buildInitThreads();
         for(Thread thread : threads.values()){
@@ -68,6 +76,10 @@ public class ProgramBuilder {
         }
         child.setOId(lastOrigId++);
         threads.get(thread).append(child);
+        // Every event in litmus tests is no-optimisable
+        if(format.equals(LITMUS)) {
+            child.addFilters(Tag.NOOPT);
+        }
         return child;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -11,7 +11,6 @@ import com.dat3m.dartagnan.parsers.LitmusAArch64Parser;
 import com.dat3m.dartagnan.parsers.LitmusAArch64Visitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
-import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.arch.aarch64.StoreExclusive;
@@ -57,7 +56,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object>
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(SourceLanguage.LITMUS);
+        return programBuilder.build();
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -10,7 +10,6 @@ import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
@@ -59,7 +58,7 @@ public class VisitorLitmusC
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(SourceLanguage.LITMUS);
+        return programBuilder.build();
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
@@ -9,7 +9,6 @@ import com.dat3m.dartagnan.parsers.LitmusLISAVisitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -52,7 +51,7 @@ public class VisitorLitmusLISA
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(SourceLanguage.LITMUS);
+        return programBuilder.build();
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -11,7 +11,6 @@ import com.dat3m.dartagnan.parsers.LitmusPPCVisitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.Cmp;
 import com.dat3m.dartagnan.program.event.core.Event;
@@ -58,7 +57,7 @@ public class VisitorLitmusPPC
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(SourceLanguage.LITMUS);
+        return programBuilder.build();
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
@@ -8,7 +8,6 @@ import com.dat3m.dartagnan.parsers.LitmusX86Visitor;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.collect.ImmutableSet;
@@ -53,7 +52,7 @@ public class VisitorLitmusX86
             String raw = ctx.assertionFilter().getStart().getInputStream().getText(new Interval(a, b));
             programBuilder.setAssertFilter(AssertionHelper.parseAssertionFilter(programBuilder, raw));
         }
-        return programBuilder.build(SourceLanguage.LITMUS);
+        return programBuilder.build();
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -16,7 +16,6 @@ import com.dat3m.dartagnan.parsers.program.boogie.PthreadPool;
 import com.dat3m.dartagnan.parsers.program.boogie.Scope;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
@@ -131,7 +130,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
     		pool.addIntPtr(threadCount + 1, next);
     		visitProc_decl(procedures.get(nextName), true, threadCallingValues.get(threadCount));	
     	}
-    	return programBuilder.build(SourceLanguage.BOOGIE);
+    	return programBuilder.build();
     }
 
 	private void preProc_decl(Proc_declContext ctx) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
@@ -23,6 +23,8 @@ public final class Tag {
     public static final String ASSERTION    = "ASS";
     public static final String BOUND   		= "BOUND";
     public static final String SPINLOOP   	= "SPINLOOP";
+    // Some events should not be optimized (e.g. fake dependencies) or delete (e.g. bounds)
+    public static final String NOOPT   		= "NOOOPT";
 
     // =============================================================================================
     // =========================================== ARMv8 ===========================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
@@ -23,7 +23,7 @@ public final class Tag {
     public static final String ASSERTION    = "ASS";
     public static final String BOUND   		= "BOUND";
     public static final String SPINLOOP   	= "SPINLOOP";
-    // Some events should not be optimized (e.g. fake dependencies) or delete (e.g. bounds)
+    // Some events should not be optimized (e.g. fake dependencies) or deleted (e.g. bounds)
     public static final String NOOPT   		= "NOOOPT";
 
     // =============================================================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
@@ -6,9 +6,12 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.verification.Context;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.SolverContext;
+
+import static com.dat3m.dartagnan.program.event.Tag.NOOPT;
 
 import java.util.*;
 
@@ -138,6 +141,7 @@ public abstract class Event implements Encoder, Comparable<Event> {
     }
 
 	public void delete(Event pred) {
+		Verify.verify(!hasFilter(NOOPT));
 		if (pred != null) {
 			pred.successor = this.successor;
 		}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ConstantPropagation.java
@@ -110,7 +110,9 @@ public class ConstantPropagation implements ProgramProcessor {
         		propagationMap = merge(propagationMap, label2PropagationMap.getOrDefault(current, Collections.emptyMap()));
         	}
 
-        	current.accept(new ConstantPropagationVisitor(propagationMap));
+        	if(!current.is(Tag.NOOPT)) {
+            	current.accept(new ConstantPropagationVisitor(propagationMap));
+        	}
             current = current.getSuccessor();
 
 			if (resetPropMap) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadAssignmentElimination.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadAssignmentElimination.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan.program.processing;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
@@ -90,7 +91,7 @@ public class DeadAssignmentElimination implements ProgramProcessor {
         Event pred = null;
         Event cur = thread.getEntry();
         while (cur != null) {
-            if (removed.contains(cur)) {
+            if (removed.contains(cur) && !cur.is(Tag.NOOPT)) {
                 cur.delete(pred);
                 cur = pred;
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadCodeElimination.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadCodeElimination.java
@@ -60,7 +60,7 @@ public class DeadCodeElimination implements ProgramProcessor {
         Event cur = entry;
         int id = startId;
         while (cur != null) {
-            if (!reachableEvents.contains(cur) && cur != exit) {
+            if (!reachableEvents.contains(cur) && cur != exit && !cur.is(Tag.NOOPT)) {
                 cur.delete(pred);
                 cur = pred;
             } else {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/FindSpinLoops.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/FindSpinLoops.java
@@ -72,8 +72,8 @@ public class FindSpinLoops implements ProgramProcessor {
         	    // for (int tmp = (__VERIFIER_loop_begin(), 0); __VERIFIER_spin_start(),  \
         	    //     tmp = cond, __VERIFIER_spin_end(!tmp), tmp;)
         		Event spinloop = curr.getSuccessors().stream().filter(e -> e instanceof CondJump && ((CondJump)e).isGoto()).findFirst().get();
-        		spinloop.addFilters(Tag.SPINLOOP);
-                ((CondJump)spinloop).getLabel().addFilters(Tag.SPINLOOP);
+        		spinloop.addFilters(Tag.SPINLOOP, Tag.NOOPT);
+                ((CondJump)spinloop).getLabel().addFilters(Tag.SPINLOOP, Tag.NOOPT);
         		spinloops++;
         	}
             curr = curr.getSuccessor();
@@ -93,8 +93,8 @@ public class FindSpinLoops implements ProgramProcessor {
                     Label loopStart = label;
                     CondJump loopEnd = (CondJump) listener.get();
                     if (isSideEffectFree(loopStart, loopEnd)) {
-                        loopStart.addFilters(Tag.SPINLOOP);
-                        loopEnd.addFilters(Tag.SPINLOOP);
+                        loopStart.addFilters(Tag.SPINLOOP, Tag.NOOPT);
+                        loopEnd.addFilters(Tag.SPINLOOP, Tag.NOOPT);
                         spinloops++;
                     }
                 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -113,9 +113,9 @@ public class LoopUnrolling implements ProgramProcessor {
                 if (bound == 1 || jump.hasFilter(Tag.SPINLOOP)) {
                     Label target = (Label) jump.getThread().getExit();
                     newPred = EventFactory.newGoto(target);
-                    newPred.addFilters(Tag.BOUND);
+                    newPred.addFilters(Tag.BOUND, Tag.NOOPT);
                     if(jump.hasFilter(Tag.SPINLOOP)) {
-                    	newPred.addFilters(Tag.SPINLOOP);
+                    	newPred.addFilters(Tag.SPINLOOP, Tag.NOOPT);
                     }
                     predecessor.setSuccessor(newPred);
                 } else {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadCondJumps.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadCondJumps.java
@@ -59,8 +59,7 @@ public class RemoveDeadCondJumps implements ProgramProcessor {
         	if(current instanceof CondJump) {
         		CondJump jump = (CondJump)current;
         		// After constant propagation some jumps have False as condition and are dead
-        		// But we still need to keep BOUND events
-        		if(jump.isDead() && !jump.is(Tag.BOUND)) {
+        		if(jump.isDead()) {
         			removed.add(jump);
         		} else {
                     immediateLabelPredecessors.computeIfAbsent(jump.getLabel(), key -> new ArrayList<>()).add(jump);
@@ -75,11 +74,12 @@ public class RemoveDeadCondJumps implements ProgramProcessor {
         for(Event label : immediateLabelPredecessors.keySet()) {
         	Event next = label.getSuccessor();
             List<Event> preds = immediateLabelPredecessors.get(label);
-        	// We never remove BOUND events
-			if(next instanceof CondJump && !next.is(Tag.BOUND) && preds.stream().allMatch(e -> mutuallyExclusiveIfs((CondJump)next, e))) {
+        	// BOUND events
+			if(next instanceof CondJump && preds.stream().allMatch(e -> mutuallyExclusiveIfs((CondJump)next, e))) {
 				removed.add(next);
 			}
-            if (next != null && preds.size() == 1 && preds.get(0).getSuccessor().equals(label) && !label.is(Tag.SPINLOOP)) {
+        	// SPINLOOP events
+            if (next != null && preds.size() == 1 && preds.get(0).getSuccessor().equals(label)) {
                 removed.add(label);
             }
         }
@@ -97,7 +97,7 @@ public class RemoveDeadCondJumps implements ProgramProcessor {
             if(dead && immediateLabelPredecessors.containsKey(cur.getSuccessor())) {
                 immediateLabelPredecessors.get(cur.getSuccessor()).remove(cur);
             }
-            if(dead || removed.contains(cur)) {
+            if(dead || removed.contains(cur) && !cur.is(Tag.NOOPT)) {
                 cur.delete(pred);
                 cur = pred;
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadCondJumps.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadCondJumps.java
@@ -97,7 +97,7 @@ public class RemoveDeadCondJumps implements ProgramProcessor {
             if(dead && immediateLabelPredecessors.containsKey(cur.getSuccessor())) {
                 immediateLabelPredecessors.get(cur.getSuccessor()).remove(cur);
             }
-            if(dead || removed.contains(cur) && !cur.is(Tag.NOOPT)) {
+            if((dead || removed.contains(cur)) && !cur.is(Tag.NOOPT)) {
                 cur.delete(pred);
                 cur = pred;
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -141,6 +141,7 @@ class VisitorArm8 extends VisitorBase implements EventVisitor<List<Event>> {
         Store store = newRMWStoreExclusive(address, dummyReg, Tag.ARMv8.extractStoreMoFromCMo(mo), true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        fakeCtrlDep.addFilters(Tag.NOOPT);
 
         return eventSequence(
                 load,
@@ -187,6 +188,7 @@ class VisitorArm8 extends VisitorBase implements EventVisitor<List<Event>> {
         Store store = newRMWStoreExclusive(address, value, Tag.ARMv8.extractStoreMoFromCMo(mo), true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        fakeCtrlDep.addFilters(Tag.NOOPT);
 
         return eventSequence(
                 load,

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
@@ -38,16 +38,16 @@ public class ExceptionsTest {
 
     @Test(expected = MalformedProgramException.class)
     public void noThread() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	// Thread 1 does not exists
     	pb.addChild(1, new Skip());
     }
 
     @Test(expected = MalformedProgramException.class)
     public void RegisterAlreadyExist() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
-    	Thread t = pb.build(SourceLanguage.LITMUS).getThreads().get(0);
+    	Thread t = pb.build().getThreads().get(0);
     	t.newRegister("r1", -1);
     	// Adding same register a second time
     	t.newRegister("r1", -1);
@@ -56,17 +56,17 @@ public class ExceptionsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void compileBeforeUnrollException() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
     	// Program must be unrolled first
-    	Compilation.newInstance().run(pb.build(SourceLanguage.LITMUS));
+    	Compilation.newInstance().run(pb.build());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void unrollBeforeReorderException() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
-    	Program p = pb.build(SourceLanguage.LITMUS);
+    	Program p = pb.build();
     	LoopUnrolling.newInstance().run(p);
     	// Reordering cannot be called after unrolling
     	BranchReordering.newInstance().run(p);
@@ -74,9 +74,9 @@ public class ExceptionsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void initializedBeforeCompileException() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
-    	Program p = pb.build(SourceLanguage.LITMUS);
+    	Program p = pb.build();
 		Wmm cat = new ParserCat().parse(new File(ResourceHelper.CAT_RESOURCE_PATH+ "cat/tso.cat"));
 		Configuration config = Configuration.defaultConfiguration();
 		VerificationTask task = VerificationTask.builder()
@@ -88,9 +88,9 @@ public class ExceptionsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void unrollBeforeDCEException() throws Exception {
-        ProgramBuilder pb = new ProgramBuilder();
+        ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
         pb.initThread(0);
-        Program p = pb.build(SourceLanguage.LITMUS);
+        Program p = pb.build();
         LoopUnrolling.newInstance().run(p);
         // DCE cannot be called after unrolling
         DeadCodeElimination.newInstance().run(p);
@@ -124,7 +124,7 @@ public class ExceptionsTest {
     
     @Test(expected = NullPointerException.class)
     public void JumpWithNullLabel() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
     	// Label cannot be null
     	pb.addChild(0, new CondJump(BConst.FALSE, null));
@@ -132,7 +132,7 @@ public class ExceptionsTest {
 
     @Test(expected = NullPointerException.class)
     public void JumpWithNullExpr() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
     	Label end = pb.getOrCreateLabel("END");
     	// The expr cannot be null

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
@@ -22,59 +22,59 @@ public class UnrollExceptionsTest {
 	
     @Test(expected = ProgramProcessingException.class)
     public void RMWStore() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
         MemoryObject object = pb.getOrNewObject("X");
         Load load = EventFactory.newRMWLoad(pb.getOrCreateRegister(0, "r1", 32), object, null);
         pb.addChild(0, EventFactory.newRMWStore(load, object, IValue.ONE, null));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(SourceLanguage.LITMUS));
+		processor.run(pb.build());
     }
 
     @Test(expected = ProgramProcessingException.class)
     public void RMWStoreCon() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
         MemoryObject object = pb.getOrNewObject("X");
         RMWReadCond load = Linux.newRMWReadCondCmp(pb.getOrCreateRegister(0, "r1", 32), BConst.TRUE, object, null);
         pb.addChild(0, Linux.newRMWStoreCond(load, object, IValue.ONE, null));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(SourceLanguage.LITMUS));
+		processor.run(pb.build());
     }
 
     @Test(expected = ProgramProcessingException.class)
     public void RMWStoreExclusive() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
     	pb.addChild(0, EventFactory.newRMWStoreExclusive(pb.getOrNewObject("X"), IValue.ONE, null, true));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(SourceLanguage.LITMUS));
+		processor.run(pb.build());
     }
 
     @Test(expected = ProgramProcessingException.class)
     public void FenceCond() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
         MemoryObject object = pb.getOrNewObject("X");
         RMWReadCond load = Linux.newRMWReadCondCmp(pb.getOrCreateRegister(0, "r1", 32), BConst.TRUE, object, null);
 		pb.addChild(0, Linux.newConditionalBarrier(load, null));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(SourceLanguage.LITMUS));
+		processor.run(pb.build());
     }
 
     @Test(expected = ProgramProcessingException.class)
     public void ExecutionStatus() throws Exception {
-    	ProgramBuilder pb = new ProgramBuilder();
+    	ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
     	pb.initThread(0);
         MemoryObject object = pb.getOrNewObject("X");
         RMWStoreExclusive store = newRMWStoreExclusive(object, IValue.ONE, null);
 		pb.addChild(0, EventFactory.newExecutionStatus(pb.getOrCreateRegister(0, "r1", 32), store));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
-		processor.run(pb.build(SourceLanguage.LITMUS));
+		processor.run(pb.build());
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -44,7 +44,7 @@ public class AnalysisTest {
 
     @Test
     public void dependencyMustOverride() throws InvalidConfigurationException {
-        ProgramBuilder b = new ProgramBuilder();
+        ProgramBuilder b = new ProgramBuilder(SourceLanguage.LITMUS);
         b.initThread(0);
         Register r0 = b.getOrCreateRegister(0,"r0",ARCH_PRECISION);
         Register r1 = b.getOrCreateRegister(0,"r1",ARCH_PRECISION);
@@ -68,7 +68,7 @@ public class AnalysisTest {
         Local e5 = newLocal(r0,r2);
         b.addChild(0,e5);
 
-        Program program = b.build(Program.SourceLanguage.LITMUS);
+        Program program = b.build();
         LoopUnrolling.newInstance().run(program);
         Compilation.newInstance().run(program);
         Configuration config = Configuration.defaultConfiguration();
@@ -101,7 +101,7 @@ public class AnalysisTest {
     }
 
     private void program0(Alias method, Result... expect) throws InvalidConfigurationException {
-        ProgramBuilder b = new ProgramBuilder();
+        ProgramBuilder b = new ProgramBuilder(SourceLanguage.LITMUS);
 
         MemoryObject x = b.newObject("x",2);
         MemoryObject y = b.getOrNewObject("y");
@@ -140,7 +140,7 @@ public class AnalysisTest {
     }
 
     private void program1(Alias method, Result... expect) throws InvalidConfigurationException {
-        ProgramBuilder b = new ProgramBuilder();
+        ProgramBuilder b = new ProgramBuilder(SourceLanguage.LITMUS);
         MemoryObject x = b.newObject("x",3);
         x.setInitialValue(0,x);
 
@@ -175,7 +175,7 @@ public class AnalysisTest {
     }
 
     private void program2(Alias method, Result... expect) throws InvalidConfigurationException {
-        ProgramBuilder b = new ProgramBuilder();
+        ProgramBuilder b = new ProgramBuilder(SourceLanguage.LITMUS);
         MemoryObject x = b.newObject("x",3);
 
         b.initThread(0);
@@ -215,7 +215,7 @@ public class AnalysisTest {
     }
 
     private void program3(Alias method, Result... expect) throws InvalidConfigurationException {
-        ProgramBuilder b = new ProgramBuilder();
+        ProgramBuilder b = new ProgramBuilder(SourceLanguage.LITMUS);
         MemoryObject x = b.newObject("x",3);
         x.setInitialValue(0,x);
 
@@ -250,7 +250,7 @@ public class AnalysisTest {
     }
 
     private void program4(Alias method, Result... expect) throws InvalidConfigurationException {
-        ProgramBuilder b = new ProgramBuilder();
+        ProgramBuilder b = new ProgramBuilder(SourceLanguage.LITMUS);
         MemoryObject x = b.getOrNewObject("x");
         MemoryObject y = b.getOrNewObject("y");
         MemoryObject z = b.getOrNewObject("z");
@@ -288,7 +288,7 @@ public class AnalysisTest {
     }
 
     private void program5(Alias method, Result... expect) throws InvalidConfigurationException {
-        ProgramBuilder b = new ProgramBuilder();
+        ProgramBuilder b = new ProgramBuilder(SourceLanguage.LITMUS);
         MemoryObject x = b.getOrNewObject("x");
         MemoryObject y = b.getOrNewObject("y");
         MemoryObject z = b.getOrNewObject("z");
@@ -340,7 +340,7 @@ public class AnalysisTest {
     }
 
     private AliasAnalysis analyze(ProgramBuilder builder, Alias method) throws InvalidConfigurationException {
-        Program program = builder.build(SourceLanguage.LITMUS);
+        Program program = builder.build();
         LoopUnrolling.newInstance().run(program);
         Compilation.newInstance().run(program);
         return AliasAnalysis.fromConfig(program,Configuration.builder().setOption(ALIAS_METHOD,method.asStringOption()).build());


### PR DESCRIPTION
This PR adds a new tag. Events having this tag should be neither removed (e.g. `DeadAssignmenetElimination`) nor simplified (e.g. `ConstanPropagation`). The following events have this tag
- any event in a litmus test (litmus tests are used to model a specific behaviour. If the effect of an optimisation would be desirable, the litmus test would already have this in its code),
- bound events,
- spinloops, and
- fake control-flow dependencies.

As as side effect, we can now apply more aggressive simplifications in the expression simplifier. Constant propagation takes care of not calling the expression simplifier if the event should not be optimised.
