### PR TITLE
Lkmm2arch

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusC.java
@@ -23,7 +23,7 @@ class ParserLitmusC implements ParserInterface {
         VisitorLitmusC visitor = new VisitorLitmusC(pb);
 
         Program program = (Program) parserEntryPoint.accept(visitor);
-        // C programs can be compiled to different target,
+        // C programs can be compiled to different targets,
         // thus we don't set the architectures.
         return program;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ParserLitmusC.java
@@ -6,7 +6,6 @@ import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.parsers.program.visitors.VisitorLitmusC;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Program.SourceLanguage;
-import com.dat3m.dartagnan.configuration.Arch;
 
 import org.antlr.v4.runtime.*;
 
@@ -24,7 +23,8 @@ class ParserLitmusC implements ParserInterface {
         VisitorLitmusC visitor = new VisitorLitmusC(pb);
 
         Program program = (Program) parserEntryPoint.accept(visitor);
-        program.setArch(Arch.LKMM);
+        // C programs can be compiled to different target,
+        // thus we don't set the architectures.
         return program;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -271,7 +271,7 @@ public class VisitorLitmusC
     @Override
     public IExpr visitReLoad(LitmusCParser.ReLoadContext ctx){
         Register register = getReturnRegister(true);
-        Event event = EventFactory.newLoad(register, getAddress(ctx.address), ctx.mo);
+        Event event = EventFactory.Linux.newLKMMLoad(register, getAddress(ctx.address), ctx.mo);
         programBuilder.addChild(currentThread, event);
         return register;
     }
@@ -279,7 +279,7 @@ public class VisitorLitmusC
     @Override
     public IExpr visitReReadOnce(LitmusCParser.ReReadOnceContext ctx){
         Register register = getReturnRegister(true);
-        Event event = EventFactory.newLoad(register, getAddress(ctx.address), ctx.mo);
+        Event event = EventFactory.Linux.newLKMMLoad(register, getAddress(ctx.address), ctx.mo);
         programBuilder.addChild(currentThread, event);
         return register;
     }
@@ -381,18 +381,18 @@ public class VisitorLitmusC
     public Object visitNreStore(LitmusCParser.NreStoreContext ctx){
         ExprInterface value = (ExprInterface)ctx.value.accept(this);
         if(ctx.mo.equals(Tag.Linux.MO_MB)){
-            Event event = EventFactory.newStore(getAddress(ctx.address), value, Tag.Linux.MO_ONCE);
+            Event event = EventFactory.Linux.newLKMMStore(getAddress(ctx.address), value, Tag.Linux.MO_ONCE);
             programBuilder.addChild(currentThread, event);
             return programBuilder.addChild(currentThread, EventFactory.Linux.newMemoryBarrier());
         }
-        Event event = EventFactory.newStore(getAddress(ctx.address), value, ctx.mo);
+        Event event = EventFactory.Linux.newLKMMStore(getAddress(ctx.address), value, ctx.mo);
         return programBuilder.addChild(currentThread, event);
     }
 
     @Override
     public Object visitNreWriteOnce(LitmusCParser.NreWriteOnceContext ctx){
         ExprInterface value = (ExprInterface)ctx.value.accept(this);
-        Event event = EventFactory.newStore(getAddress(ctx.address), value, ctx.mo);
+        Event event = EventFactory.Linux.newLKMMStore(getAddress(ctx.address), value, ctx.mo);
         return programBuilder.addChild(currentThread, event);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -432,7 +432,7 @@ public class VisitorLitmusC
 
     @Override
     public Object visitNreFence(LitmusCParser.NreFenceContext ctx){
-        return programBuilder.addChild(currentThread, EventFactory.newFence(ctx.name));
+        return programBuilder.addChild(currentThread, EventFactory.Linux.newLKMMFence(ctx.name));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -445,10 +445,12 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 	        			// Nothing to be done
 	        		}
 	        		if(!allocationRegs.contains(value)) {
+	        			// These events are eventually compiled and we need to compare its mo, thus it cannot be null
 	        			programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, ""))
 	        					.setCLine(currentLine)
 	        					.setSourceCodeFile(sourceCodeFile);
 	        		} else {
+	        			// These events are eventually compiled and we need to compare its mo, thus it cannot be null
 	        			programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, ""));
 	        		}						        			
 		            continue;
@@ -461,6 +463,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 	        }
             MemoryObject object = programBuilder.getObject(name);
             if(object != null){
+    			// These events are eventually compiled and we need to compare its mo, thus it cannot be null
 				programBuilder.addChild(threadCount, EventFactory.newStore(object, value, ""))
 						.setCLine(currentLine)
 						.setSourceCodeFile(sourceCodeFile);
@@ -688,6 +691,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 				programBuilder.getOrNewObject(text).appendInitialValue(rhs,value.reduce());
 				return null;
 			}
+			// These events are eventually compiled and we need to compare its mo, thus it cannot be null
 			programBuilder.addChild(threadCount, EventFactory.newStore(address, value, ""))
 					.setCLine(currentLine)
 					.setSourceCodeFile(sourceCodeFile);	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -445,11 +445,11 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 	        			// Nothing to be done
 	        		}
 	        		if(!allocationRegs.contains(value)) {
-	        			programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, null))
+	        			programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, ""))
 	        					.setCLine(currentLine)
 	        					.setSourceCodeFile(sourceCodeFile);
 	        		} else {
-	        			programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, null));
+	        			programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, ""));
 	        		}						        			
 		            continue;
 	        	}
@@ -461,7 +461,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 	        }
             MemoryObject object = programBuilder.getObject(name);
             if(object != null){
-				programBuilder.addChild(threadCount, EventFactory.newStore(object, value, null))
+				programBuilder.addChild(threadCount, EventFactory.newStore(object, value, ""))
 						.setCLine(currentLine)
 						.setSourceCodeFile(sourceCodeFile);
 	            continue;
@@ -688,7 +688,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> implements BoogieVi
 				programBuilder.getOrNewObject(text).appendInitialValue(rhs,value.reduce());
 				return null;
 			}
