### PR TITLE
Output folder and as an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ docker run -w /home/Dat3M -it dartagnan /bin/bash
 
 **From Sources**
 
-Set Dat3M's home and add it to the path
+Set Dat3M's home and the folder to generate output files (the output folder can be something different)
 ```
 export DAT3M_HOME=<Dat3M's root>
+export DAT3M_OUTPUT=$DAT3M_HOME/output
 ```
 
 At least the following compiler flag needs to be set, further can be added  

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -159,7 +159,7 @@ public class Dartagnan extends BaseOptions {
                 	ExecutionModel m = new ExecutionModel(task);
                 	m.initialize(prover.getModel(), ctx);
     				String name = task.getProgram().getName().substring(0, task.getProgram().getName().lastIndexOf('.'));
-    				generateGraphvizFile(m, 1, (x, y) -> true, System.getenv("DAT3M_HOME") + "/output/", name);        		
+    				generateGraphvizFile(m, 1, (x, y) -> true, System.getenv("DAT3M_OUTPUT") + "/", name);        		
             	}
 
             	boolean safetyViolationFound = false;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
@@ -23,7 +23,7 @@ public class ProgramParser {
             compileWithClang(file);
             compileWithSmack(file);
             String name = file.getName().substring(0, file.getName().lastIndexOf('.'));
-            return new ProgramParser().parse(new File(System.getenv("DAT3M_HOME") + "/output/" + name + ".bpl"));    		
+            return new ProgramParser().parse(new File(System.getenv("DAT3M_OUTPUT") + "/" + name + ".bpl"));    		
     	}
 
         Program program;
@@ -48,7 +48,7 @@ public class ProgramParser {
                 }
                 compileWithClang(CFile);
 	            compileWithSmack(CFile);
-	            File BplFile = new File(System.getenv("DAT3M_HOME") + "/output/" + name + ".bpl");
+	            File BplFile = new File(System.getenv("DAT3M_OUTPUT") + "/" + name + ".bpl");
 	            BplFile.deleteOnExit();
 	            Program p = new ProgramParser().parse(BplFile);
 	            CFile.delete();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -28,7 +28,7 @@ public class Compilation {
     	}
     	// Here there is not need to iterate over CFLAG values
         cmd.add("--clang-options=-I" + System.getenv("DAT3M_HOME") + "/include/smack " + System.getenv().getOrDefault("CFLAGS", ""));
-    	cmd.addAll(asList("-bpl", System.getenv("DAT3M_HOME") + "/output/" + name + ".bpl"));
+    	cmd.addAll(asList("-bpl", System.getenv("DAT3M_OUTPUT") + "/" + name + ".bpl"));
     	cmd.add(file.getAbsolutePath());
     	
     	ProcessBuilder processBuilder = new ProcessBuilder(cmd); 
