### PR TITLE
Do not merge events with the same Cline

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -142,9 +142,7 @@ public class ExecutionGraphVisualizer {
                 continue;
             }
 
-            if (e1.getEvent().getCLine() != e2.getEvent().getCLine()) {
-                appendEdge(e1, e2, model, (String[]) null);
-            }
+            appendEdge(e1, e2, model, (String[]) null);
         }
 
         // --- Subgraph end ---


### PR DESCRIPTION
#261 took some code from the `cna-verification` where I added an option to decide if merging or not events in the witness graph. Since we agreed that merging events was not that useful at the end (and merging them cause problems like missing po edges), mi idea was to completely remove the merging. However I just remove the option but kept the old merging code. This PR completely remove the merging of events in the graph generation.