### PR TITLE
Set Cline to all parsed memory events

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/StdProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/StdProcedures.java
@@ -121,7 +121,6 @@ public class StdProcedures {
 		Register start = visitor.programBuilder.getRegister(visitor.threadCount,ptr);
 		MemoryObject object = visitor.programBuilder.newObject(ptr,size);
 		visitor.programBuilder.addChild(visitor.threadCount,EventFactory.newLocal(start,object));
-		visitor.allocationRegs.add(start);
 	}
 	
 	private static void __assert(VisitorBoogie visitor, Call_cmdContext ctx) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -75,7 +75,6 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 	
 	private final Map<String, Proc_declContext> procedures = new HashMap<>();
 	protected PthreadPool pool = new PthreadPool();
-	protected List<Register> allocationRegs = new ArrayList<>();
 	
 	private int nextScopeID = 0;
 	protected Scope currentScope = new Scope(nextScopeID, null);
@@ -436,15 +435,10 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 	        		} catch (Exception e) {
 	        			// Nothing to be done
 	        		}
-	        		if(!allocationRegs.contains(value)) {
-	        			// These events are eventually compiled and we need to compare its mo, thus it cannot be null
-	        			programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, ""))
-	        					.setCLine(currentLine)
-	        					.setSourceCodeFile(sourceCodeFile);
-	        		} else {
-	        			// These events are eventually compiled and we need to compare its mo, thus it cannot be null
-	        			programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, ""));
-	        		}						        			
+	        		// These events are eventually compiled and we need to compare its mo, thus it cannot be null
+	        		programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, ""))
+	        				.setCLine(currentLine)
+	        				.setSourceCodeFile(sourceCodeFile);
 		            continue;
 	        	}
 	        	value = value.visit(exprSimplifier);


### PR DESCRIPTION
All parsed memory events should have a Cline (only "modeling" events should use `-1`), otherwise this can easily "break" some po-edges in the graphviz witnesses.