-			programBuilder.addChild(threadCount, EventFactory.newStore(address, value, null))
+			programBuilder.addChild(threadCount, EventFactory.newStore(address, value, ""))
 					.setCLine(currentLine)
 					.setSourceCodeFile(sourceCodeFile);	
 			return null;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -368,7 +368,11 @@ public class EventFactory {
         }
 
         public static Fence newMemoryBarrier() {
-            return newFence("Mb");
+            return new LKMMFence(Tag.Linux.MO_MB);
+        }
+
+        public static Fence newLKMMFence(String name) {
+            return new LKMMFence(name);
         }
 
         public static Fence newConditionalMemoryBarrier(RMWReadCond loadEvent) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -323,6 +323,14 @@ public class EventFactory {
     public static class Linux {
         private Linux() {}
 
+        public static LKMMLoad newLKMMLoad(Register reg, IExpr address, String mo) {
+        	return new LKMMLoad(reg, address, mo);
+        }
+        
+        public static LKMMStore newLKMMStore(IExpr address, ExprInterface value, String mo) {
+        	return new LKMMStore(address, value, mo);
+        }
+        
         public static RMWReadCondCmp newRMWReadCondCmp(Register reg, ExprInterface cmp, IExpr address, String atomic) {
             return new RMWReadCondCmp(reg, cmp, address, atomic);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
@@ -139,8 +139,8 @@ public final class Tag {
         public static final String LOCK_FAIL     = "UL";
         public static final String READ_LOCKED   = "LF";
         public static final String READ_UNLOCKED = "RU";
-        public static final String BEFORE_ATOMIC      = "Before-atomic";
-        public static final String AFTER_ATOMIC       = "After-atomic";
+        public static final String BEFORE_ATOMIC = "Before-atomic";
+        public static final String AFTER_ATOMIC  = "After-atomic";
 
         public static String loadMO(String mo){
             return mo.equals(MO_ACQUIRE) ? MO_ACQUIRE : MO_ONCE;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
@@ -139,6 +139,8 @@ public final class Tag {
         public static final String LOCK_FAIL     = "UL";
         public static final String READ_LOCKED   = "LF";
         public static final String READ_UNLOCKED = "RU";
+        public static final String BEFORE_ATOMIC      = "Before-atomic";
+        public static final String AFTER_ATOMIC       = "After-atomic";
 
         public static String loadMO(String mo){
             return mo.equals(MO_ACQUIRE) ? MO_ACQUIRE : MO_ONCE;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMFence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMFence.java
@@ -1,0 +1,11 @@
+package com.dat3m.dartagnan.program.event.lang.linux;
+
+import com.dat3m.dartagnan.program.event.core.Fence;
+
+public class LKMMFence extends Fence {
+
+	public LKMMFence(String name) {
+		super(name);
+	}
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
@@ -1,12 +1,14 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.program.event.core.Fence;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class LKMMFence extends Fence {
+public class LKMMLoad extends Load {
 
-	public LKMMFence(String name) {
-		super(name);
+	public LKMMLoad(Register register, IExpr address, String mo) {
+		super(register, address, mo);
 	}
 
 	// Visitor
@@ -14,6 +16,6 @@ public class LKMMFence extends Fence {
 
 	@Override
 	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitLKMMFence(this);
+		return visitor.visitLKMMLoad(this);
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
@@ -1,0 +1,21 @@
+package com.dat3m.dartagnan.program.event.lang.linux;
+
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.event.core.Store;
+import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
+
+public class LKMMStore extends Store {
+
+	public LKMMStore(IExpr address, ExprInterface value, String mo) {
+		super(address, value, mo);
+	}
+
+	// Visitor
+	// -----------------------------------------------------------------------------------------------------------------
+
+	@Override
+	public <T> T accept(EventVisitor<T> visitor) {
+		return visitor.visitLKMMStore(this);
+	}
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
@@ -66,7 +66,9 @@ public interface EventVisitor<T> {
 	default T visitRMWOpReturn(RMWOpReturn e) { return visitRMWAbstract(e); }
 	default T visitRMWXchg(RMWXchg e) { return visitRMWAbstract(e); }
 	default T visitLKMMFence(LKMMFence e) { return visitFence(e); }
-
+	default T visitLKMMLoad(LKMMLoad e) { return visitLoad(e); }
+	default T visitLKMMStore(LKMMStore e) { return visitStore(e); }
+	
 	// Linux Cond Events
 	default T visitFenceCond(FenceCond e) { return visitFence(e); }
 	default T visitRMWReadCond(RMWReadCond e) { return visitLoad(e); }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
@@ -65,6 +65,7 @@ public interface EventVisitor<T> {
 	default T visitRMWOpAndTest(RMWOpAndTest e) { return visitRMWAbstract(e); }
 	default T visitRMWOpReturn(RMWOpReturn e) { return visitRMWAbstract(e); }
 	default T visitRMWXchg(RMWXchg e) { return visitRMWAbstract(e); }
+	default T visitLKMMFence(LKMMFence e) { return visitFence(e); }
 
 	// Linux Cond Events
 	default T visitFenceCond(FenceCond e) { return visitFence(e); }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
@@ -190,8 +190,8 @@ public class VisitorLKMM extends VisitorBase implements EventVisitor<List<Event>
         IExpr address = e.getAddress();
 
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-		Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
 		Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
+		Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
         Fence optionalMbAfter = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
 
         return eventSequence(

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
@@ -142,6 +142,7 @@ public class VisitorLKMM extends VisitorBase implements EventVisitor<List<Event>
         IExpr address = e.getAddress();
         Register resultRegister = e.getResultRegister();
 		
+        // RMWOp does not return anything; resultRegister is just used as a dummy.
         Load load = newRMWLoad(resultRegister, address, Tag.Linux.MO_ONCE);
         load.addFilters(Tag.Linux.NORETURN);
         

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -546,8 +546,8 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	public List<Event> visitFence(Fence e) {
 		String mo = e.getName();
         Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_MB) 
-        		|| mo.equals(Tag.Linux.MO_WMB) 
-        		|| mo.equals(Tag.Linux.MO_RMB) ? 
+        		|| mo.equals(Tag.Linux.MO_WMB) || mo.equals(Tag.Linux.MO_RMB)
+        		|| mo.equals(Tag.Linux.BEFORE_ATOMIC) || mo.equals(Tag.Linux.AFTER_ATOMIC) ?
         		Power.newSyncBarrier() : null;
         
         return eventSequence(

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -406,10 +406,9 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
         Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
         // Power does not have mo tags, thus we use null
         Load load = newRMWLoadExclusive(dummyReg, address, null);
-        Local localOp = newLocal(dummyReg, new IExprBin(dummyReg, op, value));
-        Store store = newRMWStoreExclusive(address, dummyReg, null, true);
+        Store store = newRMWStoreExclusive(address, new IExprBin(dummyReg, op, value), null, true);
         Label label = newLabel("FakeDep");
-        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        Event fakeCtrlDep = newFakeCtrlDep(dummyReg, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
@@ -420,7 +419,6 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
         return eventSequence(
                 optionalMemoryBarrierBefore,
                 load,
-                localOp,
                 store,
                 fakeCtrlDep,
                 label,
@@ -471,8 +469,8 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
 
 		Load load = newRMWLoadExclusive(dummy, address, null);
-        Local updateReg = newLocal(resultRegister, dummy);
         Store store = newRMWStoreExclusive(address, new IExprBin(dummy, e.getOp(), value), null, true);
+        Local updateReg = newLocal(resultRegister, dummy);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -8,6 +8,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.Tag.C11;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
+import com.dat3m.dartagnan.program.event.lang.linux.LKMMFence;
 import com.dat3m.dartagnan.program.event.lang.linux.RMWAddUnless;
 import com.dat3m.dartagnan.program.event.lang.linux.RMWCmpXchg;
 import com.dat3m.dartagnan.program.event.lang.linux.RMWFetchOp;
@@ -533,7 +534,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	// Following
 	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
 	@Override
-	public List<Event> visitFence(Fence e) {
+	public List<Event> visitLKMMFence(LKMMFence e) {
 		String mo = e.getName();
         Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_MB) 
         		|| mo.equals(Tag.Linux.MO_WMB) || mo.equals(Tag.Linux.MO_RMB)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -363,8 +363,8 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
                     storeValue,
                     fakeCtrlDep,
                     label,
-                casEnd,
-                optionalMemoryBarrierAfter
+                    optionalMemoryBarrierAfter,
+                casEnd
         );
 	}
 	
@@ -568,15 +568,15 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 		String mo = e.getMo();
 		int precision = resultRegister.getPrecision();
 
-		ExprInterface expected = e.getCmp();
+		ExprInterface unless = e.getCmp();
         Register regValue = e.getThread().newRegister(precision);
         Label cauEnd = newLabel("CAddU_end");
-        Local cauCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, expected));
-        CondJump branchOnCauCmpResult = newJump(new Atom(resultRegister, EQ, IValue.ONE), cauEnd);
+        Local cauCmpResult = newLocal(resultRegister, new Atom(regValue, NEQ, unless));
+        CondJump branchOnCauCmpResult = newJump(new Atom(resultRegister, EQ, IValue.ZERO), cauEnd);
 
         // Power does not have mo tags, thus we use null
         Load loadValue = newRMWLoadExclusive(regValue, address, null);
-        Store storeValue = newRMWStoreExclusive(address, value, null, true);
+        Store storeValue = newRMWStoreExclusive(address, new IExprBin(regValue, IOpBin.PLUS, (IExpr) value), null, true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -514,7 +514,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 		
         // Power does not have mo tags, thus we use null
         Load load = newLoad(resultRegister, address, null);
-        Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newSyncBarrier() : null;
+        Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newLwSyncBarrier() : null;
         
         return eventSequence(
                 load,
@@ -532,7 +532,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 
         // Power does not have mo tags, thus we use null
         Store store = newStore(address, value, null);
-        Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_RELEASE) ? Power.newSyncBarrier() : null;
+        Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         
         return eventSequence(
                 optionalMemoryBarrier,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -344,15 +344,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 
         // Power does not have mo tags, thus we use null
         Load loadValue = newRMWLoadExclusive(regValue, address, null);
-        // TODO: we don't use STRONG for LKMM, should we?
-        Store storeValue = newRMWStoreExclusive(address, value, null, e.is(STRONG));
-        ExecutionStatus optionalExecStatus = null;
-        Local optionalUpdateCasCmpResult = null;
-        if (!e.is(STRONG)) {
-            Register statusReg = e.getThread().newRegister(precision);
-            optionalExecStatus = newExecutionStatus(statusReg, storeValue);
-            optionalUpdateCasCmpResult = newLocal(resultRegister, new BExprUn(BOpUn.NOT, statusReg));
-        }
+        Store storeValue = newRMWStoreExclusive(address, value, null, true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
@@ -368,8 +360,6 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
                 casCmpResult,
                 branchOnCasCmpResult,
                     storeValue,
-                    optionalExecStatus,
-                    optionalUpdateCasCmpResult,
                     fakeCtrlDep,
                     label,
                     gotoCasEnd,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -444,7 +444,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
         Load load = newRMWLoadExclusive(dummyReg, address, null);
         Store store = newRMWStoreExclusive(address, resultRegister, null, true);
         Label label = newLabel("FakeDep");
-        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        Event fakeCtrlDep = newFakeCtrlDep(dummyReg, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
@@ -479,7 +479,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
         Local optionalUpdateReg = dummy != resultRegister ? newLocal(resultRegister, dummy) : null;
         Store store = newRMWStoreExclusive(address, new IExprBin(dummy, e.getOp(), value), null, true);
         Label label = newLabel("FakeDep");
-        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
@@ -571,7 +571,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
         Load loadValue = newRMWLoadExclusive(regValue, address, null);
         Store storeValue = newRMWStoreExclusive(address, new IExprBin(regValue, IOpBin.PLUS, (IExpr) value), null, true);
         Label label = newLabel("FakeDep");
-        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        Event fakeCtrlDep = newFakeCtrlDep(regValue, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
@@ -613,7 +613,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
         Load load = newRMWLoadExclusive(dummyReg, address, null);
         Store store = newRMWStoreExclusive(address, retReg, null, true);
         Label label = newLabel("FakeDep");
-        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        Event fakeCtrlDep = newFakeCtrlDep(dummyReg, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -306,20 +306,20 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	// =============================================================================================
 	// Methods with no suffix (e.g. atomic_xchg), which are those having MO_MB in our case,
 	// are surrounded by a __atomic_pre_full_fence() or __atomic_post_full_fence()
-	// 		https://github.com/torvalds/linux/blob/master/scripts/atomic/fallbacks/fence
+	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/fence
 	// which in turn are smp_mb__before_atomic and smp_mb__after_atomic
-	// 		https://github.com/torvalds/linux/blob/master/include/linux/atomic.h
+	// 		https://elixir.bootlin.com/linux/v5.18/source/include/linux/atomic.h
 	// which in turn are __smp_mb()
-	// 		https://github.com/torvalds/linux/blob/master/include/asm-generic/barrier.h
+	// 		https://elixir.bootlin.com/linux/v5.18/source/include/asm-generic/barrier.h
 	// which in turn is just a sync
-	// 		https://github.com/torvalds/linux/blob/master/arch/powerpc/include/asm/barrier.h
+	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
 	//
 	// Methods with acquire or release as a suffix
-	// 		https://github.com/torvalds/linux/blob/master/scripts/atomic/fallbacks/acquire
-	// 		https://github.com/torvalds/linux/blob/master/scripts/atomic/fallbacks/release
+	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/acquire
+	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/release
 	// which result in a isync (acquire) or lwsync (release)
-	// 		https://github.com/torvalds/linux/blob/master/arch/powerpc/include/asm/atomic.h
-	// 		https://github.com/torvalds/linux/blob/master/arch/powerpc/include/asm/synch.h
+	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h
+	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/synch.h
 	//
 	// Most compilations have this snippet
 	// 1:	ldarx	%0,0,%2
@@ -396,12 +396,8 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
         );
 	}
 	
-	// For the following three events (i.e. RMWOpReturn, RMWOp, RMWFetchOp), the only difference here
-	// 		https://github.com/torvalds/linux/blob/master/arch/powerpc/include/asm/atomic.h
-	// is the use of #asm_op "%I2" and #asm_op "%I3". This seems to be related to using
-	// immediate assembly operations, but I could not find any difference between I2 and I3, thus
-	// all three methods have the same implementation.
-	
+	// Following
+	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h	
 	@Override
 	public List<Event> visitRMWOp(RMWOp e) {
 		Register resultRegister = e.getResultRegister();
@@ -505,7 +501,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	}
 	
 	// Following
-	//		https://github.com/torvalds/linux/blob/master/arch/powerpc/include/asm/barrier.h
+	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
 	@Override
 	public List<Event> visitLoad(Load e) {
 		Register resultRegister = e.getResultRegister();
@@ -523,7 +519,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	}
 
 	// Following
-	//		https://github.com/torvalds/linux/blob/master/arch/powerpc/include/asm/barrier.h
+	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
 	@Override
 	public List<Event> visitStore(Store e) {
 		ExprInterface value = e.getMemValue();
@@ -541,7 +537,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	}
 
 	// Following
-	//		https://github.com/torvalds/linux/blob/master/arch/powerpc/include/asm/barrier.h
+	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
 	@Override
 	public List<Event> visitFence(Fence e) {
 		String mo = e.getName();
@@ -556,9 +552,9 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	}
 	
 	// The implementation relies on arch_atomic_fetch_add_unless
-	// 		https://github.com/torvalds/linux/blob/master/scripts/atomic/fallbacks/add_unless
+	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/add_unless
 	// which uses a sub at the end to return the value before the operation
-	// 		https://github.com/torvalds/linux/blob/master/arch/powerpc/include/asm/atomic.h
+	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h
 	// Since RMWAddUnless does not care about any returned value, we don't need the final sub
 	@Override
 	public List<Event> visitRMWAddUnless(RMWAddUnless e) {
@@ -600,9 +596,9 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	};
 	
 	// The implementation is arch_${atomic}_op_return(i, v) == 0;
-	// 		https://github.com/torvalds/linux/blob/master/scripts/atomic/fallbacks/sub_and_test
-	// 		https://github.com/torvalds/linux/blob/master/scripts/atomic/fallbacks/inc_and_test
-	// 		https://github.com/torvalds/linux/blob/master/scripts/atomic/fallbacks/dec_and_test
+	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/sub_and_test
+	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/inc_and_test
+	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/dec_and_test
 	@Override
 	public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
 		Register resultRegister = e.getResultRegister();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -9,6 +9,8 @@ import com.dat3m.dartagnan.program.event.Tag.C11;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.linux.LKMMFence;
+import com.dat3m.dartagnan.program.event.lang.linux.LKMMLoad;
+import com.dat3m.dartagnan.program.event.lang.linux.LKMMStore;
 import com.dat3m.dartagnan.program.event.lang.linux.RMWAddUnless;
 import com.dat3m.dartagnan.program.event.lang.linux.RMWCmpXchg;
 import com.dat3m.dartagnan.program.event.lang.linux.RMWFetchOp;
@@ -498,7 +500,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	// Following
 	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
 	@Override
-	public List<Event> visitLoad(Load e) {
+	public List<Event> visitLKMMLoad(LKMMLoad e) {
 		Register resultRegister = e.getResultRegister();
 		IExpr address = e.getAddress();
 		String mo = e.getMo();
@@ -516,7 +518,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	// Following
 	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
 	@Override
-	public List<Event> visitStore(Store e) {
+	public List<Event> visitLKMMStore(LKMMStore e) {
 		ExprInterface value = e.getMemValue();
 		IExpr address = e.getAddress();
 		String mo = e.getMo();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -411,11 +411,11 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
                 load,
                 branchOnCasCmpResult,
                     store,
-                    newLocal(resultRegister, dummy),
                     fakeCtrlDep,
                     label,
                     optionalMemoryBarrierAfter,
-                casEnd
+                casEnd,
+                newLocal(resultRegister, dummy)
         );
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -421,11 +421,12 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 	
 	@Override
 	public List<Event> visitRMWXchg(RMWXchg e) {
+		Register resultRegister = e.getResultRegister();
 		ExprInterface value = e.getMemValue();
 		IExpr address = e.getAddress();
 		String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(e.getResultRegister().getPrecision());
+		Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
         // Power does not have mo tags, thus we use null
         Load load = newRMWLoadExclusive(dummy, address, null);
         Store store = newRMWStoreExclusive(address, value, null, true);
@@ -441,6 +442,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
                 optionalMemoryBarrierBefore,
                 load,
                 store,
+                newLocal(resultRegister, dummy),
                 fakeCtrlDep,
                 label,
                 optionalMemoryBarrierAfter

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -392,12 +392,6 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
         );
 	}
 	
-	// For the following three events (i.e. RMWOpReturn, RMWOp, RMWFetchOp), the only difference here
-	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h
-	// is the use of #asm_op "%I2" and #asm_op "%I3". This seems to be related to using
-	// immediate assembly operations, but I could not find any difference between I2 and I3, thus
-	// all three methods have the same implementation.
-	
 	@Override
 	public List<Event> visitRMWOp(RMWOp e) {
 		Register resultRegister = e.getResultRegister();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -403,6 +403,7 @@ class VisitorPower extends VisitorBase implements EventVisitor<List<Event>> {
 		IExpr address = e.getAddress();
 		String mo = e.getMo();
 		
+        // RMWOp does not return anything; resultRegister is just used as a dummy.
         Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
         Local localOp = newLocal(dummyReg, new IExprBin(resultRegister, op, value));
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractExternalTool.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/benchmarking/AbstractExternalTool.java
@@ -37,10 +37,6 @@ public abstract class AbstractExternalTool {
     protected abstract long getTimeout();
     protected abstract Result getResult(String output);
 
-    protected Provider<Integer> getTimeoutProvider() {
-        return Provider.fromSupplier(() -> 0);
-    }
-
     protected void preExecutionCmds() throws Exception { }
     
     // =============================================================
@@ -52,7 +48,6 @@ public abstract class AbstractExternalTool {
     // Provider rules
     protected final Provider<ShutdownManager> shutdownManagerProvider = Provider.fromSupplier(ShutdownManager::create);
     protected final Provider<String> filePathProvider = getProgramPathProvider();
-    protected final Provider<Integer> timeoutProvider = getTimeoutProvider();
     protected final Provider<String> toolCmdProvider = getToolCmdProvider();
     protected final Provider<List<String>> toolOptionsProvider = getToolOptionsProvider();
 
@@ -65,7 +60,6 @@ public abstract class AbstractExternalTool {
     public RuleChain ruleChain = RuleChain.outerRule(shutdownManagerProvider)
             .around(shutdownOnError)
             .around(filePathProvider)
-            .around(timeoutProvider)
             .around(toolCmdProvider)
             .around(toolOptionsProvider)
             .around(csvLogger)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractCTest.java
@@ -42,10 +42,6 @@ public abstract class AbstractCTest {
         return Provider.fromSupplier(() -> 1);
     }
 
-    protected Provider<Integer> getTimeoutProvider() {
-        return Provider.fromSupplier(() -> 0);
-    }
-
     protected Provider<Wmm> getWmmProvider() {
         return Providers.createWmmFromArch(targetProvider);
     }
@@ -65,11 +61,10 @@ public abstract class AbstractCTest {
     protected final Provider<Arch> targetProvider = () -> target;
     protected final Provider<String> filePathProvider = getProgramPathProvider();
     protected final Provider<Integer> boundProvider = getBoundProvider();
-    protected final Provider<Integer> timeoutProvider = getTimeoutProvider();
     protected final Provider<Program> programProvider = Providers.createProgramFromPath(filePathProvider);
     protected final Provider<Wmm> wmmProvider = getWmmProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
-    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, timeoutProvider);
+    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider);
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);
 
@@ -83,7 +78,6 @@ public abstract class AbstractCTest {
             .around(shutdownOnError)
             .around(filePathProvider)
             .around(boundProvider)
-            .around(timeoutProvider)
             .around(programProvider)
             .around(wmmProvider)
             .around(propertyProvider)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractCTest.java
@@ -18,6 +18,7 @@ import org.junit.Rule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
@@ -64,7 +65,7 @@ public abstract class AbstractCTest {
     protected final Provider<Program> programProvider = Providers.createProgramFromPath(filePathProvider);
     protected final Provider<Wmm> wmmProvider = getWmmProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
-    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, false);
+    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, () -> Configuration.defaultConfiguration());
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractCTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractCTest {
     protected final Provider<Program> programProvider = Providers.createProgramFromPath(filePathProvider);
     protected final Provider<Wmm> wmmProvider = getWmmProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
-    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider);
+    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, false);
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractSvCompTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractSvCompTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractSvCompTest {
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
     protected final Provider<Result> expectedResultProvider = Provider.fromSupplier(() ->
     	readExpected(filePathProvider.get().substring(0, filePathProvider.get().lastIndexOf("-")) + ".yml", "unreach-call.prp"));
-    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider);
+    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, false);
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);
     protected final Provider<ProverEnvironment> prover2Provider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractSvCompTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractSvCompTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
@@ -74,7 +75,7 @@ public abstract class AbstractSvCompTest {
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
     protected final Provider<Result> expectedResultProvider = Provider.fromSupplier(() ->
     	readExpected(filePathProvider.get().substring(0, filePathProvider.get().lastIndexOf("-")) + ".yml", "unreach-call.prp"));
-    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, false);
+    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, () -> Configuration.defaultConfiguration());
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);
     protected final Provider<ProverEnvironment> prover2Provider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractSvCompTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractSvCompTest.java
@@ -51,10 +51,6 @@ public abstract class AbstractSvCompTest {
         return Provider.fromSupplier(() -> bound);
     }
 
-    protected Provider<Integer> getTimeoutProvider() {
-        return Provider.fromSupplier(() -> 0);
-    }
-
     protected Provider<Wmm> getWmmProvider() {
         return GlobalSettings.ATOMIC_AS_LOCK ?
                 Providers.createWmmFromName(() -> "svcomp-locks") :
@@ -73,13 +69,12 @@ public abstract class AbstractSvCompTest {
     protected final Provider<Arch> targetProvider = () -> Arch.C11;
     protected final Provider<String> filePathProvider = getProgramPathProvider();
     protected final Provider<Integer> boundProvider = getBoundProvider();
-    protected final Provider<Integer> timeoutProvider = getTimeoutProvider();
     protected final Provider<Program> programProvider = Providers.createProgramFromPath(filePathProvider);
     protected final Provider<Wmm> wmmProvider = getWmmProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
     protected final Provider<Result> expectedResultProvider = Provider.fromSupplier(() ->
     	readExpected(filePathProvider.get().substring(0, filePathProvider.get().lastIndexOf("-")) + ".yml", "unreach-call.prp"));
-    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, timeoutProvider);
+    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider);
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);
     protected final Provider<ProverEnvironment> prover2Provider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);
@@ -94,7 +89,6 @@ public abstract class AbstractSvCompTest {
             .around(shutdownOnError)
             .around(filePathProvider)
             .around(boundProvider)
-            .around(timeoutProvider)
             .around(programProvider)
             .around(wmmProvider)
             .around(propertyProvider)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -21,6 +21,7 @@ import com.dat3m.dartagnan.configuration.Property;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
 import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
@@ -86,6 +87,7 @@ public abstract class AbstractCompilationTest {
     protected final Provider<ProverEnvironment> prover1Provider = Providers.createProverWithFixedOptions(context1Provider, ProverOptions.GENERATE_MODELS);
     protected final Provider<ProverEnvironment> prover2Provider = Providers.createProverWithFixedOptions(context2Provider, ProverOptions.GENERATE_MODELS);
     
+    private final Timeout timeout = Timeout.millis(getTimeout());
     private final RequestShutdownOnError shutdownOnError = RequestShutdownOnError.create(shutdownManagerProvider);
 
     @Rule
@@ -99,6 +101,7 @@ public abstract class AbstractCompilationTest {
             .around(propertyProvider)
             .around(task1Provider)
             .around(task2Provider)
+            .around(timeout)
             // Context/Prover need to be created inside test-thread spawned by <timeout>
             .around(context1Provider)
             .around(context2Provider)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -80,8 +80,8 @@ public abstract class AbstractCompilationTest {
     protected final Provider<Wmm> wmm1Provider = Providers.createWmmFromArch(getSourceProvider());
     protected final Provider<Wmm> wmm2Provider = Providers.createWmmFromArch(getTargetProvider());
     protected final Provider<EnumSet<Property>> propertyProvider = Provider.fromSupplier(() -> EnumSet.of(Property.getDefault()));
-    protected final Provider<VerificationTask> task1Provider = createTask(program1Provider, wmm1Provider, propertyProvider, sourceProvider, Provider.fromSupplier(() -> 1));    
-    protected final Provider<VerificationTask> task2Provider = createTask(program2Provider, wmm2Provider, propertyProvider, targetProvider, Provider.fromSupplier(() -> 1)); 
+    protected final Provider<VerificationTask> task1Provider = createTask(program1Provider, wmm1Provider, propertyProvider, sourceProvider, () -> 1);    
+    protected final Provider<VerificationTask> task2Provider = createTask(program2Provider, wmm2Provider, propertyProvider, targetProvider, () -> 1); 
     protected final Provider<SolverContext> context1Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<SolverContext> context2Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> prover1Provider = Providers.createProverWithFixedOptions(context1Provider, ProverOptions.GENERATE_MODELS);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
@@ -37,6 +38,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
+import static com.dat3m.dartagnan.configuration.OptionNames.INITIALIZE_REGISTERS;
 
 public abstract class AbstractCompilationTest {
 
@@ -81,8 +83,9 @@ public abstract class AbstractCompilationTest {
     protected final Provider<Wmm> wmm1Provider = Providers.createWmmFromArch(getSourceProvider());
     protected final Provider<Wmm> wmm2Provider = Providers.createWmmFromArch(getTargetProvider());
     protected final Provider<EnumSet<Property>> propertyProvider = Provider.fromSupplier(() -> EnumSet.of(Property.getDefault()));
-    protected final Provider<VerificationTask> task1Provider = Providers.createTask(program1Provider, wmm1Provider, propertyProvider, sourceProvider, () -> 1, DO_INITIALIZE_REGISTERS);    
-    protected final Provider<VerificationTask> task2Provider = Providers.createTask(program2Provider, wmm2Provider, propertyProvider, targetProvider, () -> 1, DO_INITIALIZE_REGISTERS); 
+    protected final Provider<Configuration> configProvider = Provider.fromSupplier(() -> Configuration.builder().setOption(INITIALIZE_REGISTERS, String.valueOf(DO_INITIALIZE_REGISTERS)).build());
+    protected final Provider<VerificationTask> task1Provider = Providers.createTask(program1Provider, wmm1Provider, propertyProvider, sourceProvider, () -> 1, configProvider);
+    protected final Provider<VerificationTask> task2Provider = Providers.createTask(program2Provider, wmm2Provider, propertyProvider, targetProvider,  () -> 1, configProvider);
     protected final Provider<SolverContext> context1Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<SolverContext> context2Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> prover1Provider = Providers.createProverWithFixedOptions(context1Provider, ProverOptions.GENERATE_MODELS);
@@ -100,6 +103,7 @@ public abstract class AbstractCompilationTest {
             .around(wmm1Provider)
             .around(wmm2Provider)
             .around(propertyProvider)
+            .around(configProvider)
             .around(task1Provider)
             .around(task2Provider)
             .around(timeout)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -36,10 +36,11 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static com.dat3m.dartagnan.utils.rules.Providers.createTask;
 import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractCompilationTest {
+
+    private static final boolean DO_INITIALIZE_REGISTERS = true;
 
     private String path;
 
@@ -80,8 +81,8 @@ public abstract class AbstractCompilationTest {
     protected final Provider<Wmm> wmm1Provider = Providers.createWmmFromArch(getSourceProvider());
     protected final Provider<Wmm> wmm2Provider = Providers.createWmmFromArch(getTargetProvider());
     protected final Provider<EnumSet<Property>> propertyProvider = Provider.fromSupplier(() -> EnumSet.of(Property.getDefault()));
-    protected final Provider<VerificationTask> task1Provider = createTask(program1Provider, wmm1Provider, propertyProvider, sourceProvider, () -> 1);    
-    protected final Provider<VerificationTask> task2Provider = createTask(program2Provider, wmm2Provider, propertyProvider, targetProvider, () -> 1); 
+    protected final Provider<VerificationTask> task1Provider = Providers.createTask(program1Provider, wmm1Provider, propertyProvider, sourceProvider, () -> 1, DO_INITIALIZE_REGISTERS);    
+    protected final Provider<VerificationTask> task2Provider = Providers.createTask(program2Provider, wmm2Provider, propertyProvider, targetProvider, () -> 1, DO_INITIALIZE_REGISTERS); 
     protected final Provider<SolverContext> context1Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<SolverContext> context2Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> prover1Provider = Providers.createProverWithFixedOptions(context1Provider, ProverOptions.GENERATE_MODELS);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -143,6 +143,7 @@ public abstract class AbstractCompilationTest {
 
     @Test
     public void testRefinement() throws Exception {
+    	// The following have features (locks and RCU) that PPC does not support
     	FilterAbstract rcu = FilterUnion.get(FilterBasic.get(Tag.Linux.RCU_LOCK), 
     			FilterUnion.get(FilterBasic.get(Tag.Linux.RCU_UNLOCK), FilterBasic.get(Tag.Linux.RCU_SYNC)));
     	FilterAbstract lock = FilterUnion.get(FilterBasic.get(Tag.Linux.LOCK_READ), 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -1,0 +1,164 @@
+package com.dat3m.dartagnan.compilation;
+
+import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.event.Tag;
+import com.dat3m.dartagnan.program.filter.FilterAbstract;
+import com.dat3m.dartagnan.program.filter.FilterBasic;
+import com.dat3m.dartagnan.program.filter.FilterUnion;
+import com.dat3m.dartagnan.utils.ResourceHelper;
+import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.utils.rules.CSVLogger;
+import com.dat3m.dartagnan.utils.rules.Provider;
+import com.dat3m.dartagnan.utils.rules.Providers;
+import com.dat3m.dartagnan.utils.rules.RequestShutdownOnError;
+import com.dat3m.dartagnan.verification.RefinementTask;
+import com.dat3m.dartagnan.verification.VerificationTask;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
+import com.dat3m.dartagnan.wmm.Wmm;
+
+import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.configuration.Property;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
+import org.sosy_lab.java_smt.api.SolverContext;
+import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.dat3m.dartagnan.configuration.OptionNames.INITIALIZE_REGISTERS;
+import static com.google.common.io.Files.getNameWithoutExtension;
+import static org.junit.Assert.assertEquals;
+
+public abstract class AbstractCompilationTest {
+
+    private static final boolean DO_INITIALIZE_REGISTERS = true;
+
+    private String path;
+
+    AbstractCompilationTest(String path) {
+        this.path = path;
+    }
+
+    static Iterable<Object[]> buildLitmusTests(String litmusPath) throws IOException {
+        int n = ResourceHelper.LITMUS_RESOURCE_PATH.length();
+        Map<String, Result> expectationMap = ResourceHelper.getExpectedResults();
+
+        try (Stream<Path> fileStream = Files.walk(Paths.get(ResourceHelper.LITMUS_RESOURCE_PATH + litmusPath))) {
+            return fileStream
+                    .filter(Files::isRegularFile)
+                    .map(Path::toString)
+                    .filter(f -> f.endsWith("litmus"))
+                    .filter(f -> expectationMap.containsKey(f.substring(n)))
+                    .collect(ArrayList::new,
+                            (l, f) -> l.add(new Object[]{f}), ArrayList::addAll);
+        }
+    }
+
+
+    // =================== Modifiable behavior ====================
+
+    protected abstract Provider<Arch> getTarget1Provider();
+    protected abstract Provider<Arch> getTarget2Provider();
+
+    protected Provider<Integer> getTimeoutProvider() {
+        return Provider.fromSupplier(() -> 0);
+    }
+
+    protected long getTimeout() { return 10000; }
+
+    // ============================================================
+
+
+    @ClassRule
+    public static CSVLogger.Initialization csvInit = CSVLogger.Initialization.create();
+
+    protected final Provider<ShutdownManager> shutdownManagerProvider = Provider.fromSupplier(ShutdownManager::create);
+    protected final Provider<Arch> target1Provider = getTarget1Provider();
+    protected final Provider<Arch> target2Provider = getTarget2Provider();
+    protected final Provider<String> filePathProvider = () -> path;
+    protected final Provider<String> nameProvider = Provider.fromSupplier(() -> getNameWithoutExtension(Path.of(path).getFileName().toString()));
+    protected final Provider<Integer> timeoutProvider = getTimeoutProvider();
+    protected final Provider<Program> program1Provider = Providers.createProgramFromPath(filePathProvider);
+    protected final Provider<Program> program2Provider = Providers.createProgramFromPath(filePathProvider);
+    protected final Provider<Wmm> wmm1Provider = Providers.createWmmFromArch(getTarget1Provider());
+    protected final Provider<Wmm> wmm2Provider = Providers.createWmmFromArch(getTarget2Provider());
+    protected final Provider<EnumSet<Property>> propertyProvider = Provider.fromSupplier(() -> EnumSet.of(Property.getDefault()));
+    protected final Provider<VerificationTask> task1Provider = Provider.fromSupplier(() ->
+        VerificationTask.builder()
+        .withConfig(Configuration.builder()
+            .setOption(INITIALIZE_REGISTERS,String.valueOf(DO_INITIALIZE_REGISTERS))
+            .build())
+        .withTarget(target1Provider.get())
+        .withSolverTimeout(timeoutProvider.get())
+        .build(program1Provider.get(), wmm1Provider.get(), propertyProvider.get()));
+    protected final Provider<VerificationTask> task2Provider = Provider.fromSupplier(() ->
+    	VerificationTask.builder()
+    	.withConfig(Configuration.builder()
+    		.setOption(INITIALIZE_REGISTERS,String.valueOf(DO_INITIALIZE_REGISTERS))
+    		.build())
+    	.withTarget(target2Provider.get())
+    	.withSolverTimeout(timeoutProvider.get())
+    	.build(program2Provider.get(), wmm2Provider.get(), propertyProvider.get()));
+    protected final Provider<SolverContext> context1Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
+    protected final Provider<SolverContext> context2Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
+    protected final Provider<ProverEnvironment> prover1Provider = Providers.createProverWithFixedOptions(context1Provider, ProverOptions.GENERATE_MODELS);
+    protected final Provider<ProverEnvironment> prover2Provider = Providers.createProverWithFixedOptions(context2Provider, ProverOptions.GENERATE_MODELS);
+    
+    private final Timeout timeout = Timeout.millis(getTimeout());
+    private final RequestShutdownOnError shutdownOnError = RequestShutdownOnError.create(shutdownManagerProvider);
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(shutdownManagerProvider)
+            .around(shutdownOnError)
+            .around(filePathProvider)
+            .around(nameProvider)
+            .around(timeoutProvider)
+            .around(program1Provider)
+            .around(program2Provider)
+            .around(wmm1Provider)
+            .around(wmm2Provider)
+            .around(propertyProvider)
+            .around(task1Provider)
+            .around(task2Provider)
+            .around(timeout)
+            // Context/Prover need to be created inside test-thread spawned by <timeout>
+            .around(context1Provider)
+            .around(context2Provider)
+            .around(prover1Provider)
+    		.around(prover2Provider);
+
+    @Test
+    public void testRefinement() throws Exception {
+    	FilterAbstract rcu = FilterUnion.get(FilterBasic.get(Tag.Linux.RCU_LOCK), 
+    			FilterUnion.get(FilterBasic.get(Tag.Linux.RCU_UNLOCK), FilterBasic.get(Tag.Linux.RCU_SYNC)));
+    	FilterAbstract lock = FilterUnion.get(FilterBasic.get(Tag.Linux.LOCK_READ), 
+    			FilterUnion.get(FilterBasic.get(Tag.Linux.LOCK_WRITE), FilterBasic.get(Tag.Linux.UNLOCK)));
+    	if(!task1Provider.get().getProgram().getCache().getEvents(FilterUnion.get(rcu, lock)).isEmpty()) {
+    		return;
+    	}
+    	Result res1 = RefinementSolver.run(context1Provider.get(), prover1Provider.get(),
+                RefinementTask.fromVerificationTaskWithDefaultBaselineWMM(task1Provider.get()));
+    	Result res2 = RefinementSolver.run(context2Provider.get(), prover2Provider.get(),
+                RefinementTask.fromVerificationTaskWithDefaultBaselineWMM(task2Provider.get()));
+    	if(res1.equals(Result.PASS)) {
+    		if(!res2.equals(Result.PASS)) {
+        		System.out.println(path);
+        	}
+    		assertEquals(Result.PASS, res2);
+    	}
+    }
+}

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -88,22 +88,8 @@ public abstract class AbstractCompilationTest {
     protected final Provider<Wmm> wmm1Provider = Providers.createWmmFromArch(getSourceProvider());
     protected final Provider<Wmm> wmm2Provider = Providers.createWmmFromArch(getTargetProvider());
     protected final Provider<EnumSet<Property>> propertyProvider = Provider.fromSupplier(() -> EnumSet.of(Property.getDefault()));
-    protected final Provider<VerificationTask> task1Provider = Provider.fromSupplier(() ->
-        VerificationTask.builder()
-        .withConfig(Configuration.builder()
-            .setOption(INITIALIZE_REGISTERS,String.valueOf(DO_INITIALIZE_REGISTERS))
-            .build())
-        .withTarget(sourceProvider.get())
-        .withSolverTimeout(timeoutProvider.get())
-        .build(program1Provider.get(), wmm1Provider.get(), propertyProvider.get()));
-    protected final Provider<VerificationTask> task2Provider = Provider.fromSupplier(() ->
-    	VerificationTask.builder()
-    	.withConfig(Configuration.builder()
-    		.setOption(INITIALIZE_REGISTERS,String.valueOf(DO_INITIALIZE_REGISTERS))
-    		.build())
-    	.withTarget(targetProvider.get())
-    	.withSolverTimeout(timeoutProvider.get())
-    	.build(program2Provider.get(), wmm2Provider.get(), propertyProvider.get()));
+    protected final Provider<VerificationTask> task1Provider = createTaskProvider(program1Provider, wmm1Provider, sourceProvider);    
+    protected final Provider<VerificationTask> task2Provider = createTaskProvider(program2Provider, wmm2Provider, targetProvider); 
     protected final Provider<SolverContext> context1Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<SolverContext> context2Provider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> prover1Provider = Providers.createProverWithFixedOptions(context1Provider, ProverOptions.GENERATE_MODELS);
@@ -111,6 +97,17 @@ public abstract class AbstractCompilationTest {
     
     private final RequestShutdownOnError shutdownOnError = RequestShutdownOnError.create(shutdownManagerProvider);
 
+    private Provider<VerificationTask> createTaskProvider(Provider<Program> progProvider, Provider<Wmm> wmmProvider, Provider<Arch> targetProvider) {
+    	return Provider.fromSupplier(() ->
+    		VerificationTask.builder()
+    		.withConfig(Configuration.builder()
+    			.setOption(INITIALIZE_REGISTERS,String.valueOf(DO_INITIALIZE_REGISTERS))
+    			.build())
+    		.withTarget(targetProvider.get())
+    		.withSolverTimeout(timeoutProvider.get())
+    		.build(progProvider.get(), wmmProvider.get(), propertyProvider.get()));
+    }
+    
     @Rule
     public RuleChain ruleChain = RuleChain.outerRule(shutdownManagerProvider)
             .around(shutdownOnError)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/LKMM2PPCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/LKMM2PPCTest.java
@@ -1,0 +1,31 @@
+package com.dat3m.dartagnan.compilation;
+
+import com.dat3m.dartagnan.utils.rules.Provider;
+import com.dat3m.dartagnan.configuration.Arch;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+
+@RunWith(Parameterized.class)
+public class LKMM2PPCTest extends AbstractCompilationTest {
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Iterable<Object[]> data() throws IOException {
+        return buildLitmusTests("litmus/C/");
+    }
+
+    public LKMM2PPCTest(String path) {
+        super(path);
+    }
+
+	@Override
+	protected Provider<Arch> getTarget1Provider() {
+		return () -> Arch.LKMM;
+	}
+
+	@Override
+	protected Provider<Arch> getTarget2Provider() {
+		return () -> Arch.POWER;
+	}
+}

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/LKMM2PPCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/LKMM2PPCTest.java
@@ -20,12 +20,12 @@ public class LKMM2PPCTest extends AbstractCompilationTest {
     }
 
 	@Override
-	protected Provider<Arch> getTarget1Provider() {
+	protected Provider<Arch> getSourceProvider() {
 		return () -> Arch.LKMM;
 	}
 
 	@Override
-	protected Provider<Arch> getTarget2Provider() {
+	protected Provider<Arch> getTargetProvider() {
 		return () -> Arch.POWER;
 	}
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
@@ -86,10 +86,6 @@ public abstract class AbstractLitmusTest {
         return Provider.fromSupplier(() -> 1);
     }
 
-    protected Provider<Integer> getTimeoutProvider() {
-        return Provider.fromSupplier(() -> 0);
-    }
-
     protected long getTimeout() { return 10000; }
 
     // ============================================================
@@ -103,7 +99,6 @@ public abstract class AbstractLitmusTest {
     protected final Provider<String> filePathProvider = () -> path;
     protected final Provider<String> nameProvider = Provider.fromSupplier(() -> getNameWithoutExtension(Path.of(path).getFileName().toString()));
     protected final Provider<Integer> boundProvider = getBoundProvider();
-    protected final Provider<Integer> timeoutProvider = getTimeoutProvider();
     protected final Provider<Program> programProvider = Providers.createProgramFromPath(filePathProvider);
     protected final Provider<Wmm> wmmProvider = getWmmProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
@@ -116,7 +111,6 @@ public abstract class AbstractLitmusTest {
             .build())
         .withTarget(targetProvider.get())
         .withBound(boundProvider.get())
-        .withSolverTimeout(timeoutProvider.get())
         .build(programProvider.get(), wmmProvider.get(), propertyProvider.get()));
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, ProverOptions.GENERATE_MODELS);
@@ -132,7 +126,6 @@ public abstract class AbstractLitmusTest {
             .around(filePathProvider)
             .around(nameProvider)
             .around(boundProvider)
-            .around(timeoutProvider)
             .around(programProvider)
             .around(wmmProvider)
             .around(propertyProvider)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
@@ -35,6 +36,7 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static com.dat3m.dartagnan.configuration.OptionNames.INITIALIZE_REGISTERS;
 import static com.dat3m.dartagnan.utils.ResourceHelper.*;
 import static com.google.common.io.Files.getNameWithoutExtension;
 import static org.junit.Assert.assertEquals;
@@ -102,7 +104,8 @@ public abstract class AbstractLitmusTest {
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
     protected final Provider<Result> expectedResultProvider = Provider.fromSupplier(() ->
     	getExpectedResults().get(filePathProvider.get().substring(filePathProvider.get().indexOf("/") + 1)));
-    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, DO_INITIALIZE_REGISTERS);
+    protected final Provider<Configuration> configProvider = Provider.fromSupplier(() -> Configuration.builder().setOption(INITIALIZE_REGISTERS, String.valueOf(DO_INITIALIZE_REGISTERS)).build());
+    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, configProvider);
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, ProverOptions.GENERATE_MODELS);
     protected final Provider<ProverEnvironment> prover2Provider = Providers.createProverWithFixedOptions(contextProvider, ProverOptions.GENERATE_MODELS);
@@ -120,6 +123,7 @@ public abstract class AbstractLitmusTest {
             .around(programProvider)
             .around(wmmProvider)
             .around(propertyProvider)
+            .around(configProvider)
             .around(taskProvider)
             .around(expectedResultProvider)
             .around(csvLogger)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 import org.sosy_lab.common.ShutdownManager;
-import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
@@ -36,7 +35,6 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static com.dat3m.dartagnan.configuration.OptionNames.INITIALIZE_REGISTERS;
 import static com.dat3m.dartagnan.utils.ResourceHelper.*;
 import static com.google.common.io.Files.getNameWithoutExtension;
 import static org.junit.Assert.assertEquals;
@@ -104,14 +102,7 @@ public abstract class AbstractLitmusTest {
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
     protected final Provider<Result> expectedResultProvider = Provider.fromSupplier(() ->
     	getExpectedResults().get(filePathProvider.get().substring(filePathProvider.get().indexOf("/") + 1)));
-    protected final Provider<VerificationTask> taskProvider = Provider.fromSupplier(() ->
-        VerificationTask.builder()
-        .withConfig(Configuration.builder()
-            .setOption(INITIALIZE_REGISTERS,String.valueOf(DO_INITIALIZE_REGISTERS))
-            .build())
-        .withTarget(targetProvider.get())
-        .withBound(boundProvider.get())
-        .build(programProvider.get(), wmmProvider.get(), propertyProvider.get()));
+    protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, DO_INITIALIZE_REGISTERS);
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider);
     protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, ProverOptions.GENERATE_MODELS);
     protected final Provider<ProverEnvironment> prover2Provider = Providers.createProverWithFixedOptions(contextProvider, ProverOptions.GENERATE_MODELS);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
@@ -60,11 +60,10 @@ public class Providers {
     // =========================== Task related providers ==============================
 
     public static Provider<VerificationTask> createTask(Supplier<Program> programSupplier, Supplier<Wmm> wmmSupplier, Supplier<EnumSet<Property>> propertySupplier,
-                                                        Supplier<Arch> targetSupplier, Supplier<Integer> boundSupplier, Supplier<Integer> timeoutSupplier) {
+                                                        Supplier<Arch> targetSupplier, Supplier<Integer> boundSupplier) {
     	return Provider.fromSupplier(() -> VerificationTask.builder().
     			withTarget(targetSupplier.get()).
     			withBound(boundSupplier.get()).
-    			withSolverTimeout(timeoutSupplier.get()).
     			build(programSupplier.get(), wmmSupplier.get(), propertySupplier.get()));
     }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
@@ -12,8 +12,11 @@ import com.dat3m.dartagnan.configuration.Property;
 
 import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.ShutdownNotifier;
+import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
+
+import static com.dat3m.dartagnan.configuration.OptionNames.INITIALIZE_REGISTERS;
 
 import java.io.File;
 import java.util.EnumSet;
@@ -60,8 +63,11 @@ public class Providers {
     // =========================== Task related providers ==============================
 
     public static Provider<VerificationTask> createTask(Supplier<Program> programSupplier, Supplier<Wmm> wmmSupplier, Supplier<EnumSet<Property>> propertySupplier,
-                                                        Supplier<Arch> targetSupplier, Supplier<Integer> boundSupplier) {
+                                                        Supplier<Arch> targetSupplier, Supplier<Integer> boundSupplier, boolean initiRegs) {
     	return Provider.fromSupplier(() -> VerificationTask.builder().
+    	        withConfig(Configuration.builder()
+    	                .setOption(INITIALIZE_REGISTERS, String.valueOf(initiRegs))
+    	                .build()).
     			withTarget(targetSupplier.get()).
     			withBound(boundSupplier.get()).
     			build(programSupplier.get(), wmmSupplier.get(), propertySupplier.get()));

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
@@ -16,8 +16,6 @@ import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
-import static com.dat3m.dartagnan.configuration.OptionNames.INITIALIZE_REGISTERS;
-
 import java.io.File;
 import java.util.EnumSet;
 import java.util.function.Supplier;
@@ -63,11 +61,9 @@ public class Providers {
     // =========================== Task related providers ==============================
 
     public static Provider<VerificationTask> createTask(Supplier<Program> programSupplier, Supplier<Wmm> wmmSupplier, Supplier<EnumSet<Property>> propertySupplier,
-                                                        Supplier<Arch> targetSupplier, Supplier<Integer> boundSupplier, boolean initiRegs) {
+                                                        Supplier<Arch> targetSupplier, Supplier<Integer> boundSupplier, Supplier<Configuration> config) {
     	return Provider.fromSupplier(() -> VerificationTask.builder().
-    	        withConfig(Configuration.builder()
-    	                .setOption(INITIALIZE_REGISTERS, String.valueOf(initiRegs))
-    	                .build()).
+    	        withConfig(config.get()).
     			withTarget(targetSupplier.get()).
     			withBound(boundSupplier.get()).
     			build(programSupplier.get(), wmmSupplier.get(), propertySupplier.get()));

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/WmmFromArchitectureProvider.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/WmmFromArchitectureProvider.java
@@ -29,6 +29,7 @@ public class WmmFromArchitectureProvider extends AbstractProvider<Wmm> {
         ARCH_WMM_MAP.put(Arch.TSO, () -> new ParserCat().parse(new File(CAT_RESOURCE_PATH + "cat/tso.cat")));
         ARCH_WMM_MAP.put(Arch.ARM8, () -> new ParserCat().parse(new File(CAT_RESOURCE_PATH + "cat/aarch64.cat")));
         ARCH_WMM_MAP.put(Arch.POWER, () -> new ParserCat().parse(new File(CAT_RESOURCE_PATH + "cat/power.cat")));
+        ARCH_WMM_MAP.put(Arch.LKMM, () -> new ParserCat().parse(new File(CAT_RESOURCE_PATH + "cat/linux-kernel.cat")));
     }
 
     private final Supplier<Arch> archSupplier;

--- a/dartagnan/src/test/resources/dartagnan-expected.csv
+++ b/dartagnan/src/test/resources/dartagnan-expected.csv
@@ -10486,6 +10486,7 @@ litmus/C/dart/C-atomic-cmpxchg-failure-05.litmus,0
 litmus/C/dart/C-atomic-op-and-test-02.litmus,1
 litmus/C/dart/C-atomic-cmpxchg-success-01-2.litmus,1
 litmus/C/dart/C-atomic-fetch-simple-04.litmus,0
+litmus/C/dart/C-atomic-fetch-simple-06.litmus,0
 litmus/C/dart/C-ctrl-03.litmus,0
 litmus/C/dart/C-atomic-op-return-simple-01-4.litmus,1
 litmus/C/dart/C-atomic-add-unless-03.litmus,1

--- a/litmus/C/dart/C-atomic-fetch-simple-06.litmus
+++ b/litmus/C/dart/C-atomic-fetch-simple-06.litmus
@@ -1,0 +1,13 @@
+C C-atomic-fetch-simple-06
+
+{
+  atomic_t x[2] = {0,0};
+}
+
+P0(atomic_t *x) {
+  int r0; int r1;
+  r0 = 1;
+  r0 = atomic_fetch_add(2,x+r0);
+}
+
+exists (0:r0 != 0 \/ x[1] != 2)

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -22,6 +22,8 @@ import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.PHANTOM_REFERENCES;
+import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
+import static com.dat3m.dartagnan.utils.Result.FAIL;
 
 import java.util.EnumSet;
 
@@ -112,7 +114,7 @@ public class ReachabilityResult {
     private void buildVerdict(Result result){
         StringBuilder sb = new StringBuilder();
         sb.append("Condition ").append(program.getAss().toStringWithType()).append("\n");
-        sb.append(result).append("\n");
+        sb.append(program.getFormat().equals(LITMUS) ? result == FAIL ? "Ok" : "No" : result).append("\n");
         verdict = sb.toString();
     }
 


### PR DESCRIPTION
This PR implements a compilation mapping from the Linux kernel API to Power following the inline assembly from the LK repo (links are provided as comments in the code). It also adds an abstract compilation test. Right now this is only used as the base for LKMM2Power but once we have the other compilation mapping (LKMM2TSO and LKMM2ARM8) implemented or C11 litmus tests (for which we already have all the compilation mappings), all those will also extend this abstract test,