### PR TITLE
Assertions trivially hold only for reachability

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
@@ -103,7 +103,8 @@ public class PropertyEncoder implements Encoder {
         }
         // We use the SMT variable to extract from the model if the property was violated
 		BooleanFormula enc = bmgr.equivalence(REACHABILITY.getSMTVariable(ctx), assertionEncoding);
-        return bmgr.and(REACHABILITY.getSMTVariable(ctx), enc);
+		// No need to use the SMT variable if the formula is trivially false 
+        return bmgr.isFalse(assertionEncoding) ? assertionEncoding : bmgr.and(REACHABILITY.getSMTVariable(ctx), enc);
     }
 
     public BooleanFormula encodeLiveness(SolverContext ctx) {
@@ -179,7 +180,8 @@ public class PropertyEncoder implements Encoder {
         // We use the SMT variable to extract from the model if the property was violated
 		BooleanFormula enc = bmgr.equivalence(LIVENESS.getSMTVariable(ctx), 
 											  bmgr.and(allStuckOrDone, atLeastOneStuck));
-        return bmgr.and(LIVENESS.getSMTVariable(ctx), enc);
+		// No need to use the SMT variable if the formula is trivially false 
+        return bmgr.isFalse(enc) ? enc : bmgr.and(LIVENESS.getSMTVariable(ctx), enc);
     }
 
     public BooleanFormula encodeDataRaces(SolverContext ctx) {
@@ -218,6 +220,7 @@ public class PropertyEncoder implements Encoder {
         }
         // We use the SMT variable to extract from the model if the property was violated
 		enc = bmgr.equivalence(RACES.getSMTVariable(ctx), enc);
-        return bmgr.and(RACES.getSMTVariable(ctx), enc);
+		// No need to use the SMT variable if the formula is trivially false 
+        return bmgr.isFalse(enc) ? enc : bmgr.and(RACES.getSMTVariable(ctx), enc);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.verification.solving;
 
 import com.dat3m.dartagnan.asserts.AssertTrue;
+import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.ProgramEncoder;
 import com.dat3m.dartagnan.encoding.PropertyEncoder;
 import com.dat3m.dartagnan.encoding.SymmetryEncoder;
@@ -16,6 +17,8 @@ import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
 import static java.util.Collections.singletonList;
 
+import java.util.EnumSet;
+
 public class AssumeSolver {
 
     private static final Logger logger = LogManager.getLogger(AssumeSolver.class);
@@ -25,7 +28,7 @@ public class AssumeSolver {
         Result res = Result.UNKNOWN;
         
         task.preprocessProgram();
-       	if(task.getProgram().getAss() instanceof AssertTrue) {
+       	if(task.getProperty().equals(EnumSet.of(Property.REACHABILITY)) && task.getProgram().getAss() instanceof AssertTrue) {
             logger.info("Verification finished: assertion trivially holds");
        		return PASS;
        	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.verification.solving;
 
 import com.dat3m.dartagnan.asserts.AssertTrue;
+import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.ProgramEncoder;
 import com.dat3m.dartagnan.encoding.PropertyEncoder;
 import com.dat3m.dartagnan.encoding.SymmetryEncoder;
@@ -17,6 +18,8 @@ import org.sosy_lab.java_smt.api.SolverException;
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
 
+import java.util.EnumSet;
+
 public class IncrementalSolver {
 
     private static final Logger logger = LogManager.getLogger(IncrementalSolver.class);
@@ -26,7 +29,7 @@ public class IncrementalSolver {
         Result res = Result.UNKNOWN;
         
         task.preprocessProgram();
-       	if(task.getProgram().getAss() instanceof AssertTrue) {
+       	if(task.getProperty().equals(EnumSet.of(Property.REACHABILITY)) && task.getProgram().getAss() instanceof AssertTrue) {
             logger.info("Verification finished: assertion trivially holds");
        		return PASS;
        	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -1,7 +1,5 @@
 package com.dat3m.dartagnan.verification.solving;
 
-import com.dat3m.dartagnan.asserts.AssertTrue;
-import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.ProgramEncoder;
 import com.dat3m.dartagnan.encoding.PropertyEncoder;
 import com.dat3m.dartagnan.encoding.SymmetryEncoder;
@@ -11,14 +9,13 @@ import com.dat3m.dartagnan.verification.VerificationTask;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverException;
 
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
-
-import java.util.EnumSet;
 
 public class IncrementalSolver {
 
@@ -29,10 +26,6 @@ public class IncrementalSolver {
         Result res = Result.UNKNOWN;
         
         task.preprocessProgram();
-       	if(task.getProperty().equals(EnumSet.of(Property.REACHABILITY)) && task.getProgram().getAss() instanceof AssertTrue) {
-            logger.info("Verification finished: assertion trivially holds");
-       		return PASS;
-       	}
         task.performStaticProgramAnalyses();
         task.performStaticWmmAnalyses();
 
@@ -41,6 +34,12 @@ public class IncrementalSolver {
         PropertyEncoder propertyEncoder = task.getPropertyEncoder();
         WmmEncoder wmmEncoder = task.getWmmEncoder();
         SymmetryEncoder symmEncoder = task.getSymmetryEncoder();
+        
+        BooleanFormula propertyEncoding = propertyEncoder.encodeSpecification(task.getProperty(), ctx);
+        if(ctx.getFormulaManager().getBooleanFormulaManager().isFalse(propertyEncoding)) {
+            logger.info("Verification finished: property trivially holds");
+       		return PASS;        	
+        }
 
         logger.info("Starting encoding using " + ctx.getVersion());
         prover.addConstraint(programEncoder.encodeFullProgram(ctx));
@@ -51,7 +50,7 @@ public class IncrementalSolver {
         prover.addConstraint(symmEncoder.encodeFullSymmetry(ctx));
         logger.info("Starting push()");
         prover.push();
-        prover.addConstraint(propertyEncoder.encodeSpecification(task.getProperty(), ctx));
+        prover.addConstraint(propertyEncoding);
         
         logger.info("Starting first solver.check()");
         if(prover.isUnsat()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.verification.solving;
 
 import com.dat3m.dartagnan.asserts.AssertTrue;
+import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.ProgramEncoder;
 import com.dat3m.dartagnan.encoding.PropertyEncoder;
 import com.dat3m.dartagnan.encoding.SymmetryEncoder;
@@ -27,6 +28,7 @@ import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverException;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.function.BiPredicate;
 
@@ -56,7 +58,7 @@ public class RefinementSolver {
             throws InterruptedException, SolverException, InvalidConfigurationException {
 
 		task.preprocessProgram();
-		if(task.getProgram().getAss() instanceof AssertTrue) {
+       	if(task.getProperty().equals(EnumSet.of(Property.REACHABILITY)) && task.getProgram().getAss() instanceof AssertTrue) {
             logger.info("Verification finished: assertion trivially holds");
             return PASS;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -1,7 +1,5 @@
 package com.dat3m.dartagnan.verification.solving;
 
-import com.dat3m.dartagnan.asserts.AssertTrue;
-import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.ProgramEncoder;
 import com.dat3m.dartagnan.encoding.PropertyEncoder;
 import com.dat3m.dartagnan.encoding.SymmetryEncoder;
@@ -22,13 +20,13 @@ import com.dat3m.dartagnan.verification.model.ExecutionModel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverException;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.function.BiPredicate;
 
@@ -58,11 +56,6 @@ public class RefinementSolver {
             throws InterruptedException, SolverException, InvalidConfigurationException {
 
 		task.preprocessProgram();
-       	if(task.getProperty().equals(EnumSet.of(Property.REACHABILITY)) && task.getProgram().getAss() instanceof AssertTrue) {
-            logger.info("Verification finished: assertion trivially holds");
-            return PASS;
-        }
-
         task.performStaticProgramAnalyses();
         task.performStaticWmmAnalyses();
 		task.initializeEncoders(ctx);
@@ -77,13 +70,19 @@ public class RefinementSolver {
         Refiner refiner = new Refiner(task);
         CAATSolver.Status status = INCONSISTENT;
 
+        BooleanFormula propertyEncoding = propertyEncoder.encodeSpecification(task.getProperty(), ctx);
+        if(ctx.getFormulaManager().getBooleanFormulaManager().isFalse(propertyEncoding)) {
+            logger.info("Verification finished: property trivially holds");
+       		return PASS;        	
+        }
+
         logger.info("Starting encoding using " + ctx.getVersion());
         prover.addConstraint(programEncoder.encodeFullProgram(ctx));
         prover.addConstraint(baselineEncoder.encodeFullMemoryModel(ctx));
         prover.addConstraint(symmEncoder.encodeFullSymmetry(ctx));
 
         prover.push();
-        prover.addConstraint(propertyEncoder.encodeSpecification(task.getProperty(), ctx));
+        prover.addConstraint(propertyEncoding);
 
         //  ------ Just for statistics ------
         List<DNF<CoreLiteral>> foundCoreReasons = new ArrayList<>();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.verification.solving;
 
 import com.dat3m.dartagnan.asserts.AssertTrue;
+import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.ProgramEncoder;
 import com.dat3m.dartagnan.encoding.PropertyEncoder;
 import com.dat3m.dartagnan.encoding.SymmetryEncoder;
@@ -18,6 +19,8 @@ import org.sosy_lab.java_smt.api.SolverException;
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
 
+import java.util.EnumSet;
+
 public class TwoSolvers {
 
     private static final Logger logger = LogManager.getLogger(TwoSolvers.class);
@@ -27,7 +30,7 @@ public class TwoSolvers {
     	Result res = Result.UNKNOWN;
     	
     	task.preprocessProgram();
-       	if(task.getProgram().getAss() instanceof AssertTrue) {
+       	if(task.getProperty().equals(EnumSet.of(Property.REACHABILITY)) && task.getProgram().getAss() instanceof AssertTrue) {
             logger.info("Verification finished: assertion trivially holds");
        		return PASS;
        	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -44,6 +44,12 @@ public class TwoSolvers {
         WmmEncoder wmmEncoder = task.getWmmEncoder();
         SymmetryEncoder symmEncoder = task.getSymmetryEncoder();
 
+        BooleanFormula propertyEncoding = propertyEncoder.encodeSpecification(task.getProperty(), ctx);
+        if(ctx.getFormulaManager().getBooleanFormulaManager().isFalse(propertyEncoding)) {
+            logger.info("Verification finished: property trivially holds");
+       		return PASS;        	
+        }
+
         logger.info("Starting encoding using " + ctx.getVersion());
         BooleanFormula encodeProg = programEncoder.encodeFullProgram(ctx);
         prover1.addConstraint(encodeProg);
@@ -63,7 +69,7 @@ public class TwoSolvers {
         prover1.addConstraint(encodeSymm);
         prover2.addConstraint(encodeSymm);
 
-        prover1.addConstraint(propertyEncoder.encodeSpecification(task.getProperty(), ctx));
+        prover1.addConstraint(propertyEncoding);
 
         logger.info("Starting first solver.check()");
         if(prover1.isUnsat()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -1,7 +1,5 @@
 package com.dat3m.dartagnan.verification.solving;
 
-import com.dat3m.dartagnan.asserts.AssertTrue;
-import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.ProgramEncoder;
 import com.dat3m.dartagnan.encoding.PropertyEncoder;
 import com.dat3m.dartagnan.encoding.SymmetryEncoder;
@@ -19,8 +17,6 @@ import org.sosy_lab.java_smt.api.SolverException;
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
 
-import java.util.EnumSet;
-
 public class TwoSolvers {
 
     private static final Logger logger = LogManager.getLogger(TwoSolvers.class);
@@ -30,11 +26,6 @@ public class TwoSolvers {
     	Result res = Result.UNKNOWN;
     	
     	task.preprocessProgram();
-       	if(task.getProperty().equals(EnumSet.of(Property.REACHABILITY)) && task.getProgram().getAss() instanceof AssertTrue) {
-            logger.info("Verification finished: assertion trivially holds");
-       		return PASS;
-       	}
-
         task.performStaticProgramAnalyses();
         task.performStaticWmmAnalyses();
         task.initializeEncoders(ctx);


### PR DESCRIPTION
If we test for liveness violation and the program does not contain assertions, we will trivially result PASS even if liveness is violated. This PR fixes this issue by returning "trivially PASS" only if we test just for reachability.