### PR TITLE
Cf opt

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
@@ -154,7 +154,7 @@ public class ProgramEncoder implements Encoder {
             }
 
             if(!e.cf().equals(cfCond)) {
-            	enc = bmgr.and(enc, cfCond.equals(bmgr.makeTrue()) ? e.cf() : cfEncoder.apply(e.cf(), cfCond));
+            	enc = bmgr.and(enc, e.cf().equals(bmgr.makeTrue()) ? cfCond : cfEncoder.apply(e.cf(), cfCond));
             }
             if(!e.encodeExec(ctx).equals(bmgr.makeTrue())) {            	
                 enc = bmgr.and(enc, e.encodeExec(ctx));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
@@ -153,7 +153,12 @@ public class ProgramEncoder implements Encoder {
                 }
             }
 
-            enc = bmgr.and(enc, cfEncoder.apply(e.cf(), cfCond), e.encodeExec(ctx));
+            if(!e.cf().equals(cfCond)) {
+            	enc = bmgr.and(enc, cfCond.equals(bmgr.makeTrue()) ? e.cf() : cfEncoder.apply(e.cf(), cfCond));
+            }
+            if(!e.encodeExec(ctx).equals(bmgr.makeTrue())) {            	
+                enc = bmgr.and(enc, e.encodeExec(ctx));
+            }
             pred = e;
         }
         return enc;


### PR DESCRIPTION
Due to our branch analysis, the CF encoding has unnecessary redundancies like
This PR makes the following simplifications to the CF encoding
- We can completely skip adding constraints `cf(E0) == cf(E0)` and `cf(E0) => cf(E0)`
- We simply constraints `T == cf(E0)` and `T => cf(E0)` to `cf(E0)`
- We simplify `enc /\ T` to `enc`