### PR TITLE
Implement complement in filter and relation visitor

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/visitors/VisitorFilter.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/visitors/VisitorFilter.java
@@ -4,6 +4,7 @@ import com.dat3m.dartagnan.exception.ParsingException;
 import com.dat3m.dartagnan.parsers.CatBaseVisitor;
 import com.dat3m.dartagnan.parsers.CatParser;
 import com.dat3m.dartagnan.parsers.CatVisitor;
+import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.filter.*;
 
 public class VisitorFilter extends CatBaseVisitor<FilterAbstract> implements CatVisitor<FilterAbstract> {
@@ -36,9 +37,9 @@ public class VisitorFilter extends CatBaseVisitor<FilterAbstract> implements Cat
 
     @Override
     public FilterAbstract visitExprComplement(CatParser.ExprComplementContext ctx) {
-        throw new RuntimeException("Filter complement is not implemented");
+    	return FilterMinus.get(FilterBasic.get(Tag.VISIBLE), ctx.e.accept(this));
     }
-
+    
     @Override
     public FilterAbstract visitExprBasic(CatParser.ExprBasicContext ctx) {
         FilterAbstract filter = base.wmm.getFilter(ctx.getText());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/visitors/VisitorRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/visitors/VisitorRelation.java
@@ -3,7 +3,9 @@ package com.dat3m.dartagnan.parsers.cat.visitors;
 import com.dat3m.dartagnan.parsers.CatBaseVisitor;
 import com.dat3m.dartagnan.parsers.CatParser;
 import com.dat3m.dartagnan.parsers.CatVisitor;
+import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.filter.FilterAbstract;
+import com.dat3m.dartagnan.program.filter.FilterBasic;
 import com.dat3m.dartagnan.wmm.relation.RecursiveRelation;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.relation.base.stat.RelCartesian;
@@ -77,7 +79,13 @@ public class VisitorRelation extends CatBaseVisitor<Relation> implements CatVisi
 
     @Override
     public Relation visitExprComplement(CatParser.ExprComplementContext ctx) {
-        throw new RuntimeException("Relation complement is not implemented");
+        Relation r = ctx.e.accept(this);
+        if(r != null){
+        	Relation allPairs = base.relationRepository.getRelation(RelCartesian.class, 
+					FilterBasic.get(Tag.VISIBLE), FilterBasic.get(Tag.VISIBLE));
+            return base.relationRepository.getRelation(RelMinus.class, allPairs, r);
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
This PR implements the complement of expressions (needed to update our LKMM) both in filter and relation visitor.

I tested this code in the feature branch where I'm updating the LKMM and it works as expected.