### PR TITLE
Fencerel takes filters as input

### DIFF
--- a/cat/linux-kernel.cat
+++ b/cat/linux-kernel.cat
@@ -159,13 +159,10 @@ irreflexive rb as rcu
 (* Plain accesses and data races *)
 (*********************************)
 
-let barrier = fencerel(Barrier) | fencerel(Rmb) | fencerel(Wmb) | fencerel(Mb)
-	| fencerel(Sync-rcu) | fencerel(Sync-srcu)
-	| fencerel(Before-atomic) | fencerel(After-atomic)
-	| fencerel(Acquire) | fencerel(Release)
-	| fencerel(Rcu-lock) | fencerel(Rcu-unlock)
-	| fencerel(Srcu-lock) | fencerel(Srcu-unlock) 
-	| (po ; [Release]) | ([Acquire] ; po)
+let barrier = fencerel(Barrier | Rmb | Wmb | Mb | Sync-rcu | Sync-srcu |
+		Before-atomic | After-atomic | Acquire | Release |
+		Rcu-lock | Rcu-unlock | Srcu-lock | Srcu-unlock) |
+	(po ; [Release]) | ([Acquire] ; po)
 
 (* Warn about plain writes and marked accesses in the same region *)
 let mixed-accesses = ([Plain & W] ; (po-loc \ barrier) ; [Marked]) |

--- a/dartagnan/src/main/antlr4/Cat.g4
+++ b/dartagnan/src/main/antlr4/Cat.g4
@@ -46,7 +46,7 @@ expression
     |   LBRAC DOMAIN LPAR e = expression RPAR RBRAC                     # exprDomainIdentity
     |   LBRAC RANGE LPAR e = expression RPAR RBRAC                      # exprRangeIdentity
     |   (TOID LPAR e = expression RPAR | LBRAC e = expression RBRAC)    # exprIdentity
-    |   FENCEREL LPAR n = NAME RPAR                                     # exprFencerel
+    |   FENCEREL LPAR e = expression RPAR                               # exprFencerel
     |   LPAR e = expression RPAR                                        # expr
     |   n = NAME                                                        # exprBasic
     ;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/visitors/VisitorRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/visitors/VisitorRelation.java
