### PR TITLE
Include cos.cat in riscv.cat

### DIFF
--- a/cat/riscv.cat
+++ b/cat/riscv.cat
@@ -6,6 +6,9 @@ Partial
 (* Definitions *)
 (***************)
 
+(* Define co (and fr) *)
+include "cos.cat"
+
 (*************)
 (* Utilities *)
 (*************)


### PR DESCRIPTION
File `riscv.cat` uses `fre` which we can interpret (i.e. we always include its definition), but herd does not.
Thus we need to include `cos.cat` to be able to run the herd tests.