### PR TITLE
Graphviz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
     apt-get install -y libcap-dev && \
     apt-get install -y cmake && \
     apt-get install -y udev && \
+    apt-get install -y graphviz && \
     apt-get install --no-install-recommends -y benchexec
 
 # Install SMACK

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,6 @@ RUN cd home && \
 RUN ln -s clang-12 /usr/bin/clang
 
 ENV DAT3M_HOME=/home/Dat3M
+ENV DAT3M_OUTPUT=$DAT3M_HOME/output
 ENV CFLAGS="-I$DAT3M_HOME/include"
 ENV SMACK_FLAGS="-q -t --no-memory-splitting"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Requirements
 * [Java](https://openjdk.java.net/projects/jdk/16/) 8 or above
 * [Smack](https://github.com/smackers/smack) 2.8.0 or above (only to verify C programs)
 * [Clang](https://clang.llvm.org) the concrete version depends on Smack (only to verify C programs)
+* [Graphviz](https://graphviz.org) (only to generate violations graphs)
 
 Installation
 ======


### PR DESCRIPTION
The witness generation relies on Graphviz. This PR adds it to the requirements in the documentation and installs it in the docker container.