### PR TITLE
Fixed cutting code

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -332,9 +332,8 @@ public class RefinementSolver extends ModelChecker {
         Relation copy = copy(rel, first, second);
         if (rel.getIsNamed()) {
             copy.setName(rel.getName());
-            m.updateRelation(copy);
         }
-
+        m.addRelation(copy);
         return copy;
     }
 


### PR DESCRIPTION
This PR fixes a problem in the cutting code introduced with a recent PR that reworked the WMM.
Basically, copied relations were not properly added to the baseline WMM unless they were named.

@hernanponcedeleon I haven't tested this code thoroughly, so maybe you should test this in a few memory models before merging.