### PR TITLE
Make the output of litmus test be similar to the one of herd7

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -161,17 +161,12 @@ public class Dartagnan extends BaseOptions {
     				String name = task.getProgram().getName().substring(0, task.getProgram().getName().lastIndexOf('.'));
     				generateGraphvizFile(m, 1, (x, y) -> true, System.getenv("DAT3M_HOME") + "/output/", name);        		
             	}
-                
-                if (p.getFormat().equals(SourceLanguage.LITMUS)) {
-                    if (p.getAssFilter() != null) {
-                        System.out.println("Filter " + (p.getAssFilter()));
-                    }
-                    System.out.println("Condition " + p.getAss().toStringWithType());
-                    System.out.println(result == FAIL ? "Ok" : "No");
-                }
+
+            	boolean safetyViolationFound = false;
             	if((result == FAIL && !p.getAss().getInvert()) || 
             			(result == PASS && p.getAss().getInvert())) {
             		if(TRUE.equals(prover.getModel().evaluate(REACHABILITY.getSMTVariable(ctx)))) {
+            			safetyViolationFound = true;
             			System.out.println("Safety violation found");
             		}
             		if(TRUE.equals(prover.getModel().evaluate(LIVENESS.getSMTVariable(ctx)))) {
@@ -182,7 +177,15 @@ public class Dartagnan extends BaseOptions {
                 			System.out.println("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName()));
                 		}                			
             		}
-                    System.out.println(result);
+                }
+                if (p.getFormat().equals(SourceLanguage.LITMUS)) {
+                    if (p.getAssFilter() != null) {
+                        System.out.println("Filter " + (p.getAssFilter()));
+                    }
+                    System.out.println("Condition " + p.getAss().toStringWithType());
+                    System.out.println(safetyViolationFound ? "Ok" : "No");
+                } else {
+                    System.out.println(result);                	
                 }
 
 				try {

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -18,6 +18,7 @@ import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
+import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
@@ -28,16 +29,13 @@ import static com.dat3m.dartagnan.configuration.Property.REACHABILITY;
 import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
 import static java.lang.Boolean.TRUE;
 
-import java.util.EnumSet;
-
 public class ReachabilityResult {
 
     private final Program program;
     private final Wmm wmm;
     private final UiOptions options;
-	private boolean safetyViolationFound = false;
 
-    private String verdict = "";
+    private String verdict;
 
     public ReachabilityResult(Program program, Wmm wmm, UiOptions options){
         this.program = program;
@@ -105,15 +103,7 @@ public class ReachabilityResult {
                     }
                     // Verification ended, we can interrupt the timeout Thread
                     t.interrupt();
-            		for(Axiom ax : wmm.getAxioms()) {
-                		if(ax.isFlagged() && TRUE.equals(prover.getModel().evaluate(CAT.getSMTVariable(ax, ctx)))) {
-                			verdict += "Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName());
-                		}                			
-            		}
-                    buildVerdict(result);
-            		if(TRUE.equals(prover.getModel().evaluate(REACHABILITY.getSMTVariable(ctx)))) {
-            			safetyViolationFound = true;
-            		}
+                    buildVerdict(result, prover.getModel(), ctx);
                 }
             } catch (InterruptedException e){
             	verdict = "TIMEOUT";
@@ -123,11 +113,17 @@ public class ReachabilityResult {
         }
     }
 
-    private void buildVerdict(Result result){
-        StringBuilder sb = new StringBuilder();
-        sb.append("\n").append("Condition ").append(program.getAss().toStringWithType()).append("\n");
-        sb.append(program.getFormat().equals(LITMUS) ? safetyViolationFound ? "Ok" : "No" : result).append("\n");
-        verdict += sb.toString();
+    private void buildVerdict(Result result, Model m, SolverContext ctx){
+        StringBuilder sb = new StringBuilder();    	
+		for(Axiom ax : wmm.getAxioms()) {
+    		if(ax.isFlagged() && TRUE.equals(m.evaluate(CAT.getSMTVariable(ax, ctx)))) {
+    			sb.append("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName())).append("\n");
+    		}                			
+		}
+		// TODO We might want to output different messages once we allow to check LIVENESS from the UI
+		sb.append("Condition ").append(program.getAss().toStringWithType()).append("\n");
+		sb.append(program.getFormat().equals(LITMUS) ? TRUE.equals(m.evaluate(REACHABILITY.getSMTVariable(ctx))) ? "Ok" : "No" : result).append("\n");			
+        verdict = sb.toString();
     }
 
     private boolean validate(){

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -114,15 +114,15 @@ public class ReachabilityResult {
     }
 
     private void buildVerdict(Result result, Model m, SolverContext ctx){
-        StringBuilder sb = new StringBuilder();    	
+        StringBuilder sb = new StringBuilder();
 		for(Axiom ax : wmm.getAxioms()) {
     		if(ax.isFlagged() && TRUE.equals(m.evaluate(CAT.getSMTVariable(ax, ctx)))) {
     			sb.append("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName())).append("\n");
-    		}                			
+    		}
 		}
 		// TODO We might want to output different messages once we allow to check LIVENESS from the UI
 		sb.append("Condition ").append(program.getAss().toStringWithType()).append("\n");
-		sb.append(program.getFormat().equals(LITMUS) ? TRUE.equals(m.evaluate(REACHABILITY.getSMTVariable(ctx))) ? "Ok" : "No" : result).append("\n");			
+		sb.append(program.getFormat().equals(LITMUS) ? TRUE.equals(m.evaluate(REACHABILITY.getSMTVariable(ctx))) ? "Ok" : "No" : result).append("\n");
         verdict = sb.toString();
     }
 


### PR DESCRIPTION
Herd7 reports `Ok` or `No` only based on the outcome of the (reachability) condition, but not if there are other violations like data races. Thus if a program does not violate safety but it has a data race, the output should be something like
```
Flag data-race
Condition exists X
No
```
This PR implements this.