@@ -119,7 +119,12 @@ public class VisitorRelation extends CatBaseVisitor<Relation> {
 
     @Override
     public Relation visitExprFencerel(CatParser.ExprFencerelContext ctx) {
-        return base.relationRepository.getRelation(RelFencerel.class, ctx.n.getText());
+        boolean orig = base.recursiveDef;
+        base.recursiveDef = false;
+        FilterAbstract filter = ctx.e.accept(base.filterVisitor);
+        Relation relation = base.relationRepository.getRelation(RelFencerel.class, filter);
+        base.recursiveDef = orig;
+        return relation;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
@@ -293,7 +293,7 @@ public class ExecutionGraph {
             } else if (relClass == RelInt.class) {
                 graph = new InternalGraph();
             } else if (relClass == RelFencerel.class) {
-                graph = new FenceGraph(((RelFencerel) rel).getFenceName());
+                graph = new FenceGraph(((RelFencerel) rel).getFilter());
             } else if (relClass == RelSetIdentity.class) {
                 SetPredicate set = getOrCreateSetFromFilter(((RelSetIdentity) rel).getFilter());
                 graph = new SetIdentityGraph(set);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/FenceGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/FenceGraph.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.solver.caat4wmm.basePredicates;
 
 
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.filter.FilterAbstract;
 import com.dat3m.dartagnan.solver.caat.misc.EdgeDirection;
 import com.dat3m.dartagnan.solver.caat.predicates.relationGraphs.Edge;
 import com.dat3m.dartagnan.verification.model.EventData;
@@ -11,11 +12,11 @@ import java.util.stream.Stream;
 
 public class FenceGraph extends StaticWMMGraph {
 
-    private final String fenceName;
+    private final FilterAbstract fenceFilter;
     private Map<Thread, List<EventData>> threadFencesMap;
 
-    public FenceGraph(String fenceName) {
-        this.fenceName = fenceName;
+    public FenceGraph(FilterAbstract fenceFilter) {
+        this.fenceFilter = fenceFilter;
     }
 
     @Override
@@ -37,14 +38,10 @@ public class FenceGraph extends StaticWMMGraph {
         for (Thread t : model.getThreads()) {
             threadFencesMap.put(t, new ArrayList<>());
         }
-        Set<EventData> fenceEvents = model.getFenceMap().get(fenceName);
-        if (fenceEvents == null) {
-            return;
-        }
 
-        for (EventData fence : fenceEvents) {
-            threadFencesMap.get(fence.getThread()).add(fence);
-        }
+        model.getEventList().stream().filter(e -> fenceFilter.filter(e.getEvent()))
+                .forEach(fence -> threadFencesMap.get(fence.getThread()).add(fence));
+
         for (List<EventData> fenceList : threadFencesMap.values()) {
             fenceList.sort(Comparator.comparingInt(EventData::getLocalId));
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -40,7 +40,6 @@ The ExecutionModel wraps a Model and extracts data from it in a more workable ma
 public class ExecutionModel {
 
     private final VerificationTask task;
-    private final RelCo co;
 
     // ============= Model specific  =============
     private Model model;
@@ -90,7 +89,6 @@ public class ExecutionModel {
 
     public ExecutionModel(VerificationTask task) {
         this.task = task;
-        co = (RelCo)task.getMemoryModel().getRelationRepository().getRelation(CO);
 
         eventList = new ArrayList<>(100);
         threadList = new ArrayList<>(getProgram().getThreads().size());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelFencerel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelFencerel.java
@@ -4,6 +4,7 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.filter.FilterAbstract;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
@@ -15,24 +16,24 @@ import java.util.List;
 
 public class RelFencerel extends StaticRelation {
 
-    private final String fenceName;
+    protected FilterAbstract filter;
 
-    public static String makeTerm(String fenceName){
-        return "fencerel(" + fenceName + ")";
+    public static String makeTerm(FilterAbstract filter){
+        return "fencerel(" + filter + ")";
     }
 
-    public RelFencerel(String fenceName) {
-        this.fenceName = fenceName;
-        term = makeTerm(fenceName);
+    public RelFencerel(FilterAbstract filter) {
+        this.filter = filter;
+        term = makeTerm(filter);
     }
 
-    public RelFencerel(String fenceName, String name) {
+    public RelFencerel(FilterAbstract filter, String name) {
         super(name);
-        this.fenceName = fenceName;
-        term = makeTerm(fenceName);
+        this.filter = filter;
+        term = makeTerm(filter);
     }
 
-    public String getFenceName() { return fenceName; }
+    public String getFenceName() { return name != null ? name : filter.getName(); }
 
     @Override
     public TupleSet getMinTupleSet(){
@@ -40,7 +41,7 @@ public class RelFencerel extends StaticRelation {
             ExecutionAnalysis exec = analysisContext.get(ExecutionAnalysis.class);
             minTupleSet = new TupleSet();
             for(Thread t : task.getProgram().getThreads()){
-                List<Event> fences = t.getCache().getEvents(FilterBasic.get(fenceName));
+                List<Event> fences = t.getCache().getEvents(filter);
                 List<Event> memEvents = t.getCache().getEvents(FilterBasic.get(Tag.MEMORY));
                 for (Event fence : fences) {
                     int numEventsBeforeFence = (int) memEvents.stream()
@@ -69,7 +70,7 @@ public class RelFencerel extends StaticRelation {
         if(maxTupleSet == null){
             maxTupleSet = new TupleSet();
             for(Thread t : task.getProgram().getThreads()){
-                List<Event> fences = t.getCache().getEvents(FilterBasic.get(fenceName));
+                List<Event> fences = t.getCache().getEvents(filter);
                 List<Event> memEvents = t.getCache().getEvents(FilterBasic.get(Tag.MEMORY));
                 for (Event fence : fences) {
                     int numEventsBeforeFence = (int) memEvents.stream()
@@ -95,7 +96,7 @@ public class RelFencerel extends StaticRelation {
     	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
 		BooleanFormula enc = bmgr.makeTrue();
 
-        List<Event> fences = task.getProgram().getCache().getEvents(FilterBasic.get(fenceName));
+        List<Event> fences = task.getProgram().getCache().getEvents(filter);
 
         for(Tuple tuple : encodeTupleSet){
             Event e1 = tuple.getFirst();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelFencerel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelFencerel.java
@@ -34,6 +34,7 @@ public class RelFencerel extends StaticRelation {
     }
 
     public String getFenceName() { return name != null ? name : filter.getName(); }
+    public FilterAbstract getFilter() { return filter; }
 
     @Override
     public TupleSet getMinTupleSet(){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RelationRepository.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RelationRepository.java
@@ -105,9 +105,9 @@ public class RelationRepository {
             return new Class<?>[]{Relation.class};
         } else if(RelCartesian.class.isAssignableFrom(cls)){
             return new Class<?>[]{FilterAbstract.class, FilterAbstract.class};
-        } else if(RelSetIdentity.class.isAssignableFrom(cls)){
+        } else if(RelFencerel.class.isAssignableFrom(cls) || RelSetIdentity.class.isAssignableFrom(cls)){
             return new Class<?>[]{FilterAbstract.class};
-        } else if(RelFencerel.class.isAssignableFrom(cls) || RecursiveRelation.class.isAssignableFrom(cls)) {
+        } else if(RecursiveRelation.class.isAssignableFrom(cls)) {
             return new Class<?>[]{String.class};
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RelationRepository.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/RelationRepository.java
@@ -189,17 +189,17 @@ public class RelationRepository {
             case FRI:
                 return getRelation(RelIntersection.class, getRelation(FR), getRelation(INT)).setName(FRI);
             case MFENCE:
-                return getRelation(RelFencerel.class, MFENCE);
+                return getRelation(RelFencerel.class, FilterBasic.get(MFENCE));
             case ISH:
-                return getRelation(RelFencerel.class, ISH);
+                return getRelation(RelFencerel.class, FilterBasic.get(ISH));
             case ISB:
-                return getRelation(RelFencerel.class, ISB);
+                return getRelation(RelFencerel.class, FilterBasic.get(ISB));
             case SYNC:
-                return getRelation(RelFencerel.class, SYNC);
+                return getRelation(RelFencerel.class, FilterBasic.get(SYNC));
             case ISYNC:
-                return getRelation(RelFencerel.class, ISYNC);
+                return getRelation(RelFencerel.class, FilterBasic.get(ISYNC));
             case LWSYNC:
-                return getRelation(RelFencerel.class, LWSYNC);
+                return getRelation(RelFencerel.class, FilterBasic.get(LWSYNC));
             case CTRLISYNC:
                 return getRelation(RelIntersection.class, getRelation(CTRL), getRelation(ISYNC)).setName(CTRLISYNC);
             case CTRLISB:


### PR DESCRIPTION
CAT allows `fencerel` to use any set (i.e. filters implementation-wise) and not just base ones.
This PR generalizes `RelFencerel` to accommodate this.

Now we can use the original `let barrier = ...` from the LKMM.