### PR TITLE
Add call stack to violation witnesses

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -12,6 +12,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
+import com.dat3m.dartagnan.program.processing.CallStackAnalysis;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.verification.VerificationTask;
@@ -170,8 +171,10 @@ public class Dartagnan extends BaseOptions {
             	if(result.equals(FAIL) && o.generateGraphviz()) {
                 	ExecutionModel m = ExecutionModel.withContext(modelChecker.getEncodingContext());
                 	m.initialize(prover.getModel());
+					CallStackAnalysis csa = CallStackAnalysis.fromConfig(config);
+					csa.run(p);
     				String name = task.getProgram().getName().substring(0, task.getProgram().getName().lastIndexOf('.'));
-    				generateGraphvizFile(m, 1, (x, y) -> true, System.getenv("DAT3M_OUTPUT") + "/", name);        		
+    				generateGraphvizFile(m, 1, (x, y) -> true, System.getenv("DAT3M_OUTPUT") + "/", name, csa.getCallStackMappint());        		
             	}
 
             	boolean safetyViolationFound = false;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -8,11 +8,11 @@ import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.parsers.witness.ParserWitness;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Program.SourceLanguage;
+import com.dat3m.dartagnan.program.analysis.CallStackComputation;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.filter.FilterBasic;
-import com.dat3m.dartagnan.program.processing.CallStackAnalysis;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.verification.VerificationTask;
@@ -171,10 +171,10 @@ public class Dartagnan extends BaseOptions {
             	if(result.equals(FAIL) && o.generateGraphviz()) {
                 	ExecutionModel m = ExecutionModel.withContext(modelChecker.getEncodingContext());
                 	m.initialize(prover.getModel());
-					CallStackAnalysis csa = CallStackAnalysis.fromConfig(config);
-					csa.run(p);
+					CallStackComputation csc = CallStackComputation.fromConfig(config);
+					csc.run(p);
     				String name = task.getProgram().getName().substring(0, task.getProgram().getName().lastIndexOf('.'));
-    				generateGraphvizFile(m, 1, (x, y) -> true, System.getenv("DAT3M_OUTPUT") + "/", name, csa.getCallStackMappint());        		
+    				generateGraphvizFile(m, 1, (x, y) -> true, System.getenv("DAT3M_OUTPUT") + "/", name, csc.getCallStackMapping());        		
             	}
 
             	boolean safetyViolationFound = false;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/AtomicProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/AtomicProcedures.java
@@ -72,7 +72,7 @@ public class AtomicProcedures {
 		IExpr add = (IExpr)ctx.call_params().exprs().expr().get(0).accept(visitor);
 		ExprInterface value = (ExprInterface)ctx.call_params().exprs().expr().get(1).accept(visitor);
 		visitor.programBuilder.addChild(visitor.threadCount, newStore(add, value, ""))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 
 	private static void atomicStore(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -83,7 +83,7 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newStore(add, value, mo))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 
 	private static void atomicLoad(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -94,7 +94,7 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(1).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newLoad(reg, add, mo))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 
 	private static void atomicFetchOp(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -120,7 +120,7 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newFetchOp(reg, add, value, op, mo))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 
 	private static void atomicXchg(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -132,7 +132,7 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newExchange(reg, add, value, mo))
-			.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+			.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 
 	private static void DAT3M_CAS(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -146,13 +146,13 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst) params.get(3).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newDat3mCAS(reg, addr, expectedVal, desiredVal, mo))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 
 	private static void atomicThreadFence(VisitorBoogie visitor, Call_cmdContext ctx) {
 		String mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(0).accept(visitor)).getValueAsInt());
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newFence(mo))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 	
 	private static void atomicCmpXchg(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -169,6 +169,6 @@ public class AtomicProcedures {
 			// (see issue #123 for an explanation)
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newCompareExchange(reg, addr, expectedAddr, desiredVal, mo, strong))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/AtomicProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/AtomicProcedures.java
@@ -72,8 +72,7 @@ public class AtomicProcedures {
 		IExpr add = (IExpr)ctx.call_params().exprs().expr().get(0).accept(visitor);
 		ExprInterface value = (ExprInterface)ctx.call_params().exprs().expr().get(1).accept(visitor);
 		visitor.programBuilder.addChild(visitor.threadCount, newStore(add, value, ""))
-				.setCLine(visitor.currentLine)
-				.setSourceCodeFile(visitor.sourceCodeFile);
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 
 	private static void atomicStore(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -84,8 +83,7 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newStore(add, value, mo))
-				.setCLine(visitor.currentLine)
-				.setSourceCodeFile(visitor.sourceCodeFile);
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 
 	private static void atomicLoad(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -96,8 +94,7 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(1).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newLoad(reg, add, mo))
-				.setCLine(visitor.currentLine)
-				.setSourceCodeFile(visitor.sourceCodeFile);
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 
 	private static void atomicFetchOp(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -123,8 +120,7 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newFetchOp(reg, add, value, op, mo))
-				.setCLine(visitor.currentLine)
-				.setSourceCodeFile(visitor.sourceCodeFile);
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 
 	private static void atomicXchg(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -136,8 +132,7 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(2).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newExchange(reg, add, value, mo))
-				.setCLine(visitor.currentLine)
-				.setSourceCodeFile(visitor.sourceCodeFile);
+			.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 
 	private static void DAT3M_CAS(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -151,15 +146,13 @@ public class AtomicProcedures {
 			mo = intToMo(((IConst) params.get(3).accept(visitor)).getValueAsInt());
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newDat3mCAS(reg, addr, expectedVal, desiredVal, mo))
-				.setCLine(visitor.currentLine)
-				.setSourceCodeFile(visitor.sourceCodeFile);
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 
 	private static void atomicThreadFence(VisitorBoogie visitor, Call_cmdContext ctx) {
 		String mo = intToMo(((IConst)ctx.call_params().exprs().expr().get(0).accept(visitor)).getValueAsInt());
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newFence(mo))
-				.setCLine(visitor.currentLine)
-				.setSourceCodeFile(visitor.sourceCodeFile);
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 	
 	private static void atomicCmpXchg(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -176,7 +169,6 @@ public class AtomicProcedures {
 			// (see issue #123 for an explanation)
 		}
 		visitor.programBuilder.addChild(visitor.threadCount, Atomic.newCompareExchange(reg, addr, expectedAddr, desiredVal, mo, strong))
-				.setCLine(visitor.currentLine)
-				.setSourceCodeFile(visitor.sourceCodeFile);
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LkmmProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LkmmProcedures.java
@@ -45,67 +45,56 @@ public class LkmmProcedures {
 		case "__LKMM_LOAD":
 			mo = Linux.intToMo(((IConst) p1).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newLKMMLoad(reg, (IExpr) p0, mo))
-	        		.setCLine(visitor.currentLine)
-	        		.setSourceCodeFile(visitor.sourceCodeFile);
+	        		.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	        return;
 		case "__LKMM_STORE":
 			mo = Linux.intToMo(((IConst) p2).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newLKMMStore((IExpr) p0, (IExpr) p1, mo.equals(Linux.MO_MB) ? Tag.Linux.MO_ONCE : mo))
-    				.setCLine(visitor.currentLine)
-    				.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	        if(mo.equals(Tag.Linux.MO_MB)){
 	            visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newMemoryBarrier())
-        				.setCLine(visitor.currentLine)
-        				.setSourceCodeFile(visitor.sourceCodeFile);
+						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	        }
 	        return;
 		case "__LKMM_XCHG":
 			mo = Linux.intToMo(((IConst) p2).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWExchange((IExpr) p0, reg, (IExpr) p1, mo))
-	        		.setCLine(visitor.currentLine)
-	        		.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 			return;
 		case "__LKMM_CMPXCHG":
 			mo = Linux.intToMo(((IConst) p3).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWCompareExchange((IExpr) p0, reg, (IExpr) p1, (IExpr) p2, mo))
-	        		.setCLine(visitor.currentLine)
-	        		.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 			return;
 		case "__LKMM_ATOMIC_FETCH_OP":
 			mo = Linux.intToMo(((IConst) p2).getValueAsInt());
 			op = IOpBin.intToOp(((IConst) p3).getValueAsInt());
 	        visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWFetchOp((IExpr) p0, reg, (IExpr) p1, op, mo))
-	        		.setCLine(visitor.currentLine)
-	        		.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 			return;
 		case "__LKMM_ATOMIC_OP_RETURN":
 			mo = Linux.intToMo(((IConst) p2).getValueAsInt());
 			op = IOpBin.intToOp(((IConst) p3).getValueAsInt());
 	        visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWOpReturn((IExpr) p0, reg, (IExpr) p1, op, mo))
-	        		.setCLine(visitor.currentLine)
-	        		.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 			return;
 		case "__LKMM_ATOMIC_OP":
 			op = IOpBin.intToOp(((IConst) p2).getValueAsInt());
 	        visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWOp((IExpr) p0, reg, (IExpr) p1, op))
-	        		.setCLine(visitor.currentLine)
-	        		.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 			return;
 		case "__LKMM_FENCE":
 			String fence = Linux.intToMo(((IConst) p0).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newLKMMFence(fence))
-					.setCLine(visitor.currentLine)
-					.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 			return;
 		case "__LKMM_SPIN_LOCK":
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newLock((IExpr) p0))
-					.setCLine(visitor.currentLine)
-					.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 			return;
 		case "__LKMM_SPIN_UNLOCK":
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newUnlock((IExpr) p0))
-					.setCLine(visitor.currentLine)
-					.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 			return;
 		default:
 			throw new UnsupportedOperationException(name + " procedure is not part of LKMMPROCEDURES");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LkmmProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LkmmProcedures.java
