### PR TITLE
Liveness fix

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
@@ -153,10 +153,12 @@ public class PropertyEncoder implements Encoder {
             		loads = new ArrayList<>();
             	}
                 if(cur.is(Tag.READ)) {
+                	// Update
                     loads.add((Load)cur);
                 }
                 if(cur.is(Tag.SPINLOOP) && !spinStarts.contains(cur)) {
                 	// We found one possible end of the loop
+                	// There might be others thus we keep the load list
                     SpinLoop loop = new SpinLoop();
                     loop.bound = cur;
                     loop.loads.addAll(loads);


### PR DESCRIPTION
This PR solves two problems with the liveness encoding based on two wrong assumptions the code was making
- the old `markAnnotatedSpinLoops` assumed a `LoopEnd` is followed by a buckjump
- the old `encodeLiveness` assumed each spinloop has a single exit