### PR TITLE
Wmm cleanup

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/exception/MalformedMemoryModelException.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/exception/MalformedMemoryModelException.java
@@ -1,0 +1,8 @@
+package com.dat3m.dartagnan.exception;
+
+public class MalformedMemoryModelException extends RuntimeException {
+
+    public MalformedMemoryModelException(String msg){
+        super(msg);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Wmm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Wmm.java
@@ -8,7 +8,6 @@ import com.dat3m.dartagnan.wmm.relation.RecursiveRelation;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.RecursiveGroup;
 import com.dat3m.dartagnan.wmm.utils.RelationRepository;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
@@ -61,9 +60,7 @@ public class Wmm {
     }
 
     public void addRecursiveGroup(Set<RecursiveRelation> recursiveGroup){
-        int id = 1 << recursiveGroups.size();
-        Preconditions.checkArgument(id >= 0, "Exceeded maximum number of recursive relations.");
-        recursiveGroups.add(new RecursiveGroup(id, recursiveGroup));
+        recursiveGroups.add(new RecursiveGroup(recursiveGroup));
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
@@ -43,9 +43,6 @@ public class RelationAnalysis {
     private void run(VerificationTask task, Context context) {
         // Init data context so that each relation is able to compute its may/must sets.
         final Wmm memoryModel = task.getMemoryModel();
-        for (Axiom ax : memoryModel.getAxioms()) {
-            ax.getRelation().updateRecursiveGroupId(ax.getRelation().getRecursiveGroupId());
-        }
         for(RecursiveGroup recursiveGroup : memoryModel.getRecursiveGroups()){
             recursiveGroup.setDoRecurse();
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/WmmAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/WmmAnalysis.java
@@ -1,10 +1,17 @@
 package com.dat3m.dartagnan.wmm.analysis;
 
+import com.dat3m.dartagnan.exception.MalformedMemoryModelException;
+import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.relation.binary.RelMinus;
+import com.dat3m.dartagnan.wmm.relation.unary.UnaryRelation;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
+
+import java.util.Set;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.LOCALLY_CONSISTENT;
 
@@ -27,22 +34,43 @@ public class WmmAnalysis {
     // =====================================================================
 
     public boolean isLocallyConsistent() {
-        // For now we return a configured value. Ideally, we would like to
+        // For now, we return a configured value. Ideally, we would like to
         // find this property automatically.
         return assumeLocalConsistency;
     }
 
     public boolean doesRespectAtomicBlocks() {
-        // For now we return a configured value. Ideally, we would like to
+        // For now, we return a configured value. Ideally, we would like to
         // find this property automatically. This is currently only relevant for SVCOMP
         return respectsAtomicBlocks;
     }
 
-    private WmmAnalysis(Configuration config) throws InvalidConfigurationException {
+    private WmmAnalysis(Wmm memoryModel, Configuration config) throws InvalidConfigurationException {
         config.inject(this);
+        checkWellformedness(memoryModel);
     }
 
     public static WmmAnalysis fromConfig(Wmm memoryModel, Configuration config) throws InvalidConfigurationException {
-        return new WmmAnalysis(config);
+        return new WmmAnalysis(memoryModel, config);
+    }
+
+    private void checkWellformedness(Wmm memoryModel) {
+        final DependencyGraph<Relation> depGraph = DependencyGraph.from(memoryModel.getRelations());
+        for (Set<DependencyGraph<Relation>.Node> scc : depGraph.getSCCs()) {
+            for (DependencyGraph<Relation>.Node node : scc) {
+                final Relation rel = node.getContent();
+                if (rel instanceof UnaryRelation && scc.size() > 1) {
+                    // Unary relations are not implemented in recursions right now
+                    throw new UnsupportedOperationException(String.format(
+                            "Unary relation %s not supported in recursive definitions.", rel
+                    ));
+                } else if (rel instanceof RelMinus && scc.contains(depGraph.get(rel.getSecond()))) {
+                    // Non-monotonic recursion gives ill-defined memory models.
+                    throw new MalformedMemoryModelException(String.format(
+                            "Non-monotonic recursion is not supported: %s", rel
+                    ));
+                }
+            }
+        }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RecursiveRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RecursiveRelation.java
@@ -55,10 +55,8 @@ public class RecursiveRelation extends Relation {
     }
 
     public void setConcreteRelation(Relation r1){
-        r1.isRecursive = true;
         r1.setName(name);
         this.r1 = r1;
-        this.isRecursive = true;
         this.term = r1.getTerm();
     }
 
@@ -113,16 +111,6 @@ public class RecursiveRelation extends Relation {
             doRecurse = false;
             r1.addEncodeTupleSet(encodeTupleSet);
         }
-    }
-
-    @Override
-    public int updateRecursiveGroupId(int parentId){
-        if(forceUpdateRecursiveGroupId){
-            forceUpdateRecursiveGroupId = false;
-            int r1Id = r1.updateRecursiveGroupId(parentId | recursiveGroupId);
-            recursiveGroupId |= r1Id & parentId;
-        }
-        return recursiveGroupId;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RecursiveRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RecursiveRelation.java
@@ -114,17 +114,8 @@ public class RecursiveRelation extends Relation {
     }
 
     @Override
-    public BooleanFormula encode(SolverContext ctx) {
-        if(isEncoded){
-            return ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
-        }
-        isEncoded = true;
-        return r1.encode(ctx);
-    }
-
-    @Override
     protected BooleanFormula encodeApprox(SolverContext ctx) {
-        return r1.encodeApprox(ctx);
+        return ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
@@ -40,13 +40,9 @@ public abstract class Relation implements Encoder, Dependent<Relation> {
     protected VerificationTask task;
     protected Context analysisContext;
 
-    protected boolean isEncoded;
-
     protected TupleSet minTupleSet = null;
     protected TupleSet maxTupleSet = null;
     protected TupleSet encodeTupleSet = null;
-
-    protected boolean forceDoEncode = false;
 
     public Relation() { }
 
@@ -69,7 +65,6 @@ public abstract class Relation implements Encoder, Dependent<Relation> {
     public void initializeEncoding(SolverContext ctx) {
     	Preconditions.checkState(this.maxTupleSet != null && this.minTupleSet != null,
     			String.format("No available relation data to encode %s. Perform RelationAnalysis before encoding.", this));
-        this.isEncoded = false;
         this.encodeTupleSet = new TupleSet();
     }
 
@@ -144,21 +139,10 @@ public abstract class Relation implements Encoder, Dependent<Relation> {
     }
 
     public BooleanFormula encode(SolverContext ctx) {
-        if(isEncoded){
-            return ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
-        }
-        isEncoded = true;
-        return doEncode(ctx);
+        return encodeApprox(ctx);
     }
 
     protected abstract BooleanFormula encodeApprox(SolverContext ctx);
-
-    protected BooleanFormula doEncode(SolverContext ctx){
-        if(!encodeTupleSet.isEmpty() || forceDoEncode){
-        	return encodeApprox(ctx);
-        }
-        return ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
-    }
 
     public BooleanFormula getSMTVar(Tuple edge, SolverContext ctx) {
         return !getMaxTupleSet().contains(edge) ?

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
@@ -46,9 +46,6 @@ public abstract class Relation implements Encoder, Dependent<Relation> {
     protected TupleSet maxTupleSet = null;
     protected TupleSet encodeTupleSet = null;
 
-    protected int recursiveGroupId = 0;
-    protected boolean forceUpdateRecursiveGroupId = false;
-    protected boolean isRecursive = false;
     protected boolean forceDoEncode = false;
 
     public Relation() { }
@@ -61,19 +58,6 @@ public abstract class Relation implements Encoder, Dependent<Relation> {
     @Override
     public List<Relation> getDependencies() {
         return Collections.emptyList();
-    }
-
-    public int getRecursiveGroupId(){
-        return recursiveGroupId;
-    }
-
-    public void setRecursiveGroupId(int id){
-        forceUpdateRecursiveGroupId = true;
-        recursiveGroupId = id;
-    }
-
-    public int updateRecursiveGroupId(int parentId){
-        return recursiveGroupId;
     }
 
     // TODO: The following two methods are provided because currently Relations are treated as three things:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/RelRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/RelRMW.java
@@ -38,7 +38,6 @@ public class RelRMW extends StaticRelation {
 
     public RelRMW(){
         term = RMW;
-        forceDoEncode = true;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/local/RelAddrDirect.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/local/RelAddrDirect.java
@@ -14,7 +14,6 @@ public class RelAddrDirect extends BasicRegRelation {
 
     public RelAddrDirect(){
         term = ADDRDIRECT;
-        forceDoEncode = true;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/local/RelIdd.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/local/RelIdd.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
+
 import java.util.Collection;
 
 import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.IDD;
@@ -13,7 +14,6 @@ public class RelIdd extends BasicRegRelation {
 
     public RelIdd(){
         term = IDD;
-        forceDoEncode = true;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelCo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelCo.java
@@ -57,7 +57,6 @@ public class RelCo extends Relation {
 
     public RelCo(){
         term = CO;
-        forceDoEncode = true;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelRf.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelRf.java
@@ -33,7 +33,6 @@ public class RelRf extends Relation {
 
     public RelRf(){
         term = RF;
-        forceDoEncode = true;
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/BinaryRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/BinaryRelation.java
@@ -3,9 +3,6 @@ package com.dat3m.dartagnan.wmm.relation.binary;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.Arrays;
 import java.util.List;
@@ -55,13 +52,4 @@ public abstract class BinaryRelation extends Relation {
         }
     }
 
-    @Override
-    public BooleanFormula encode(SolverContext ctx) {
-        BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-        if(isEncoded){
-			return bmgr.makeTrue();
-        }
-        isEncoded = true;
-        return bmgr.and(r1.encode(ctx), r2.encode(ctx), doEncode(ctx));
-    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/BinaryRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/BinaryRelation.java
@@ -44,17 +44,6 @@ public abstract class BinaryRelation extends Relation {
     }
 
     @Override
-    public int updateRecursiveGroupId(int parentId){
-        if(recursiveGroupId == 0 || forceUpdateRecursiveGroupId){
-            forceUpdateRecursiveGroupId = false;
-            int r1Id = r1.updateRecursiveGroupId(parentId | recursiveGroupId);
-            int r2Id = r2.updateRecursiveGroupId(parentId | recursiveGroupId);
-            recursiveGroupId |= (r1Id | r2Id) & parentId;
-        }
-        return recursiveGroupId;
-    }
-
-    @Override
     public void addEncodeTupleSet(TupleSet tuples){ // Not valid for composition
         TupleSet activeSet = new TupleSet(Sets.intersection(Sets.difference(tuples, encodeTupleSet), maxTupleSet));
         encodeTupleSet.addAll(activeSet);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelComposition.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelComposition.java
@@ -56,7 +56,7 @@ public class RelComposition extends BinaryRelation {
 
     @Override
     public TupleSet getMinTupleSetRecursive(){
-        if(recursiveGroupId > 0 && maxTupleSet != null){
+        if(maxTupleSet != null){
             ExecutionAnalysis exec = analysisContext.get(ExecutionAnalysis.class);
             minTupleSet = r1.getMinTupleSetRecursive().postComposition(r2.getMinTupleSetRecursive(),
                     (t1, t2) -> exec.isImplied(t1.getFirst(), t1.getSecond())
@@ -69,7 +69,7 @@ public class RelComposition extends BinaryRelation {
 
     @Override
     public TupleSet getMaxTupleSetRecursive(){
-        if(recursiveGroupId > 0 && maxTupleSet != null){
+        if(maxTupleSet != null){
             ExecutionAnalysis exec = analysisContext.get(ExecutionAnalysis.class);
             maxTupleSet = r1.getMaxTupleSetRecursive().postComposition(r2.getMaxTupleSetRecursive(),
                     (t1, t2) -> !exec.areMutuallyExclusive(t1.getFirst(), t2.getSecond()));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelIntersection.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelIntersection.java
@@ -1,13 +1,12 @@
 package com.dat3m.dartagnan.wmm.relation.binary;
 
+import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
+import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
-
-import com.dat3m.dartagnan.wmm.relation.Relation;
-import com.dat3m.dartagnan.wmm.utils.Tuple;
-import com.dat3m.dartagnan.wmm.utils.TupleSet;
 
 /**
  *
@@ -47,7 +46,7 @@ public class RelIntersection extends BinaryRelation {
 
     @Override
     public TupleSet getMinTupleSetRecursive(){
-        if(recursiveGroupId > 0 && minTupleSet != null){
+        if(minTupleSet != null){
             minTupleSet.addAll(Sets.intersection(r1.getMinTupleSetRecursive(), r2.getMinTupleSetRecursive()));
             return minTupleSet;
         }
@@ -56,7 +55,7 @@ public class RelIntersection extends BinaryRelation {
 
     @Override
     public TupleSet getMaxTupleSetRecursive(){
-        if(recursiveGroupId > 0 && maxTupleSet != null){
+        if(maxTupleSet != null){
             maxTupleSet.addAll(Sets.intersection(r1.getMaxTupleSetRecursive(), r2.getMaxTupleSetRecursive()));
             return maxTupleSet;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelMinus.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelMinus.java
@@ -31,9 +31,6 @@ public class RelMinus extends BinaryRelation {
     @Override
     public void initializeEncoding(SolverContext ctx){
         super.initializeEncoding(ctx);
-        if(r2.getRecursiveGroupId() > 0){
-            throw new RuntimeException("Relation " + r2.getName() + " cannot be recursive since it occurs in a set minus.");
-        }
     }
 
     @Override
@@ -55,7 +52,7 @@ public class RelMinus extends BinaryRelation {
 
     @Override
     public TupleSet getMinTupleSetRecursive(){
-        if(recursiveGroupId > 0 && minTupleSet != null){
+        if(minTupleSet != null){
             minTupleSet.addAll(Sets.difference(r1.getMinTupleSetRecursive(), r2.getMaxTupleSetRecursive()));
             return minTupleSet;
         }
@@ -64,7 +61,7 @@ public class RelMinus extends BinaryRelation {
 
     @Override
     public TupleSet getMaxTupleSetRecursive(){
-        if(recursiveGroupId > 0 && maxTupleSet != null){
+        if(maxTupleSet != null){
             maxTupleSet.addAll(Sets.difference(r1.getMaxTupleSetRecursive(), r2.getMinTupleSetRecursive()));
             return maxTupleSet;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelMinus.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelMinus.java
@@ -29,11 +29,6 @@ public class RelMinus extends BinaryRelation {
     }
 
     @Override
-    public void initializeEncoding(SolverContext ctx){
-        super.initializeEncoding(ctx);
-    }
-
-    @Override
     public TupleSet getMinTupleSet(){
         if(minTupleSet == null){
             minTupleSet = new TupleSet(Sets.difference(r1.getMinTupleSet(), r2.getMaxTupleSet()));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelUnion.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelUnion.java
@@ -1,13 +1,12 @@
 package com.dat3m.dartagnan.wmm.relation.binary;
 
+import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
+import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
-
-import com.dat3m.dartagnan.wmm.relation.Relation;
-import com.dat3m.dartagnan.wmm.utils.Tuple;
-import com.dat3m.dartagnan.wmm.utils.TupleSet;
 
 /**
  *
@@ -47,7 +46,7 @@ public class RelUnion extends BinaryRelation {
 
     @Override
     public TupleSet getMinTupleSetRecursive(){
-        if(recursiveGroupId > 0 && minTupleSet != null){
+        if(minTupleSet != null){
             minTupleSet.addAll(Sets.union(r1.getMinTupleSetRecursive(), r2.getMinTupleSetRecursive()));
             return minTupleSet;
         }
@@ -56,7 +55,7 @@ public class RelUnion extends BinaryRelation {
 
     @Override
     public TupleSet getMaxTupleSetRecursive(){
-        if(recursiveGroupId > 0 && maxTupleSet != null){
+        if(maxTupleSet != null){
             maxTupleSet.addAll(Sets.union(r1.getMaxTupleSetRecursive(), r2.getMaxTupleSetRecursive()));
             return maxTupleSet;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/UnaryRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/UnaryRelation.java
@@ -35,24 +35,6 @@ public abstract class UnaryRelation extends Relation {
     }
 
     @Override
-    public int updateRecursiveGroupId(int parentId){
-        if(recursiveGroupId == 0 || forceUpdateRecursiveGroupId){
-            forceUpdateRecursiveGroupId = false;
-            int r1Id = r1.updateRecursiveGroupId(parentId | recursiveGroupId);
-            recursiveGroupId |= r1Id & parentId;
-        }
-        return recursiveGroupId;
-    }
-
-    @Override
-    public void initializeEncoding(SolverContext ctx){
-        super.initializeEncoding(ctx);
-        if(recursiveGroupId > 0){
-            throw new UnsupportedOperationException("Recursion is not implemented for " + this.getClass().getName());
-        }
-    }
-
-    @Override
     public BooleanFormula encode(SolverContext ctx) {
     	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
         if(isEncoded){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/UnaryRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/UnaryRelation.java
@@ -1,9 +1,6 @@
 package com.dat3m.dartagnan.wmm.relation.unary;
 
 import com.dat3m.dartagnan.wmm.relation.Relation;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,13 +31,4 @@ public abstract class UnaryRelation extends Relation {
         return Collections.singletonList(r1);
     }
 
-    @Override
-    public BooleanFormula encode(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-        if(isEncoded){
-            return bmgr.makeTrue();
-        }
-        isEncoded = true;
-        return bmgr.and(r1.encode(ctx), doEncode(ctx));
-    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RecursiveGroup.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RecursiveGroup.java
@@ -7,20 +7,13 @@ import java.util.*;
 
 public class RecursiveGroup {
 
-    private final int id;
     private final List<RecursiveRelation> relations;
 
-    public RecursiveGroup(int id, Collection<RecursiveRelation> relations){
+    public RecursiveGroup(Collection<RecursiveRelation> relations){
         for(RecursiveRelation relation : relations){
             relation.setDoRecurse();
-            relation.setRecursiveGroupId(id);
         }
         this.relations = new ArrayList<>(relations);
-        this.id = id;
-    }
-
-    public int getId(){
-        return id;
     }
 
     public void setDoRecurse(){


### PR DESCRIPTION
This PR cleans up code surrounding `Wmm` and `Relation`.

- `Relations` do not remember if they got encoded or not anymore. This behaviour to skip encoding on subsequent calls was dangerous.
- `WmmEncoder` makes sure that each relation gets encoded only once without relying on maintaining various flags and doing recursive encodings.
- As a result of the previous changes, `Relation.doForceEncode` and `Relation.isEncoded` are gone. The function `Relation.doEncode` is gone as well. `Relation.encode` has got a trivial implementation now (we may even remove it altogether as well).
- Also, `Relation.recursiveGroupId` as well as `Recursion.isRecursive` are gone now. Neither of them had any uses.
- `UnaryRelation` and `RelMinus` are not allowed in recursions. These relations used to check for this by examining their now gone `recursiveGroupId`. This functionality has been moved to `WmmAnalysis` which will now throw appropriate exceptions (including a new `MalformedMemoryModelException`) if the memory model contains unsupported recursions.