@@ -45,56 +45,56 @@ public class LkmmProcedures {
 		case "__LKMM_LOAD":
 			mo = Linux.intToMo(((IConst) p1).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newLKMMLoad(reg, (IExpr) p0, mo))
-	        		.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+	        		.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	        return;
 		case "__LKMM_STORE":
 			mo = Linux.intToMo(((IConst) p2).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newLKMMStore((IExpr) p0, (IExpr) p1, mo.equals(Linux.MO_MB) ? Tag.Linux.MO_ONCE : mo))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	        if(mo.equals(Tag.Linux.MO_MB)){
 	            visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newMemoryBarrier())
-						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	        }
 	        return;
 		case "__LKMM_XCHG":
 			mo = Linux.intToMo(((IConst) p2).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWExchange((IExpr) p0, reg, (IExpr) p1, mo))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 			return;
 		case "__LKMM_CMPXCHG":
 			mo = Linux.intToMo(((IConst) p3).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWCompareExchange((IExpr) p0, reg, (IExpr) p1, (IExpr) p2, mo))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 			return;
 		case "__LKMM_ATOMIC_FETCH_OP":
 			mo = Linux.intToMo(((IConst) p2).getValueAsInt());
 			op = IOpBin.intToOp(((IConst) p3).getValueAsInt());
 	        visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWFetchOp((IExpr) p0, reg, (IExpr) p1, op, mo))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 			return;
 		case "__LKMM_ATOMIC_OP_RETURN":
 			mo = Linux.intToMo(((IConst) p2).getValueAsInt());
 			op = IOpBin.intToOp(((IConst) p3).getValueAsInt());
 	        visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWOpReturn((IExpr) p0, reg, (IExpr) p1, op, mo))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 			return;
 		case "__LKMM_ATOMIC_OP":
 			op = IOpBin.intToOp(((IConst) p2).getValueAsInt());
 	        visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newRMWOp((IExpr) p0, reg, (IExpr) p1, op))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 			return;
 		case "__LKMM_FENCE":
 			String fence = Linux.intToMo(((IConst) p0).getValueAsInt());
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newLKMMFence(fence))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 			return;
 		case "__LKMM_SPIN_LOCK":
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newLock((IExpr) p0))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 			return;
 		case "__LKMM_SPIN_UNLOCK":
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Linux.newUnlock((IExpr) p0))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 			return;
 		default:
 			throw new UnsupportedOperationException(name + " procedure is not part of LKMMPROCEDURES");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
