### PR TITLE
Fix pom file in ui plugin to run from console

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -34,12 +34,41 @@
   </dependencies>
   
   <build>
-    <plugins>
+  <plugins>
+	<plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-dependency-plugin</artifactId>
+      <version>2.1</version>
+      <executions>
+        <execution>
+          <id>copy-dependencies</id>
+          <phase>package</phase>
+          <goals>
+            <goal>copy-dependencies</goal>
+          </goals>
+          <configuration>
+            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+          </configuration>
+        </execution>
+      </executions>
+    </plugin>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-jar-plugin</artifactId>
+      <configuration>
+        <archive>
+          <manifest>
+            <addClasspath>true</addClasspath>
+            <classpathPrefix>lib/</classpathPrefix>
+            <mainClass>com.dat3m.ui.Dat3M</mainClass>
+          </manifest>
+        </archive>
+      </configuration>
+    </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
 		  <failIfNoTests>false</failIfNoTests>
-		  <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Our README states that we can open the UI by running
```
java -jar ui/target/ui-3.1.0.jar
```
but this command was failing. This PR fixes this.

**How to test:** simply run the command above from the console
**Expected result:** the UI should open 