### PR TITLE
Use Linux.LOCK_READ in EventData.isLock()

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/EventData.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/EventData.java
@@ -89,7 +89,7 @@ public class EventData implements Comparable<EventData> {
     	return event.is(EXCL);
     }
     public boolean isLock() {
-    	return event.is(C11.LOCK);
+    	return event.is(C11.LOCK) || event.is(Linux.LOCK_READ);
     }
     public boolean isRMW() {
     	return event.is(RMW);


### PR DESCRIPTION
The last PR added new events to the RMW relation, but those changes were not reflected in the CAAT solver resulting in wrong results for tests using lock/unlock.
This PR solves. the issue.