@@ -83,7 +83,7 @@ public class PthreadsProcedures {
 		visitor.pool.addMatcher(cc, matcher);
 		MemoryObject object = visitor.programBuilder.getOrNewObject(cc);
 		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newCreate(threadPtr, threadName, object))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(reg, IValue.ZERO));
 		}
 	
@@ -97,7 +97,7 @@ public class PthreadsProcedures {
         MemoryObject object = visitor.programBuilder.getOrNewObject(String.format("%s(%s)_active", visitor.pool.getPtrFromReg(callReg), visitor.pool.getCreatorFromPtr(visitor.pool.getPtrFromReg(callReg))));
         Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, null, ARCH_PRECISION);
         visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newJoin(visitor.pool.getPtrFromReg(callReg), reg, object))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 
 	private static void mutexInit(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -106,7 +106,7 @@ public class PthreadsProcedures {
 		IExpr value = (IExpr)ctx.call_params().exprs().expr(1).accept(visitor);
 		if(lockAddress != null) {
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newInitLock(lock.getText(), lockAddress, value))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());	
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);	
 		}
 	}
 	
@@ -116,7 +116,7 @@ public class PthreadsProcedures {
 		IExpr lockAddress = (IExpr)lock.accept(visitor);
 		if(lockAddress != null) {
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newLock(lock.getText(), lockAddress, register))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 		}
 	}
 	