@@ -52,7 +52,7 @@ public class Compilation {
 
 	public static void compileWithClang(File file) throws Exception {
 		ArrayList<String> cmd = new ArrayList<String>();
-    	cmd.addAll(asList("clang", "-S", "-o", System.getenv("DAT3M_HOME") + "/output/test.s"));
+    	cmd.addAll(asList("clang", "-S", "-o", System.getenv("DAT3M_OUTPUT") + "/test.s"));
     	// Needed to handle more than one flag in CFLAGS
     	for(String option : System.getenv().getOrDefault("CFLAGS", "").split(" ")) {
     		cmd.add(option);
@@ -67,7 +67,7 @@ public class Compilation {
     		String errorString = CharStreams.toString(new InputStreamReader(proc.getErrorStream(), Charsets.UTF_8));
 			throw new Exception(errorString);
     	}
-    	File testFile = new File(System.getenv("DAT3M_HOME") + "/output/test.s");
+    	File testFile = new File(System.getenv("DAT3M_OUTPUT") + "/test.s");
     	testFile.delete();
 	}	
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/options/BaseOptions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/options/BaseOptions.java
@@ -62,7 +62,7 @@ public abstract class BaseOptions {
 
 	@Option(
 		name=WITNESS_GRAPHVIZ,
-		description="Generates a violation graph in /output.")
+		description="Generates a violation graph in $DAT3M_OUTPUT.")
 	private boolean generateGraphviz = false;
 		
 	public boolean generateGraphviz() { return generateGraphviz; }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -372,7 +372,7 @@ public class RefinementSolver {
 
         String programName = task.getProgram().getName();
         programName = programName.substring(0, programName.lastIndexOf("."));
-        String directoryName = String.format("%s/output/refinement/%s-%s-debug/", System.getenv("DAT3M_HOME"), programName, task.getProgram().getArch());
+        String directoryName = String.format("%s/refinement/%s-%s-debug/", System.getenv("DAT3M_OUTPUT"), programName, task.getProgram().getArch());
         String fileNameBase = String.format("%s-%d", programName, iterationCount);
         // File with reason edges only
         generateGraphvizFile(model, iterationCount, edgeFilter, directoryName, fileNameBase);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
@@ -115,8 +115,8 @@ public class WitnessGraph extends ElemWithAttributes {
 	}
 	
 	public void write() {
-		try (FileWriter fw = new FileWriter(String.format("%s/output/%s.graphml", 
-				System.getenv("DAT3M_HOME"), Files.getNameWithoutExtension(getProgram())))) {
+		try (FileWriter fw = new FileWriter(String.format("%s/%s.graphml", 
+				System.getenv("DAT3M_OUTPUT"), Files.getNameWithoutExtension(getProgram())))) {
 			fw.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
 			fw.write("<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n");
 			for(GraphAttributes attr : GraphAttributes.values()) {fw.write("<key attr.name=\"" + attr.toString() + "\" attr.type=\"string\" for=\"graph\" id=\"" + attr + "\"/>\n");}

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/ResourceHelper.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/ResourceHelper.java
@@ -84,6 +84,6 @@ public class ResourceHelper {
         int dirIndex = name.lastIndexOf("/");
         String dirPrefix = dirIndex == -1 ? "" : name.substring(0, dirIndex + 1);
         String fileName = dirIndex == -1 ? name : name.substring(dirIndex + 1);
-        return String.format("%s/output/%s%s-%s.csv", System.getenv("DAT3M_HOME"), dirPrefix, testingClass.getSimpleName(), fileName);
+        return String.format("%s/%s%s-%s.csv", System.getenv("DAT3M_OUTPUT"), dirPrefix, testingClass.getSimpleName(), fileName);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/CSVLogger.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/CSVLogger.java
@@ -30,7 +30,7 @@ import static com.dat3m.dartagnan.utils.ResourceHelper.getCSVFileName;
              as possible, to get the most accurate timings. The rule populates the created .csv files.
            - Annotate test methods with the @CSVLogger.FileName Attribute. e.g.
                 @CSVLogger.FileName("csv/mytest")
-             which will cause the creation of a .csv file "DAT3M_HOME/output/csv/<TESTCLASS>-mytest.csv"
+             which will cause the creation of a .csv file "DAT3M_OUTPUT/csv/<TESTCLASS>-mytest.csv"
              ( See ResourceHelper.getCSVFileName for details)
            - The <nameSupplier> is used to name the entry inside the .csv file
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/witness/BuildWitnessTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/witness/BuildWitnessTest.java
@@ -46,7 +46,7 @@ public class BuildWitnessTest {
     		WitnessBuilder witnessBuilder = new WitnessBuilder(task, ctx, prover, res);
     		config.inject(witnessBuilder);
 			WitnessGraph graph = witnessBuilder.build();
-    		File witnessFile = new File(System.getenv("DAT3M_HOME") + "/output/lazy01-for-witness.graphml");
+    		File witnessFile = new File(System.getenv("DAT3M_OUTPUT") + "/lazy01-for-witness.graphml");
     		// The file should not exist
 			assertFalse(witnessFile.exists());
     		// Write to file


### PR DESCRIPTION
This PR allows to set the output folder (where log, bpl, csv, etc files are created) using environment variable `DAT3M_OUTPUT` rather than fixing it to be `$DAT3M_HOME/output`.