### PR TITLE
C11

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -30,7 +30,7 @@ public class VisitorC11 extends VisitorBase {
 	public List<Event> visitCreate(Create e) {
 
         Store store = newStore(e.getAddress(), e.getMemValue(), Tag.C11.MO_RELEASE);
-        store.addFilters(C11.PTHREAD);
+        store.addFilters(C11.PTHREAD, C11.ATOMIC);
 
         return eventSequence(
                 store
@@ -39,8 +39,10 @@ public class VisitorC11 extends VisitorBase {
 
 	@Override
 	public List<Event> visitEnd(End e) {
+        Store store = newStore(e.getAddress(), IValue.ZERO, Tag.C11.MO_RELEASE);
+        store.addFilters(C11.ATOMIC);
         return eventSequence(
-                newStore(e.getAddress(), IValue.ZERO, Tag.C11.MO_RELEASE)
+                store
         );
 	}
 
@@ -48,7 +50,7 @@ public class VisitorC11 extends VisitorBase {
 	public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
 		Load load = newLoad(resultRegister, e.getAddress(), Tag.C11.MO_ACQUIRE);
-        load.addFilters(C11.PTHREAD);
+        load.addFilters(C11.PTHREAD, C11.ATOMIC);
         
         return eventSequence(
         		load,
@@ -60,7 +62,7 @@ public class VisitorC11 extends VisitorBase {
 	public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
         Load load = newLoad(resultRegister, e.getAddress(), Tag.C11.MO_ACQUIRE);
-        load.addFilters(Tag.STARTLOAD);
+        load.addFilters(Tag.STARTLOAD, C11.ATOMIC);
 
         return eventSequence(
         		load,

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LFDSTest.java
@@ -57,7 +57,7 @@ public class C11LFDSTest extends AbstractCTest {
             {"dglm-3-CAS-relaxed", C11, FAIL},
             // {"ms-3", C11, UNKNOWN},
             {"ms-3-CAS-relaxed", C11, FAIL},
-            {"treiber-3", C11, UNKNOWN},
+            // {"treiber-3", C11, UNKNOWN},
             {"treiber-3-CAS-relaxed", C11, FAIL},
             {"chase-lev-5", C11, PASS},
             // These ones have an extra thief that violate the assertion

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LFDSTest.java
@@ -1,0 +1,82 @@
+package com.dat3m.dartagnan.c;
+
+import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.utils.rules.CSVLogger;
+import com.dat3m.dartagnan.utils.rules.Provider;
+import com.dat3m.dartagnan.verification.solving.AssumeSolver;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
+import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.parsers.cat.ParserCat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.dat3m.dartagnan.utils.ResourceHelper.CAT_RESOURCE_PATH;
+import static com.dat3m.dartagnan.utils.ResourceHelper.TEST_RESOURCE_PATH;
+import static com.dat3m.dartagnan.utils.Result.*;
+import static com.dat3m.dartagnan.configuration.Arch.*;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class C11LFDSTest extends AbstractCTest {
+
+    public C11LFDSTest(String name, Arch target, Result expected) {
+        super(name, target, expected);
+    }
+
+    @Override
+    protected Provider<String> getProgramPathProvider() {
+        return Provider.fromSupplier(() -> TEST_RESOURCE_PATH + "lfds/" + name + ".bpl");
+    }
+
+    @Override
+    protected long getTimeout() {
+        return 600000;
+    }
+
+    protected Provider<Integer> getBoundProvider() {
+        return Provider.fromSupplier(() -> 2);
+    }
+
+    @Override
+    protected Provider<Wmm> getWmmProvider() {
+        return Provider.fromSupplier(() -> new ParserCat().parse(new File(CAT_RESOURCE_PATH + "cat/c11.cat")));
+    }
+
+	@Parameterized.Parameters(name = "{index}: {0}, target={1}")
+    public static Iterable<Object[]> data() throws IOException {
+        // Commented ones take too long ATM
+		return Arrays.asList(new Object[][]{
+            // {"dglm-3", C11, UNKNOWN},
+            {"dglm-3-CAS-relaxed", C11, FAIL},
+            // {"ms-3", C11, UNKNOWN},
+            {"ms-3-CAS-relaxed", C11, FAIL},
+            {"treiber-3", C11, UNKNOWN},
+            {"treiber-3-CAS-relaxed", C11, FAIL},
+            {"chase-lev-5", C11, PASS},
+            // These ones have an extra thief that violate the assertion
+            {"chase-lev-6", C11, FAIL},
+        });
+    }
+
+	@Test
+	@CSVLogger.FileName("csv/assume")
+	public void testAssume() throws Exception {
+        AssumeSolver s = AssumeSolver.run(contextProvider.get(), proverProvider.get(), taskProvider.get());
+		assertEquals(expected, s.getResult());
+	}
+
+    // CAAT might not yet work for C11 
+	// @Test
+	@CSVLogger.FileName("csv/refinement")
+	public void testRefinement() throws Exception {
+        RefinementSolver s = RefinementSolver.run(contextProvider.get(), proverProvider.get(), taskProvider.get());
+		assertEquals(expected, s.getResult());
+	}
+}

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LocksTest.java
@@ -1,0 +1,93 @@
+package com.dat3m.dartagnan.c;
+
+import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.utils.rules.CSVLogger;
+import com.dat3m.dartagnan.utils.rules.Provider;
+import com.dat3m.dartagnan.verification.solving.AssumeSolver;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
+import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.parsers.cat.ParserCat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.dat3m.dartagnan.utils.ResourceHelper.CAT_RESOURCE_PATH;
+import static com.dat3m.dartagnan.utils.ResourceHelper.TEST_RESOURCE_PATH;
+import static com.dat3m.dartagnan.utils.Result.*;
+import static com.dat3m.dartagnan.configuration.Arch.*;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class C11LocksTest extends AbstractCTest {
+	
+	// We use this for a fast CI.
+	// For benchmarking we use CLocksTest{TSO, ARM, Power}
+	// which use higher bounds and more threads
+	
+    public C11LocksTest(String name, Arch target, Result expected) {
+        super(name, target, expected);
+    }
+
+    @Override
+    protected Provider<String> getProgramPathProvider() {
+        return Provider.fromSupplier(() -> TEST_RESOURCE_PATH + "locks/" + name + ".bpl");
+    }
+
+    @Override
+    protected long getTimeout() {
+        return 60000;
+    }
+
+    @Override
+    protected Provider<Wmm> getWmmProvider() {
+        return Provider.fromSupplier(() -> new ParserCat().parse(new File(CAT_RESOURCE_PATH + "cat/c11.cat")));
+    }
+
+	@Parameterized.Parameters(name = "{index}: {0}, target={1}")
+    public static Iterable<Object[]> data() throws IOException {
+    	return Arrays.asList(new Object[][]{
+            {"ttas-5", C11, UNKNOWN},
+            {"ttas-5-acq2rx", C11, FAIL},
+            {"ttas-5-rel2rx", C11, FAIL},
+            {"ticketlock-3", C11, PASS},
+            {"ticketlock-3-acq2rx", C11, FAIL},
+            {"ticketlock-3-rel2rx", C11, FAIL},
+            {"mutex-3", C11, UNKNOWN},
+            {"mutex-3-acq2rx_futex", C11, UNKNOWN},
+            {"mutex-3-acq2rx_lock", C11, FAIL},
+            {"mutex-3-rel2rx_futex", C11, UNKNOWN},
+            {"mutex-3-rel2rx_unlock", C11, FAIL},
+            {"spinlock-5", C11, UNKNOWN},
+            {"spinlock-5-acq2rx", C11, FAIL},
+            {"spinlock-5-rel2rx", C11, FAIL},
+            {"linuxrwlock-3", C11, FAIL},
+            {"mutex_musl-3", C11, UNKNOWN},
+            {"mutex_musl-3-acq2rx_futex", C11, UNKNOWN},
+            {"mutex_musl-3-acq2rx_lock", C11, FAIL},
+            {"mutex_musl-3-rel2rx_futex", C11, UNKNOWN},
+            {"mutex_musl-3-rel2rx_unlock", C11, FAIL},
+            {"seqlock-6", C11, UNKNOWN},
+		});
+    }
+
+   @Test
+	@CSVLogger.FileName("csv/assume")
+	public void testAssume() throws Exception {
+        AssumeSolver s = AssumeSolver.run(contextProvider.get(), proverProvider.get(), taskProvider.get());
+		assertEquals(expected, s.getResult());
+	}
+
+    // CAAT might not yet work for C11 
+    // @Test
+	@CSVLogger.FileName("csv/refinement")
+	public void testRefinement() throws Exception {
+        RefinementSolver s = RefinementSolver.run(contextProvider.get(), proverProvider.get(), taskProvider.get());
+        assertEquals(expected, s.getResult());
+	}
+}

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LocksTest.java
@@ -75,7 +75,9 @@ public class C11LocksTest extends AbstractCTest {
             {"mutex_musl-3-acq2rx_lock", C11, FAIL},
             {"mutex_musl-3-rel2rx_futex", C11, UNKNOWN},
             {"mutex_musl-3-rel2rx_unlock", C11, FAIL},
-            {"seqlock-6", C11, UNKNOWN},
+            // The actual result is PASS, but CAAT returns UNKNOWN
+            // because we do not refine for the bound check 
+            {"seqlock-6", C11, PASS},
 		});
     }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LocksTest.java
@@ -66,6 +66,9 @@ public class C11LocksTest extends AbstractCTest {
             {"spinlock-5", C11, UNKNOWN},
             {"spinlock-5-acq2rx", C11, FAIL},
             {"spinlock-5-rel2rx", C11, FAIL},
+            // For most models the one below is safe (UNKNOWN)
+            // It could be the case for C11 is unsafe (because it is weaker)
+            // but we are not 100% sure about this
             {"linuxrwlock-3", C11, FAIL},
             {"mutex_musl-3", C11, UNKNOWN},
             {"mutex_musl-3-acq2rx_futex", C11, UNKNOWN},

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/C11LocksTest.java
@@ -41,7 +41,7 @@ public class C11LocksTest extends AbstractCTest {
 
     @Override
     protected long getTimeout() {
-        return 60000;
+        return 180000;
     }
 
     @Override

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/CLocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/CLocksTest.java
@@ -130,6 +130,8 @@ public class CLocksTest extends AbstractCTest {
                 {"mutex_musl-3-rel2rx_unlock", ARM8, FAIL},
                 {"mutex_musl-3-rel2rx_unlock", POWER, FAIL},
     			{"mutex_musl-3-rel2rx_unlock", RISCV, FAIL},
+                // The actual result is PASS, but CAAT returns UNKNOWN
+                // because we do not refine for the bound check 
                 {"seqlock-6", TSO, UNKNOWN},
                 {"seqlock-6", ARM8, UNKNOWN},
                 {"seqlock-6", POWER, UNKNOWN},

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/IMMLocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/IMMLocksTest.java
@@ -74,6 +74,8 @@ public class IMMLocksTest extends AbstractCTest {
             {"mutex_musl-3-acq2rx_lock", IMM, FAIL},
             {"mutex_musl-3-rel2rx_futex", IMM, UNKNOWN},
             {"mutex_musl-3-rel2rx_unlock", IMM, FAIL},
+            // The actual result is PASS, but CAAT returns UNKNOWN
+            // because we do not refine for the bound check 
             {"seqlock-6", IMM, UNKNOWN},
 		});
     }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/RC11LocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/RC11LocksTest.java
@@ -74,6 +74,8 @@ public class RC11LocksTest extends AbstractCTest {
                 {"mutex_musl-3-acq2rx_lock", C11, FAIL},
                 {"mutex_musl-3-rel2rx_futex", C11, UNKNOWN},
                 {"mutex_musl-3-rel2rx_unlock", C11, FAIL},
+                // The actual result is PASS, but CAAT returns UNKNOWN
+                // because we do not refine for the bound check 
                 {"seqlock-6", C11, UNKNOWN},
 		});
     }


### PR DESCRIPTION
This PR marks the compiled (when C11 is the target) events related to create/join/start/end as `Tag.C11.Atomic` (since they have Rel-Acq semantics).
With these changes, all C11 results makes sense (they are similar to the other models with the exception of linuxrwlock which returns FAIL; but this is possible because C11 is weaker than any other model we tested before).
Refinement might still require some work and thus, for now, we use the assume solver in the CI.
Two of the safe instances of LFDS take too long so they are not (yet) part of the CI. 