@@ -126,7 +126,7 @@ public class PthreadsProcedures {
 		IExpr lockAddress = (IExpr)lock.accept(visitor);
 		if(lockAddress != null) {
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newUnlock(lock.getText(), lockAddress, register))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 		}
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
@@ -83,8 +83,7 @@ public class PthreadsProcedures {
 		visitor.pool.addMatcher(cc, matcher);
 		MemoryObject object = visitor.programBuilder.getOrNewObject(cc);
 		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newCreate(threadPtr, threadName, object))
-			.setCLine(visitor.currentLine)
-			.setSourceCodeFile(visitor.sourceCodeFile);
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(reg, IValue.ZERO));
 		}
 	
@@ -97,7 +96,8 @@ public class PthreadsProcedures {
 		}
         MemoryObject object = visitor.programBuilder.getOrNewObject(String.format("%s(%s)_active", visitor.pool.getPtrFromReg(callReg), visitor.pool.getCreatorFromPtr(visitor.pool.getPtrFromReg(callReg))));
         Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, null, ARCH_PRECISION);
-        visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newJoin(visitor.pool.getPtrFromReg(callReg), reg, object));
+        visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newJoin(visitor.pool.getPtrFromReg(callReg), reg, object))
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 
 	private static void mutexInit(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -105,7 +105,8 @@ public class PthreadsProcedures {
 		IExpr lockAddress = (IExpr)lock.accept(visitor);
 		IExpr value = (IExpr)ctx.call_params().exprs().expr(1).accept(visitor);
 		if(lockAddress != null) {
-			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newInitLock(lock.getText(), lockAddress, value));
+			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newInitLock(lock.getText(), lockAddress, value))
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());	
 		}
 	}
 	
@@ -114,7 +115,8 @@ public class PthreadsProcedures {
         Register register = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, null, ARCH_PRECISION);
 		IExpr lockAddress = (IExpr)lock.accept(visitor);
 		if(lockAddress != null) {
-			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newLock(lock.getText(), lockAddress, register));
+			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newLock(lock.getText(), lockAddress, register))
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 		}
 	}
 	
@@ -123,7 +125,8 @@ public class PthreadsProcedures {
         Register register = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, null, ARCH_PRECISION);
 		IExpr lockAddress = (IExpr)lock.accept(visitor);
 		if(lockAddress != null) {
-			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newUnlock(lock.getText(), lockAddress, register));
+			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newUnlock(lock.getText(), lockAddress, register))
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 		}
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
@@ -167,7 +167,7 @@ public class SvcompProcedures {
 		Register register = visitor.programBuilder.getRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + registerName);
 	    if(register != null){
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(register, new INonDet(type, register.getPrecision())))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	    }
 	}
 
@@ -176,13 +176,13 @@ public class SvcompProcedures {
 		Register register = visitor.programBuilder.getRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + registerName);
 	    if(register != null){
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(register, new BNonDet(register.getPrecision())))
-					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	    }
 	}
 
 	private static void __VERIFIER_loop_bound(VisitorBoogie visitor, Call_cmdContext ctx) {
 		int bound = ((IExpr)ctx.call_params().exprs().expr(0).accept(visitor)).reduce().getValueAsInt();
 		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Svcomp.newLoopBound(bound))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
