### PR TITLE
Memory order cannot be null

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
@@ -108,7 +108,7 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
 	public Object visitLoad(LitmusLISAParser.LoadContext ctx) {
         Register reg = programBuilder.getOrCreateRegister(mainThread, ctx.register().getText(), ARCH_PRECISION);
         IExpr address = (IExpr) ctx.expression().accept(this);
-        String mo = ctx.mo() != null ? ctx.mo().getText() : null;
+        String mo = ctx.mo() != null ? ctx.mo().getText() : "";
 		programBuilder.addChild(mainThread, EventFactory.newLoad(reg, address, mo));
 		return null;
 	}
@@ -125,7 +125,7 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
 	public Object visitStore(LitmusLISAParser.StoreContext ctx) {
 		IExpr value = (IExpr) ctx.value().accept(this);
         IExpr address = (IExpr) ctx.expression().accept(this);
-        String mo = ctx.mo() != null ? ctx.mo().getText() : null;
+        String mo = ctx.mo() != null ? ctx.mo().getText() : "";
         programBuilder.addChild(mainThread, EventFactory.newStore(address, value, mo));
 		return null;
 
@@ -136,14 +136,14 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
         Register reg = programBuilder.getOrCreateRegister(mainThread, ctx.register().getText(), ARCH_PRECISION);
 		IExpr value = (IExpr) ctx.value().accept(this);
         IExpr address = (IExpr) ctx.expression().accept(this);
-        String mo = ctx.mo() != null ? ctx.mo().getText() : null;
+        String mo = ctx.mo() != null ? ctx.mo().getText() : "";
         programBuilder.addChild(mainThread, EventFactory.LISA.newRMW(address, reg, value, mo));
 		return null;
 	}
 
 	@Override
 	public Object visitFence(LitmusLISAParser.FenceContext ctx) {
-        String mo = ctx.mo() != null ? ctx.mo().getText() : null;
+        String mo = ctx.mo() != null ? ctx.mo().getText() : "";
         programBuilder.addChild(mainThread, EventFactory.newFence(mo));
 		return null;
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -247,8 +247,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
 	// =======================================
 	
 	private String getMo(LitmusRISCVParser.MoRISCVContext mo1, LitmusRISCVParser.MoRISCVContext mo2) {
-		String moR = mo1 != null ? mo1.mo : null;
-		String moW = mo2 != null ? mo2.mo : null;
+		String moR = mo1 != null ? mo1.mo : "";
+		String moW = mo2 != null ? mo2.mo : "";
 		return moR != null ? (moW != null ? Tag.RISCV.MO_ACQ_REL : moR) : moW;
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -249,6 +249,6 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
 	private String getMo(LitmusRISCVParser.MoRISCVContext mo1, LitmusRISCVParser.MoRISCVContext mo2) {
 		String moR = mo1 != null ? mo1.mo : "";
 		String moW = mo2 != null ? mo2.mo : "";
-		return moR != null ? (moW != null ? Tag.RISCV.MO_ACQ_REL : moR) : moW;
+		return !moR.isEmpty() ? (!moW.isEmpty() ? Tag.RISCV.MO_ACQ_REL : moR) : moW;
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/AtomicProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/AtomicProcedures.java
@@ -71,7 +71,7 @@ public class AtomicProcedures {
 	private static void atomicInit(VisitorBoogie visitor, Call_cmdContext ctx) {
 		IExpr add = (IExpr)ctx.call_params().exprs().expr().get(0).accept(visitor);
 		ExprInterface value = (ExprInterface)ctx.call_params().exprs().expr().get(1).accept(visitor);
-		visitor.programBuilder.addChild(visitor.threadCount, newStore(add, value, null))
+		visitor.programBuilder.addChild(visitor.threadCount, newStore(add, value, ""))
 				.setCLine(visitor.currentLine)
 				.setSourceCodeFile(visitor.sourceCodeFile);
 	}
@@ -79,7 +79,7 @@ public class AtomicProcedures {
 	private static void atomicStore(VisitorBoogie visitor, Call_cmdContext ctx) {
 		IExpr add = (IExpr)ctx.call_params().exprs().expr().get(0).accept(visitor);
 		ExprInterface value = (ExprInterface)ctx.call_params().exprs().expr().get(1).accept(visitor);
-		String mo = null;
+		String mo = "";
 		if(ctx.call_params().exprs().expr().size() > 2) {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getValueAsInt());
 		}
@@ -91,7 +91,7 @@ public class AtomicProcedures {
 	private static void atomicLoad(VisitorBoogie visitor, Call_cmdContext ctx) {
 		Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText(), ARCH_PRECISION);
 		IExpr add = (IExpr)ctx.call_params().exprs().expr().get(0).accept(visitor);
-		String mo = null;
+		String mo = "";
 		if(ctx.call_params().exprs().expr().size() > 1) {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(1).accept(visitor)).getValueAsInt());
 		}
@@ -104,7 +104,7 @@ public class AtomicProcedures {
 		Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText(), ARCH_PRECISION);
 		IExpr add = (IExpr)ctx.call_params().exprs().expr().get(0).accept(visitor);
 		IExpr value = (IExpr)ctx.call_params().exprs().expr().get(1).accept(visitor);
-		String mo = null;
+		String mo = "";
 		IOpBin op;
 		if(ctx.getText().contains("_add")) {
 			op = IOpBin.PLUS;
@@ -131,7 +131,7 @@ public class AtomicProcedures {
 		Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText(), ARCH_PRECISION);
 		IExpr add = (IExpr)ctx.call_params().exprs().expr().get(0).accept(visitor);
 		IExpr value = (IExpr)ctx.call_params().exprs().expr().get(1).accept(visitor);
-		String mo = null;
+		String mo = "";
 		if(ctx.call_params().exprs().expr().size() > 2) {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getValueAsInt());
 		}
@@ -146,7 +146,7 @@ public class AtomicProcedures {
 		IExpr addr = (IExpr) params.get(0).accept(visitor);
 		IExpr expectedVal = (IExpr) params.get(1).accept(visitor);
 		IExpr desiredVal = (IExpr) params.get(2).accept(visitor);
-		String mo = null;
+		String mo = "";
 		if(params.size() > 3) {
 			mo = intToMo(((IConst) params.get(3).accept(visitor)).getValueAsInt());
 		}
@@ -168,7 +168,7 @@ public class AtomicProcedures {
 		IExpr addr = (IExpr) params.get(0).accept(visitor);
 		IExpr expectedAddr = (IExpr) params.get(1).accept(visitor); // NOTE: We assume a register here
 		IExpr desiredVal = (IExpr) params.get(2).accept(visitor);
-		String mo = null;
+		String mo = "";
 		boolean strong = ctx.getText().contains("strong");
 		if(params.size() > 3) {
 			mo = intToMo(((IConst) params.get(3).accept(visitor)).getValueAsInt());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
@@ -53,11 +53,11 @@ public final class Tag {
         }
 
         public static String extractStoreMoFromLKMo(String lkMo) {
-            return lkMo.equals(Tag.Linux.MO_RELEASE) || lkMo.equals(Tag.Linux.MO_MB) ? Tag.ARMv8.MO_REL : null;
+            return lkMo.equals(Tag.Linux.MO_RELEASE) || lkMo.equals(Tag.Linux.MO_MB) ? Tag.ARMv8.MO_REL : "";
         }
 
         public static String extractLoadMoFromLKMo(String lkMo) {
-            return lkMo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.ARMv8.MO_ACQ : null;
+            return lkMo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.ARMv8.MO_ACQ : "";
         }
 
     }
@@ -86,16 +86,16 @@ public final class Tag {
 			case C11.MO_SC:
 				return MO_ACQ_REL;
 			default:
-				return null;
+				return "";
 			}
         }
         
         public static String extractStoreMoFromCMo(String cMo) {
-            return cMo.equals(C11.MO_SC) || cMo.equals(C11.MO_RELEASE) || cMo.equals(C11.MO_ACQUIRE_RELEASE) ? MO_REL : null;
+            return cMo.equals(C11.MO_SC) || cMo.equals(C11.MO_RELEASE) || cMo.equals(C11.MO_ACQUIRE_RELEASE) ? MO_REL : "";
         }
 
         public static String extractLoadMoFromCMo(String cMo) {
-            return cMo.equals(C11.MO_SC) || cMo.equals(C11.MO_ACQUIRE) || cMo.equals(C11.MO_ACQUIRE_RELEASE) ? MO_ACQ : null;
+            return cMo.equals(C11.MO_SC) || cMo.equals(C11.MO_ACQUIRE) || cMo.equals(C11.MO_ACQUIRE_RELEASE) ? MO_ACQ : "";
         }
 
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -16,7 +16,7 @@ public class Xchg extends MemEvent implements RegWriter, RegReaderData {
     private final Register resultRegister;
 
     public Xchg(MemoryObject address, Register register) {
-        super(address, null);
+        super(address, "");
         this.resultRegister = register;
         addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, TSO.ATOM, REG_WRITER, REG_READER);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -16,7 +16,7 @@ public class Init extends MemEvent {
 	private final int offset;
 	
 	public Init(MemoryObject b, int o) {
-		super(b.add(o), null);
+		super(b.add(o), "");
 		base = b;
 		offset = o;
 		addFilters(Tag.ANY, Tag.VISIBLE, Tag.MEMORY, Tag.WRITE, Tag.INIT);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -29,7 +29,7 @@ public class Load extends MemEvent implements RegWriter {
 
     @Override
     public String toString() {
-        return resultRegister + " = load(*" + address + (mo != null ? ", " + mo : "") + ")";
+        return resultRegister + " = load(*" + address + (!mo.isEmpty() ? ", " + mo : "") + ")";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
@@ -15,7 +15,7 @@ public abstract class MemEvent extends Event {
     	Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;
         this.mo = mo;
-        if(mo != null){
+        if(!mo.isEmpty()){
             addFilters(mo);
         }
     }
@@ -48,7 +48,7 @@ public abstract class MemEvent extends Event {
 
     public void setMo(String mo){
     	Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
-    	if(this.mo != null) {
+    	if(!this.mo.isEmpty()) {
             removeFilters(this.mo);    		
     	}
         this.mo = mo;
@@ -56,7 +56,7 @@ public abstract class MemEvent extends Event {
     }
 
     public boolean canRace() {
-    	return mo.equals("") || mo.equals(C11.NONATOMIC);
+    	return mo.isEmpty() || mo.equals(C11.NONATOMIC);
     }
 
 	// Visitor

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
@@ -11,6 +11,7 @@ public abstract class MemEvent extends Event {
     protected IExpr address;
     protected String mo;
 
+    // The empty string means no memory order 
     public MemEvent(IExpr address, String mo){
     	Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
@@ -52,7 +52,10 @@ public abstract class MemEvent extends Event {
             removeFilters(this.mo);    		
     	}
         this.mo = mo;
-        addFilters(mo);
+        // This cannot be merged with the if above, because this.mo was updated
+        if(!this.mo.isEmpty()) {
+            addFilters(mo);
+    	}
     }
 
     public boolean canRace() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
@@ -12,6 +12,7 @@ public abstract class MemEvent extends Event {
     protected String mo;
 
     public MemEvent(IExpr address, String mo){
+    	Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;
         this.mo = mo;
         if(mo != null){
@@ -46,7 +47,7 @@ public abstract class MemEvent extends Event {
     }
 
     public void setMo(String mo){
-    	Preconditions.checkNotNull(mo, "Only the parser can set the memory ordering to null");
+    	Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
     	if(this.mo != null) {
             removeFilters(this.mo);    		
     	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -30,7 +30,7 @@ public class Store extends MemEvent implements RegReaderData {
 
     @Override
     public String toString() {
-        return "store(*" + address + ", " + value + (mo != null ? ", " + mo : "") + ")";
+        return "store(*" + address + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/StoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/StoreExclusive.java
@@ -30,7 +30,7 @@ public class StoreExclusive extends Store implements RegWriter {
 
     @Override
     public String toString(){
-        return register + " <- store(*" + address + ", " + value + (mo != null ? ", " + mo : "") + ")";
+        return register + " <- store(*" + address + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")";
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
@@ -36,8 +36,8 @@ public class AtomicCmpXchg extends AtomicAbstract {
     @Override
     public String toString() {
     	String tag = is(STRONG) ? "_strong" : "_weak";
-    	tag += mo != null ? "_explicit" : "";
-        return resultRegister + " = atomic_compare_exchange" + tag + "(*" + address + ", " + expectedAddr + ", " + value + (mo != null ? ", " + mo : "") + ")\t### C11";
+    	tag += !mo.isEmpty() ? "_explicit" : "";
+        return resultRegister + " = atomic_compare_exchange" + tag + "(*" + address + ", " + expectedAddr + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")\t### C11";
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
@@ -23,8 +23,8 @@ public class AtomicFetchOp extends AtomicAbstract {
 
     @Override
     public String toString() {
-    	String tag = mo != null ? "_explicit" : "";
-        return resultRegister + " = atomic_fetch_" + op.toLinuxName() + tag + "(*" + address + ", " + value + (mo != null ? ", " + mo : "") + ")\t### C11";
+    	String tag = !mo.isEmpty() ? "_explicit" : "";
+        return resultRegister + " = atomic_fetch_" + op.toLinuxName() + tag + "(*" + address + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")\t### C11";
     }
 
     public IOpBin getOp() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -34,8 +34,8 @@ public class AtomicLoad extends MemEvent implements RegWriter {
 
     @Override
     public String toString() {
-    	String tag = mo != null ? "_explicit" : "";
-        return resultRegister + " = atomic_load" + tag + "(*" + address + (mo != null ? ", " + mo : "") + ")\t### C11";
+    	String tag = !mo.isEmpty() ? "_explicit" : "";
+        return resultRegister + " = atomic_load" + tag + "(*" + address + (!mo.isEmpty() ? ", " + mo : "") + ")\t### C11";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -36,8 +36,8 @@ public class AtomicStore extends MemEvent implements RegReaderData {
 
     @Override
     public String toString() {
-    	String tag = mo != null ? "_explicit" : "";
-        return "atomic_store" + tag + "(*" + address + ", " +  value + (mo != null ? ", " + mo : "") + ")\t### C11";
+    	String tag = !mo.isEmpty() ? "_explicit" : "";
+        return "atomic_store" + tag + "(*" + address + ", " +  value + (!mo.isEmpty() ? ", " + mo : "") + ")\t### C11";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
@@ -18,8 +18,8 @@ public class AtomicXchg extends AtomicAbstract {
 
     @Override
     public String toString() {
-    	String tag = mo != null ? "_explicit" : "";
-        return resultRegister + " = atomic_exchange" + tag + "(*" + address + ", " + value + (mo != null ? ", " + mo : "") + ")\t### C11";
+    	String tag = !mo.isEmpty() ? "_explicit" : "";
+        return resultRegister + " = atomic_exchange" + tag + "(*" + address + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")\t### C11";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/Dat3mCAS.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/Dat3mCAS.java
@@ -22,7 +22,7 @@ public class Dat3mCAS extends AtomicAbstract {
 
     @Override
     public String toString() {
-        return resultRegister + " = __DAT3M_CAS(*" + address + ", " + expectedValue + ", " + value + (mo != null ? ", " + mo : "") + ")";
+        return resultRegister + " = __DAT3M_CAS(*" + address + ", " + expectedValue + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
@@ -9,7 +9,7 @@ public class LKMMLock extends MemEvent {
 	public LKMMLock(IExpr lock) {
 		// This event will be compiled to LKMMLockRead + LKMMLockWrite 
 		// and each of those will be assigned a proper memory ordering
-		super(lock, null);
+		super(lock, "");
 	}
 
     protected LKMMLock(LKMMLock other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/AtomicAsLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/AtomicAsLock.java
@@ -62,9 +62,9 @@ public class AtomicAsLock implements ProgramProcessor {
 			Event event = predecessor.getSuccessor();
 			boolean begin = event instanceof BeginAtomic;
 			if(begin || event instanceof EndAtomic) {
-				Event load = EventFactory.newLoad(register,address,null);
+				Event load = EventFactory.newLoad(register,address,"");
 				Event check = EventFactory.newJump(new Atom(register,NEQ,begin?IValue.ZERO:IValue.ONE),end);
-				Event store = EventFactory.newStore(address,begin?IValue.ONE:IValue.ZERO,null);
+				Event store = EventFactory.newStore(address,begin?IValue.ONE:IValue.ZERO,"");
 				load.setOId(event.getOId());
 				check.setOId(event.getOId());
 				store.setOId(event.getOId());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -110,8 +110,8 @@ class VisitorArm8 extends VisitorBase {
 
 		Register regExpected = e.getThread().newRegister(precision);
         Register regValue = e.getThread().newRegister(precision);
-        Load loadExpected = newLoad(regExpected, expectedAddr, null);
-        Store storeExpected = newStore(expectedAddr, regValue, null);
+        Load loadExpected = newLoad(regExpected, expectedAddr, "");
+        Store storeExpected = newStore(expectedAddr, regValue, "");
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");
         Local casCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, regExpected));
@@ -269,7 +269,7 @@ class VisitorArm8 extends VisitorBase {
 		IExpr address = e.getAddress();
 		String mo = e.getMo();
 
-        Store store = newStore(address, value, mo.equals(Tag.Linux.MO_RELEASE) ? Tag.ARMv8.MO_REL : null);
+        Store store = newStore(address, value, mo.equals(Tag.Linux.MO_RELEASE) ? Tag.ARMv8.MO_REL : "");
         
         return eventSequence(
                 store
@@ -387,8 +387,8 @@ class VisitorArm8 extends VisitorBase {
 		IExpr address = e.getAddress();
 		
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-        Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = newRMWStoreExclusive(address, new IExprBin(dummy, op, value), null, true);
+        Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = newRMWStoreExclusive(address, new IExprBin(dummy, op, value), "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -81,9 +81,9 @@ public class VisitorC11 extends VisitorBase {
 
 		Register regExpected = e.getThread().newRegister(precision);
         Register regValue = e.getThread().newRegister(precision);
-        Load loadExpected = newLoad(regExpected, expectedAddr, null);
+        Load loadExpected = newLoad(regExpected, expectedAddr, "");
         loadExpected.addFilters(C11.ATOMIC);
-        Store storeExpected = newStore(expectedAddr, regValue, null);
+        Store storeExpected = newStore(expectedAddr, regValue, "");
         storeExpected.addFilters(C11.ATOMIC);
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -31,7 +31,7 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitLoad(Load e) {
 		String mo = e.getMo();
         return eventSequence(
-        		newLoad(e.getResultRegister(), e.getAddress(), mo == null || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
+        		newLoad(e.getResultRegister(), e.getAddress(), mo.isEmpty() || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
         );
 	}
 
@@ -39,7 +39,7 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitStore(Store e) {
 		String mo = e.getMo();
         return eventSequence(
-        		newStore(e.getAddress(), e.getMemValue(), mo == null || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
+        		newStore(e.getAddress(), e.getMemValue(), mo.isEmpty() || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
         );
 	}
 	
@@ -101,9 +101,9 @@ class VisitorIMM extends VisitorBase {
 
 		Register regExpected = e.getThread().newRegister(precision);
         Register regValue = e.getThread().newRegister(precision);
-        Load loadExpected = newLoad(regExpected, expectedAddr, null);
+        Load loadExpected = newLoad(regExpected, expectedAddr, "");
         loadExpected.addFilters(Tag.IMM.CASDEPORIGIN);
-        Store storeExpected = newStore(expectedAddr, regValue, null);
+        Store storeExpected = newStore(expectedAddr, regValue, "");
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");
         Local casCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, regExpected));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -111,17 +111,17 @@ public class VisitorPower extends VisitorBase {
 
 		Register regExpected = e.getThread().newRegister(precision);
         Register regValue = e.getThread().newRegister(precision);
-        Load loadExpected = newLoad(regExpected, expectedAddr, null);
-        Store storeExpected = newStore(expectedAddr, regValue, null);
+        Load loadExpected = newLoad(regExpected, expectedAddr, "");
+        Store storeExpected = newStore(expectedAddr, regValue, "");
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");
         Local casCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, regExpected));
         CondJump branchOnCasCmpResult = newJump(new Atom(resultRegister, NEQ, IValue.ONE), casFail);
         CondJump gotoCasEnd = newGoto(casEnd);
 
-        // Power does not have mo tags, thus we use null
-        Load loadValue = newRMWLoadExclusive(regValue, address, null);
-        Store storeValue = Power.newRMWStoreConditional(address, value, null, e.is(STRONG));
+        // Power does not have mo tags, thus we use the emptz string
+        Load loadValue = newRMWLoadExclusive(regValue, address, "");
+        Store storeValue = Power.newRMWStoreConditional(address, value, "", e.is(STRONG));
         ExecutionStatus optionalExecStatus = null;
         Local optionalUpdateCasCmpResult = null;
         if (!e.is(STRONG)) {
@@ -184,9 +184,9 @@ public class VisitorPower extends VisitorBase {
         Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
         Local localOp = newLocal(dummyReg, new IExprBin(resultRegister, op, value));
 
-        // Power does not have mo tags, thus we use null
-        Load load = newRMWLoadExclusive(resultRegister, address, null);
-        Store store = Power.newRMWStoreConditional(address, dummyReg, null, true);
+        // Power does not have mo tags, thus we use the emptz string
+        Load load = newRMWLoadExclusive(resultRegister, address, "");
+        Store store = Power.newRMWStoreConditional(address, dummyReg, "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
@@ -322,9 +322,9 @@ public class VisitorPower extends VisitorBase {
 		IExpr address = e.getAddress();
 		String mo = e.getMo();
 
-        // Power does not have mo tags, thus we use null
-        Load load = newRMWLoadExclusive(resultRegister, address, null);
-        Store store = Power.newRMWStoreConditional(address, value, null, true);
+        // Power does not have mo tags, thus we use the emptz string
+        Load load = newRMWLoadExclusive(resultRegister, address, "");
+        Store store = Power.newRMWStoreConditional(address, value, "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
@@ -375,8 +375,8 @@ public class VisitorPower extends VisitorBase {
         Local casCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, expectedValue));
         Label casEnd = newLabel("CAS_end");
         CondJump branchOnCasCmpResult = newJump(new Atom(resultRegister, NEQ, IValue.ONE), casEnd);
-        Load load = newRMWLoadExclusive(regValue, address, null);
-        Store store = Power.newRMWStoreConditional(address, value, null, true);
+        Load load = newRMWLoadExclusive(regValue, address, "");
+        Store store = Power.newRMWStoreConditional(address, value, "", true);
 
         Fence optionalBarrierBefore = null;
         Fence optionalBarrierAfter = null;
@@ -428,8 +428,8 @@ public class VisitorPower extends VisitorBase {
 		IExpr address = e.getAddress();
 		String mo = e.getMo();
 		
-        // Power does not have mo tags, thus we use null
-        Load load = newLoad(resultRegister, address, null);
+        // Power does not have mo tags, thus we use the empty string
+        Load load = newLoad(resultRegister, address, "");
         Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newLwSyncBarrier() : null;
         
         return eventSequence(
@@ -446,8 +446,8 @@ public class VisitorPower extends VisitorBase {
 		IExpr address = e.getAddress();
 		String mo = e.getMo();
 
-        // Power does not have mo tags, thus we use null
-        Store store = newStore(address, value, null);
+        // Power does not have mo tags, thus we use the empty string
+        Store store = newStore(address, value, "");
         Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         
         return eventSequence(
@@ -517,9 +517,9 @@ public class VisitorPower extends VisitorBase {
         Label casEnd = newLabel("CAS_end");
         CondJump branchOnCasCmpResult = newJump(new Atom(dummy, NEQ, e.getCmp()), casEnd);
 
-        // Power does not have mo tags, thus we use null
-        Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = Power.newRMWStoreConditional(address, value, null, true);
+        // Power does not have mo tags, thus we use the empty string
+        Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = Power.newRMWStoreConditional(address, value, "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
@@ -550,9 +550,9 @@ public class VisitorPower extends VisitorBase {
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-        // Power does not have mo tags, thus we use null
-        Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = Power.newRMWStoreConditional(address, value, null, true);
+        // Power does not have mo tags, thus we use the empty string
+        Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = Power.newRMWStoreConditional(address, value, "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
@@ -581,9 +581,9 @@ public class VisitorPower extends VisitorBase {
 		String mo = e.getMo();
 		
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-        // Power does not have mo tags, thus we use null
-        Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = Power.newRMWStoreConditional(address, new IExprBin(dummy, op, value), null, true);
+        // Power does not have mo tags, thus we use the empty string
+        Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = Power.newRMWStoreConditional(address, new IExprBin(dummy, op, value), "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
@@ -612,9 +612,9 @@ public class VisitorPower extends VisitorBase {
 		String mo = e.getMo();
 		
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-        // Power does not have mo tags, thus we use null
-        Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = Power.newRMWStoreConditional(address, dummy, null, true);
+        // Power does not have mo tags, thus we use the empty string
+        Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = Power.newRMWStoreConditional(address, dummy, "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
@@ -644,8 +644,8 @@ public class VisitorPower extends VisitorBase {
 		String mo = e.getMo();
 		
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-		Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = Power.newRMWStoreConditional(address, new IExprBin(dummy, e.getOp(), value), null, true);
+		Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = Power.newRMWStoreConditional(address, new IExprBin(dummy, e.getOp(), value), "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
@@ -679,9 +679,9 @@ public class VisitorPower extends VisitorBase {
 		int precision = resultRegister.getPrecision();
 
         Register regValue = e.getThread().newRegister(precision);
-        // Power does not have mo tags, thus we use null
-        Load load = newRMWLoadExclusive(regValue, address, null);
-        Store store = Power.newRMWStoreConditional(address, new IExprBin(regValue, IOpBin.PLUS, (IExpr) value), null, true);
+        // Power does not have mo tags, thus we use the empty string
+        Load load = newRMWLoadExclusive(regValue, address, "");
+        Store store = Power.newRMWStoreConditional(address, new IExprBin(regValue, IOpBin.PLUS, (IExpr) value), "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(regValue, label);
 
@@ -727,9 +727,9 @@ public class VisitorPower extends VisitorBase {
         Local localOp = newLocal(retReg, new IExprBin(dummy, op, value));
         Local testOp = newLocal(resultRegister, new Atom(retReg, EQ, IValue.ZERO));
 
-        // Power does not have mo tags, thus we use null
-        Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = Power.newRMWStoreConditional(address, retReg, null, true);
+        // Power does not have mo tags, thus we use the empty string
+        Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = Power.newRMWStoreConditional(address, retReg, "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -112,8 +112,8 @@ class VisitorRISCV extends VisitorBase {
 
 		Register regExpected = e.getThread().newRegister(precision);
         Register regValue = e.getThread().newRegister(precision);
-        Load loadExpected = newLoad(regExpected, expectedAddr, null);
-        Store storeExpected = newStore(expectedAddr, regValue, null);
+        Load loadExpected = newLoad(regExpected, expectedAddr, "");
+        Store storeExpected = newStore(expectedAddr, regValue, "");
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");
         Local casCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, regExpected));
@@ -183,7 +183,7 @@ class VisitorRISCV extends VisitorBase {
 
 		return eventSequence(
 				optionalBarrierBefore,
-				newLoad(e.getResultRegister(), e.getAddress(), null),
+				newLoad(e.getResultRegister(), e.getAddress(), ""),
 				optionalBarrierAfter
 		);
 	}
@@ -195,7 +195,7 @@ class VisitorRISCV extends VisitorBase {
 
 		return eventSequence(
 				optionalBarrierBefore,
-				newStore(e.getAddress(), e.getMemValue(), null)
+				newStore(e.getAddress(), e.getMemValue(), "")
 		);
 	}
 
@@ -257,7 +257,7 @@ class VisitorRISCV extends VisitorBase {
 		Fence optionalMemoryBarrier = mo.equals(MO_ACQUIRE) ? RISCV.newRRWFence() : null;
     
 		return eventSequence(
-        		newLoad(e.getResultRegister(), e.getAddress(), null),
+        		newLoad(e.getResultRegister(), e.getAddress(), ""),
         		optionalMemoryBarrier
         );
 
@@ -270,7 +270,7 @@ class VisitorRISCV extends VisitorBase {
 		
 		return eventSequence(
         		optionalMemoryBarrier,
-				newStore(e.getAddress(), e.getMemValue(), null)
+				newStore(e.getAddress(), e.getMemValue(), "")
         );
 
 	}
@@ -315,8 +315,8 @@ class VisitorRISCV extends VisitorBase {
         Label casEnd = newLabel("CAS_end");
         CondJump branchOnCasCmpResult = newJump(new Atom(dummy, NEQ, e.getCmp()), casEnd);
         
-        Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = RISCV.newRMWStoreConditional(address, value, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : null, true);
+        Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = RISCV.newRMWStoreConditional(address, value, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newJump(new Atom(statusReg, EQ, IValue.ZERO), label);
@@ -350,9 +350,9 @@ class VisitorRISCV extends VisitorBase {
 
 		Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
 		Register statusReg = e.getThread().newRegister(e.getResultRegister().getPrecision());
-		String moLoad = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.RISCV.MO_ACQ : null;
+		String moLoad = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.RISCV.MO_ACQ : "";
         Load load = newRMWLoadExclusive(dummy, address, moLoad);
-        String moStore = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_RELEASE) ? Tag.RISCV.MO_ACQ_REL : null;
+        String moStore = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_RELEASE) ? Tag.RISCV.MO_ACQ_REL : "";
 		Store store = RISCV.newRMWStoreConditional(address, value, moStore, true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
@@ -383,9 +383,9 @@ class VisitorRISCV extends VisitorBase {
 
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
 		Register statusReg = e.getThread().newRegister(e.getResultRegister().getPrecision());
-		String moLoad = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.RISCV.MO_ACQ : null;
+		String moLoad = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.RISCV.MO_ACQ : "";
         Load load = newRMWLoadExclusive(dummy, address, moLoad);
-        String moStore = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_RELEASE) ? Tag.RISCV.MO_ACQ_REL : null;
+        String moStore = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_RELEASE) ? Tag.RISCV.MO_ACQ_REL : "";
         Store store = RISCV.newRMWStoreConditional(address, new IExprBin(dummy, op, value), moStore, true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
@@ -415,8 +415,8 @@ class VisitorRISCV extends VisitorBase {
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
 		Register statusReg = e.getThread().newRegister(e.getResultRegister().getPrecision());
 
-		Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = RISCV.newRMWStoreConditional(address, new IExprBin(dummy, e.getOp(), value), mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : null, true);
+		Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = RISCV.newRMWStoreConditional(address, new IExprBin(dummy, e.getOp(), value), mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newJump(new Atom(statusReg, EQ, IValue.ZERO), label);
@@ -451,8 +451,8 @@ class VisitorRISCV extends VisitorBase {
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
 		Register statusReg = e.getThread().newRegister(e.getResultRegister().getPrecision());
 
-        Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = RISCV.newRMWStoreConditional(address, dummy, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : null, true);
+        Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = RISCV.newRMWStoreConditional(address, dummy, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newJump(new Atom(statusReg, EQ, IValue.ZERO), label);
@@ -488,8 +488,8 @@ class VisitorRISCV extends VisitorBase {
         Register regValue = e.getThread().newRegister(precision);
 		Register statusReg = e.getThread().newRegister(e.getResultRegister().getPrecision());
 
-		Load load = newRMWLoadExclusive(regValue, address, null);
-        Store store = RISCV.newRMWStoreConditional(address, new IExprBin(regValue, IOpBin.PLUS, (IExpr) value), mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : null, true);
+		Load load = newRMWLoadExclusive(regValue, address, "");
+        Store store = RISCV.newRMWStoreConditional(address, new IExprBin(regValue, IOpBin.PLUS, (IExpr) value), mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
 
         Label label = newLabel("FakeDep");
@@ -534,8 +534,8 @@ class VisitorRISCV extends VisitorBase {
         Local localOp = newLocal(retReg, new IExprBin(dummy, op, value));
         Local testOp = newLocal(resultRegister, new Atom(retReg, EQ, IValue.ZERO));
 
-        Load load = newRMWLoadExclusive(dummy, address, null);
-        Store store = newRMWStoreExclusive(address, retReg, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : null, true);
+        Load load = newRMWLoadExclusive(dummy, address, "");
+        Store store = newRMWStoreExclusive(address, retReg, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -76,10 +76,10 @@ class VisitorTso extends VisitorBase {
         IExpr address = e.getAddress();
 
         Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
-		Load load = newRMWLoad(dummyReg, address, null);
+		Load load = newRMWLoad(dummyReg, address, "");
         load.addFilters(Tag.TSO.ATOM);
 
-        RMWStore store = newRMWStore(load, address, resultRegister, null);
+        RMWStore store = newRMWStore(load, address, resultRegister, "");
         store.addFilters(Tag.TSO.ATOM);
 
         return eventSequence(

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -99,7 +99,7 @@ class VisitorTso extends VisitorBase {
 		int precision = resultRegister.getPrecision();
 
 		Register regExpected = e.getThread().newRegister(precision);
-        Load loadExpected = newLoad(regExpected, expectedAddr, null);
+        Load loadExpected = newLoad(regExpected, expectedAddr, "");
         Register regValue = e.getThread().newRegister(precision);
         Load loadValue = newRMWLoad(regValue, address, mo);
         Local casCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, regExpected));
@@ -108,7 +108,7 @@ class VisitorTso extends VisitorBase {
         Store storeValue = newRMWStore(loadValue, address, value, mo);
         Label casEnd = newLabel("CAS_end");
         CondJump gotoCasEnd = newGoto(casEnd);
-        Store storeExpected = newStore(expectedAddr, regValue, null);
+        Store storeExpected = newStore(expectedAddr, regValue, "");
 
         return eventSequence(
                 // Indentation shows the branching structure

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
@@ -29,7 +29,7 @@ public class UnrollExceptionsTest {
 		Label start = pb.getOrCreateLabel("loopStart");
 		pb.addChild(0, start);
         Load load = EventFactory.newRMWLoad(pb.getOrCreateRegister(0, "r1", 32), object, null);
-        pb.addChild(0, EventFactory.newRMWStore(load, object, IValue.ONE, null));
+        pb.addChild(0, EventFactory.newRMWStore(load, object, IValue.ONE, ""));
 		pb.addChild(0, EventFactory.newGoto(start));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
@@ -43,7 +43,7 @@ public class UnrollExceptionsTest {
         MemoryObject object = pb.getOrNewObject("X");
 		Label start = pb.getOrCreateLabel("loopStart");
 		pb.addChild(0, start);
-        RMWReadCond load = Linux.newRMWReadCondCmp(pb.getOrCreateRegister(0, "r1", 32), BConst.TRUE, object, null);
+        RMWReadCond load = Linux.newRMWReadCondCmp(pb.getOrCreateRegister(0, "r1", 32), BConst.TRUE, object, "");
         pb.addChild(0, Linux.newRMWStoreCond(load, object, IValue.ONE, ""));
 		pb.addChild(0, EventFactory.newGoto(start));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
@@ -57,7 +57,7 @@ public class UnrollExceptionsTest {
     	pb.initThread(0);
 		Label start = pb.getOrCreateLabel("loopStart");
 		pb.addChild(0, start);
-    	pb.addChild(0, newRMWStoreExclusive(pb.getOrNewObject("X"), IValue.ONE, null, true));
+    	pb.addChild(0, newRMWStoreExclusive(pb.getOrNewObject("X"), IValue.ONE, "", true));
 		pb.addChild(0, EventFactory.newGoto(start));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
@@ -71,7 +71,7 @@ public class UnrollExceptionsTest {
         MemoryObject object = pb.getOrNewObject("X");
 		Label start = pb.getOrCreateLabel("loopStart");
 		pb.addChild(0, start);
-        RMWReadCond load = Linux.newRMWReadCondCmp(pb.getOrCreateRegister(0, "r1", 32), BConst.TRUE, object, null);
+        RMWReadCond load = Linux.newRMWReadCondCmp(pb.getOrCreateRegister(0, "r1", 32), BConst.TRUE, object, "");
 		pb.addChild(0, Linux.newConditionalBarrier(load, null));
 		pb.addChild(0, EventFactory.newGoto(start));
     	LoopUnrolling processor = LoopUnrolling.newInstance();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/UnrollExceptionsTest.java
@@ -28,7 +28,7 @@ public class UnrollExceptionsTest {
         MemoryObject object = pb.getOrNewObject("X");
 		Label start = pb.getOrCreateLabel("loopStart");
 		pb.addChild(0, start);
-        Load load = EventFactory.newRMWLoad(pb.getOrCreateRegister(0, "r1", 32), object, null);
+        Load load = EventFactory.newRMWLoad(pb.getOrCreateRegister(0, "r1", 32), object, "");
         pb.addChild(0, EventFactory.newRMWStore(load, object, IValue.ONE, ""));
 		pb.addChild(0, EventFactory.newGoto(start));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
@@ -44,7 +44,7 @@ public class UnrollExceptionsTest {
 		Label start = pb.getOrCreateLabel("loopStart");
 		pb.addChild(0, start);
         RMWReadCond load = Linux.newRMWReadCondCmp(pb.getOrCreateRegister(0, "r1", 32), BConst.TRUE, object, null);
-        pb.addChild(0, Linux.newRMWStoreCond(load, object, IValue.ONE, null));
+        pb.addChild(0, Linux.newRMWStoreCond(load, object, IValue.ONE, ""));
 		pb.addChild(0, EventFactory.newGoto(start));
     	LoopUnrolling processor = LoopUnrolling.newInstance();
     	processor.setUnrollingBound(2);
@@ -86,7 +86,7 @@ public class UnrollExceptionsTest {
 		Label start = pb.getOrCreateLabel("loopStart");
 		pb.addChild(0, start);
         MemoryObject object = pb.getOrNewObject("X");
-        RMWStoreExclusive store = newRMWStoreExclusive(object, IValue.ONE, null);
+        RMWStoreExclusive store = newRMWStoreExclusive(object, IValue.ONE, "");
 		pb.addChild(0, EventFactory.newExecutionStatus(pb.getOrCreateRegister(0, "r1", 32), store));
 		pb.addChild(0, EventFactory.newGoto(start));
     	LoopUnrolling processor = LoopUnrolling.newInstance();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -318,7 +318,7 @@ public class AnalysisTest {
     }
 
     private Load newLoad(Register value, IExpr address) {
-        return EventFactory.newLoad(value,address,null);
+        return EventFactory.newLoad(value,address,"");
     }
 
     private Store newStore(IExpr address) {
@@ -326,7 +326,7 @@ public class AnalysisTest {
     }
 
     private Store newStore(IExpr address, IExpr value) {
-        return EventFactory.newStore(address,value,null);
+        return EventFactory.newStore(address,value,"");
     }
 
     private IValue value(long v) {


### PR DESCRIPTION
We recently changed to the empty string as a default memory order (before we were using `null`).
There was one remaining use of null that caused a null pointer when checking if some event could race.
This PR fixes this issue.