### PR TITLE
Improved co encoding

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -487,7 +487,7 @@ public class ExecutionModel {
             Map<EventData, BigInteger> writeCoIndexMap = new HashMap<>(writes.size() * 4 / 3, 0.75f);
 
             for (EventData w : writes) {
-                writeCoIndexMap.put(w, model.evaluate(co.getIntVar(w.getEvent(), context)));
+                writeCoIndexMap.put(w, model.evaluate(co.getClockVar(w.getEvent(), context)));
             }
 
             List<EventData> sortedWrites = writes.stream().sorted(Comparator.comparing(writeCoIndexMap::get)).collect(Collectors.toList());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelCo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelCo.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.wmm.relation.base.memory;
 
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Init;
@@ -12,6 +13,7 @@ import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
@@ -22,7 +24,9 @@ import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.CO_ANTISYMMETRY;
 import static com.dat3m.dartagnan.configuration.Property.LIVENESS;
@@ -79,11 +83,11 @@ public class RelCo extends Relation {
     }
 
     private void applyLocalConsistencyMinSet() {
+        AliasAnalysis alias = analysisContext.get(AliasAnalysis.class);
         for (Tuple t : getMaxTupleSet()) {
-            AliasAnalysis alias = analysisContext.get(AliasAnalysis.class);
             MemEvent w1 = (MemEvent) t.getFirst();
             MemEvent w2 = (MemEvent) t.getSecond();
-            if (!w1.is(INIT) && alias.mustAlias(w1, w2) && (w1.is(INIT) || t.isForward())) {
+            if (!w2.is(INIT) && alias.mustAlias(w1, w2) && (w1.is(INIT) || t.isForward())) {
                 minTupleSet.add(t);
             }
         }
@@ -120,7 +124,7 @@ public class RelCo extends Relation {
 
             removeMutuallyExclusiveTuples(maxTupleSet);
             if (wmmAnalysis.isLocallyConsistent()) {
-                applyLocalConsistencyMaxSet();
+                maxTupleSet.removeIf(Tuple::isBackward);
             }
 
             logger.info("maxTupleSet size for " + getName() + ": " + maxTupleSet.size());
@@ -128,15 +132,9 @@ public class RelCo extends Relation {
         return maxTupleSet;
     }
 
-    private void applyLocalConsistencyMaxSet() {
-        //TODO: Make sure that this is correct and does not cause any issues with totality of co
-        maxTupleSet.removeIf(t -> t.getSecond().is(INIT) || t.isBackward());
-    }
-
     @Override
     protected BooleanFormula encodeApprox(SolverContext ctx) {
         AliasAnalysis alias = analysisContext.get(AliasAnalysis.class);
-        WmmAnalysis wmmAnalysis = analysisContext.get(WmmAnalysis.class);
     	FormulaManager fmgr = ctx.getFormulaManager();
 		BooleanFormulaManager bmgr = fmgr.getBooleanFormulaManager();
         IntegerFormulaManager imgr = fmgr.getIntegerFormulaManager();
@@ -166,11 +164,14 @@ public class RelCo extends Relation {
 
         enc = bmgr.and(enc, distinct);
 
+        final Set<Tuple> transCo = findTransitivelyImpliedCo();
+        final TupleSet maxSet = getMaxTupleSet();
+        final TupleSet minSet = getMinTupleSet();
         for(Event w :  task.getProgram().getCache().getEvents(FilterBasic.get(WRITE))) {
             MemEvent w1 = (MemEvent)w;
             BooleanFormula lastCo = w1.exec();
 
-            for(Tuple t : maxTupleSet.getByFirst(w1)){
+            for(Tuple t : maxSet.getByFirst(w1)){
                 MemEvent w2 = (MemEvent)t.getSecond();
                 BooleanFormula relation = getSMTVar(t, ctx);
                 BooleanFormula execPair = getExecPair(t, ctx);
@@ -178,22 +179,18 @@ public class RelCo extends Relation {
 
                 Formula a1 = w1.getMemAddressExpr();
                 Formula a2 = w2.getMemAddressExpr();
-                BooleanFormula sameAddress = generalEqual(a1, a2, ctx); 
+                BooleanFormula sameAddress = generalEqual(a1, a2, ctx);
+                BooleanFormula clockConstr = (w1.is(INIT) || transCo.contains(t)) ? bmgr.makeTrue()
+                        : imgr.lessThan(getIntVar(w1, ctx), getIntVar(w2, ctx));
 
-                enc = bmgr.and(enc, bmgr.equivalence(relation,
-                        bmgr.and(execPair, sameAddress, imgr.lessThan(getIntVar(w1, ctx), getIntVar(w2, ctx))
-                )));
-
-                // ============ Local consistency optimizations ============
-                if (getMinTupleSet().contains(t)) {
-                   enc = bmgr.and(enc, bmgr.equivalence(relation, execPair));
-                } else if (wmmAnalysis.isLocallyConsistent()) {
-                    if (w2.is(INIT) || t.isBackward()){
-                        enc = bmgr.and(enc, bmgr.equivalence(relation, bmgr.makeFalse()));
-                    }
-                    if (w1.is(INIT) || t.isForward()) {
-                        enc = bmgr.and(enc, bmgr.implication(bmgr.and(execPair, sameAddress), relation));
-                    }
+                if (minSet.contains(t)) {
+                    enc = bmgr.and(enc, clockConstr, bmgr.equivalence(relation, execPair));
+                } else if (!maxSet.contains(t.getInverse())) {
+                    enc = bmgr.and(enc,
+                            bmgr.equivalence(relation, bmgr.and(execPair, sameAddress)),
+                            bmgr.implication(sameAddress, clockConstr));
+                } else {
+                    enc = bmgr.and(enc, bmgr.equivalence(relation, bmgr.and(execPair, sameAddress, clockConstr)));
                 }
             }
 
@@ -220,7 +217,47 @@ public class RelCo extends Relation {
         }
         return enc;
     }
-    
+
+    /*
+        Returns a set of co-edges (w1, w2) (subset of maxTupleSet) whose clock-constraints
+        do not need to get encoded explicitly.
+        The reason is that whenever we have co(w1,w2) then there exists an intermediary
+        w3 s.t. co(w1, w3) /\ co(w3, w2). As a result we have c(w1) < c(w3) < c(w2) transitively.
+        Reasoning: Let (w1, w2) be a potential co-edge. Suppose there exists a w3 different to w1 and w2,
+        whose execution is either implied by either w1 or w2.
+        Now, if co(w1, w3) is a must-edge and co(w2, w3) is impossible, then we can reason as follows.
+            - Suppose w1 and w2 get executed and their addresses match, then w3 must also get executed.
+            - Since co(w1, w3) is a must-edge, we have that w3 accesses the same address as w1 and w2,
+              and c(w1) < c(w3).
+            - Because addr(w2)==addr(w3), we must also have either co(w2, e3) or co(w3, w2).
+              The former is disallowed by assumption, so we have co(w3, w2) and hence c(w3) < c(w2).
+            - By transitivity, we have c(w1) < c(w3) < c(w2) as desired.
+            - Note that this reasoning has to be done inductively, because co(w1, w3) or co(w3, w2) may
+              not involve encoding a clock constraint (due to this optimization).
+        There is also a symmetric case where co(w3, w1) is impossible and co(w3, w2) is a must-edge.
+
+     */
+    private Set<Tuple> findTransitivelyImpliedCo() {
+        ExecutionAnalysis exec = analysisContext.requires(ExecutionAnalysis.class);
+        Set<Tuple> transCo = new HashSet<>();
+
+        final TupleSet min = getMinTupleSet();
+        final TupleSet max = getMaxTupleSet();
+        for (final Tuple t : max) {
+            final MemEvent e1 = (MemEvent) t.getFirst();
+            final MemEvent e2 = (MemEvent) t.getSecond();
+            final Predicate<Event> execPred = (e3 -> e3 != e1 && e3 != e2 && (exec.isImplied(e1, e3) || exec.isImplied(e2, e3)));
+            final boolean hasIntermediary = min.getByFirst(e1).stream().map(tuple -> (MemEvent)tuple.getSecond())
+                                    .anyMatch(e3 -> execPred.apply(e3) && !max.contains(new Tuple(e2, e3))) ||
+                                min.getBySecond(e2).stream().map(tuple -> (MemEvent)tuple.getFirst())
+                                    .anyMatch(e3 -> execPred.apply(e3) && !max.contains(new Tuple(e3, e1)));
+            if (hasIntermediary) {
+                transCo.add(t);
+            }
+        }
+        return transCo;
+    }
+
     @Override
     public BooleanFormula getSMTVar(Tuple edge, SolverContext ctx) {
         if(!antisymmetry) {


### PR DESCRIPTION
Fixed minor bug in RelCo.applyLocalConsistencyMinSet.
Refactored, simplified and hopefully improved co-encoding by avoiding to encode some transitively implied clock constraints.

I don't know if this improves the solving times in any way. It reduces the co-encoding a little bit though.

Edit: Added simple trick to reduce number of theory literals produced in co-encoding. The idea is this: 
if there are w1, w2 such that both coherence orders are possible, then we usually encode one direction via `c(w1) < c(w2)` and the other via `c(w2) < c(w1)`, which results in two different theory literals. However, due to the distinctness constraint on clock variables, we can soundly change the second version to `c(w2) <= c(w1)` instead. Now notice that `c(w2) <= c(w1) IFF not (c(w1) < c(w2))`, that is, we can reuse the first clock constraint but negated.
This reusage of the same theory atom might help the solver.

Edit 2: I reverted the last change as it negatively impacted `SafeStack` (by a lot). I cannot really tell why that happens, but maybe the fact that literals appear in both polarities can disallow some reasoning/optimization.