@@ -167,8 +167,7 @@ public class SvcompProcedures {
 		Register register = visitor.programBuilder.getRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + registerName);
 	    if(register != null){
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(register, new INonDet(type, register.getPrecision())))
-					.setCLine(visitor.currentLine)
-					.setSourceCodeFile(visitor.sourceCodeFile);
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	    }
 	}
 
@@ -177,13 +176,13 @@ public class SvcompProcedures {
 		Register register = visitor.programBuilder.getRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + registerName);
 	    if(register != null){
 			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(register, new BNonDet(register.getPrecision())))
-					.setCLine(visitor.currentLine)
-					.setSourceCodeFile(visitor.sourceCodeFile);		
+					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	    }
 	}
 
 	private static void __VERIFIER_loop_bound(VisitorBoogie visitor, Call_cmdContext ctx) {
 		int bound = ((IExpr)ctx.call_params().exprs().expr(0).accept(visitor)).reduce().getValueAsInt();
-		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Svcomp.newLoopBound(bound));
+		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Svcomp.newLoopBound(bound))
+				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile, visitor.stackToString());
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -63,6 +63,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 
 	protected int currentLine= -1;
 	protected String sourceCodeFile = "";
+	protected Stack<String> callStack = new Stack<>();
 	
     private Label currentLabel = null;
     private final Map<Label, Label> pairLabels = new HashMap<>();
@@ -266,8 +267,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
         				Register register = programBuilder.getOrCreateRegister(threadCount, currentScope.getID() + ":" + ident.getText(), precision);
         				ExprInterface value = callingValues.get(index);
 						programBuilder.addChild(threadCount, EventFactory.newLocal(register, value))
-    							.setCLine(currentLine)
-    							.setSourceCodeFile(sourceCodeFile);
+								.setCFileInformation(currentLine, sourceCodeFile, stackToString());
         				index++;    					
     				}
     			}
@@ -378,9 +378,9 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 			throw new ParsingException("Procedure " + name + " is not defined");
 		}
 		FunCall call = EventFactory.newFunctionCall(name);
+		callStack.push(name);
 		programBuilder.addChild(threadCount, call)
-				.setCLine(currentLine)
-				.setSourceCodeFile(sourceCodeFile);	
+				.setCFileInformation(currentLine, sourceCodeFile, stackToString());
 		visitProc_decl(procedures.get(name), false, callingValues);
 		if(ctx.equals(atomicMode)) {
 			atomicMode = null;
@@ -391,9 +391,9 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 			}
 			
 		}
+		callStack.pop();
 		programBuilder.addChild(threadCount, EventFactory.newFunctionReturn(name))
-				.setCLine(call.getCLine())
-				.setSourceCodeFile(sourceCodeFile);
+				.setCFileInformation(currentLine, sourceCodeFile, stackToString());
 		if(name.equals("$initialize")) {
 			initMode = false;
 		}
@@ -438,30 +438,26 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 	        		}
 	        		// These events are eventually compiled and we need to compare its mo, thus it cannot be null
 	        		programBuilder.addChild(threadCount, EventFactory.newLoad(register, (IExpr)value, ""))
-	        				.setCLine(currentLine)
-	        				.setSourceCodeFile(sourceCodeFile);
+							.setCFileInformation(currentLine, sourceCodeFile, stackToString());
 		            continue;
 	        	}
 	        	value = value.visit(exprSimplifier);
 				programBuilder.addChild(threadCount, EventFactory.newLocal(register, value))
