### PR TITLE
Make dartagnan compatible with herd in the precedence order of operators

### DIFF
--- a/dartagnan/src/main/antlr4/Cat.g4
+++ b/dartagnan/src/main/antlr4/Cat.g4
@@ -39,10 +39,10 @@ expression
     |   e = expression (POW)? INV                                       # exprInverse
     |   e = expression OPT                                              # exprOptional
     |   NOT e = expression                                              # exprComplement
+    |   e1 = expression AMP e2 = expression                             # exprIntersection
+    |   e1 = expression BSLASH e2 = expression                          # exprMinus
     |   e1 = expression SEMI e2 = expression                            # exprComposition
     |   e1 = expression BAR e2 = expression                             # exprUnion
-    |   e1 = expression BSLASH e2 = expression                          # exprMinus
-    |   e1 = expression AMP e2 = expression                             # exprIntersection
     |   LBRAC DOMAIN LPAR e = expression RPAR RBRAC                     # exprDomainIdentity
     |   LBRAC RANGE LPAR e = expression RPAR RBRAC                      # exprRangeIdentity
     |   (TOID LPAR e = expression RPAR | LBRAC e = expression RBRAC)    # exprIdentity


### PR DESCRIPTION
Until now, dartagnan had a different precedence order than herd for certain operators, e.g. it interpreted relation `r1 ; r2 \ r3` as `(r1 ; r2) \ r3` while herd interprets this as `r1 ; (r2 \ r3)`.

The [CAT paper](https://arxiv.org/abs/1608.07531) does not specify the precedence order, but for compatibility reasons, we agreed that we should follow herd.

This PR makes dartagnan compatible with herd w.r.t the precedence order defined [here](https://github.com/herd/herdtools7/blob/4eaabb3ed445eab4c6b76174c3ad0e6ebec6d127/lib/modelParser.mly#L64-L71).