### PR TITLE
Allow relation aliases

### DIFF
--- a/cat/riscv.cat
+++ b/cat/riscv.cat
@@ -46,8 +46,7 @@ let r4 = fence
 let r5 = [AQ];po;[M]
 let r6 = [M];po;[RL]
 let r7 = [RCsc];po;[RCsc]
-// We don't support relation aliases
-//let r8 = rmw
+let r8 = rmw
 (* Syntactic Dependencies *)
 let r9 = [M];addr;[M]
 let r10 = [M];data;[W]
@@ -64,8 +63,7 @@ let ppo =
 | r5
 | r6
 | r7
-// We don't support relation aliases
-//| r8
+| r8
 | rmw
 | r9
 | r10

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/visitors/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/visitors/VisitorBase.java
@@ -9,6 +9,7 @@ import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.dat3m.dartagnan.wmm.relation.RecursiveRelation;
 import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.relation.RelationNameRepository;
 import com.dat3m.dartagnan.wmm.utils.RelationRepository;
 
 import java.lang.reflect.Constructor;
@@ -62,8 +63,12 @@ public class VisitorBase extends CatBaseVisitor<Object> implements CatVisitor<Ob
     public Object visitLetDefinition(CatParser.LetDefinitionContext ctx) {
         Relation r = ctx.e.accept(relationVisitor);
         if(r != null){
-            r.setName(ctx.n.getText());
-            relationRepository.updateRelation(r);
+        	if(RelationNameRepository.contains(r.getName()) || r.getIsNamed()) {
+        		relationRepository.addAlias(ctx.n.getText(), r);
+        	} else {
+                r.setName(ctx.n.getText());
+                relationRepository.updateRelation(r);
+        	}
         } else {
             FilterAbstract f = ctx.e.accept(filterVisitor);
             f.setName(ctx.n.getText());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RelationNameRepository.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RelationNameRepository.java
@@ -1,5 +1,9 @@
 package com.dat3m.dartagnan.wmm.relation;
 
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Arrays;
+
 public class RelationNameRepository {
 
 	public static final String POWITHLOCALEVENTS = "_po";
@@ -41,17 +45,25 @@ public class RelationNameRepository {
 	public static final String CTRLISB = "ctrlisb";
 	public static final String CASDEP = "casdep";
 	// Any new string must be also added to method contains() below
+
+	public static final ImmutableSet<String> RELATION_NAMES;
+
+	static {
+		// CARE: Using reflection inside the class initializer is dangerous,
+		// but it works here because all constants get initialized before the initializer runs.
+		RELATION_NAMES = Arrays.stream(RelationNameRepository.class.getDeclaredFields())
+				.filter(f -> f.getType().equals(String.class))
+				.map(f -> {
+					try {
+						return (String)f.get(null);
+					} catch (IllegalAccessException e) {
+						throw new RuntimeException(e);
+					}
+				}).collect(ImmutableSet.toImmutableSet());
+	}
 	
 	public static boolean contains(String name) {
-		switch (name) {
-			case POWITHLOCALEVENTS: case PO: case LOC: case ID: case INT: case EXT: case CO: case RF: case RMW: case CRIT: case IDD:
-			case ADDRDIRECT: case CTRLDIRECT: case EMPTY: case RFINV: case FR: case MM: case MV: case IDDTRANS: case DATA: case ADDR:
-			case CTRL: case POLOC: case RFE: case RFI: case COE: case COI: case FRE: case FRI: case MFENCE: case ISH: case ISB:
-			case SYNC: case ISYNC: case LWSYNC: case CTRLISYNC: case CTRLISB: case CASDEP:
-				return true;
-			default:
-				return false;
-		}
+		return RELATION_NAMES.contains(name);
 	}
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RelationNameRepository.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RelationNameRepository.java
@@ -40,5 +40,18 @@ public class RelationNameRepository {
 	public static final String CTRLISYNC = "ctrlisync";
 	public static final String CTRLISB = "ctrlisb";
 	public static final String CASDEP = "casdep";
+	// Any new string must be also added to method contains() below
+	
+	public static boolean contains(String name) {
+		switch (name) {
+			case POWITHLOCALEVENTS: case PO: case LOC: case ID: case INT: case EXT: case CO: case RF: case RMW: case CRIT: case IDD:
+			case ADDRDIRECT: case CTRLDIRECT: case EMPTY: case RFINV: case FR: case MM: case MV: case IDDTRANS: case DATA: case ADDR:
+			case CTRL: case POLOC: case RFE: case RFI: case COE: case COI: case FRE: case FRI: case MFENCE: case ISH: case ISB:
+			case SYNC: case ISYNC: case LWSYNC: case CTRLISYNC: case CTRLISB: case CASDEP:
+				return true;
+			default:
+				return false;
+		}
+	}
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelEmpty.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelEmpty.java
@@ -1,11 +1,15 @@
 package com.dat3m.dartagnan.wmm.relation.base.stat;
 
+import com.dat3m.dartagnan.wmm.relation.RelationNameRepository;
+import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.SolverContext;
 
-import com.dat3m.dartagnan.wmm.utils.TupleSet;
-
 public class RelEmpty extends StaticRelation {
+
+    public RelEmpty() {
+        term = RelationNameRepository.EMPTY;
+    }
 
     public RelEmpty(String name) {
         super(name);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RelationRepository.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RelationRepository.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.program.filter.FilterAbstract;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
 import com.dat3m.dartagnan.wmm.relation.RecursiveRelation;
 import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.relation.RelationNameRepository;
 import com.dat3m.dartagnan.wmm.relation.base.RelCrit;
 import com.dat3m.dartagnan.wmm.relation.base.RelRMW;
 import com.dat3m.dartagnan.wmm.relation.base.local.RelAddrDirect;
@@ -50,8 +51,8 @@ public class RelationRepository {
     public Relation getRelation(String name){
         Relation relation = relationMap.get(name);
         if(relation == null){
-            relation = getBasicRelation(name);
-            if(relation != null){
+            if(RelationNameRepository.contains(name)){
+                relation = getBasicRelation(name);
                 addRelation(relation);
             }
         }
@@ -91,6 +92,10 @@ public class RelationRepository {
         if(relation.getIsNamed()){
             relationMap.put(relation.getName(), relation);
         }
+    }
+
+    public void addAlias(String alias, Relation relation) {
+        relationMap.put(alias, relation);
     }
 
     public boolean containsRelation(String name) {
@@ -207,6 +212,7 @@ public class RelationRepository {
             case CTRLISB:
                 return getRelation(RelIntersection.class, getRelation(CTRL), getRelation(ISB)).setName(CTRLISB);
             default:
+            	Preconditions.checkState(!RelationNameRepository.contains(name), name + " belongs to RelationNameRepository but has no associated relation");
                 return null;
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RelationRepository.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RelationRepository.java
@@ -15,11 +15,7 @@ import com.dat3m.dartagnan.wmm.relation.base.memory.RelCo;
 import com.dat3m.dartagnan.wmm.relation.base.memory.RelLoc;
 import com.dat3m.dartagnan.wmm.relation.base.memory.RelRf;
 import com.dat3m.dartagnan.wmm.relation.base.stat.*;
-import com.dat3m.dartagnan.wmm.relation.binary.BinaryRelation;
-import com.dat3m.dartagnan.wmm.relation.binary.RelComposition;
-import com.dat3m.dartagnan.wmm.relation.binary.RelIntersection;
-import com.dat3m.dartagnan.wmm.relation.binary.RelMinus;
-import com.dat3m.dartagnan.wmm.relation.binary.RelUnion;
+import com.dat3m.dartagnan.wmm.relation.binary.*;
 import com.dat3m.dartagnan.wmm.relation.unary.RelInverse;
 import com.dat3m.dartagnan.wmm.relation.unary.RelTrans;
 import com.dat3m.dartagnan.wmm.relation.unary.UnaryRelation;
@@ -119,6 +115,7 @@ public class RelationRepository {
     }
 
     private Relation getBasicRelation(String name){
+        Preconditions.checkArgument(RelationNameRepository.contains(name), name + " is not listed in RelationNameRepository.");
         switch (name){
             case POWITHLOCALEVENTS:
                 return new RelPo(true);
@@ -149,7 +146,7 @@ public class RelationRepository {
             case CTRLDIRECT:
                 return new RelCtrlDirect();
             case EMPTY:
-                return new RelEmpty(EMPTY);
+                return new RelEmpty();
             case RFINV:
                 return getRelation(RelInverse.class, getRelation(RF));
             case FR:
@@ -212,8 +209,7 @@ public class RelationRepository {
             case CTRLISB:
                 return getRelation(RelIntersection.class, getRelation(CTRL), getRelation(ISB)).setName(CTRLISB);
             default:
-            	Preconditions.checkState(!RelationNameRepository.contains(name), name + " belongs to RelationNameRepository but has no associated relation");
-                return null;
+                throw new RuntimeException(name + "is part of RelationNameRepository but it has no associated relation.");
         }
     }
 }


### PR DESCRIPTION
This PR adds support for alias between relations which allows to handle cat files with things like `let r1 = co`.