-						.setCLine(currentLine)
-						.setSourceCodeFile(sourceCodeFile);
+						.setCFileInformation(currentLine, sourceCodeFile, stackToString());
 	            continue;
 	        }
             MemoryObject object = programBuilder.getObject(name);
             if(object != null){
     			// These events are eventually compiled and we need to compare its mo, thus it cannot be null
 				programBuilder.addChild(threadCount, EventFactory.newStore(object, value, ""))
-						.setCLine(currentLine)
-						.setSourceCodeFile(sourceCodeFile);
+						.setCFileInformation(currentLine, sourceCodeFile, stackToString());
 	            continue;
 	        }
 	        if(currentReturnName.equals(name)) {
 	        	if(!returnRegister.isEmpty()) {
 	        		Register ret = returnRegister.remove(returnRegister.size() - 1);
 					programBuilder.addChild(threadCount, EventFactory.newLocal(ret, value))
-							.setCLine(currentLine)
-							.setSourceCodeFile(sourceCodeFile);
+							.setCFileInformation(currentLine, sourceCodeFile, stackToString());
 	        	}
 	        	continue;
 	        }
@@ -681,10 +677,8 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 				programBuilder.getOrNewObject(text).appendInitialValue(rhs,value.reduce());
 				return null;
 			}
-			// These events are eventually compiled and we need to compare its mo, thus it cannot be null
 			programBuilder.addChild(threadCount, EventFactory.newStore(address, value, ""))
-					.setCLine(currentLine)
-					.setSourceCodeFile(sourceCodeFile);	
+					.setCFileInformation(currentLine, sourceCodeFile, stackToString());
 			return null;
 		}
 		// push currentCall to the call stack
@@ -763,13 +757,25 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 		Register ass = programBuilder.getOrCreateRegister(threadCount, "assert_" + assertionIndex, expr.getPrecision());
     	assertionIndex++;
     	programBuilder.addChild(threadCount, EventFactory.newLocal(ass, expr))
-				.setCLine(currentLine)
-				.setSourceCodeFile(sourceCodeFile)
+				.setCFileInformation(currentLine, sourceCodeFile, stackToString())
 				.addFilters(Tag.ASSERTION);
        	Label end = programBuilder.getOrCreateLabel("END_OF_T" + threadCount);
 		CondJump jump = EventFactory.newJump(new Atom(ass, COpBin.NEQ, IValue.ONE), end);
 		jump.addFilters(Tag.EARLYTERMINATION);
 		programBuilder.addChild(threadCount, jump);
 		
