### PR TITLE
CAAT cutting

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
@@ -211,6 +211,8 @@ public class ExecutionGraph {
                 default:
                     throw new UnsupportedOperationException(rel.getName() + " is marked as special relation but has associated graph.");
             }
+        } else if (rel.isCut()) {
+            graph = new DynamicDefaultWMMGraph(rel);
         } else if (relClass == RelRf.class) {
             graph = new ReadFromGraph();
         } else if (relClass == RelLoc.class) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
@@ -66,6 +66,7 @@ public class ExecutionGraph {
     private final BiMap<Relation, RelationGraph> relationGraphMap;
     private final BiMap<FilterAbstract, SetPredicate> filterSetMap;
     private final BiMap<Axiom, Constraint> constraintMap;
+    private final Set<Relation> cutRelations;
 
     private CAATModel caatModel;
     private EventDomain domain;
@@ -74,11 +75,12 @@ public class ExecutionGraph {
 
     // ============= Construction & Init ===============
 
-    public ExecutionGraph(VerificationTask verificationTask, boolean createOnlyAxiomRelevantGraphs) {
+    public ExecutionGraph(VerificationTask verificationTask, Set<Relation> cutRelations, boolean createOnlyAxiomRelevantGraphs) {
         this.verificationTask = verificationTask;
         relationGraphMap = HashBiMap.create();
         filterSetMap = HashBiMap.create();
         constraintMap = HashBiMap.create();
+        this.cutRelations = cutRelations;
         constructMappings(createOnlyAxiomRelevantGraphs);
     }
 
@@ -131,6 +133,7 @@ public class ExecutionGraph {
         return Maps.unmodifiableBiMap(constraintMap);
     }
 
+    public Set<Relation> getCutRelations() { return cutRelations; }
 
     public RelationGraph getRelationGraph(Relation rel) {
         return relationGraphMap.get(rel);
@@ -215,7 +218,7 @@ public class ExecutionGraph {
                 default:
                     throw new UnsupportedOperationException(rel.getName() + " is marked as special relation but has associated graph.");
             }
-        } else if (rel.isCut()) {
+        } else if (cutRelations.contains(rel)) {
             graph = new DynamicDefaultWMMGraph(rel);
         } else if (relClass == RelRf.class) {
             graph = new ReadFromGraph();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
@@ -15,6 +15,7 @@ import com.dat3m.dartagnan.solver.caat4wmm.basePredicates.*;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
 import com.dat3m.dartagnan.wmm.axiom.Axiom;
+import com.dat3m.dartagnan.wmm.axiom.ForceEncodeAxiom;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.relation.base.RelRMW;
 import com.dat3m.dartagnan.wmm.relation.base.memory.RelCo;
@@ -93,6 +94,9 @@ public class ExecutionGraph {
         Set<Constraint> constraints = new HashSet<>();
 
         for (Axiom axiom : verificationTask.getAxioms()) {
+            if (axiom instanceof ForceEncodeAxiom) {
+                continue;
+            }
             Constraint constraint = getOrCreateConstraintFromAxiom(axiom);
             constraints.add(constraint);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
@@ -10,11 +10,13 @@ import com.dat3m.dartagnan.utils.logic.DNF;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
+import com.dat3m.dartagnan.wmm.relation.Relation;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /*
     This is our domain-specific bridging component that specializes the CAATSolver to the WMM setting.
@@ -26,9 +28,9 @@ public class WMMSolver {
     private final CAATSolver solver;
     private final CoreReasoner reasoner;
 
-    public WMMSolver(VerificationTask task) {
+    public WMMSolver(VerificationTask task, Set<Relation> cutRelations) {
         task.getAnalysisContext().requires(RelationAnalysis.class);
-        this.executionGraph = new ExecutionGraph(task, true);
+        this.executionGraph = new ExecutionGraph(task, cutRelations, true);
         this.executionModel = new ExecutionModel(task);
         this.reasoner = new CoreReasoner(task, executionGraph);
         this.solver = CAATSolver.create();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/DynamicDefaultWMMGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/DynamicDefaultWMMGraph.java
@@ -1,0 +1,62 @@
+package com.dat3m.dartagnan.solver.caat4wmm.basePredicates;
+
+import com.dat3m.dartagnan.solver.caat.predicates.relationGraphs.Edge;
+import com.dat3m.dartagnan.solver.caat.predicates.relationGraphs.RelationGraph;
+import com.dat3m.dartagnan.verification.model.EventData;
+import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
+import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.SolverContext;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+// A default implementation for any encoded relation, e.g. base relations or non-base but cut relations.
+public class DynamicDefaultWMMGraph extends MaterializedWMMGraph {
+    private final Relation relation;
+
+    public DynamicDefaultWMMGraph(Relation rel) {
+        this.relation = rel;
+    }
+
+    @Override
+    public List<RelationGraph> getDependencies() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void repopulate() {
+        // Careful: The wrapped model <getModel> might get closed/disposed while ExecutionModel as a whole is
+        // still in use. The caller should make sure that the underlying model is still alive right now.
+        Model m = model.getModel();
+        SolverContext ctx = model.getContext();
+
+        if (relation.getMaxTupleSet().size() < domain.size() * domain.size()) {
+            relation.getMaxTupleSet()
+                    .stream().map(t -> this.getEdgeFromTuple(t, m, ctx)).filter(Objects::nonNull)
+                    .forEach(simpleGraph::add);
+        } else {
+            for (EventData e1 : model.getEventList()) {
+                for (EventData e2 : model.getEventList()) {
+                    Edge e = getEdgeFromEventData(e1, e2, m, ctx);
+                    if (e != null) {
+                        simpleGraph.add(e);
+                    }
+                }
+            }
+        }
+    }
+
+    private Edge getEdgeFromEventData(EventData e1, EventData e2, Model m, SolverContext ctx) {
+        return m.evaluate(relation.getSMTVar(e1.getEvent(), e2.getEvent(), ctx)) == Boolean.TRUE
+                ? new Edge(e1.getId(), e2.getId()) : null;
+    }
+
+    private Edge getEdgeFromTuple(Tuple t, Model m, SolverContext ctx) {
+        Optional<EventData> e1 = model.getData(t.getFirst());
+        Optional<EventData> e2 = model.getData(t.getSecond());
+        return e1.isPresent() && e2.isPresent() ? getEdgeFromEventData(e1.get(), e2.get(), m, ctx) : null;
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
@@ -72,7 +72,7 @@ public class CoreReasoner {
                         addFenceReason(rel, edge, coreReason);
                     } else if (rel.getName().equals(LOC)) {
                         coreReason.add(new AddressLiteral(tuple, lit.isNegative()));
-                    } else if (rel.getName().equals(RF) || rel.getName().equals(CO)) {
+                    } else if (rel.getName().equals(RF) || rel.getName().equals(CO) || rel.isCut()) {
                         coreReason.add(new RelLiteral(rel.getName(), tuple, lit.isNegative()));
                     } else {
                         //TODO: Right now, we assume many relations like Data, Ctrl and Addr to be

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
@@ -63,17 +63,18 @@ public class CoreReasoner {
                 } else if (lit.isNegative() && !rel.getMaxTupleSet().contains(tuple)) {
                     // Statically absent edges
                 } else {
-                    if (rel instanceof RelFencerel) {
+                    if (rel.getName().equals(RF) || rel.getName().equals(CO)
+                            || rel.isCut()) {
+                        coreReason.add(new RelLiteral(rel.getName(), tuple, lit.isNegative()));
+                    } else if (rel.getName().equals(LOC)) {
+                        coreReason.add(new AddressLiteral(tuple, lit.isNegative()));
+                    } else if (rel instanceof RelFencerel) {
                         // This is a special case since "fencerel(F) = po;[F];po".
                         // We should do this transformation directly on the Wmm to avoid this special reasoning
                         if (lit.isNegative()) {
                             throw new UnsupportedOperationException(String.format("FenceRel %s is not allowed on the rhs of differences.", rel));
                         }
                         addFenceReason(rel, edge, coreReason);
-                    } else if (rel.getName().equals(LOC)) {
-                        coreReason.add(new AddressLiteral(tuple, lit.isNegative()));
-                    } else if (rel.getName().equals(RF) || rel.getName().equals(CO) || rel.isCut()) {
-                        coreReason.add(new RelLiteral(rel.getName(), tuple, lit.isNegative()));
                     } else {
                         //TODO: Right now, we assume many relations like Data, Ctrl and Addr to be
                         // static.

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
@@ -64,7 +64,7 @@ public class CoreReasoner {
                     // Statically absent edges
                 } else {
                     if (rel.getName().equals(RF) || rel.getName().equals(CO)
-                            || rel.isCut()) {
+                            || executionGraph.getCutRelations().contains(rel)) {
                         coreReason.add(new RelLiteral(rel.getName(), tuple, lit.isNegative()));
                     } else if (rel.getName().equals(LOC)) {
                         coreReason.add(new AddressLiteral(tuple, lit.isNegative()));
@@ -93,11 +93,11 @@ public class CoreReasoner {
         // Their execution variable can only be removed if it is contained in some
         // RelLiteral but not if it gets cf-implied!
         reason.removeIf( lit -> {
-            if (!(lit instanceof ExecLiteral)) {
+            if (!(lit instanceof ExecLiteral) || lit.isNegative()) {
                 return false;
             }
             Event ev = ((ExecLiteral) lit).getData();
-            return reason.stream().filter(e -> e instanceof RelLiteral)
+            return reason.stream().filter(e -> e instanceof RelLiteral && e.isPositive())
                     .map(RelLiteral.class::cast)
                     .anyMatch(e -> exec.isImplied(e.getData().getFirst(), ev)
                             || exec.isImplied(e.getData().getSecond(), ev));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
@@ -78,6 +78,10 @@ public class CoreReasoner {
                     } else {
                         //TODO: Right now, we assume many relations like Data, Ctrl and Addr to be
                         // static.
+                        if (lit.isNegative()) {
+                            // TODO: Support negated literals
+                            throw new UnsupportedOperationException(String.format("Negated literals of type %s are not supported.", rel));
+                        }
                         addExecReason(tuple, coreReason);
                     }
                 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/RefinementTask.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/RefinementTask.java
@@ -14,13 +14,9 @@ import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.analysis.WmmAnalysis;
 import com.dat3m.dartagnan.wmm.axiom.Acyclic;
 import com.dat3m.dartagnan.wmm.axiom.Empty;
-import com.dat3m.dartagnan.wmm.axiom.ForceEncodeAxiom;
 import com.dat3m.dartagnan.wmm.relation.Relation;
-import com.dat3m.dartagnan.wmm.relation.base.stat.RelCartesian;
-import com.dat3m.dartagnan.wmm.relation.base.stat.RelSetIdentity;
 import com.dat3m.dartagnan.wmm.relation.binary.RelComposition;
 import com.dat3m.dartagnan.wmm.relation.binary.RelIntersection;
-import com.dat3m.dartagnan.wmm.relation.binary.RelMinus;
 import com.dat3m.dartagnan.wmm.relation.binary.RelUnion;
 import com.dat3m.dartagnan.wmm.utils.RelationRepository;
 import org.apache.logging.log4j.LogManager;
@@ -31,9 +27,7 @@ import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 import org.sosy_lab.java_smt.api.SolverContext;
 
-import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.List;
 
 import static com.dat3m.dartagnan.configuration.Baseline.*;
 import static com.dat3m.dartagnan.configuration.OptionNames.BASELINE;
@@ -155,49 +149,7 @@ public class RefinementTask extends VerificationTask {
             repo.addRelation(rmwANDfrecoe);
             baseline.addAxiom(new Empty(rmwANDfrecoe));
         }
-
-        // Cut negated relations
-        for (Relation rel : getMemoryModel().getRelationRepository().getRelations()) {
-            if (rel instanceof RelMinus && rel.getSecond().getDependencies().size() != 0) {
-                Relation copy = getCopyOfRelation(rel.getSecond(), repo);
-                rel.getSecond().setIsCut(true);
-                baseline.addAxiom(new ForceEncodeAxiom(copy));
-
-                logger.info("Found difference {}. Cutting rhs relation {}", rel, rel.getSecond());
-            }
-        }
-        
         return baseline;
-    }
-
-    private Relation getCopyOfRelation(Relation rel, RelationRepository repo) {
-        if (repo.containsRelation(rel.getName())) {
-            return repo.getRelation(rel.getName());
-        }
-
-        Relation copy = repo.getRelation(rel.getName());
-        if (copy == null) {
-            List<Object> deps = new ArrayList<>(rel.getDependencies().size());
-            if (rel instanceof RelSetIdentity) {
-                deps.add(((RelSetIdentity)rel).getFilter());
-            } else if (rel instanceof RelCartesian) {
-                deps.add(((RelCartesian)rel).getFirstFilter());
-                deps.add(((RelCartesian)rel).getSecondFilter());
-            } else {
-                for (Relation dep : rel.getDependencies()) {
-                    deps.add(getCopyOfRelation(dep, repo));
-                }
-            }
-
-            copy = repo.getRelation(rel.getClass(), deps.toArray());
-            if (rel.getIsNamed()) {
-                copy.setName(rel.getName());
-                repo.updateRelation(copy);
-            }
-        }
-
-
-        return copy;
     }
 
     // ==================== Builder =====================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -232,10 +232,15 @@ public class RefinementSolver {
         RelationRepository repo = baselineWmm.getRelationRepository();
         Set<Relation> cutRelations = new HashSet<>();
         for (Relation rel : targetWmm.getRelationRepository().getRelations()) {
-            if (rel instanceof RelMinus && rel.getSecond().getDependencies().size() != 0) {
-                logger.info("Found difference {}. Cutting rhs relation {}", rel, rel.getSecond());
-                cutRelations.add(rel.getSecond());
-                baselineWmm.addAxiom(new ForceEncodeAxiom(getCopyOfRelation(rel.getSecond(), repo)));
+            if (rel instanceof RelMinus) {
+                Relation sec = rel.getSecond();
+                if (sec.getDependencies().size() != 0 || sec instanceof RelSetIdentity || sec instanceof RelCartesian) {
+                    // NOTE: The check for RelSetIdentity/RelCartesian is needed because they appear non-derived
+                    // in our Wmm but for CAAT they are derived from unary predicates!
+                    logger.info("Found difference {}. Cutting rhs relation {}", rel, sec);
+                    cutRelations.add(sec);
+                    baselineWmm.addAxiom(new ForceEncodeAxiom(getCopyOfRelation(sec, repo)));
+                }
             }
         }
         return cutRelations;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/ForceEncodeAxiom.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/ForceEncodeAxiom.java
@@ -1,0 +1,30 @@
+package com.dat3m.dartagnan.wmm.axiom;
+
+import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.utils.TupleSet;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.SolverContext;
+
+/*
+    This is a fake axiom that forces a relation to get encoded!
+ */
+public class ForceEncodeAxiom extends Axiom {
+    public ForceEncodeAxiom(Relation rel) {
+        super(rel);
+    }
+
+    @Override
+    public TupleSet getEncodeTupleSet(){
+        return rel.getMaxTupleSet();
+    }
+
+    @Override
+    public BooleanFormula consistent(SolverContext ctx) {
+        return ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
+    }
+
+    @Override
+    public String toString() {
+        return "forceEncode " + rel.getName();
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
@@ -39,6 +39,7 @@ public abstract class Relation implements Encoder, Dependent<Relation> {
     protected Context analysisContext;
 
     protected boolean isEncoded;
+    protected boolean isCut = false;
 
     protected TupleSet minTupleSet = null;
     protected TupleSet maxTupleSet = null;
@@ -55,6 +56,9 @@ public abstract class Relation implements Encoder, Dependent<Relation> {
         this();
         this.name = name;
     }
+
+    public boolean isCut() { return this.isCut; }
+    public void setIsCut(boolean value) { this.isCut = value; }
 
     @Override
     public List<Relation> getDependencies() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
@@ -39,7 +39,6 @@ public abstract class Relation implements Encoder, Dependent<Relation> {
     protected Context analysisContext;
 
     protected boolean isEncoded;
-    protected boolean isCut = false;
 
     protected TupleSet minTupleSet = null;
     protected TupleSet maxTupleSet = null;
@@ -56,9 +55,6 @@ public abstract class Relation implements Encoder, Dependent<Relation> {
         this();
         this.name = name;
     }
-
-    public boolean isCut() { return this.isCut; }
-    public void setIsCut(boolean value) { this.isCut = value; }
 
     @Override
     public List<Relation> getDependencies() {


### PR DESCRIPTION
This PR adds support for automatically cutting non-semipositive memory models that lie outside the fragment supported by CAAT.

Concretely, CAAT fails if the memory model contains a relation `r = a \ d` where `d` is a derived relation. Such a model is not `semi-positive`. "Cutting" lifts the derived relation `d` up to a base relation by eagerly encoding its definition.
From the perspective of the CAAT solver, `d` now appears to be base and it generates reasons wrt. `d`.

Current issue:
- The cutting algorithm fails if `d` is dependent on a recursive relation although cutting recursive relations in general is valid. However, this is not a major problem since we do not support negated recursions (this requires exact fixed points instead of the Knaster-Tarski approximation) and the cutting only runs for negated relations.