### PR TITLE
Ask for model only when result is FAIL

### DIFF
--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -126,7 +126,9 @@ public class ReachabilityResult {
 		// TODO We might want to output different messages once we allow to check LIVENESS from the UI
 		sb.append("Condition ").append(program.getAss().toStringWithType()).append("\n");
 		sb.append(program.getFormat().equals(LITMUS) ? (model != null && TRUE.equals(model.evaluate(REACHABILITY.getSMTVariable(ctx)))) ? "Ok" : "No" : result).append("\n");
-		model.close();
+		if(model != null) {
+			model.close();			
+		}
         verdict = sb.toString();
     }
 

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -18,6 +18,7 @@ import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
+import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
@@ -116,16 +117,16 @@ public class ReachabilityResult {
 
     private void buildVerdict(Result result, ProverEnvironment prover, SolverContext ctx) throws SolverException {
         StringBuilder sb = new StringBuilder();
-        if(result.equals(FAIL)) {
-    		for(Axiom ax : wmm.getAxioms()) {
-        		if(ax.isFlagged() && TRUE.equals(prover.getModel().evaluate(CAT.getSMTVariable(ax, ctx)))) {
-        			sb.append("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName())).append("\n");
-        		}
-    		}
-        }
+        Model model = result.equals(FAIL) ? prover.getModel() : null;
+    	for(Axiom ax : wmm.getAxioms()) {
+        	if(ax.isFlagged() && model != null && TRUE.equals(model.evaluate(CAT.getSMTVariable(ax, ctx)))) {
+        		sb.append("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName())).append("\n");
+        	}
+    	}
 		// TODO We might want to output different messages once we allow to check LIVENESS from the UI
 		sb.append("Condition ").append(program.getAss().toStringWithType()).append("\n");
-		sb.append(program.getFormat().equals(LITMUS) ? (result.equals(FAIL) && TRUE.equals(prover.getModel().evaluate(REACHABILITY.getSMTVariable(ctx)))) ? "Ok" : "No" : result).append("\n");
+		sb.append(program.getFormat().equals(LITMUS) ? (model != null && TRUE.equals(model.evaluate(REACHABILITY.getSMTVariable(ctx)))) ? "Ok" : "No" : result).append("\n");
+		model.close();
         verdict = sb.toString();
     }
 

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -27,6 +27,7 @@ import static com.dat3m.dartagnan.configuration.OptionNames.PHANTOM_REFERENCES;
 import static com.dat3m.dartagnan.configuration.Property.CAT;
 import static com.dat3m.dartagnan.configuration.Property.REACHABILITY;
 import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
+import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static java.lang.Boolean.TRUE;
 
 public class ReachabilityResult {
@@ -115,14 +116,16 @@ public class ReachabilityResult {
 
     private void buildVerdict(Result result, Model m, SolverContext ctx){
         StringBuilder sb = new StringBuilder();
-		for(Axiom ax : wmm.getAxioms()) {
-    		if(ax.isFlagged() && TRUE.equals(m.evaluate(CAT.getSMTVariable(ax, ctx)))) {
-    			sb.append("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName())).append("\n");
+        if(result.equals(FAIL)) {
+    		for(Axiom ax : wmm.getAxioms()) {
+        		if(ax.isFlagged() && TRUE.equals(m.evaluate(CAT.getSMTVariable(ax, ctx)))) {
+        			sb.append("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName())).append("\n");
+        		}
     		}
-		}
+        }
 		// TODO We might want to output different messages once we allow to check LIVENESS from the UI
 		sb.append("Condition ").append(program.getAss().toStringWithType()).append("\n");
-		sb.append(program.getFormat().equals(LITMUS) ? TRUE.equals(m.evaluate(REACHABILITY.getSMTVariable(ctx))) ? "Ok" : "No" : result).append("\n");
+		sb.append(program.getFormat().equals(LITMUS) ? (result.equals(FAIL) && TRUE.equals(m.evaluate(REACHABILITY.getSMTVariable(ctx)))) ? "Ok" : "No" : result).append("\n");
         verdict = sb.toString();
     }
 


### PR DESCRIPTION
`ReachabilityResult.buildVerdict()` calls `solver.evaluate()` even when there is no model (i.e. `result != FAIL`) which causes an exception. 