### PR TITLE
Relation encoder

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -164,7 +164,7 @@ public class Dartagnan extends BaseOptions {
                 t.interrupt();
 
             	if(result.equals(FAIL) && o.generateGraphviz()) {
-                	ExecutionModel m = new ExecutionModel(task);
+                	ExecutionModel m = ExecutionModel.fromConfig(task, config);
                 	m.initialize(prover.getModel(), ctx);
     				String name = task.getProgram().getName().substring(0, task.getProgram().getName().lastIndexOf('.'));
     				generateGraphvizFile(m, 1, (x, y) -> true, System.getenv("DAT3M_OUTPUT") + "/", name);        		

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -26,7 +26,6 @@ public class OptionNames {
 	public static final String PRECISION = "encoding.precision";
 	public static final String BREAK_SYMMETRY_ON_RELATION = "encoding.symmetry.breakOnRelation";
 	public static final String BREAK_SYMMETRY_BY_SYNC_DEGREE = "encoding.symmetry.orderBySyncDegree";
-	public static final String POST_FIXPOINT = "encoding.wmm.postFixApproximate";
 	public static final String IDL_TO_SAT = "encoding.wmm.idl2sat";
 	
 	// Program Processing Options

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -26,6 +26,7 @@ public class OptionNames {
 	public static final String PRECISION = "encoding.precision";
 	public static final String BREAK_SYMMETRY_ON_RELATION = "encoding.symmetry.breakOnRelation";
 	public static final String BREAK_SYMMETRY_BY_SYNC_DEGREE = "encoding.symmetry.orderBySyncDegree";
+	public static final String POST_FIXPOINT = "encoding.wmm.postFixApproximate";
 	public static final String IDL_TO_SAT = "encoding.wmm.idl2sat";
 	
 	// Program Processing Options

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
@@ -1,11 +1,14 @@
 package com.dat3m.dartagnan.encoding;
 
 import com.dat3m.dartagnan.configuration.Property;
+import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.Init;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
@@ -14,10 +17,11 @@ import com.dat3m.dartagnan.program.filter.FilterMinus;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.axiom.Axiom;
+import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.relation.RelationNameRepository;
-import com.dat3m.dartagnan.wmm.relation.base.memory.RelCo;
 import com.dat3m.dartagnan.wmm.relation.base.memory.RelRf;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
+import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
@@ -25,6 +29,7 @@ import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Options;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.Formula;
 import org.sosy_lab.java_smt.api.IntegerFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
 
@@ -34,6 +39,11 @@ import java.util.stream.Collectors;
 
 import static com.dat3m.dartagnan.configuration.Property.*;
 import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
+import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
+import static com.dat3m.dartagnan.program.event.Tag.INIT;
+import static com.dat3m.dartagnan.program.event.Tag.WRITE;
+import static com.dat3m.dartagnan.wmm.analysis.RelationAnalysis.findTransitivelyImpliedCo;
+import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.CO;
 import static com.dat3m.dartagnan.wmm.utils.Utils.edge;
 import static com.dat3m.dartagnan.wmm.utils.Utils.intVar;
 import static com.google.common.base.Preconditions.*;
@@ -46,6 +56,7 @@ public class PropertyEncoder implements Encoder {
 
     private final Program program;
     private final Wmm memoryModel;
+    private final ExecutionAnalysis exec;
     private final AliasAnalysis alias;
 
     // =====================================================================
@@ -55,6 +66,7 @@ public class PropertyEncoder implements Encoder {
                 "The program must get compiled first before its properties can be encoded.");
         this.program = checkNotNull(program);
         this.memoryModel = checkNotNull(wmm);
+        this.exec = context.requires(ExecutionAnalysis.class);
         this.alias = context.requires(AliasAnalysis.class);
         config.inject(this);
     }
@@ -82,6 +94,9 @@ public class PropertyEncoder implements Encoder {
     	if(property.contains(CAT)) {
     		enc = bmgr.or(enc, encodeCATProperties(ctx));
     	}
+        if (program.getFormat().equals(LITMUS) || property.contains(LIVENESS)) {
+            enc = bmgr.and(enc, encodeLastCoConstraints(ctx));
+        }
     	return enc;
     }
 
@@ -165,7 +180,6 @@ public class PropertyEncoder implements Encoder {
 
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
         RelRf rf = (RelRf) memoryModel.getRelation(RelationNameRepository.RF);
-        RelCo co = (RelCo) memoryModel.getRelation(RelationNameRepository.CO);
         // Compute "stuckness": A thread is stuck if it reaches a spinloop bound event
         // while reading from a co-maximal write.
         Map<Thread, BooleanFormula> isStuckMap = new HashMap<>();
@@ -181,7 +195,7 @@ public class PropertyEncoder implements Encoder {
                 for (Load load : pair.loads) {
                     BooleanFormula coMaximalLoad = bmgr.makeFalse();
                     for (Tuple rfEdge : rf.getMaxTupleSet().getBySecond(load)) {
-                        coMaximalLoad = bmgr.or(coMaximalLoad, bmgr.and(rf.getSMTVar(rfEdge, ctx), co.getLastCoVar(rfEdge.getFirst(), ctx)));
+                        coMaximalLoad = bmgr.or(coMaximalLoad, bmgr.and(rf.getSMTVar(rfEdge, ctx), lastCoVar(rfEdge.getFirst(), ctx)));
                     }
                     allCoMaximalLoad = bmgr.and(allCoMaximalLoad, coMaximalLoad);
                 }
@@ -247,5 +261,66 @@ public class PropertyEncoder implements Encoder {
 		enc = bmgr.equivalence(RACES.getSMTVariable(ctx), enc);
 		// No need to use the SMT variable if the formula is trivially false 
         return bmgr.isFalse(enc) ? enc : bmgr.and(RACES.getSMTVariable(ctx), enc);
+    }
+
+    private BooleanFormula encodeLastCoConstraints(SolverContext ctx) {
+        final Relation co = memoryModel.getRelation(CO);
+        final BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
+        final TupleSet minSet = co.getMinTupleSet();
+        final TupleSet maxSet = co.getMaxTupleSet();
+        final List<Event> initEvents = program.getCache().getEvents(FilterBasic.get(INIT));
+        final List<Event> writes = program.getCache().getEvents(FilterBasic.get(WRITE));
+        final boolean doEncodeFinalAddressValues = program.getFormat() == LITMUS;
+        // Find transitively implied coherences. We can use these to reduce the encoding.
+        final Set<Tuple> transCo = findTransitivelyImpliedCo(co, exec);
+        // Find all writes that are never last, i.e., those that will always have a co-successor.
+        final Set<Event> dominatedWrites = minSet.stream()
+                .filter(t -> exec.isImplied(t.getFirst(), t.getSecond()))
+                .map(Tuple::getFirst).collect(Collectors.toSet());
+        // ---- Construct encoding ----
+        BooleanFormula enc = bmgr.makeTrue();
+        for (Event writeEvent : writes) {
+            MemEvent w1 = (MemEvent) writeEvent;
+            if (dominatedWrites.contains(w1)) {
+                enc = bmgr.and(enc, bmgr.equivalence(lastCoVar(w1, ctx), bmgr.makeFalse()));
+                continue;
+            }
+            BooleanFormula isLast = w1.exec();
+            // ---- Find all possibly overwriting writes ----
+            for (Tuple t : maxSet.getByFirst(w1)) {
+                if (transCo.contains(t)) {
+                    // We can skip the co-edge (w1,w2), because there will be an intermediate write w3
+                    // that already witnesses that w1 is not last.
+                    continue;
+                }
+                Event w2 = t.getSecond();
+                BooleanFormula isAfter = minSet.contains(t) ? bmgr.not(w2.exec()) : bmgr.not(co.getSMTVar(t, ctx));
+                isLast = bmgr.and(isLast, isAfter);
+            }
+            BooleanFormula lastCoExpr = lastCoVar(w1, ctx);
+            enc = bmgr.and(enc, bmgr.equivalence(lastCoExpr, isLast));
+            if (doEncodeFinalAddressValues) {
+                // ---- Encode final values of addresses ----
+                for (Event initEvent : initEvents) {
+                    Init init = (Init) initEvent;
+                    if (!alias.mayAlias(w1, init)) {
+                        continue;
+                    }
+                    IExpr address = init.getAddress();
+                    Formula a1 = w1.getMemAddressExpr();
+                    Formula a2 = address.toIntFormula(init, ctx);
+                    BooleanFormula sameAddress = alias.mustAlias(init, w1) ? bmgr.makeTrue() : generalEqual(a1, a2, ctx);
+                    Formula v1 = w1.getMemValueExpr();
+                    Formula v2 = init.getBase().getLastMemValueExpr(ctx, init.getOffset());
+                    BooleanFormula sameValue = generalEqual(v1, v2, ctx);
+                    enc = bmgr.and(enc, bmgr.implication(bmgr.and(lastCoExpr, sameAddress), sameValue));
+                }
+            }
+        }
+        return enc;
+    }
+
+    private BooleanFormula lastCoVar(Event write, SolverContext ctx) {
+        return ctx.getFormulaManager().getBooleanFormulaManager().makeVariable("co_last(" + write.repr() + ")");
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -1,12 +1,27 @@
 package com.dat3m.dartagnan.encoding;
 
+import com.dat3m.dartagnan.GlobalSettings;
+import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
+import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
+import com.dat3m.dartagnan.program.event.Tag;
+import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.filter.FilterAbstract;
+import com.dat3m.dartagnan.program.filter.FilterBasic;
+import com.dat3m.dartagnan.program.filter.FilterIntersection;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.relation.base.stat.StaticRelation;
+import com.dat3m.dartagnan.wmm.utils.Flag;
 import com.dat3m.dartagnan.wmm.utils.RecursiveGroup;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
+import com.dat3m.dartagnan.wmm.utils.TupleSet;
+import com.dat3m.dartagnan.wmm.utils.Utils;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -14,27 +29,64 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.configuration.Option;
+import org.sosy_lab.common.configuration.Options;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+import org.sosy_lab.java_smt.api.Formula;
+import org.sosy_lab.java_smt.api.IntegerFormulaManager;
+import org.sosy_lab.java_smt.api.NumeralFormula;
 import org.sosy_lab.java_smt.api.SolverContext;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import static com.dat3m.dartagnan.configuration.OptionNames.IDL_TO_SAT;
+import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
+import static com.dat3m.dartagnan.program.event.Tag.INIT;
+import static com.dat3m.dartagnan.program.event.Tag.WRITE;
+import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.RF;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.stream.Collectors.toList;
+
+@Options
 public class WmmEncoder implements Encoder {
 
     private static final Logger logger = LogManager.getLogger(WmmEncoder.class);
 
+    // =========================== Configurables ===========================
+
+    @Option(
+            name=IDL_TO_SAT,
+            description = "Use SAT-based encoding for totality and acyclicity.",
+            secure = true)
+    private boolean useSATEncoding = false;
+
+    // =====================================================================
+
+    private final Program program;
     private final Wmm memoryModel;
+    private final Context analysisContext;
     private boolean isInitialized = false;
 
     // =====================================================================
 
-    private WmmEncoder(Wmm memoryModel, Context context) {
-        this.memoryModel = Preconditions.checkNotNull(memoryModel);
+    private WmmEncoder(Program p, Wmm m, Context context) {
+        program = checkNotNull(p);
+        memoryModel = checkNotNull(m);
+        analysisContext = context;
         context.requires(RelationAnalysis.class);
     }
 
-    public static WmmEncoder fromConfig(Wmm memoryModel, Context context, Configuration config) throws InvalidConfigurationException {
-        return new WmmEncoder(memoryModel, context);
+    public static WmmEncoder fromConfig(Program program, Wmm memoryModel, Context context, Configuration config) throws InvalidConfigurationException {
+        WmmEncoder encoder = new WmmEncoder(program, memoryModel, context);
+        config.inject(encoder);
+        return encoder;
     }
 
     @Override
@@ -84,15 +136,18 @@ public class WmmEncoder implements Encoder {
     public BooleanFormula encodeRelations(SolverContext ctx) {
         checkInitialized();
         logger.info("Encoding relations");
-        final BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
         final DependencyGraph<Relation> depGraph = DependencyGraph.from(
                 Iterables.concat(
                         Iterables.transform(Wmm.BASE_RELATIONS, memoryModel::getRelation), // base relations
                         Iterables.transform(memoryModel.getAxioms(), Axiom::getRelation) // axiom relations
                 )
         );
-
-        return depGraph.getNodeContents().stream().map(rel -> rel.encode(ctx)).reduce(bmgr.makeTrue(), bmgr::and);
+        RelationEncoder v = new RelationEncoder(ctx);
+        BooleanFormula enc = v.bmgr.makeTrue();
+        for (Relation rel : depGraph.getNodeContents()) {
+            enc = v.bmgr.and(enc, rel.accept(v));
+        }
+        return enc;
     }
 
     // Encodes all axioms. This should be called after <encodeRelations>
@@ -100,10 +155,462 @@ public class WmmEncoder implements Encoder {
         checkInitialized();
         logger.info("Encoding consistency");
         final BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-
         return memoryModel.getAxioms().stream()
                 .filter(ax -> !ax.isFlagged())
-                .map(ax -> ax.consistent(ctx))
+                .map(ax -> ax.consistent(ax.getRelation().getEncodeTupleSet(), analysisContext, ctx))
                 .reduce(bmgr.makeTrue(), bmgr::and);
+    }
+
+    private final class RelationEncoder implements Relation.Visitor<BooleanFormula> {
+        final ExecutionAnalysis exec = analysisContext.get(ExecutionAnalysis.class);
+        final AliasAnalysis alias = analysisContext.get(AliasAnalysis.class);
+        final SolverContext ctx;
+        final BooleanFormulaManager bmgr;
+        final IntegerFormulaManager imgr;
+        public RelationEncoder(SolverContext c) {
+            ctx = c;
+            bmgr = c.getFormulaManager().getBooleanFormulaManager();
+            imgr = c.getFormulaManager().getIntegerFormulaManager();
+        }
+        @Override
+        public BooleanFormula visitDefinition(Relation rel, List<? extends Relation> dependencies) {
+            Preconditions.checkArgument(rel instanceof StaticRelation);
+            BooleanFormula enc = bmgr.makeTrue();
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                enc = bmgr.and(enc, bmgr.equivalence(edge(rel, tuple), execution(tuple)));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitUnion(Relation rel, Relation... r) {
+            BooleanFormula enc = bmgr.makeTrue();
+            TupleSet min = rel.getMinTupleSet();
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                BooleanFormula edge = edge(rel, tuple);
+                if (min.contains(tuple)) {
+                    enc = bmgr.and(enc, bmgr.equivalence(edge, execution(tuple)));
+                    continue;
+                }
+                List<BooleanFormula> opt = new ArrayList<>(r.length);
+                for (Relation relation : r) {
+                    opt.add(edge(relation, tuple));
+                }
+                if (Relation.PostFixApprox) {
+                    enc = bmgr.and(enc, bmgr.implication(bmgr.or(opt), edge));
+                } else {
+                    enc = bmgr.and(enc, bmgr.equivalence(edge, bmgr.or(opt)));
+                }
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitIntersection(Relation rel, Relation... r) {
+            BooleanFormula enc = bmgr.makeTrue();
+            TupleSet min = rel.getMinTupleSet();
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                BooleanFormula edge = edge(rel, tuple);
+                if (min.contains(tuple)) {
+                    enc = bmgr.and(enc, bmgr.equivalence(edge, execution(tuple)));
+                    continue;
+                }
+                List<BooleanFormula> opt = new ArrayList<>(r.length);
+                for (Relation relation : r) {
+                    opt.add(edge(relation, tuple));
+                }
+                enc = bmgr.and(enc, bmgr.equivalence(edge, bmgr.and(opt)));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitDifference(Relation rel, Relation r1, Relation r2) {
+            BooleanFormula enc = bmgr.makeTrue();
+            TupleSet min = rel.getMinTupleSet();
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                BooleanFormula edge = edge(rel, tuple);
+                if (min.contains(tuple)) {
+                    enc = bmgr.and(enc, bmgr.equivalence(edge, execution(tuple)));
+                    continue;
+                }
+                BooleanFormula opt1 = edge(r1, tuple);
+                BooleanFormula opt2 = bmgr.not(edge(r2, tuple));
+                if (Relation.PostFixApprox) {
+                    enc = bmgr.and(enc, bmgr.implication(bmgr.and(opt1, opt2), edge));
+                } else {
+                    enc = bmgr.and(enc, bmgr.equivalence(edge, bmgr.and(opt1, opt2)));
+                }
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitComposition(Relation rel, Relation r1, Relation r2) {
+            BooleanFormula enc = bmgr.makeTrue();
+            TupleSet r1Set = r1.getEncodeTupleSet();
+            TupleSet r2Set = r2.getEncodeTupleSet();
+            TupleSet minSet = rel.getMinTupleSet();
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                BooleanFormula expr = bmgr.makeFalse();
+                if (minSet.contains(tuple)) {
+                    expr = execution(tuple);
+                } else {
+                    for (Tuple t1 : r1Set.getByFirst(tuple.getFirst())) {
+                        Tuple t2 = new Tuple(t1.getSecond(), tuple.getSecond());
+                        if (r2Set.contains(t2)) {
+                            expr = bmgr.or(expr, bmgr.and(edge(r1, t1), edge(r2, t2)));
+                        }
+                    }
+                }
+                enc = bmgr.and(enc, bmgr.equivalence(edge(rel, tuple), expr));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitDomainIdentity(Relation rel, Relation r1) {
+            BooleanFormula enc = bmgr.makeTrue();
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                Event e = tuple.getFirst();
+                BooleanFormula opt = bmgr.makeFalse();
+                //TODO: Optimize using minSets (but no CAT uses this anyway)
+                for (Tuple t : r1.getMaxTupleSet().getByFirst(e)) {
+                    opt = bmgr.or(opt, edge(r1, t));
+                }
+                enc = bmgr.and(enc, bmgr.equivalence(edge(rel, tuple), opt));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitRangeIdentity(Relation rel, Relation r1) {
+            BooleanFormula enc = bmgr.makeTrue();
+            //TODO: Optimize using minSets (but no CAT uses this anyway)
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                Event e = tuple.getFirst();
+                BooleanFormula opt = bmgr.makeFalse();
+                for (Tuple t : r1.getMaxTupleSet().getBySecond(e)) {
+                    opt = bmgr.or(opt, edge(r1, t));
+                }
+                enc = bmgr.and(enc, bmgr.equivalence(edge(rel, tuple), opt));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitTransitiveClosure(Relation rel, Relation r1) {
+            BooleanFormula enc = bmgr.makeTrue();
+            TupleSet maySet = rel.getMaxTupleSet();
+            TupleSet minSet = rel.getMinTupleSet();
+            TupleSet r1Max = r1.getMaxTupleSet();
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                BooleanFormula edge = edge(rel, tuple);
+                if (minSet.contains(tuple)) {
+                    if (Relation.PostFixApprox) {
+                        enc = bmgr.and(enc, bmgr.implication(execution(tuple), edge));
+                    } else {
+                        enc = bmgr.and(enc, bmgr.equivalence(edge, execution(tuple)));
+                    }
+                    continue;
+                }
+                BooleanFormula orClause = bmgr.makeFalse();
+                Event e1 = tuple.getFirst();
+                Event e2 = tuple.getSecond();
+                if (r1Max.contains(tuple)) {
+                    orClause = bmgr.or(orClause, edge(r1, tuple));
+                }
+                for (Tuple t : r1Max.getByFirst(e1)) {
+                    Event e3 = t.getSecond();
+                    if (e3.getCId() != e1.getCId() && e3.getCId() != e2.getCId() && maySet.contains(new Tuple(e3, e2))) {
+                        BooleanFormula tVar = minSet.contains(t) ? edge(rel, t) : edge(r1, t);
+                        orClause = bmgr.or(orClause, bmgr.and(tVar, edge(rel, new Tuple(e3, e2))));
+                    }
+                }
+                if (Relation.PostFixApprox) {
+                    enc = bmgr.and(enc, bmgr.implication(orClause, edge));
+                } else {
+                    enc = bmgr.and(enc, bmgr.equivalence(edge, orClause));
+                }
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitInverse(Relation rel, Relation r1) {
+            BooleanFormula enc = bmgr.makeTrue();
+            TupleSet minSet = rel.getMinTupleSet();
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                enc = bmgr.and(enc, bmgr.equivalence(
+                        edge(rel, tuple),
+                        minSet.contains(tuple) ?
+                                execution(tuple) :
+                                edge(r1, tuple.getInverse())));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitFences(Relation rel, FilterAbstract fenceSet) {
+            BooleanFormula enc = bmgr.makeTrue();
+            List<Event> fences = program.getCache().getEvents(fenceSet);
+            for (Tuple tuple : rel.getEncodeTupleSet()) {
+                Event e1 = tuple.getFirst();
+                Event e2 = tuple.getSecond();
+                BooleanFormula orClause;
+                if (rel.getMinTupleSet().contains(tuple)) {
+                    orClause = bmgr.makeTrue();
+                } else {
+                    orClause = fences.stream()
+                            .filter(f -> e1.getCId() < f.getCId() && f.getCId() < e2.getCId())
+                            .map(Event::exec).reduce(bmgr.makeFalse(), bmgr::or);
+                }
+                enc = bmgr.and(enc, bmgr.equivalence(
+                        edge(rel, tuple),
+                        bmgr.and(execution(tuple), orClause)));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitCriticalSections(Relation rscs) {
+            BooleanFormula enc = bmgr.makeTrue();
+            TupleSet maySet = rscs.getMaxTupleSet();
+            for (Tuple tuple : rscs.getEncodeTupleSet()) {
+                Event lock = tuple.getFirst();
+                Event unlock = tuple.getSecond();
+                BooleanFormula relation = execution(tuple);
+                for (Tuple t : maySet.getBySecond(unlock)) {
+                    Event y = t.getFirst();
+                    if (lock.getCId() < y.getCId() && y.getCId() < unlock.getCId()) {
+                        relation = bmgr.and(relation, bmgr.not(edge(rscs, t)));
+                    }
+                }
+                for (Tuple t : maySet.getByFirst(lock)) {
+                    Event y = t.getSecond();
+                    if (lock.getCId() < y.getCId() && y.getCId() < unlock.getCId()) {
+                        relation = bmgr.and(relation, bmgr.not(edge(rscs, t)));
+                    }
+                }
+                enc = bmgr.and(enc, bmgr.equivalence(edge(rscs, tuple), relation));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitReadModifyWrites(Relation rmw) {
+            BooleanFormula enc = bmgr.makeTrue();
+            BooleanFormula unpredictable = bmgr.makeFalse();
+            TupleSet maySet = rmw.getMaxTupleSet();
+            TupleSet mustSet = rmw.getMinTupleSet();
+            for (Event store : program.getCache().getEvents(
+                    FilterIntersection.get(FilterBasic.get(Tag.WRITE), FilterBasic.get(Tag.EXCL)))) {
+                checkState(store instanceof MemEvent, "non-memory event participating in '" + rmw.getName() + "'");
+                BooleanFormula storeExec = bmgr.makeFalse();
+                for (Tuple t : maySet.getBySecond(store)) {
+                    MemEvent load = (MemEvent) t.getFirst();
+                    BooleanFormula sameAddress = generalEqual(load.getMemAddressExpr(), ((MemEvent) store).getMemAddressExpr(), ctx);
+                    // Encode if load and store form an exclusive pair
+                    BooleanFormula isPair = exclPair(load, store);
+                    BooleanFormula pairingCond = pairingCond(load, store, maySet);
+                    // For ARMv8, the store can be executed if addresses mismatch, but behaviour is "constrained unpredictable"
+                    // The implementation does not include all possible unpredictable cases: in case of address
+                    // mismatch, addresses of read and write are unknown, i.e. read and write can use any address.
+                    // For RISCV and Power, addresses should match.
+                    if (store.is(Tag.MATCHADDRESS)) {
+                        pairingCond = bmgr.and(pairingCond, sameAddress);
+                    } else {
+                        unpredictable = bmgr.or(unpredictable, bmgr.and(store.exec(), isPair, bmgr.not(sameAddress)));
+                    }
+                    enc = bmgr.and(enc, bmgr.equivalence(isPair, pairingCond));
+                    storeExec = bmgr.or(storeExec, isPair);
+                }
+                enc = bmgr.and(enc, bmgr.implication(store.exec(), storeExec));
+            }
+            for (Tuple tuple : rmw.getEncodeTupleSet()) {
+                MemEvent load = (MemEvent) tuple.getFirst();
+                MemEvent store = (MemEvent) tuple.getSecond();
+                BooleanFormula sameAddress = (alias.mustAlias(load, store) || store.is(Tag.MATCHADDRESS)) ? bmgr.makeTrue()
+                        : generalEqual(load.getMemAddressExpr(), store.getMemAddressExpr(), ctx);
+                enc = bmgr.and(enc, bmgr.equivalence(
+                        edge(rmw, tuple),
+                        mustSet.contains(tuple) ? execution(tuple) :
+                                // Relation between exclusive load and store
+                                bmgr.and(store.exec(), exclPair(load, store), sameAddress)));
+            }
+            return bmgr.and(enc, bmgr.equivalence(Flag.ARM_UNPREDICTABLE_BEHAVIOUR.repr(ctx), unpredictable));
+        }
+        @Override
+        public BooleanFormula visitSameAddress(Relation loc) {
+            BooleanFormula enc = bmgr.makeTrue();
+            for (Tuple tuple : loc.getEncodeTupleSet()) {
+                BooleanFormula rel = edge(loc, tuple);
+                enc = bmgr.and(enc, bmgr.equivalence(rel, bmgr.and(
+                        execution(tuple),
+                        generalEqual(
+                                ((MemEvent) tuple.getFirst()).getMemAddressExpr(),
+                                ((MemEvent) tuple.getSecond()).getMemAddressExpr(), ctx)
+                )));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitReadFrom(Relation rf) {
+            BooleanFormula enc = bmgr.makeTrue();
+            Map<MemEvent, List<BooleanFormula>> edgeMap = new HashMap<>();
+            for (Tuple tuple : rf.getMaxTupleSet()) {
+                MemEvent w = (MemEvent) tuple.getFirst();
+                MemEvent r = (MemEvent) tuple.getSecond();
+                BooleanFormula edge = edge(rf, tuple);
+                // The boogie file might have a different type (Ints vs BVs) that the imposed by ARCH_PRECISION
+                // In such cases we perform the transformation
+                Formula a1 = w.getMemAddressExpr();
+                Formula a2 = r.getMemAddressExpr();
+                BooleanFormula sameAddress = generalEqual(a1, a2, ctx);
+                Formula v1 = w.getMemValueExpr();
+                Formula v2 = r.getMemValueExpr();
+                BooleanFormula sameValue = generalEqual(v1, v2, ctx);
+                edgeMap.computeIfAbsent(r, key -> new ArrayList<>()).add(edge);
+                enc = bmgr.and(enc, bmgr.implication(edge, bmgr.and(execution(tuple), sameAddress, sameValue)));
+            }
+            for (MemEvent r : edgeMap.keySet()) {
+                enc = bmgr.and(enc, encodeEdgeSeq(r, edgeMap.get(r)));
+            }
+            return enc;
+        }
+        @Override
+        public BooleanFormula visitMemoryOrder(Relation co) {
+            return useSATEncoding ? encodeSAT(co) : encodeIDL(co);
+        }
+        private BooleanFormula pairingCond(Event load, Event store, TupleSet maySet) {
+            BooleanFormula pairingCond = bmgr.and(load.exec(), store.cf());
+            for (Tuple t : maySet.getBySecond(store)) {
+                Event otherLoad = t.getFirst();
+                if (otherLoad.getCId() > load.getCId()) {
+                    pairingCond = bmgr.and(pairingCond, bmgr.not(otherLoad.exec()));
+                }
+            }
+            for (Tuple t : maySet.getByFirst(load)) {
+                Event otherStore = t.getSecond();
+                if (otherStore.getCId() < store.getCId()) {
+                    pairingCond = bmgr.and(pairingCond, bmgr.not(otherStore.cf()));
+                }
+            }
+            return pairingCond;
+        }
+        private BooleanFormula exclPair(Event load, Event store) {
+            return bmgr.makeVariable("excl(" + load.getCId() + "," + store.getCId() + ")");
+        }
+
+        private BooleanFormula encodeEdgeSeq(Event read, List<BooleanFormula> edges) {
+            if (GlobalSettings.ALLOW_MULTIREADS) {
+                return bmgr.implication(read.exec(), bmgr.or(edges));
+            }
+            int num = edges.size();
+            int readId = read.getCId();
+            BooleanFormula lastSeqVar = mkSeqVar(readId, 0);
+            BooleanFormula newSeqVar = lastSeqVar;
+            BooleanFormula atMostOne = bmgr.equivalence(lastSeqVar, edges.get(0));
+            for (int i = 1; i < num; i++) {
+                newSeqVar = mkSeqVar(readId, i);
+                atMostOne = bmgr.and(atMostOne, bmgr.equivalence(newSeqVar, bmgr.or(lastSeqVar, edges.get(i))));
+                atMostOne = bmgr.and(atMostOne, bmgr.not(bmgr.and(edges.get(i), lastSeqVar)));
+                lastSeqVar = newSeqVar;
+            }
+            BooleanFormula atLeastOne = bmgr.or(newSeqVar, edges.get(edges.size() - 1));
+            atLeastOne = bmgr.implication(read.exec(), atLeastOne);
+            return bmgr.and(atMostOne, atLeastOne);
+        }
+        private BooleanFormula mkSeqVar(int readId, int i) {
+            return bmgr.makeVariable("s(" + RF + ",E" + readId + "," + i + ")");
+        }
+        private BooleanFormula encodeIDL(Relation co) {
+            List<MemEvent> allWrites = program.getCache().getEvents(FilterBasic.get(WRITE)).stream()
+                    .map(MemEvent.class::cast)
+                    .sorted(Comparator.comparingInt(Event::getCId))
+                    .collect(toList());
+            TupleSet maxSet = co.getMaxTupleSet();
+            Set<Tuple> transCo = RelationAnalysis.findTransitivelyImpliedCo(co, exec);
+            BooleanFormula enc = bmgr.makeTrue();
+            // ---- Encode clock conditions (init = 0, non-init > 0) ----
+            NumeralFormula.IntegerFormula zero = imgr.makeNumber(0);
+            for (MemEvent w : allWrites) {
+                NumeralFormula.IntegerFormula clock = Utils.coClockVar(w, ctx);
+                enc = bmgr.and(enc, w.is(INIT) ? imgr.equal(clock, zero) : imgr.greaterThan(clock, zero));
+            }
+
+            // ---- Encode coherences ----
+            for (int i = 0; i < allWrites.size() - 1; i++) {
+                MemEvent w1 = allWrites.get(i);
+                for (MemEvent w2 : allWrites.subList(i + 1, allWrites.size())) {
+                    Tuple t = new Tuple(w1, w2);
+                    boolean forwardPossible = maxSet.contains(t);
+                    boolean backwardPossible = maxSet.contains(t.getInverse());
+                    if (!forwardPossible && !backwardPossible) {
+                        continue;
+                    }
+                    BooleanFormula execPair = execution(t);
+                    BooleanFormula sameAddress = alias.mustAlias(w1, w2) ? bmgr.makeTrue() :
+                            generalEqual(w1.getMemAddressExpr(), w2.getMemAddressExpr(), ctx);
+                    BooleanFormula pairingCond = bmgr.and(execPair, sameAddress);
+                    BooleanFormula fCond = (w1.is(INIT) || transCo.contains(t)) ? bmgr.makeTrue() :
+                            imgr.lessThan(Utils.coClockVar(w1, ctx), Utils.coClockVar(w2, ctx));
+                    BooleanFormula bCond = (w2.is(INIT) || transCo.contains(t.getInverse())) ? bmgr.makeTrue() :
+                            imgr.lessThan(Utils.coClockVar(w2, ctx), Utils.coClockVar(w1, ctx));
+                    BooleanFormula coF = forwardPossible ? edge(co, new Tuple(w1, w2)) : bmgr.makeFalse();
+                    BooleanFormula coB = backwardPossible ? edge(co, new Tuple(w2, w1)) : bmgr.makeFalse();
+                    enc = bmgr.and(enc,
+                            bmgr.implication(coF, fCond),
+                            bmgr.implication(coB, bCond),
+                            bmgr.equivalence(pairingCond, bmgr.or(coF, coB))
+                    );
+                }
+            }
+            return enc;
+        }
+        private BooleanFormula encodeSAT(Relation co) {
+            List<MemEvent> allWrites = program.getCache().getEvents(FilterBasic.get(WRITE)).stream()
+                    .map(MemEvent.class::cast)
+                    .sorted(Comparator.comparingInt(Event::getCId))
+                    .collect(toList());
+            TupleSet maxSet = co.getMaxTupleSet();
+            TupleSet minSet = co.getMinTupleSet();
+            BooleanFormula enc = bmgr.makeTrue();
+            // ---- Encode coherences ----
+            for (int i = 0; i < allWrites.size() - 1; i++) {
+                MemEvent w1 = allWrites.get(i);
+                for (MemEvent w2 : allWrites.subList(i + 1, allWrites.size())) {
+                    Tuple t = new Tuple(w1, w2);
+                    Tuple tInv = t.getInverse();
+                    boolean forwardPossible = maxSet.contains(t);
+                    boolean backwardPossible = maxSet.contains(tInv);
+                    if (!forwardPossible && !backwardPossible) {
+                        continue;
+                    }
+                    BooleanFormula execPair = execution(t);
+                    BooleanFormula sameAddress = alias.mustAlias(w1, w2) ? bmgr.makeTrue() :
+                            generalEqual(w1.getMemAddressExpr(), w2.getMemAddressExpr(), ctx);
+                    BooleanFormula pairingCond = bmgr.and(execPair, sameAddress);
+                    BooleanFormula coF = forwardPossible ? edge(co, t) : bmgr.makeFalse();
+                    BooleanFormula coB = backwardPossible ? edge(co, tInv) : bmgr.makeFalse();
+                    enc = bmgr.and(enc,
+                            bmgr.equivalence(pairingCond, bmgr.or(coF, coB)),
+                            bmgr.or(bmgr.not(coF), bmgr.not(coB))
+                    );
+                    if (!minSet.contains(t) && !minSet.contains(tInv)) {
+                        for (MemEvent w3 : allWrites) {
+                            Tuple t1 = new Tuple(w1, w3);
+                            Tuple t2 = new Tuple(w3, w2);
+                            if (forwardPossible && maxSet.contains(t1) && maxSet.contains(t2)) {
+                                BooleanFormula co1 = edge(co, t1);
+                                BooleanFormula co2 = edge(co, t2);
+                                enc = bmgr.and(enc, bmgr.implication(bmgr.and(co1, co2), coF));
+                            }
+                            if (backwardPossible && maxSet.contains(t1.getInverse()) && maxSet.contains(t2.getInverse())) {
+                                BooleanFormula co1 = edge(co, t2.getInverse());
+                                BooleanFormula co2 = edge(co, t1.getInverse());
+                                enc = bmgr.and(enc, bmgr.implication(bmgr.and(co1, co2), coB));
+                            }
+                        }
+                    }
+                }
+            }
+            return enc;
+        }
+        private BooleanFormula edge(Relation relation, Tuple tuple) {
+            return relation.getSMTVar(tuple, ctx);
+        }
+        private BooleanFormula execution(Tuple tuple) {
+            return ProgramEncoder.execution(tuple.getFirst(), tuple.getSecond(), exec, ctx);
+        }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.IDL_TO_SAT;
-import static com.dat3m.dartagnan.configuration.OptionNames.POST_FIXPOINT;
 import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
 import static com.dat3m.dartagnan.program.event.Tag.INIT;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
@@ -67,12 +66,6 @@ public class WmmEncoder implements Encoder {
             description = "Use SAT-based encoding for totality and acyclicity.",
             secure = true)
     private boolean useSATEncoding = false;
-
-    @Option(
-            name = POST_FIXPOINT,
-            description = "Allow relationship variables to be assigned true without reason.",
-            secure = true)
-    private boolean postFixApprox = false;
 
     // =====================================================================
 
@@ -202,11 +195,7 @@ public class WmmEncoder implements Encoder {
                 for (Relation relation : r) {
                     opt.add(edge(relation, tuple));
                 }
-                if (postFixApprox) {
-                    enc = bmgr.and(enc, bmgr.implication(bmgr.or(opt), edge));
-                } else {
-                    enc = bmgr.and(enc, bmgr.equivalence(edge, bmgr.or(opt)));
-                }
+                enc = bmgr.and(enc, bmgr.equivalence(edge, bmgr.or(opt)));
             }
             return enc;
         }
@@ -240,11 +229,7 @@ public class WmmEncoder implements Encoder {
                 }
                 BooleanFormula opt1 = edge(r1, tuple);
                 BooleanFormula opt2 = bmgr.not(edge(r2, tuple));
-                if (postFixApprox) {
-                    enc = bmgr.and(enc, bmgr.implication(bmgr.and(opt1, opt2), edge));
-                } else {
-                    enc = bmgr.and(enc, bmgr.equivalence(edge, bmgr.and(opt1, opt2)));
-                }
+                enc = bmgr.and(enc, bmgr.equivalence(edge, bmgr.and(opt1, opt2)));
             }
             return enc;
         }
@@ -307,11 +292,7 @@ public class WmmEncoder implements Encoder {
             for (Tuple tuple : rel.getEncodeTupleSet()) {
                 BooleanFormula edge = edge(rel, tuple);
                 if (minSet.contains(tuple)) {
-                    if (postFixApprox) {
-                        enc = bmgr.and(enc, bmgr.implication(execution(tuple), edge));
-                    } else {
-                        enc = bmgr.and(enc, bmgr.equivalence(edge, execution(tuple)));
-                    }
+                    enc = bmgr.and(enc, bmgr.equivalence(edge, execution(tuple)));
                     continue;
                 }
                 BooleanFormula orClause = bmgr.makeFalse();
@@ -327,11 +308,7 @@ public class WmmEncoder implements Encoder {
                         orClause = bmgr.or(orClause, bmgr.and(tVar, edge(rel, new Tuple(e3, e2))));
                     }
                 }
-                if (postFixApprox) {
-                    enc = bmgr.and(enc, bmgr.implication(orClause, edge));
-                } else {
-                    enc = bmgr.and(enc, bmgr.equivalence(edge, orClause));
-                }
+                enc = bmgr.and(enc, bmgr.equivalence(edge, orClause));
             }
             return enc;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -326,6 +326,10 @@ public class WmmEncoder implements Encoder {
             return enc;
         }
         @Override
+        public BooleanFormula visitRecursive(Relation rel, Relation r1) {
+            return bmgr.makeTrue();
+        }
+        @Override
         public BooleanFormula visitFences(Relation rel, FilterAbstract fenceSet) {
             BooleanFormula enc = bmgr.makeTrue();
             List<Event> fences = program.getCache().getEvents(fenceSet);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.IDL_TO_SAT;
+import static com.dat3m.dartagnan.configuration.OptionNames.POST_FIXPOINT;
 import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
 import static com.dat3m.dartagnan.program.event.Tag.INIT;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
@@ -66,6 +67,12 @@ public class WmmEncoder implements Encoder {
             description = "Use SAT-based encoding for totality and acyclicity.",
             secure = true)
     private boolean useSATEncoding = false;
+
+    @Option(
+            name = POST_FIXPOINT,
+            description = "Allow relationship variables to be assigned true without reason.",
+            secure = true)
+    private boolean postFixApprox = false;
 
     // =====================================================================
 
@@ -195,7 +202,7 @@ public class WmmEncoder implements Encoder {
                 for (Relation relation : r) {
                     opt.add(edge(relation, tuple));
                 }
-                if (Relation.PostFixApprox) {
+                if (postFixApprox) {
                     enc = bmgr.and(enc, bmgr.implication(bmgr.or(opt), edge));
                 } else {
                     enc = bmgr.and(enc, bmgr.equivalence(edge, bmgr.or(opt)));
@@ -233,7 +240,7 @@ public class WmmEncoder implements Encoder {
                 }
                 BooleanFormula opt1 = edge(r1, tuple);
                 BooleanFormula opt2 = bmgr.not(edge(r2, tuple));
-                if (Relation.PostFixApprox) {
+                if (postFixApprox) {
                     enc = bmgr.and(enc, bmgr.implication(bmgr.and(opt1, opt2), edge));
                 } else {
                     enc = bmgr.and(enc, bmgr.equivalence(edge, bmgr.and(opt1, opt2)));
@@ -300,7 +307,7 @@ public class WmmEncoder implements Encoder {
             for (Tuple tuple : rel.getEncodeTupleSet()) {
                 BooleanFormula edge = edge(rel, tuple);
                 if (minSet.contains(tuple)) {
-                    if (Relation.PostFixApprox) {
+                    if (postFixApprox) {
                         enc = bmgr.and(enc, bmgr.implication(execution(tuple), edge));
                     } else {
                         enc = bmgr.and(enc, bmgr.equivalence(edge, execution(tuple)));
@@ -320,7 +327,7 @@ public class WmmEncoder implements Encoder {
                         orClause = bmgr.or(orClause, bmgr.and(tVar, edge(rel, new Tuple(e3, e2))));
                     }
                 }
-                if (Relation.PostFixApprox) {
+                if (postFixApprox) {
                     enc = bmgr.and(enc, bmgr.implication(orClause, edge));
                 } else {
                     enc = bmgr.and(enc, bmgr.equivalence(edge, orClause));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
@@ -12,6 +12,8 @@ import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.relation.Relation;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.SolverContext;
 
@@ -29,12 +31,16 @@ public class WMMSolver {
     private final CAATSolver solver;
     private final CoreReasoner reasoner;
 
-    public WMMSolver(VerificationTask task, Context analysisContext, Set<Relation> cutRelations) {
+    private WMMSolver(VerificationTask task, Context analysisContext, Set<Relation> cutRelations, ExecutionModel m) {
         analysisContext.requires(RelationAnalysis.class);
         this.executionGraph = new ExecutionGraph(task, cutRelations, true);
-        this.executionModel = new ExecutionModel(task);
+        this.executionModel = m;
         this.reasoner = new CoreReasoner(task, analysisContext, executionGraph);
         this.solver = CAATSolver.create();
+    }
+
+    public static WMMSolver fromConfig(VerificationTask task, Context analysisContext, Set<Relation> cutRelations, Configuration config) throws InvalidConfigurationException {
+        return new WMMSolver(task, analysisContext, cutRelations, ExecutionModel.fromConfig(task, config));
     }
 
     public ExecutionModel getExecution() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.CO;
 import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.RF;
+import static com.dat3m.dartagnan.wmm.utils.Utils.coClockVar;
 
 /*
 The ExecutionModel wraps a Model and extracts data from it in a more workable manner.
@@ -477,7 +478,7 @@ public class ExecutionModel {
     }
 
     private void extractCoherences() {
-        final RelCo co = (RelCo) task.getMemoryModel().getRelation(CO);
+        final Relation co = task.getMemoryModel().getRelation(CO);
 
         for (Map.Entry<BigInteger, Set<EventData>> addrWrites : addressWritesMap.entrySet()) {
             final BigInteger addr = addrWrites.getKey();
@@ -501,7 +502,7 @@ public class ExecutionModel {
                 // --- Extracting co from IDL-based encoding using clock variables ---
                 Map<EventData, BigInteger> writeClockMap = new HashMap<>(writes.size() * 4 / 3, 0.75f);
                 for (EventData w : writes) {
-                    writeClockMap.put(w, model.evaluate(co.getClockVar(w.getEvent(), context)));
+                    writeClockMap.put(w, model.evaluate(coClockVar(w.getEvent(), context)));
                 }
                 coSortedWrites = writes.stream().sorted(Comparator.comparing(writeClockMap::get)).collect(Collectors.toList());
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -52,7 +52,7 @@ public class AssumeSolver extends ModelChecker {
 
         ProgramEncoder programEncoder = ProgramEncoder.fromConfig(program, analysisContext, config);
         PropertyEncoder propertyEncoder = PropertyEncoder.fromConfig(program, memoryModel,analysisContext, config);
-        WmmEncoder wmmEncoder = WmmEncoder.fromConfig(memoryModel, analysisContext, config);
+        WmmEncoder wmmEncoder = WmmEncoder.fromConfig(program, memoryModel, analysisContext, config);
         SymmetryEncoder symmetryEncoder = SymmetryEncoder.fromConfig(memoryModel, analysisContext, config);
 
         programEncoder.initializeEncoding(ctx);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
@@ -54,7 +54,7 @@ public class DataRaceSolver extends ModelChecker {
 
 		ProgramEncoder programEncoder = ProgramEncoder.fromConfig(program, analysisContext, config);
 		PropertyEncoder propertyEncoder = PropertyEncoder.fromConfig(program, memoryModel,analysisContext, config);
-		WmmEncoder wmmEncoder = WmmEncoder.fromConfig(memoryModel, analysisContext, config);
+		WmmEncoder wmmEncoder = WmmEncoder.fromConfig(program, memoryModel, analysisContext, config);
 		SymmetryEncoder symmetryEncoder = SymmetryEncoder.fromConfig(memoryModel, analysisContext, config);
 
 		programEncoder.initializeEncoding(ctx);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -35,7 +35,7 @@ public class IncrementalSolver extends ModelChecker {
         task = t;
     }
 
-    public static Result run(SolverContext ctx, ProverEnvironment prover, VerificationTask task) 
+    public static Result run(SolverContext ctx, ProverEnvironment prover, VerificationTask task)
     		throws InterruptedException, SolverException, InvalidConfigurationException {
         return new IncrementalSolver(ctx, prover, task).run();
     }
@@ -54,7 +54,7 @@ public class IncrementalSolver extends ModelChecker {
 
         ProgramEncoder programEncoder = ProgramEncoder.fromConfig(program, analysisContext, config);
         PropertyEncoder propertyEncoder = PropertyEncoder.fromConfig(program, memoryModel,analysisContext, config);
-        WmmEncoder wmmEncoder = WmmEncoder.fromConfig(memoryModel, analysisContext, config);
+        WmmEncoder wmmEncoder = WmmEncoder.fromConfig(program, memoryModel, analysisContext, config);
         SymmetryEncoder symmetryEncoder = SymmetryEncoder.fromConfig(memoryModel, analysisContext, config);
 
         programEncoder.initializeEncoding(ctx);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -329,9 +329,6 @@ public class RefinementSolver extends ModelChecker {
             return namedCopy;
         }
         Relation copy = rel.accept(new RelationCopier(m));
-        if (copy == null) {
-            throw new UnsupportedOperationException("copying relation " + rel);
-        }
         if (rel.getIsNamed()) {
             copy.setName(rel.getName());
             m.updateRelation(copy);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -138,7 +138,7 @@ public class RefinementSolver extends ModelChecker {
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
         BooleanFormula globalRefinement = bmgr.makeTrue();
 
-        WMMSolver solver = new WMMSolver(task, analysisContext, cutRelations);
+        WMMSolver solver = WMMSolver.fromConfig(task, analysisContext, cutRelations, config);
         Refiner refiner = new Refiner(memoryModel, analysisContext);
         CAATSolver.Status status = INCONSISTENT;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -129,7 +129,7 @@ public class RefinementSolver extends ModelChecker {
         // We use the original memory model for symmetry breaking because we need axioms
         // to compute the breaking order.
         SymmetryEncoder symmEncoder = SymmetryEncoder.fromConfig(memoryModel, analysisContext, config);
-        WmmEncoder baselineEncoder = WmmEncoder.fromConfig(baselineModel, baselineContext, config);
+        WmmEncoder baselineEncoder = WmmEncoder.fromConfig(program, baselineModel, baselineContext, config);
         programEncoder.initializeEncoding(ctx);
         propertyEncoder.initializeEncoding(ctx);
         symmEncoder.initializeEncoding(ctx);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -329,6 +329,9 @@ public class RefinementSolver extends ModelChecker {
             return namedCopy;
         }
         Relation copy = rel.accept(new RelationCopier(m));
+        if (copy == null) {
+            throw new UnsupportedOperationException("copying relation " + rel);
+        }
         if (rel.getIsNamed()) {
             copy.setName(rel.getName());
             m.updateRelation(copy);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -55,7 +55,7 @@ public class TwoSolvers extends ModelChecker {
 
         ProgramEncoder programEncoder = ProgramEncoder.fromConfig(program, analysisContext, config);
         PropertyEncoder propertyEncoder = PropertyEncoder.fromConfig(program, memoryModel,analysisContext, config);
-        WmmEncoder wmmEncoder = WmmEncoder.fromConfig(memoryModel, analysisContext, config);
+        WmmEncoder wmmEncoder = WmmEncoder.fromConfig(program, memoryModel, analysisContext, config);
         SymmetryEncoder symmetryEncoder = SymmetryEncoder.fromConfig(memoryModel, analysisContext, config);
 
         programEncoder.initializeEncoding(ctx);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
@@ -3,14 +3,20 @@ package com.dat3m.dartagnan.wmm.analysis;
 import com.dat3m.dartagnan.program.analysis.Dependency;
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
+import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.RecursiveGroup;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
+import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class RelationAnalysis {
 
@@ -38,6 +44,42 @@ public class RelationAnalysis {
         RelationAnalysis a = new RelationAnalysis(task, context, config);
         a.run(task, context);
         return a;
+    }
+
+    /*
+        Returns a set of co-edges (w1, w2) (subset of maxTupleSet) whose clock-constraints
+        do not need to get encoded explicitly.
+        The reason is that whenever we have co(w1,w2) then there exists an intermediary
+        w3 s.t. co(w1, w3) /\ co(w3, w2). As a result we have c(w1) < c(w3) < c(w2) transitively.
+        Reasoning: Let (w1, w2) be a potential co-edge. Suppose there exists a w3 different to w1 and w2,
+        whose execution is either implied by either w1 or w2.
+        Now, if co(w1, w3) is a must-edge and co(w2, w3) is impossible, then we can reason as follows.
+            - Suppose w1 and w2 get executed and their addresses match, then w3 must also get executed.
+            - Since co(w1, w3) is a must-edge, we have that w3 accesses the same address as w1 and w2,
+              and c(w1) < c(w3).
+            - Because addr(w2)==addr(w3), we must also have either co(w2, e3) or co(w3, w2).
+              The former is disallowed by assumption, so we have co(w3, w2) and hence c(w3) < c(w2).
+            - By transitivity, we have c(w1) < c(w3) < c(w2) as desired.
+            - Note that this reasoning has to be done inductively, because co(w1, w3) or co(w3, w2) may
+              not involve encoding a clock constraint (due to this optimization).
+        There is also a symmetric case where co(w3, w1) is impossible and co(w3, w2) is a must-edge.
+     */
+    public static Set<Tuple> findTransitivelyImpliedCo(Relation co, ExecutionAnalysis exec) {
+        final TupleSet min = co.getMinTupleSet();
+        final TupleSet max = co.getMaxTupleSet();
+        Set<Tuple> transCo = new HashSet<>();
+        for (final Tuple t : max) {
+            final MemEvent x = (MemEvent) t.getFirst();
+            final MemEvent z = (MemEvent) t.getSecond();
+            final boolean hasIntermediary = min.getByFirst(x).stream().map(Tuple::getSecond)
+                            .anyMatch(y -> y != x && y != z && (exec.isImplied(x, y) || exec.isImplied(z, y)) && !max.contains(new Tuple(z, y))) ||
+                    min.getBySecond(z).stream().map(Tuple::getFirst)
+                            .anyMatch(y -> y != x && y != z && (exec.isImplied(x, y) || exec.isImplied(z, y)) && !max.contains(new Tuple(y, x)));
+            if (hasIntermediary) {
+                transCo.add(t);
+            }
+        }
+        return transCo;
     }
 
     private void run(VerificationTask task, Context context) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Axiom.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Axiom.java
@@ -4,6 +4,7 @@ import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Constraint;
 import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.base.Preconditions;
 import org.sosy_lab.common.configuration.Configuration;
@@ -14,6 +15,7 @@ import org.sosy_lab.java_smt.api.SolverContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  *
@@ -80,7 +82,7 @@ public abstract class Axiom implements Constraint {
 
     public abstract TupleSet getEncodeTupleSet();
 
-    public abstract BooleanFormula consistent(SolverContext ctx);
+    public abstract BooleanFormula consistent(Set<Tuple> toBeEncoded, Context analysisContext, SolverContext ctx);
 
     @Override
     public int hashCode() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Empty.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Empty.java
@@ -1,11 +1,14 @@
 package com.dat3m.dartagnan.wmm.axiom;
 
+import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
+
+import java.util.Set;
 
 public class Empty extends Axiom {
 
@@ -23,10 +26,10 @@ public class Empty extends Axiom {
     }
 
     @Override
-    public BooleanFormula consistent(SolverContext ctx) {
+    public BooleanFormula consistent(Set<Tuple> toBeEncoded, Context analysisContext, SolverContext ctx) {
     	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
 		BooleanFormula enc = bmgr.makeTrue();
-        for(Tuple tuple : rel.getEncodeTupleSet()){
+        for (Tuple tuple : toBeEncoded) {
             enc = bmgr.and(enc, bmgr.not(rel.getSMTVar(tuple, ctx)));
         }
         return negated ? bmgr.not(enc) : enc;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/ForceEncodeAxiom.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/ForceEncodeAxiom.java
@@ -1,10 +1,14 @@
 package com.dat3m.dartagnan.wmm.axiom;
 
+import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.wmm.relation.Relation;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
+
+import java.util.Set;
 
 /*
     This is a fake axiom that forces a relation to get encoded!
@@ -24,7 +28,7 @@ public class ForceEncodeAxiom extends Axiom {
     }
 
     @Override
-    public BooleanFormula consistent(SolverContext ctx) {
+    public BooleanFormula consistent(Set<Tuple> toBeEncoded, Context analysisContext, SolverContext ctx) {
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
 		return negated ? bmgr.makeFalse() : bmgr.makeTrue();
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Irreflexive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/axiom/Irreflexive.java
@@ -1,11 +1,14 @@
 package com.dat3m.dartagnan.wmm.axiom;
 
+import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.SolverContext;
+
+import java.util.Set;
 
 /**
  *
@@ -29,10 +32,10 @@ public class Irreflexive extends Axiom {
     }
 
     @Override
-    public BooleanFormula consistent(SolverContext ctx) {
+    public BooleanFormula consistent(Set<Tuple> toBeEncoded, Context analysisContext, SolverContext ctx) {
     	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
 		BooleanFormula enc = bmgr.makeTrue();
-        for(Tuple tuple : rel.getEncodeTupleSet()){
+        for (Tuple tuple : toBeEncoded) {
             if(tuple.isLoop()){
                 enc = bmgr.and(enc, bmgr.not(rel.getSMTVar(tuple, ctx)));
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RecursiveRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/RecursiveRelation.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.wmm.relation;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
-import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 /**
@@ -109,10 +108,4 @@ public class RecursiveRelation extends Relation {
             r1.addEncodeTupleSet(encodeTupleSet);
         }
     }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-        return ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
-    }
-
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import static com.dat3m.dartagnan.encoding.ProgramEncoder.execution;
 import static com.dat3m.dartagnan.wmm.utils.Utils.edge;
 
 /**
@@ -164,12 +163,6 @@ public abstract class Relation implements Constraint, Encoder, Dependent<Relatio
         return getName().equals(((Relation)obj).getName());
     }
 
-    public BooleanFormula encode(SolverContext ctx) {
-        return encodeApprox(ctx);
-    }
-
-    protected abstract BooleanFormula encodeApprox(SolverContext ctx);
-
     public BooleanFormula getSMTVar(Tuple edge, SolverContext ctx) {
         return !getMaxTupleSet().contains(edge) ?
         		ctx.getFormulaManager().getBooleanFormulaManager().makeFalse() :
@@ -178,15 +171,6 @@ public abstract class Relation implements Constraint, Encoder, Dependent<Relatio
 
     public final BooleanFormula getSMTVar(Event e1, Event e2, SolverContext ctx) {
         return getSMTVar(new Tuple(e1, e2), ctx);
-    }
-
-    protected BooleanFormula getExecPair(Event e1, Event e2, SolverContext ctx) {
-        ExecutionAnalysis exec = analysisContext.requires(ExecutionAnalysis.class);
-        return execution(e1, e2, exec, ctx);
-    }
-
-    protected final BooleanFormula getExecPair(Tuple t, SolverContext ctx) {
-        return getExecPair(t.getFirst(), t.getSecond(), ctx);
     }
 
     protected void removeMutuallyExclusiveTuples(Set<Tuple> tupleSet) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
@@ -207,7 +207,7 @@ public abstract class Relation implements Constraint, Encoder, Dependent<Relatio
     }
 
     public interface Visitor <T> {
-        default T visitDefinition(Relation rel, List<? extends Relation> dependencies) { return null; }
+        default T visitDefinition(Relation rel, List<? extends Relation> dependencies) { throw new UnsupportedOperationException("applying" + getClass().getSimpleName() + " to relation " + rel); }
         default T visitUnion(Relation rel, Relation... operands) { return visitDefinition(rel, List.of(operands)); }
         default T visitIntersection(Relation rel, Relation... operands) { return visitDefinition(rel, List.of(operands)); }
         default T visitDifference(Relation rel, Relation superset, Relation complement) { return visitDefinition(rel, List.of(superset, complement)); }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/Relation.java
@@ -33,8 +33,6 @@ import static com.dat3m.dartagnan.wmm.utils.Utils.edge;
 //TODO: Remove "Encoder" once we split data and operations appropriately
 public abstract class Relation implements Constraint, Encoder, Dependent<Relation> {
 
-    public static boolean PostFixApprox = false;
-
     protected String name;
     protected String term;
 
@@ -179,19 +177,19 @@ public abstract class Relation implements Constraint, Encoder, Dependent<Relatio
     }
 
     // ========================== Utility methods =========================
-    
+
     public boolean isStaticRelation() {
     	return this instanceof StaticRelation;
     }
-    
+
     public boolean isUnaryRelation() {
     	return this instanceof UnaryRelation;
     }
-    
+
     public boolean isBinaryRelation() {
     	return this instanceof BinaryRelation;
     }
-    
+
     public boolean isRecursiveRelation() {
     	return this instanceof RecursiveRelation;
     }
@@ -199,11 +197,11 @@ public abstract class Relation implements Constraint, Encoder, Dependent<Relatio
     public Relation getInner() {
         return (isUnaryRelation() || isRecursiveRelation()) ? getDependencies().get(0) : null;
     }
-    
+
     public Relation getFirst() {
     	return isBinaryRelation() ? getDependencies().get(0) : null;
     }
-    
+
     public Relation getSecond() {
     	return isBinaryRelation() ? getDependencies().get(1) : null;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/RelCrit.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/RelCrit.java
@@ -7,9 +7,6 @@ import com.dat3m.dartagnan.program.filter.FilterBasic;
 import com.dat3m.dartagnan.wmm.relation.base.stat.StaticRelation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.ArrayDeque;
 import java.util.List;
@@ -102,29 +99,6 @@ public class RelCrit extends StaticRelation {
                 }
             }
         }
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-        for (Tuple tuple : encodeTupleSet) {
-            Event lock = tuple.getFirst();
-            Event unlock = tuple.getSecond();
-            BooleanFormula relation = getExecPair(tuple, ctx);
-            for (Tuple t : maxTupleSet.getBySecond(unlock)) {
-                if (isOrdered(lock, t.getFirst(), unlock)) {
-                    relation = bmgr.and(relation, bmgr.not(getSMTVar(t, ctx)));
-                }
-            }
-            for (Tuple t : maxTupleSet.getByFirst(lock)) {
-                if (isOrdered(lock, t.getSecond(), unlock)) {
-                    relation = bmgr.and(relation, bmgr.not(getSMTVar(t, ctx)));
-                }
-            }
-            enc = bmgr.and(enc, bmgr.equivalence(getSMTVar(tuple, ctx), relation));
-        }
-        return enc;
     }
 
     private boolean isOrdered(Event x, Event y, Event z) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/RelRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/RelRMW.java
@@ -12,23 +12,15 @@ import com.dat3m.dartagnan.program.filter.FilterBasic;
 import com.dat3m.dartagnan.program.filter.FilterIntersection;
 import com.dat3m.dartagnan.program.filter.FilterUnion;
 import com.dat3m.dartagnan.wmm.relation.base.stat.StaticRelation;
-import com.dat3m.dartagnan.wmm.utils.Flag;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.FormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.List;
 
-import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
 import static com.dat3m.dartagnan.program.event.Tag.SVCOMP.SVCOMPATOMIC;
 import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.RMW;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.iterate;
-import static org.sosy_lab.java_smt.api.FormulaType.BooleanType;
 
 /*
     NOTE: Changes to the semantics of this class may need to be reflected
@@ -127,74 +119,5 @@ public class RelRMW extends StaticRelation {
                 }
             }
         }
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-        FormulaManager fmgr = ctx.getFormulaManager();
-		BooleanFormulaManager bmgr = fmgr.getBooleanFormulaManager();
-        BooleanFormula enc = bmgr.makeTrue();
-        BooleanFormula unpredictable = bmgr.makeFalse();
-        for(Event store : task.getProgram().getCache().getEvents(
-                FilterIntersection.get(FilterBasic.get(Tag.WRITE), FilterBasic.get(Tag.EXCL)))) {
-            checkState(store instanceof MemEvent, "non-memory event participating in '" + getName() + "'");
-            BooleanFormula storeExec = bmgr.makeFalse();
-            for(Tuple t : maxTupleSet.getBySecond(store)) {
-                MemEvent load = (MemEvent) t.getFirst();
-                BooleanFormula sameAddress = generalEqual(load.getMemAddressExpr(), ((MemEvent) store).getMemAddressExpr(), ctx);
-                // Encode if load and store form an exclusive pair
-                BooleanFormula isPair = exclPair(load, store, ctx);
-                BooleanFormula pairingCond = pairingCond(load, store, ctx);
-                // For ARMv8, the store can be executed if addresses mismatch, but behaviour is "constrained unpredictable"
-                // The implementation does not include all possible unpredictable cases: in case of address
-                // mismatch, addresses of read and write are unknown, i.e. read and write can use any address.
-                // For RISCV and Power, addresses should match.
-                if(store.is(Tag.MATCHADDRESS)) {
-                    pairingCond = bmgr.and(pairingCond, sameAddress);
-                } else {
-                    unpredictable = bmgr.or(unpredictable, bmgr.and(store.exec(), isPair, bmgr.not(sameAddress)));
-                }
-                enc = bmgr.and(enc, bmgr.equivalence(isPair, pairingCond));
-                storeExec = bmgr.or(storeExec, isPair);
-            }
-            enc = bmgr.and(enc, bmgr.implication(store.exec(), storeExec));
-        }
-
-        final AliasAnalysis alias = analysisContext.requires(AliasAnalysis.class);
-        for(Tuple tuple : encodeTupleSet) {
-            MemEvent load = (MemEvent) tuple.getFirst();
-            MemEvent store = (MemEvent) tuple.getSecond();
-            BooleanFormula sameAddress = (alias.mustAlias(load, store) || store.is(Tag.MATCHADDRESS)) ? bmgr.makeTrue()
-                    : generalEqual(load.getMemAddressExpr(), store.getMemAddressExpr(), ctx);
-            enc = bmgr.and(enc, bmgr.equivalence(
-                    getSMTVar(tuple, ctx),
-                    minTupleSet.contains(tuple) ? getExecPair(tuple, ctx) :
-                            // Relation between exclusive load and store
-                            bmgr.and(store.exec(), exclPair(load, store, ctx), sameAddress)));
-        }
-        return bmgr.and(enc, bmgr.equivalence(Flag.ARM_UNPREDICTABLE_BEHAVIOUR.repr(ctx), unpredictable));
-    }
-
-    private BooleanFormula pairingCond(Event load, Event store, SolverContext ctx){
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula pairingCond = bmgr.and(load.exec(), store.cf());
-
-        for (Tuple t : maxTupleSet.getBySecond(store)) {
-            Event otherLoad = t.getFirst();
-            if(otherLoad.getCId() > load.getCId()) {
-                pairingCond = bmgr.and(pairingCond, bmgr.not(otherLoad.exec()));
-            }
-        }
-        for (Tuple t : maxTupleSet.getByFirst(load)) {
-            Event otherStore = t.getSecond();
-            if(otherStore.getCId() < store.getCId()) {
-                pairingCond = bmgr.and(pairingCond, bmgr.not(otherStore.cf()));
-            }
-        }
-        return pairingCond;
-    }
-
-    private BooleanFormula exclPair(Event load, Event store, SolverContext ctx){
-    	return ctx.getFormulaManager().makeVariable(BooleanType, "excl(" + load.getCId() + "," + store.getCId() + ")");
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/local/BasicRegRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/local/BasicRegRelation.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.wmm.relation.base.local;
 
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.analysis.Dependency;
+import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.ExecutionStatus;
 import com.dat3m.dartagnan.wmm.relation.base.stat.StaticRelation;
@@ -18,6 +19,7 @@ import java.util.Set;
 import static com.dat3m.dartagnan.configuration.Arch.RISCV;
 
 import static com.dat3m.dartagnan.encoding.ProgramEncoder.dependencyEdgeVariable;
+import static com.dat3m.dartagnan.encoding.ProgramEncoder.execution;
 
 abstract class BasicRegRelation extends StaticRelation {
 
@@ -83,14 +85,9 @@ abstract class BasicRegRelation extends StaticRelation {
     public BooleanFormula getSMTVar(Tuple t, SolverContext ctx) {
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
         return minTupleSet.contains(t) ?
-        		getExecPair(t, ctx) :
+        		execution(t.getFirst(), t.getSecond(), analysisContext.get(ExecutionAnalysis.class), ctx) :
         		maxTupleSet.contains(t) ?
                         dependencyEdgeVariable(t.getFirst(), t.getSecond(), bmgr) :
         				bmgr.makeFalse();
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-        return ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelCo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelCo.java
@@ -1,11 +1,9 @@
 package com.dat3m.dartagnan.wmm.relation.base.memory;
 
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.EventCache;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.Init;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
 import com.dat3m.dartagnan.program.filter.FilterMinus;
@@ -13,8 +11,6 @@ import com.dat3m.dartagnan.wmm.analysis.WmmAnalysis;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,17 +22,14 @@ import org.sosy_lab.java_smt.api.*;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.IDL_TO_SAT;
-import static com.dat3m.dartagnan.configuration.Property.LIVENESS;
 import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
-import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
 import static com.dat3m.dartagnan.program.event.Tag.INIT;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
+import static com.dat3m.dartagnan.wmm.analysis.RelationAnalysis.findTransitivelyImpliedCo;
 import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.CO;
-import static com.dat3m.dartagnan.wmm.utils.Utils.intVar;
-import static org.sosy_lab.java_smt.api.FormulaType.BooleanType;
+import static com.dat3m.dartagnan.wmm.utils.Utils.*;
 
 @Options
 public class RelCo extends Relation {
@@ -126,15 +119,7 @@ public class RelCo extends Relation {
 
     @Override
     protected BooleanFormula encodeApprox(SolverContext ctx) {
-        final BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-        final boolean doEncodeLastCo = task.getProgram().getFormat().equals(LITMUS) || task.getProperty().contains(LIVENESS);
-
-        BooleanFormula enc = useSATEncoding ? encodeSAT(ctx) : encodeIDL(ctx);
-        if (doEncodeLastCo) {
-            enc = bmgr.and(enc, encodeLastCoConstraints(ctx));
-        }
-
-        return enc;
+        return useSATEncoding ? encodeSAT(ctx) : encodeIDL(ctx);
     }
 
     private BooleanFormula encodeIDL(SolverContext ctx) {
@@ -145,13 +130,13 @@ public class RelCo extends Relation {
         final List<MemEvent> allWrites = new ArrayList<>(Lists.transform(cache.getEvents(FilterBasic.get(WRITE)), MemEvent.class::cast));
         allWrites.sort(Comparator.comparingInt(Event::getCId));
         final TupleSet maxSet = getMaxTupleSet();
-        final Set<Tuple> transCo = findTransitivelyImpliedCo();
+        final Set<Tuple> transCo = findTransitivelyImpliedCo(this, exec);
 
         BooleanFormula enc = bmgr.makeTrue();
         // ---- Encode clock conditions (init = 0, non-init > 0) ----
         IntegerFormula zero = imgr.makeNumber(0);
         for (MemEvent w : allWrites) {
-            IntegerFormula clock = getClockVar(w, ctx);
+            IntegerFormula clock = coClockVar(w, ctx);
             enc = bmgr.and(enc, w.is(INIT) ? imgr.equal(clock, zero) : imgr.greaterThan(clock, zero));
         }
 
@@ -171,9 +156,9 @@ public class RelCo extends Relation {
                         generalEqual(w1.getMemAddressExpr(), w2.getMemAddressExpr(), ctx);
                 BooleanFormula pairingCond = bmgr.and(execPair, sameAddress);
                 BooleanFormula fCond = (w1.is(INIT) || transCo.contains(t)) ? bmgr.makeTrue() :
-                        imgr.lessThan(getClockVar(w1, ctx), getClockVar(w2, ctx));
+                        imgr.lessThan(coClockVar(w1, ctx), coClockVar(w2, ctx));
                 BooleanFormula bCond = (w2.is(INIT) || transCo.contains(t.getInverse())) ? bmgr.makeTrue() :
-                        imgr.lessThan(getClockVar(w2, ctx), getClockVar(w1, ctx));
+                        imgr.lessThan(coClockVar(w2, ctx), coClockVar(w1, ctx));
                 BooleanFormula coF = forwardPossible ? getSMTVar(w1, w2, ctx) : bmgr.makeFalse();
                 BooleanFormula coB = backwardPossible ? getSMTVar(w2, w1, ctx) : bmgr.makeFalse();
 
@@ -242,119 +227,5 @@ public class RelCo extends Relation {
         }
 
         return enc;
-    }
-
-    private BooleanFormula encodeLastCoConstraints(SolverContext ctx) {
-        final AliasAnalysis alias = analysisContext.requires(AliasAnalysis.class);
-        final ExecutionAnalysis exec = analysisContext.requires(ExecutionAnalysis.class);
-        final BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-        final TupleSet minSet = getMinTupleSet();
-        final TupleSet maxSet = getMaxTupleSet();
-        final EventCache cache = task.getProgram().getCache();
-        final List<Init> initEvents = Lists.transform(cache.getEvents(FilterBasic.get(INIT)), Init.class::cast);
-        final List<MemEvent> writes = Lists.transform(cache.getEvents(FilterBasic.get(WRITE)), MemEvent.class::cast);
-        final boolean doEncodeFinalAddressValues = task.getProgram().getFormat() == LITMUS;
-
-        // Find transitively implied coherences. We can use these to reduce the encoding.
-        final Set<Tuple> transCo = findTransitivelyImpliedCo();
-        // Find all writes that are never last, i.e., those that will always have a co-successor.
-        final Set<Event> dominatedWrites = minSet.stream()
-                .filter(t -> exec.isImplied(t.getFirst(), t.getSecond()))
-                .map(Tuple::getFirst).collect(Collectors.toSet());
-
-
-        // ---- Construct encoding ----
-        BooleanFormula enc = bmgr.makeTrue();
-        for (MemEvent w1 : writes) {
-            if (dominatedWrites.contains(w1)) {
-                enc = bmgr.and(enc, bmgr.equivalence(getLastCoVar(w1, ctx), bmgr.makeFalse()));
-                continue;
-            }
-
-            BooleanFormula isLast = w1.exec();
-            // ---- Find all possibly overwriting writes ----
-            for (Tuple t : maxSet.getByFirst(w1)) {
-                if (transCo.contains(t)) {
-                    // We can skip the co-edge (w1,w2), because there will be an intermediate write w3
-                    // that already witnesses that w1 is not last.
-                    continue;
-                }
-                Event w2 = t.getSecond();
-                BooleanFormula isAfter = minSet.contains(t) ? bmgr.not(w2.exec()) : bmgr.not(getSMTVar(t, ctx));
-                isLast = bmgr.and(isLast, isAfter);
-            }
-            BooleanFormula lastCoExpr = getLastCoVar(w1, ctx);
-            enc = bmgr.and(enc, bmgr.equivalence(lastCoExpr, isLast));
-
-            if (doEncodeFinalAddressValues) {
-                // ---- Encode final values of addresses ----
-                for (Init init : initEvents) {
-                    if (!alias.mayAlias(w1, init)) {
-                        continue;
-                    }
-                    IExpr address = init.getAddress();
-                    Formula a1 = w1.getMemAddressExpr();
-                    Formula a2 = address.toIntFormula(init, ctx);
-                    BooleanFormula sameAddress = alias.mustAlias(init, w1) ? bmgr.makeTrue() : generalEqual(a1, a2, ctx);
-                    Formula v1 = w1.getMemValueExpr();
-                    Formula v2 = init.getBase().getLastMemValueExpr(ctx, init.getOffset());
-                    BooleanFormula sameValue = generalEqual(v1, v2, ctx);
-                    enc = bmgr.and(enc, bmgr.implication(bmgr.and(lastCoExpr, sameAddress), sameValue));
-                }
-            }
-        }
-        return enc;
-    }
-
-    /*
-        Returns a set of co-edges (w1, w2) (subset of maxTupleSet) whose clock-constraints
-        do not need to get encoded explicitly.
-        The reason is that whenever we have co(w1,w2) then there exists an intermediary
-        w3 s.t. co(w1, w3) /\ co(w3, w2). As a result we have c(w1) < c(w3) < c(w2) transitively.
-        Reasoning: Let (w1, w2) be a potential co-edge. Suppose there exists a w3 different to w1 and w2,
-        whose execution is either implied by either w1 or w2.
-        Now, if co(w1, w3) is a must-edge and co(w2, w3) is impossible, then we can reason as follows.
-            - Suppose w1 and w2 get executed and their addresses match, then w3 must also get executed.
-            - Since co(w1, w3) is a must-edge, we have that w3 accesses the same address as w1 and w2,
-              and c(w1) < c(w3).
-            - Because addr(w2)==addr(w3), we must also have either co(w2, e3) or co(w3, w2).
-              The former is disallowed by assumption, so we have co(w3, w2) and hence c(w3) < c(w2).
-            - By transitivity, we have c(w1) < c(w3) < c(w2) as desired.
-            - Note that this reasoning has to be done inductively, because co(w1, w3) or co(w3, w2) may
-              not involve encoding a clock constraint (due to this optimization).
-        There is also a symmetric case where co(w3, w1) is impossible and co(w3, w2) is a must-edge.
-
-     */
-    private Set<Tuple> findTransitivelyImpliedCo() {
-        final ExecutionAnalysis exec = analysisContext.requires(ExecutionAnalysis.class);
-        final TupleSet min = getMinTupleSet();
-        final TupleSet max = getMaxTupleSet();
-
-        Set<Tuple> transCo = new HashSet<>();
-        for (final Tuple t : max) {
-            final MemEvent e1 = (MemEvent) t.getFirst();
-            final MemEvent e2 = (MemEvent) t.getSecond();
-            final Predicate<Event> execPred = (e3 -> e3 != e1 && e3 != e2 && (exec.isImplied(e1, e3) || exec.isImplied(e2, e3)));
-            final boolean hasIntermediary = min.getByFirst(e1).stream().map(tuple -> (MemEvent)tuple.getSecond())
-                                    .anyMatch(e3 -> execPred.apply(e3) && !max.contains(new Tuple(e2, e3))) ||
-                                min.getBySecond(e2).stream().map(tuple -> (MemEvent)tuple.getFirst())
-                                    .anyMatch(e3 -> execPred.apply(e3) && !max.contains(new Tuple(e3, e1)));
-            if (hasIntermediary) {
-                transCo.add(t);
-            }
-        }
-        return transCo;
-    }
-
-    public IntegerFormula getClockVar(Event write, SolverContext ctx) {
-    	Preconditions.checkArgument(write.is(WRITE), "Cannot get a clock-var for non-writes.");
-        if (write.is(INIT)) {
-            return ctx.getFormulaManager().getIntegerFormulaManager().makeNumber(0);
-        }
-        return intVar(term, write, ctx);
-    }
-
-    public BooleanFormula getLastCoVar(Event write, SolverContext ctx) {
-        return ctx.getFormulaManager().makeVariable(BooleanType, "co_last(" + write.repr() + ")");
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelCo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelCo.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.wmm.relation.base.memory;
 
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
-import com.dat3m.dartagnan.program.event.EventCache;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
@@ -11,42 +10,17 @@ import com.dat3m.dartagnan.wmm.analysis.WmmAnalysis;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
-import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.sosy_lab.common.configuration.Configuration;
-import org.sosy_lab.common.configuration.InvalidConfigurationException;
-import org.sosy_lab.common.configuration.Option;
-import org.sosy_lab.common.configuration.Options;
-import org.sosy_lab.java_smt.api.*;
-import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 
 import java.util.*;
-
-import static com.dat3m.dartagnan.configuration.OptionNames.IDL_TO_SAT;
-import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
 import static com.dat3m.dartagnan.program.event.Tag.INIT;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
-import static com.dat3m.dartagnan.wmm.analysis.RelationAnalysis.findTransitivelyImpliedCo;
 import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.CO;
-import static com.dat3m.dartagnan.wmm.utils.Utils.*;
 
-@Options
 public class RelCo extends Relation {
 
 	private static final Logger logger = LogManager.getLogger(RelCo.class);
-
-    // =========================== Configurables ===========================
-
-    @Option(
-            name=IDL_TO_SAT,
-            description = "Use SAT-based encoding for totality and acyclicity.",
-            secure = true)
-    private boolean useSATEncoding = false;
-
-    public boolean usesSATEncoding() { return useSATEncoding; }
-
-	// =====================================================================
 
     public RelCo(){
         term = CO;
@@ -55,11 +29,6 @@ public class RelCo extends Relation {
     @Override
     public <T> T accept(Visitor<? extends T> v) {
         return v.visitMemoryOrder(this);
-    }
-
-    @Override
-    public void configure(Configuration config) throws InvalidConfigurationException {
-        config.inject(this);
     }
 
     @Override
@@ -115,117 +84,5 @@ public class RelCo extends Relation {
             logger.info("maxTupleSet size for " + getName() + ": " + maxTupleSet.size());
         }
         return maxTupleSet;
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-        return useSATEncoding ? encodeSAT(ctx) : encodeIDL(ctx);
-    }
-
-    private BooleanFormula encodeIDL(SolverContext ctx) {
-        final AliasAnalysis alias = analysisContext.get(AliasAnalysis.class);
-        final BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-        final IntegerFormulaManager imgr = ctx.getFormulaManager().getIntegerFormulaManager();
-        final EventCache cache = task.getProgram().getCache();
-        final List<MemEvent> allWrites = new ArrayList<>(Lists.transform(cache.getEvents(FilterBasic.get(WRITE)), MemEvent.class::cast));
-        allWrites.sort(Comparator.comparingInt(Event::getCId));
-        final TupleSet maxSet = getMaxTupleSet();
-        final Set<Tuple> transCo = findTransitivelyImpliedCo(this, exec);
-
-        BooleanFormula enc = bmgr.makeTrue();
-        // ---- Encode clock conditions (init = 0, non-init > 0) ----
-        IntegerFormula zero = imgr.makeNumber(0);
-        for (MemEvent w : allWrites) {
-            IntegerFormula clock = coClockVar(w, ctx);
-            enc = bmgr.and(enc, w.is(INIT) ? imgr.equal(clock, zero) : imgr.greaterThan(clock, zero));
-        }
-
-        // ---- Encode coherences ----
-        for (int i = 0; i < allWrites.size() - 1; i++) {
-            MemEvent w1 = allWrites.get(i);
-            for (MemEvent w2 : allWrites.subList(i + 1, allWrites.size())) {
-                Tuple t = new Tuple(w1, w2);
-                boolean forwardPossible = maxSet.contains(t);
-                boolean backwardPossible = maxSet.contains(t.getInverse());
-                if (!forwardPossible && ! backwardPossible) {
-                    continue;
-                }
-
-                BooleanFormula execPair = getExecPair(t, ctx);
-                BooleanFormula sameAddress = alias.mustAlias(w1, w2) ? bmgr.makeTrue() :
-                        generalEqual(w1.getMemAddressExpr(), w2.getMemAddressExpr(), ctx);
-                BooleanFormula pairingCond = bmgr.and(execPair, sameAddress);
-                BooleanFormula fCond = (w1.is(INIT) || transCo.contains(t)) ? bmgr.makeTrue() :
-                        imgr.lessThan(coClockVar(w1, ctx), coClockVar(w2, ctx));
-                BooleanFormula bCond = (w2.is(INIT) || transCo.contains(t.getInverse())) ? bmgr.makeTrue() :
-                        imgr.lessThan(coClockVar(w2, ctx), coClockVar(w1, ctx));
-                BooleanFormula coF = forwardPossible ? getSMTVar(w1, w2, ctx) : bmgr.makeFalse();
-                BooleanFormula coB = backwardPossible ? getSMTVar(w2, w1, ctx) : bmgr.makeFalse();
-
-                enc = bmgr.and(enc,
-                        bmgr.implication(coF, fCond),
-                        bmgr.implication(coB, bCond),
-                        bmgr.equivalence(pairingCond, bmgr.or(coF, coB))
-                );
-            }
-        }
-
-        return enc;
-    }
-
-    protected BooleanFormula encodeSAT(SolverContext ctx) {
-        final AliasAnalysis alias = analysisContext.get(AliasAnalysis.class);
-        final BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-        final EventCache cache = task.getProgram().getCache();
-        final List<MemEvent> allWrites = new ArrayList<>(Lists.transform(cache.getEvents(FilterBasic.get(WRITE)), MemEvent.class::cast));
-        allWrites.sort(Comparator.comparingInt(Event::getCId));
-        final TupleSet maxSet = getMaxTupleSet();
-        final TupleSet minSet = getMinTupleSet();
-
-        BooleanFormula enc = bmgr.makeTrue();
-        // ---- Encode coherences ----
-        for (int i = 0; i < allWrites.size() - 1; i++) {
-            MemEvent w1 = allWrites.get(i);
-            for (MemEvent w2 : allWrites.subList(i + 1, allWrites.size())) {
-                Tuple t = new Tuple(w1, w2);
-                Tuple tInv = t.getInverse();
-                boolean forwardPossible = maxSet.contains(t);
-                boolean backwardPossible = maxSet.contains(tInv);
-                if (!forwardPossible && !backwardPossible) {
-                    continue;
-                }
-
-                BooleanFormula execPair = getExecPair(t, ctx);
-                BooleanFormula sameAddress = alias.mustAlias(w1, w2) ? bmgr.makeTrue() :
-                        generalEqual(w1.getMemAddressExpr(), w2.getMemAddressExpr(), ctx);
-                BooleanFormula pairingCond = bmgr.and(execPair, sameAddress);
-                BooleanFormula coF = forwardPossible ? getSMTVar(w1, w2, ctx) : bmgr.makeFalse();
-                BooleanFormula coB = backwardPossible ? getSMTVar(w2, w1, ctx) : bmgr.makeFalse();
-
-                enc = bmgr.and(enc,
-                        bmgr.equivalence(pairingCond, bmgr.or(coF, coB)),
-                        bmgr.or(bmgr.not(coF), bmgr.not(coB))
-                );
-
-                if (!minSet.contains(t) && !minSet.contains(tInv)) {
-                    for (MemEvent w3 : allWrites) {
-                        Tuple t1 = new Tuple(w1, w3);
-                        Tuple t2 = new Tuple(w3, w2);
-                        if (forwardPossible && maxSet.contains(t1) && maxSet.contains(t2)) {
-                            BooleanFormula co1 = getSMTVar(w1, w3, ctx);
-                            BooleanFormula co2 = getSMTVar(w3, w2, ctx);
-                            enc = bmgr.and(enc, bmgr.implication(bmgr.and(co1, co2), coF));
-                        }
-                        if (backwardPossible && maxSet.contains(t1.getInverse()) && maxSet.contains(t2.getInverse())) {
-                            BooleanFormula co1 = getSMTVar(w2, w3, ctx);
-                            BooleanFormula co2 = getSMTVar(w3, w1, ctx);
-                            enc = bmgr.and(enc, bmgr.implication(bmgr.and(co1, co2), coB));
-                        }
-                    }
-                }
-            }
-        }
-
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelLoc.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelLoc.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.wmm.relation.base.memory;
 
-import com.dat3m.dartagnan.expression.utils.Utils;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
@@ -8,10 +7,6 @@ import com.dat3m.dartagnan.program.filter.FilterBasic;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.FormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.Collection;
 
@@ -59,23 +54,5 @@ public class RelLoc extends Relation {
             removeMutuallyExclusiveTuples(maxTupleSet);
         }
         return maxTupleSet;
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	FormulaManager fmgr = ctx.getFormulaManager();
-		BooleanFormulaManager bmgr = fmgr.getBooleanFormulaManager();
-
-    	BooleanFormula enc = bmgr.makeTrue();
-        for(Tuple tuple : encodeTupleSet) {
-        	BooleanFormula rel = this.getSMTVar(tuple, ctx);
-            enc = bmgr.and(enc, bmgr.equivalence(rel, bmgr.and(
-                    getExecPair(tuple, ctx),
-                    Utils.generalEqual(
-                            ((MemEvent)tuple.getFirst()).getMemAddressExpr(),
-                            ((MemEvent)tuple.getSecond()).getMemAddressExpr(), ctx)
-            )));
-        }
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelRf.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/memory/RelRf.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.wmm.relation.base.memory;
 
-import com.dat3m.dartagnan.GlobalSettings;
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.core.Event;
@@ -17,15 +16,12 @@ import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.sosy_lab.java_smt.api.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.dat3m.dartagnan.expression.utils.Utils.generalEqual;
 import static com.dat3m.dartagnan.program.event.Tag.*;
 import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.RF;
-import static org.sosy_lab.java_smt.api.FormulaType.BooleanType;
 
 public class RelRf extends Relation {
 
@@ -168,65 +164,4 @@ public class RelRf extends Relation {
         }
         logger.info("Atomic block optimization eliminated "  + (sizeBefore - maxTupleSet.size()) + " reads");
     }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	FormulaManager fmgr = ctx.getFormulaManager();
-		BooleanFormulaManager bmgr = fmgr.getBooleanFormulaManager();
-
-    	BooleanFormula enc = bmgr.makeTrue();
-        Map<MemEvent, List<BooleanFormula>> edgeMap = new HashMap<>();
-
-        for(Tuple tuple : maxTupleSet){
-            MemEvent w = (MemEvent) tuple.getFirst();
-            MemEvent r = (MemEvent) tuple.getSecond();
-            BooleanFormula edge = this.getSMTVar(tuple, ctx);
-
-            // The boogie file might have a different type (Ints vs BVs) that the imposed by ARCH_PRECISION
-            // In such cases we perform the transformation 
-            Formula a1 = w.getMemAddressExpr();
-            Formula a2 = r.getMemAddressExpr();
-            BooleanFormula sameAddress = generalEqual(a1, a2, ctx);
-            Formula v1 = w.getMemValueExpr();
-            Formula v2 = r.getMemValueExpr();
-            BooleanFormula sameValue = generalEqual(v1, v2, ctx);
-
-            edgeMap.computeIfAbsent(r, key -> new ArrayList<>()).add(edge);
-            enc = bmgr.and(enc, bmgr.implication(edge, bmgr.and(getExecPair(w, r, ctx), sameAddress, sameValue)));
-        }
-
-        for(MemEvent r : edgeMap.keySet()){
-            enc = bmgr.and(enc, encodeEdgeSeq(r, edgeMap.get(r), ctx));
-        }
-        return enc;
-    }
-
-    private BooleanFormula encodeEdgeSeq(Event read, List<BooleanFormula> edges, SolverContext ctx){
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-        if (GlobalSettings.ALLOW_MULTIREADS) {
-            return bmgr.implication(read.exec(), bmgr.or(edges));
-        }
-    	
-        int num = edges.size();
-        int readId = read.getCId();
-        BooleanFormula lastSeqVar = mkSeqVar(readId, 0, ctx);
-        BooleanFormula newSeqVar = lastSeqVar;
-        BooleanFormula atMostOne = bmgr.equivalence(lastSeqVar, edges.get(0));
-
-        for(int i = 1; i < num; i++){
-            newSeqVar = mkSeqVar(readId, i, ctx);
-            atMostOne = bmgr.and(atMostOne, bmgr.equivalence(newSeqVar, bmgr.or(lastSeqVar, edges.get(i))));
-            atMostOne = bmgr.and(atMostOne, bmgr.not(bmgr.and(edges.get(i), lastSeqVar)));
-            lastSeqVar = newSeqVar;
-        }
-        BooleanFormula atLeastOne = bmgr.or(newSeqVar, edges.get(edges.size() - 1));
-
-        atLeastOne = bmgr.implication(read.exec(), atLeastOne);
-        return bmgr.and(atMostOne, atLeastOne);
-    }
-
-    private BooleanFormula mkSeqVar(int readId, int i, SolverContext ctx) {
-    	return ctx.getFormulaManager().makeVariable(BooleanType, "s(" + term + ",E" + readId + "," + i + ")");
-    }
-
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelEmpty.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelEmpty.java
@@ -36,9 +36,4 @@ public class RelEmpty extends StaticRelation {
         }
         return maxTupleSet;
     }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-        return ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
-    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelFencerel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/RelFencerel.java
@@ -8,9 +8,6 @@ import com.dat3m.dartagnan.program.filter.FilterAbstract;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.List;
 
@@ -95,32 +92,5 @@ public class RelFencerel extends StaticRelation {
             removeMutuallyExclusiveTuples(maxTupleSet);
         }
         return maxTupleSet;
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-
-        List<Event> fences = task.getProgram().getCache().getEvents(filter);
-
-        for(Tuple tuple : encodeTupleSet){
-            Event e1 = tuple.getFirst();
-            Event e2 = tuple.getSecond();
-
-            BooleanFormula orClause;
-            if(minTupleSet.contains(tuple)) {
-                orClause = bmgr.makeTrue();
-            } else {
-                orClause = fences.stream()
-                        .filter(f -> e1.getCId() < f.getCId() && f.getCId() < e2.getCId())
-                        .map(Event::exec).reduce(bmgr.makeFalse(), bmgr::or);
-            }
-
-            BooleanFormula rel = this.getSMTVar(tuple, ctx);
-            enc = bmgr.and(enc, bmgr.equivalence(rel, bmgr.and(getExecPair(tuple, ctx), orClause)));
-        }
-
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/StaticRelation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/base/stat/StaticRelation.java
@@ -1,12 +1,8 @@
 package com.dat3m.dartagnan.wmm.relation.base.stat;
 
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import com.dat3m.dartagnan.wmm.relation.Relation;
-import com.dat3m.dartagnan.wmm.utils.Tuple;
 
 //TODO(TH): RelCrit, RelRMW and RelFencerel are NOT strongly static like the other static relations
 // It might be reasonable to group them into weakly static relations (or alternatively the other one's into
@@ -34,17 +30,5 @@ public abstract class StaticRelation extends Relation {
             minTupleSet = getMaxTupleSet();
         }
         return minTupleSet;
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-
-        for(Tuple tuple : encodeTupleSet) {
-        	BooleanFormula rel = this.getSMTVar(tuple, ctx);
-            enc = bmgr.and(enc, bmgr.equivalence(rel, bmgr.and(getExecPair(tuple, ctx))));
-        }
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelComposition.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelComposition.java
@@ -6,9 +6,6 @@ import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -111,32 +108,5 @@ public class RelComposition extends BinaryRelation {
             r1.addEncodeTupleSet(r1Set);
             r2.addEncodeTupleSet(r2Set);
         }
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-
-        TupleSet r1Set = r1.getEncodeTupleSet();
-        TupleSet r2Set = r2.getEncodeTupleSet();
-        TupleSet minSet = getMinTupleSet();
-
-        for(Tuple tuple : encodeTupleSet) {
-            BooleanFormula expr = bmgr.makeFalse();
-            if (minSet.contains(tuple)) {
-                expr = getExecPair(tuple, ctx);
-            } else {
-                for (Tuple t1 : r1Set.getByFirst(tuple.getFirst())) {
-                    Tuple t2 = new Tuple(t1.getSecond(), tuple.getSecond());
-                    if (r2Set.contains(t2)) {
-                        expr = bmgr.or(expr, bmgr.and(r1.getSMTVar(t1, ctx), r2.getSMTVar(t2, ctx)));
-                    }
-                }
-            }
-
-            enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), expr));
-        }
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelIntersection.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelIntersection.java
@@ -1,12 +1,8 @@
 package com.dat3m.dartagnan.wmm.relation.binary;
 
 import com.dat3m.dartagnan.wmm.relation.Relation;
-import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 /**
  *
@@ -65,23 +61,5 @@ public class RelIntersection extends BinaryRelation {
             return maxTupleSet;
         }
         return getMaxTupleSet();
-    }
-
-    @Override
-    public BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-
-        TupleSet min = getMinTupleSet();
-        for(Tuple tuple : encodeTupleSet){
-            if (min.contains(tuple)) {
-                enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), getExecPair(tuple, ctx)));
-                continue;
-            }
-            BooleanFormula opt1 = r1.getSMTVar(tuple, ctx);
-            BooleanFormula opt2 = r2.getSMTVar(tuple, ctx);
-            enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), bmgr.and(opt1, opt2)));
-        }
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelMinus.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelMinus.java
@@ -1,12 +1,8 @@
 package com.dat3m.dartagnan.wmm.relation.binary;
 
 import com.dat3m.dartagnan.wmm.relation.Relation;
-import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 /**
  *
@@ -66,28 +62,5 @@ public class RelMinus extends BinaryRelation {
             return maxTupleSet;
         }
         return getMaxTupleSet();
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-
-        TupleSet min = getMinTupleSet();
-        for(Tuple tuple : encodeTupleSet){
-            if (min.contains(tuple)) {
-                enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), getExecPair(tuple, ctx)));
-                continue;
-            }
-
-            BooleanFormula opt1 = r1.getSMTVar(tuple, ctx);
-            BooleanFormula opt2 = bmgr.not(r2.getSMTVar(tuple, ctx));
-            if (Relation.PostFixApprox) {
-                enc = bmgr.and(enc, bmgr.implication(bmgr.and(opt1, opt2), this.getSMTVar(tuple, ctx)));
-            } else {
-                enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), bmgr.and(opt1, opt2)));
-            }
-        }
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelUnion.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/binary/RelUnion.java
@@ -1,12 +1,8 @@
 package com.dat3m.dartagnan.wmm.relation.binary;
 
 import com.dat3m.dartagnan.wmm.relation.Relation;
-import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 /**
  *
@@ -65,27 +61,5 @@ public class RelUnion extends BinaryRelation {
             return maxTupleSet;
         }
         return getMaxTupleSet();
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-
-        TupleSet min = getMinTupleSet();
-        for(Tuple tuple : encodeTupleSet){
-            if (min.contains(tuple)) {
-                enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), getExecPair(tuple, ctx)));
-                continue;
-            }
-            BooleanFormula opt1 = r1.getSMTVar(tuple, ctx);
-            BooleanFormula opt2 = r2.getSMTVar(tuple, ctx);
-            if (Relation.PostFixApprox) {
-                enc = bmgr.and(enc, bmgr.implication(bmgr.or(opt1, opt2), this.getSMTVar(tuple, ctx)));
-            } else {
-                enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), bmgr.or(opt1, opt2)));
-            }
-        }
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/RelDomainIdentity.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/RelDomainIdentity.java
@@ -1,14 +1,10 @@
 package com.dat3m.dartagnan.wmm.relation.unary;
 
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
-import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 public class RelDomainIdentity extends UnaryRelation {
 
@@ -67,22 +63,5 @@ public class RelDomainIdentity extends UnaryRelation {
             }
             r1.addEncodeTupleSet(r1Set);
         }
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-
-        for(Tuple tuple1 : encodeTupleSet){
-            Event e = tuple1.getFirst();
-            BooleanFormula opt = bmgr.makeFalse();
-            //TODO: Optimize using minSets (but no CAT uses this anyway)
-            for(Tuple tuple2 : r1.getMaxTupleSet().getByFirst(e)){
-                opt = bmgr.or(r1.getSMTVar(e, tuple2.getSecond(), ctx));
-            }
-            enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(e, e, ctx), opt));
-        }
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/RelInverse.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/RelInverse.java
@@ -1,12 +1,8 @@
 package com.dat3m.dartagnan.wmm.relation.unary;
 
 import com.dat3m.dartagnan.wmm.relation.Relation;
-import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 /**
  *
@@ -60,19 +56,5 @@ public class RelInverse extends UnaryRelation {
         if(!activeSet.isEmpty()){
             r1.addEncodeTupleSet(activeSet.inverse());
         }
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-
-
-		TupleSet minSet = getMinTupleSet();
-        for(Tuple tuple : encodeTupleSet){
-        	BooleanFormula opt = minSet.contains(tuple) ? getExecPair(tuple, ctx) : r1.getSMTVar(tuple.getInverse(), ctx);
-            enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), opt));
-        }
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/RelRangeIdentity.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/RelRangeIdentity.java
@@ -1,14 +1,10 @@
 package com.dat3m.dartagnan.wmm.relation.unary;
 
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
-import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 public class RelRangeIdentity extends UnaryRelation {
 
@@ -66,22 +62,5 @@ public class RelRangeIdentity extends UnaryRelation {
             }
             r1.addEncodeTupleSet(r1Set);
         }
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-		
-        //TODO: Optimize using minSets (but no CAT uses this anyway)
-        for(Tuple tuple1 : encodeTupleSet){
-            Event e = tuple1.getFirst();
-            BooleanFormula opt = bmgr.makeFalse();
-            for(Tuple tuple2 : r1.getMaxTupleSet().getBySecond(e)){
-                opt = bmgr.or(r1.getSMTVar(tuple2.getFirst(), e, ctx));
-            }
-            enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(e, e, ctx), opt));
-        }
-        return enc;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/RelTrans.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/relation/unary/RelTrans.java
@@ -6,9 +6,6 @@ import com.dat3m.dartagnan.wmm.relation.Relation;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import com.dat3m.dartagnan.wmm.utils.TupleSet;
 import com.google.common.collect.Sets;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.Map;
 import java.util.Set;
@@ -82,50 +79,6 @@ public class RelTrans extends UnaryRelation {
             fullActiveSet.removeAll(getMinTupleSet());
             r1.addEncodeTupleSet(fullActiveSet);
         }
-    }
-
-    @Override
-    protected BooleanFormula encodeApprox(SolverContext ctx) {
-    	BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-		BooleanFormula enc = bmgr.makeTrue();
-
-        TupleSet minSet = getMinTupleSet();
-        TupleSet r1Max = r1.getMaxTupleSet();
-        for(Tuple tuple : encodeTupleSet){
-            if (minSet.contains(tuple)) {
-                if(Relation.PostFixApprox) {
-                    enc = bmgr.and(enc, bmgr.implication(getExecPair(tuple, ctx), this.getSMTVar(tuple, ctx)));
-                } else {
-                    enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), getExecPair(tuple, ctx)));
-                }
-                continue;
-            }
-
-            BooleanFormula orClause = bmgr.makeFalse();
-            Event e1 = tuple.getFirst();
-            Event e2 = tuple.getSecond();
-
-            if(r1Max.contains(tuple)){
-                orClause = bmgr.or(orClause, r1.getSMTVar(tuple, ctx));
-            }
-
-
-            for(Tuple t : r1Max.getByFirst(e1)){
-                Event e3 = t.getSecond();
-                if(e3.getCId() != e1.getCId() && e3.getCId() != e2.getCId() && maxTupleSet.contains(new Tuple(e3, e2))){
-                    BooleanFormula tVar = minSet.contains(t) ? this.getSMTVar(t, ctx) : r1.getSMTVar(t, ctx);
-                    orClause = bmgr.or(orClause, bmgr.and(tVar, this.getSMTVar(e3, e2, ctx)));
-                }
-            }
-
-            if(Relation.PostFixApprox) {
-                enc = bmgr.and(enc, bmgr.implication(orClause, this.getSMTVar(tuple, ctx)));
-            } else {
-                enc = bmgr.and(enc, bmgr.equivalence(this.getSMTVar(tuple, ctx), orClause));
-            }
-        }
-
-        return enc;
     }
 
     private TupleSet getFullEncodeTupleSet(TupleSet tuples){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/Utils.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/Utils.java
@@ -1,11 +1,15 @@
 package com.dat3m.dartagnan.wmm.utils;
 
 import com.dat3m.dartagnan.program.event.core.Event;
+import com.google.common.base.Preconditions;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FormulaManager;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 import org.sosy_lab.java_smt.api.SolverContext;
 
+import static com.dat3m.dartagnan.program.event.Tag.INIT;
+import static com.dat3m.dartagnan.program.event.Tag.WRITE;
+import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.CO;
 import static org.sosy_lab.java_smt.api.FormulaType.BooleanType;
 import static org.sosy_lab.java_smt.api.FormulaType.IntegerType;
 
@@ -26,4 +30,11 @@ public class Utils {
 		return fmgr.makeVariable(BooleanType, fmgr.escape(relName) + "-cycle(" + e.repr() + ")");
 	}
 
+	public static IntegerFormula coClockVar(Event write, SolverContext ctx) {
+		Preconditions.checkArgument(write.is(WRITE), "Cannot get a clock-var for non-writes.");
+		if (write.is(INIT)) {
+			return ctx.getFormulaManager().getIntegerFormulaManager().makeNumber(0);
+		}
+		return intVar(CO, write, ctx);
+	}
 }


### PR DESCRIPTION
Moves code around, such that `WmmEncoder` controls how the encode tuple sets translate into defining SMT propositions.  The remaining WMM encoding is still handled by `Axiom`.

The `RelCo.encodeLastCoConstraints()` is moved into `PropertyEncoder`.  Therefore, `WmmEncoder` does not need to consult the property.

Part of #315.