+	}
+
+	protected String stackToString() {
+		StringBuilder strB = new StringBuilder();
+		Iterator<String> it = callStack.iterator();
+		while(it.hasNext()) {
+			String next = it.next();
+			strB.append(next);
+			if(it.hasNext()) {
+				strB.append(" -> \\n");
+			}
+		}
+		return strB.toString();
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
@@ -1,10 +1,11 @@
-package com.dat3m.dartagnan.program.processing;
+package com.dat3m.dartagnan.program.analysis;
 
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.core.annotations.FunCall;
 import com.dat3m.dartagnan.program.event.core.annotations.FunRet;
+
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 
@@ -13,25 +14,24 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Stack;
 
-public class CallStackAnalysis  implements ProgramProcessor {
+public class CallStackComputation  {
 	
 	private Map<Event, String> callStackMapping = new HashMap<>(); 
 
-    private CallStackAnalysis () { }
+    private CallStackComputation () { }
 
-    public static CallStackAnalysis  fromConfig(Configuration config) throws InvalidConfigurationException {
+    public static CallStackComputation  fromConfig(Configuration config) throws InvalidConfigurationException {
         return newInstance();
     }
 
-    public static CallStackAnalysis  newInstance() {
-        return new CallStackAnalysis ();
+    public static CallStackComputation  newInstance() {
+        return new CallStackComputation ();
     }
 
-	public Map<Event, String> getCallStackMappint() {
+	public Map<Event, String> getCallStackMapping() {
 		return callStackMapping;
 	}
 
-    @Override
     public void run(Program program) {
 
         for(Thread thread : program.getThreads()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
@@ -23,7 +23,6 @@ public abstract class Event implements Encoder, Comparable<Event> {
 
 	protected int cLine = -1;				// line in the original C program
 	protected String sourceCodeFile = "";	// filename of the original C program
-	protected String callStack = "";		// call stack of procedures
 
 	protected Thread thread; // The thread this event belongs to
 
@@ -45,7 +44,6 @@ public abstract class Event implements Encoder, Comparable<Event> {
         this.fId = other.fId;
         this.cLine = other.cLine;
         this.sourceCodeFile = other.sourceCodeFile;
-        this.callStack = other.callStack;
         this.filter = other.filter; // TODO: Dangerous code! A Copy-on-Write Set should be used (e.g. PersistentSet/Map)
         this.thread = other.thread;
     }
@@ -71,14 +69,9 @@ public abstract class Event implements Encoder, Comparable<Event> {
 		return sourceCodeFile;
 	}
 
-	public String getCallStack() {
-		return callStack;
-	}
-
-	public Event setCFileInformation(int line, String file, String callStack) {
+	public Event setCFileInformation(int line, String file) {
 		this.cLine = line;
 		this.sourceCodeFile = file;
-		this.callStack = callStack;
 		return this;
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
@@ -23,6 +23,7 @@ public abstract class Event implements Encoder, Comparable<Event> {
 
 	protected int cLine = -1;				// line in the original C program
 	protected String sourceCodeFile = "";	// filename of the original C program
+	protected String callStack = "";		// call stack of procedures
 
 	protected Thread thread; // The thread this event belongs to
 
@@ -44,6 +45,7 @@ public abstract class Event implements Encoder, Comparable<Event> {
         this.fId = other.fId;
         this.cLine = other.cLine;
         this.sourceCodeFile = other.sourceCodeFile;
+        this.callStack = other.callStack;
         this.filter = other.filter; // TODO: Dangerous code! A Copy-on-Write Set should be used (e.g. PersistentSet/Map)
         this.thread = other.thread;
     }
@@ -64,17 +66,19 @@ public abstract class Event implements Encoder, Comparable<Event> {
 	public int getCLine() {
 		return cLine;
 	}
-	public Event setCLine(int line) {
-		this.cLine = line;
-		return this;
-	}
-
+	
 	public String getSourceCodeFile() {
 		return sourceCodeFile;
 	}
 
-	public Event setSourceCodeFile(String name) {
-		this.sourceCodeFile = name;
+	public String getCallStack() {
+		return callStack;
+	}
+
+	public Event setCFileInformation(int line, String file, String callStack) {
+		this.cLine = line;
+		this.sourceCodeFile = file;
+		this.callStack = callStack;
 		return this;
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/CallStackAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/CallStackAnalysis.java
@@ -1,0 +1,68 @@
+package com.dat3m.dartagnan.program.processing;
+
+import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.core.annotations.FunCall;
+import com.dat3m.dartagnan.program.event.core.annotations.FunRet;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Stack;
+
+public class CallStackAnalysis  implements ProgramProcessor {
+	
+	private Map<Event, String> callStackMapping = new HashMap<>(); 
+
+    private CallStackAnalysis () { }
+
+    public static CallStackAnalysis  fromConfig(Configuration config) throws InvalidConfigurationException {
+        return newInstance();
+    }
+
+    public static CallStackAnalysis  newInstance() {
+        return new CallStackAnalysis ();
+    }
+
+	public Map<Event, String> getCallStackMappint() {
+		return callStackMapping;
+	}
+
+    @Override
+    public void run(Program program) {
+
+        for(Thread thread : program.getThreads()) {
+			Stack<String> callStack = new Stack<>();
+			Event current = thread.getEntry();
+			while (current != null) {
+				if(current instanceof FunCall) {
+					FunCall call = (FunCall)current;
+					callStack.push(call.getFunctionName());
+				}
+				if(current instanceof FunRet) {
+					callStack.pop();
+				}
+				if(current instanceof MemEvent) {
+					callStackMapping.put(current, stackToString(callStack));
+				}
+				current = current.getSuccessor();
+			}       
+		}
+    }
+
+	private String stackToString(Stack<String> s) {
+		StringBuilder strB = new StringBuilder();
+		Iterator<String> it = s.iterator();
+		while(it.hasNext()) {
+			String next = it.next();
+			strB.append(next);
+			if(it.hasNext()) {
+				strB.append(" -> \\n");
+			}
+		}
+		return strB.toString();
+	}
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/Compilation.java
@@ -141,8 +141,7 @@ public class Compilation implements ProgramProcessor {
                 e.setCId(nextId++);
                 e.setThread(thread);
                 e.setCFileInformation(toBeCompiled.getCLine(), 
-                                    toBeCompiled.getSourceCodeFile(),
-                                    toBeCompiled.getCallStack());
+                                    toBeCompiled.getSourceCodeFile());
                 pred.setSuccessor(e);
                 pred = e;
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/Compilation.java
@@ -140,8 +140,9 @@ public class Compilation implements ProgramProcessor {
                 e.setUId(toBeCompiled.getUId());
                 e.setCId(nextId++);
                 e.setThread(thread);
-                e.setCLine(toBeCompiled.getCLine());
-                e.setSourceCodeFile(toBeCompiled.getSourceCodeFile());
+                e.setCFileInformation(toBeCompiled.getCLine(), 
+                                    toBeCompiled.getSourceCodeFile(),
+                                    toBeCompiled.getCallStack());
                 pred.setSuccessor(e);
                 pred = e;
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -176,11 +176,12 @@ public class ExecutionGraphVisualizer {
             		String.format("W(%s, %d, %s)", address, value, mo) :
             		String.format("%d = R(%s, %s)", value, address, mo);
         }
-        return String.format("\"T%d:E%s (%s:L%d)\\n%s\"", 
+        return String.format("\"T%d:E%s (%s:L%d)\\n%s\\n%s\"", 
         				e.getThread().getId(), 
         				e.getEvent().getCId(), 
         				e.getEvent().getSourceCodeFile(), 
         				e.getEvent().getCLine(), 
+        				e.getEvent().getCallStack(), 
         				tag);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -35,14 +35,18 @@ public class ExecutionGraphVisualizer {
     private static final Logger logger = LogManager.getLogger(ExecutionGraphVisualizer.class);
 	
     private final Graphviz graphviz;
-    private final Map<Event, String> callStackMapping;
+    private Map<Event, String> callStackMapping;
     private BiPredicate<EventData, EventData> rfFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> coFilter = (x, y) -> true;
     private Map<BigInteger, IExpr> addresses = new HashMap<BigInteger, IExpr>();
 
-    public ExecutionGraphVisualizer(Map<Event, String> callStackMapping) {
+    public ExecutionGraphVisualizer() {
         this.graphviz = new Graphviz();
+    }
+
+    public ExecutionGraphVisualizer setCallStackMapping(Map<Event, String> callStackMapping) {
         this.callStackMapping = callStackMapping;
+        return this;
     }
 
     public ExecutionGraphVisualizer setReadFromFilter(BiPredicate<EventData, EventData> filter) {
@@ -197,7 +201,8 @@ public class ExecutionGraphVisualizer {
         fileVio.getParentFile().mkdirs();
         try (FileWriter writer = new FileWriter(fileVio)) {
             // Create .dot file
-            new ExecutionGraphVisualizer(callStackMapping)
+            new ExecutionGraphVisualizer()
+                    .setCallStackMapping(callStackMapping)
                     .setReadFromFilter(edgeFilter)
                     .setCoherenceFilter(edgeFilter)
                     .generateGraphOfExecutionModel(writer, "Iteration " + iterationCount, model);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -419,9 +419,9 @@ public class RefinementSolver extends ModelChecker {
         String directoryName = String.format("%s/refinement/%s-%s-debug/", System.getenv("DAT3M_OUTPUT"), programName, task.getProgram().getArch());
         String fileNameBase = String.format("%s-%d", programName, iterationCount);
         // File with reason edges only
-        generateGraphvizFile(model, iterationCount, edgeFilter, directoryName, fileNameBase);
+        generateGraphvizFile(model, iterationCount, edgeFilter, directoryName, fileNameBase, new HashMap<>());
         // File with all edges
-        generateGraphvizFile(model, iterationCount, (x,y) -> true, directoryName, fileNameBase + "-full");
+        generateGraphvizFile(model, iterationCount, (x,y) -> true, directoryName, fileNameBase + "-full", new HashMap<>());
     }
 
     private Wmm createDefaultWmm() {


### PR DESCRIPTION
Debugging large violation witnesses is hard when method calls are spawned over different files (or the same but large file). Assigning to each event the call stack that leads to its execution makes the debugging task easier.

This PR adds the stack call information to such events and the generated witness graphs.