### PR TITLE
Missing parenthesis in IValue.hashCode()

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
@@ -44,7 +44,7 @@ public final class IValue extends IConst {
 
     @Override
     public int hashCode() {
-        return value.hashCode() + precision > 0 ? 0 : precision;
+        return value.hashCode() + (precision > 0 ? 0 : precision);
     }
 
     @Override


### PR DESCRIPTION
The missing parenthesis allow `IValue.hashCode()` to return zero which can (and does) result in a division by zero in `IExpBin.hashCode()`