### PR TITLE
336 (2)

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStoreExclusive.java
@@ -10,7 +10,6 @@ import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 
 public class RMWStoreExclusive extends Store {
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
@@ -4,8 +4,6 @@ import com.dat3m.dartagnan.program.event.arch.lisa.RMW;
 import com.dat3m.dartagnan.program.event.arch.tso.Xchg;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.core.annotations.CodeAnnotation;
-import com.dat3m.dartagnan.program.event.core.annotations.FunCall;
-import com.dat3m.dartagnan.program.event.core.annotations.FunRet;
 import com.dat3m.dartagnan.program.event.core.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.core.rmw.RMWStoreExclusive;
 import com.dat3m.dartagnan.program.event.core.rmw.StoreExclusive;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -547,10 +547,12 @@ class VisitorArm8 extends VisitorBase {
 	public List<Event> visitLKMMLock(LKMMLock e) {
 	Register dummy = e.getThread().newRegister(GlobalSettings.ARCH_PRECISION);
         // Spinlock events are guaranteed to succeed, i.e. we can use assumes
+        // With this we miss a ctrl dependency, but this does not matter
+        // becase the load is an acquire one.
 	return eventSequence(
                 newRMWLoadExclusive(dummy, e.getLock(), ARMv8.MO_ACQ),
                 newAssume(new Atom(dummy, COpBin.EQ, IValue.ZERO)),
-                newRMWStoreExclusive(e.getLock(), IValue.ONE, ARMv8.MO_RX, true)
+                newRMWStoreExclusive(e.getLock(), IValue.ONE, "", true)
         );
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -1,7 +1,9 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
+import com.dat3m.dartagnan.GlobalSettings;
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.BOpUn;
+import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventFactory.*;
@@ -300,6 +302,18 @@ class VisitorArm8 extends VisitorBase {
 			case Tag.Linux.AFTER_ATOMIC:
 				optionalMemoryBarrier = AArch64.DMB.newISHBarrier();
 				break;
+                        // #define smp_mb__after_spinlock()	smp_mb()       
+                        //        https://elixir.bootlin.com/linux/v6.1/source/arch/arm64/include/asm/spinlock.h#L12
+                        case Tag.Linux.AFTER_SPINLOCK:
+                                optionalMemoryBarrier = AArch64.DSB.newISHBarrier();
+                                break;
+                        // #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
+                        // https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
+                        // It seem to be only used for RCU related stuff in the kernel so it makes sense
+                        // it is defined in that header file
+                        case Tag.Linux.AFTER_UNLOCK_LOCK:
+                                optionalMemoryBarrier = AArch64.DSB.newISHBarrier();
+                                break;
 			default:
 				throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
 		}
@@ -528,4 +542,23 @@ class VisitorArm8 extends VisitorBase {
                 testOp
         );	
 	};
+
+        @Override
+	public List<Event> visitLKMMLock(LKMMLock e) {
+	Register dummy = e.getThread().newRegister(GlobalSettings.ARCH_PRECISION);
+        // Spinlock events are guaranteed to succeed, i.e. we can use assumes
+	return eventSequence(
+                newRMWLoadExclusive(dummy, e.getLock(), ARMv8.MO_ACQ),
+                newAssume(new Atom(dummy, COpBin.EQ, IValue.ZERO)),
+                newRMWStoreExclusive(e.getLock(), IValue.ONE, ARMv8.MO_RX, true)
+        );
+	}
+
+        @Override
+	public List<Event> visitLKMMUnlock(LKMMUnlock e) {
+	return eventSequence(
+                newStore(e.getAddress(), IValue.ZERO, ARMv8.MO_REL)
+        );
+	}
+
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -303,12 +303,12 @@ class VisitorArm8 extends VisitorBase {
 				optionalMemoryBarrier = AArch64.DMB.newISHBarrier();
 				break;
                         // #define smp_mb__after_spinlock()	smp_mb()       
-                        //        https://elixir.bootlin.com/linux/v6.1/source/arch/arm64/include/asm/spinlock.h#L12
+                        //              https://elixir.bootlin.com/linux/v6.1/source/arch/arm64/include/asm/spinlock.h#L12
                         case Tag.Linux.AFTER_SPINLOCK:
                                 optionalMemoryBarrier = AArch64.DSB.newISHBarrier();
                                 break;
                         // #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
-                        // https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
+                        //              https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
                         // It seem to be only used for RCU related stuff in the kernel so it makes sense
                         // it is defined in that header file
                         case Tag.Linux.AFTER_UNLOCK_LOCK:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -774,7 +774,7 @@ public class VisitorPower extends VisitorBase {
 				newRMWLoadExclusive(dummy, e.getLock(), ""),
                 newAssume(new Atom(dummy, COpBin.EQ, IValue.ZERO)),
                 Power.newRMWStoreConditional(e.getLock(), IValue.ONE, "", true),
-				// Fake depedency to guarantee acquire semantics
+				// Fake dependency to guarantee acquire semantics
 				newFakeCtrlDep(dummy, label),
 				label,
 				Power.newISyncBarrier()

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -1,7 +1,9 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
+import com.dat3m.dartagnan.GlobalSettings;
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.BOpUn;
+import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventFactory.*;
@@ -14,6 +16,7 @@ import com.dat3m.dartagnan.program.event.lang.pthread.Create;
 import com.dat3m.dartagnan.program.event.lang.pthread.End;
 import com.dat3m.dartagnan.program.event.lang.pthread.Join;
 import com.dat3m.dartagnan.program.event.lang.pthread.Start;
+
 
 import java.util.List;
 
@@ -469,6 +472,18 @@ public class VisitorPower extends VisitorBase {
 			case Tag.Linux.AFTER_ATOMIC:
 				optionalMemoryBarrier = Power.newSyncBarrier();
 				break;
+        	// #define smp_mb__after_spinlock()	smp_mb()       
+            //        https://elixir.bootlin.com/linux/v6.1/source/arch/powerpc/include/asm/spinlock.h#L14
+            case Tag.Linux.AFTER_SPINLOCK:
+				optionalMemoryBarrier = Power.newSyncBarrier();
+				break;
+            // #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
+            // https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
+            // It seem to be only used for RCU related stuff in the kernel so it makes sense
+            // it is defined in that header file
+            case Tag.Linux.AFTER_UNLOCK_LOCK:
+				optionalMemoryBarrier = Power.newSyncBarrier();
+                break;
 			default:
 				throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
 		}
@@ -751,6 +766,30 @@ public class VisitorPower extends VisitorBase {
         );
 	};
 	
+	@Override
+	public List<Event> visitLKMMLock(LKMMLock e) {
+	Register dummy = e.getThread().newRegister(GlobalSettings.ARCH_PRECISION);
+	Label label = newLabel("FakeDep");
+    // Spinlock events are guaranteed to succeed, i.e. we can use assumes
+	return eventSequence(
+				newRMWLoadExclusive(dummy, e.getLock(), ""),
+                newAssume(new Atom(dummy, COpBin.EQ, IValue.ZERO)),
+                Power.newRMWStoreConditional(e.getLock(), IValue.ONE, "", true),
+				// Fake depedency to guarantee acquire semantics
+				newFakeCtrlDep(dummy, label),
+				label,
+				Power.newISyncBarrier()
+        );
+	}
+
+        @Override
+	public List<Event> visitLKMMUnlock(LKMMUnlock e) {
+	return eventSequence(
+				Power.newLwSyncBarrier(),
+                newStore(e.getAddress(), IValue.ZERO, "")
+        );
+	}
+
 	public enum PowerScheme {
 
 		LEADING_SYNC, TRAILING_SYNC;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -17,7 +17,6 @@ import com.dat3m.dartagnan.program.event.lang.pthread.End;
 import com.dat3m.dartagnan.program.event.lang.pthread.Join;
 import com.dat3m.dartagnan.program.event.lang.pthread.Start;
 
-
 import java.util.List;
 
 import static com.dat3m.dartagnan.expression.op.COpBin.EQ;
@@ -473,12 +472,12 @@ public class VisitorPower extends VisitorBase {
 				optionalMemoryBarrier = Power.newSyncBarrier();
 				break;
         	// #define smp_mb__after_spinlock()	smp_mb()       
-            //        https://elixir.bootlin.com/linux/v6.1/source/arch/powerpc/include/asm/spinlock.h#L14
+            // 		https://elixir.bootlin.com/linux/v6.1/source/arch/powerpc/include/asm/spinlock.h#L14
             case Tag.Linux.AFTER_SPINLOCK:
 				optionalMemoryBarrier = Power.newSyncBarrier();
 				break;
             // #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
-            // https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
+            // 		https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
             // It seem to be only used for RCU related stuff in the kernel so it makes sense
             // it is defined in that header file
             case Tag.Linux.AFTER_UNLOCK_LOCK:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -19,7 +19,6 @@ import com.dat3m.dartagnan.program.event.lang.pthread.Join;
 import com.dat3m.dartagnan.program.event.lang.pthread.Start;
 
 import com.dat3m.dartagnan.GlobalSettings;
-
 import java.util.List;
 
 import static com.dat3m.dartagnan.expression.op.COpBin.EQ;
@@ -299,16 +298,16 @@ class VisitorRISCV extends VisitorBase {
 				optionalMemoryBarrier = RISCV.newWWFence();
 				break;
 			// ##define smp_mb__after_spinlock()	RISCV_FENCE(iorw,iorw)    
-            //        https://elixir.bootlin.com/linux/v6.1/source/arch/riscv/include/asm/barrier.h#L72
+            // 		https://elixir.bootlin.com/linux/v6.1/source/arch/riscv/include/asm/barrier.h#L72
 			// RISCV_FENCE(iorw,iorw) imposes ordering both on devices and memory
-			// 		  https://github.com/westerndigitalcorporation/RISC-V-Linux/blob/master/linux/arch/riscv/include/asm/barrier.h
+			// 		https://github.com/westerndigitalcorporation/RISC-V-Linux/blob/master/linux/arch/riscv/include/asm/barrier.h
 			// Since the memory model says nothing about devices, we use RISCV_FENCE(rw,rw) which I think
 			// gives the ordering we want wrt. memory
             case Tag.Linux.AFTER_SPINLOCK:
 				optionalMemoryBarrier = RISCV.newRWRWFence();
 				break;
             // #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
-            // https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
+            // 		https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
             // It seem to be only used for RCU related stuff in the kernel so it makes sense
             // it is defined in that header file
             case Tag.Linux.AFTER_UNLOCK_LOCK:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing.compilation;
 
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.BOpUn;
+import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventFactory.*;
@@ -16,6 +17,8 @@ import com.dat3m.dartagnan.program.event.lang.pthread.Create;
 import com.dat3m.dartagnan.program.event.lang.pthread.End;
 import com.dat3m.dartagnan.program.event.lang.pthread.Join;
 import com.dat3m.dartagnan.program.event.lang.pthread.Start;
+
+import com.dat3m.dartagnan.GlobalSettings;
 
 import java.util.List;
 
@@ -295,6 +298,22 @@ class VisitorRISCV extends VisitorBase {
 			case Tag.Linux.MO_WMB:
 				optionalMemoryBarrier = RISCV.newWWFence();
 				break;
+			// ##define smp_mb__after_spinlock()	RISCV_FENCE(iorw,iorw)    
+            //        https://elixir.bootlin.com/linux/v6.1/source/arch/riscv/include/asm/barrier.h#L72
+			// RISCV_FENCE(iorw,iorw) imposes ordering both on devices and memory
+			// 		  https://github.com/westerndigitalcorporation/RISC-V-Linux/blob/master/linux/arch/riscv/include/asm/barrier.h
+			// Since the memory model says nothing about devices, we use RISCV_FENCE(rw,rw) which I think
+			// gives the ordering we want wrt. memory
+            case Tag.Linux.AFTER_SPINLOCK:
+				optionalMemoryBarrier = RISCV.newRWRWFence();
+				break;
+            // #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
+            // https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
+            // It seem to be only used for RCU related stuff in the kernel so it makes sense
+            // it is defined in that header file
+            case Tag.Linux.AFTER_UNLOCK_LOCK:
+				optionalMemoryBarrier = RISCV.newRWRWFence();
+				break;
 			default:
 				throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
 		}
@@ -552,4 +571,26 @@ class VisitorRISCV extends VisitorBase {
                 testOp
         );	
 	};
+
+	@Override
+	public List<Event> visitLKMMLock(LKMMLock e) {
+	Register dummy = e.getThread().newRegister(GlobalSettings.ARCH_PRECISION);
+    // From this "unofficial" source (there is no RISCV specific implementation in the kernel)
+	// 		https://github.com/westerndigitalcorporation/RISC-V-Linux/blob/master/linux/arch/riscv/include/asm/spinlock.h
+	// We replace AMO instructions with LL/SC
+	return eventSequence(
+				newRMWLoadExclusive(dummy, e.getLock(), ""),
+                newAssume(new Atom(dummy, COpBin.EQ, IValue.ZERO)),
+                newRMWStoreExclusive(e.getLock(), IValue.ONE, "", true),
+				RISCV.newRRWFence()
+        );
+	}
+
+    @Override
+	public List<Event> visitLKMMUnlock(LKMMUnlock e) {
+	return eventSequence(
+				RISCV.newRWWFence(),
+				newStore(e.getAddress(), IValue.ZERO, "")
+        );
+	}
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -129,12 +129,10 @@ public abstract class AbstractCompilationTest {
     	// The following have features (locks and RCU) that hardware models do not support
     	FilterAbstract rcu = FilterUnion.get(FilterBasic.get(Tag.Linux.RCU_LOCK), 
     			FilterUnion.get(FilterBasic.get(Tag.Linux.RCU_UNLOCK), FilterBasic.get(Tag.Linux.RCU_SYNC)));
-    	FilterAbstract lock = FilterUnion.get(FilterBasic.get(Tag.Linux.LOCK_READ), 
-    			FilterUnion.get(FilterBasic.get(Tag.Linux.LOCK_WRITE), FilterBasic.get(Tag.Linux.UNLOCK)));
     	
     	Result expected = getCompilationBreakers().contains(path) ? Result.FAIL : Result.PASS;
     	
-    	if(task1Provider.get().getProgram().getCache().getEvents(FilterUnion.get(rcu, lock)).isEmpty()) {
+    	if(task1Provider.get().getProgram().getCache().getEvents(rcu).isEmpty()) {
             IncrementalSolver s1 = IncrementalSolver.run(context1Provider.get(), prover1Provider.get(), task1Provider.get());
         	if(s1.getResult().equals(Result.PASS)) {
                 IncrementalSolver s2 = IncrementalSolver.run(context2Provider.get(), prover2Provider.get(), task2Provider.get());


### PR DESCRIPTION
This PR implements the second part of #336, i.e., it allows to compile LKMM locks to hardware.
Now there is no need to exclude the litmus tests containing locks from the compilation tests.

The hardware implementation is more from a modeling perspective (i.e., I don't expect bugs in real simple spinloops implementation in the kernel) meaning that this would allow us to target verification of real kernel code which uses simple spinloops under hardware architectures.