### PR TITLE
Compilation scheme for RC11 to RISCV

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/Compilation.java
@@ -96,7 +96,7 @@ public class Compilation implements ProgramProcessor {
             case IMM:
                 visitor = new VisitorIMM(); break;
             case RISCV:
-                visitor = new VisitorRISCV(); break;
+                visitor = new VisitorRISCV(useRC11Scheme); break;
             default:
                 throw new UnsupportedOperationException(String.format("Compilation to %s is not supported.", target));
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -207,11 +207,11 @@ class VisitorRISCV extends VisitorBase implements EventVisitor<List<Event>> {
 	@Override
 	public List<Event> visitAtomicStore(AtomicStore e) {
 		String mo = e.getMo();
-		Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_RELEASE.equals(mo) ? RISCV.newRWWFence() :  null;
+		Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_RELEASE.equals(mo) || useRC11Scheme ? RISCV.newRWWFence() :  null;
 
 		return eventSequence(
 				optionalBarrierBefore,
-				newStore(e.getAddress(), e.getMemValue(), useRC11Scheme ? Tag.RISCV.MO_REL : null)
+				newStore(e.getAddress(), e.getMemValue(), null)
 		);
 	}
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/RC11ToRISCVTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/RC11ToRISCVTest.java
@@ -1,0 +1,49 @@
+package com.dat3m.dartagnan.compilation;
+
+import com.dat3m.dartagnan.utils.rules.Provider;
+import com.dat3m.dartagnan.utils.rules.Providers;
+import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.configuration.Arch;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.sosy_lab.common.configuration.Configuration;
+
+import static com.dat3m.dartagnan.configuration.OptionNames.*;
+
+import java.io.IOException;
+
+@RunWith(Parameterized.class)
+public class RC11ToRISCVTest extends AbstractCompilationTest {
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Iterable<Object[]> data() throws IOException {
+        return buildLitmusTests("litmus/C11/");
+    }
+
+    public RC11ToRISCVTest(String path) {
+        super(path);
+    }
+
+	@Override
+	protected Provider<Arch> getSourceProvider() {
+		return () -> Arch.C11;
+	}
+
+    @Override
+    protected Provider<Wmm> getSourceWmmProvider() {
+        return Providers.createWmmFromName(() -> "rc11");
+    }
+
+	@Override
+	protected Provider<Arch> getTargetProvider() {
+		return () -> Arch.RISCV;
+	}
+	
+	@Override
+    protected Provider<Configuration> getConfigurationProvider() {
+		return Provider.fromSupplier(() -> Configuration.builder().
+				setOption(INITIALIZE_REGISTERS, String.valueOf(true)).
+				setOption(USE_RC11_TO_ARCH_SCHEME, String.valueOf(true)).
+				build());
+    }
+}


### PR DESCRIPTION
This PR implements the compilation scheme from RC11 to RISCV (following the same idea used for ARMv8 and Power).