### PR TITLE
Guarantee always correct acquire semantics for loads related to pthread_join

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
@@ -2,14 +2,15 @@ package com.dat3m.dartagnan.program.event.lang.pthread;
 
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.Local;
+import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.expression.IExpr;
 
-public class Join extends Local {
+public class Join extends Load {
 
     public Join(Register reg, IExpr expr) {
-    	super(reg, expr);
+        // We will set the correct (C11 or LKMM) acquire tag (or barriers) when the event is compiled
+    	super(reg, expr, "");
         addFilters(Tag.C11.PTHREAD);
     }
 
@@ -19,7 +20,7 @@ public class Join extends Local {
 
     @Override
     public String toString() {
-        return "pthread_join(" + expr + ")";
+        return "pthread_join(" + getAddress() + ")";
     }
 
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
@@ -47,7 +47,7 @@ public interface EventVisitor<T> {
 	default T visitCreate(Create e) { return visitStore(e); }
 	default T visitEnd(End e) { return visitStore(e); }
 	default T visitInitLock(InitLock e) { return visitStore(e); }
-	default T visitJoin(Join e) { return visitLocal(e); }
+	default T visitJoin(Join e) { return visitLoad(e); }
 	default T visitLock(Lock e) { return visitMemEvent(e); }
 	default T visitStart(Start e) { return visitLoad(e); }
 	default T visitUnlock(Unlock e) { return visitMemEvent(e); }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -41,9 +41,11 @@ public class VisitorC11 extends VisitorBase {
         @Override
         public List<Event> visitJoin(Join e) {
                 Register resultRegister = e.getResultRegister();
+                Load load = newLoad(resultRegister, e.getAddress(), Tag.C11.MO_ACQUIRE);
+                load.addFilters(C11.PTHREAD);
 
                 return tagList(eventSequence(
-                                newLocal(resultRegister, e.getExpr()),
+                                load,
                                 newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit())));
         }
 
@@ -56,8 +58,7 @@ public class VisitorC11 extends VisitorBase {
                 return tagList(eventSequence(
                                 load,
                                 super.visitStart(e),
-                                newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE),
-                                                (Label) e.getThread().getExit())));
+                                newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit())));
         }
 
         @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
@@ -30,39 +30,34 @@ public class VisitorLKMM extends VisitorBase {
 		super(forceStart);
         }
 	
-	@Override
-	public List<Event> visitCreate(Create e) {
-        Store store = newStore(e.getAddress(), e.getMemValue(), Tag.Linux.MO_RELEASE);
-        store.addFilters(C11.PTHREAD);
+        @Override
+        public List<Event> visitCreate(Create e) {
+                Store store = newStore(e.getAddress(), e.getMemValue(), Tag.Linux.MO_RELEASE);
+                store.addFilters(C11.PTHREAD);
 
-        return eventSequence(
-        		Linux.newMemoryBarrier(),
-                store
-        );
-	}
+                return eventSequence(
+                                store);
+        }
 
-	@Override
-	public List<Event> visitEnd(End e) {
-        return eventSequence(
-        		Linux.newMemoryBarrier(),
-                newStore(e.getAddress(), IValue.ZERO, Tag.Linux.MO_RELEASE)
-        );
-	}
+        @Override
+        public List<Event> visitEnd(End e) {
+                return eventSequence(
+                                newStore(e.getAddress(), IValue.ZERO, Tag.Linux.MO_RELEASE));
+        }
 
-	@Override
+    @Override
 	public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-	Local load = newLocal(resultRegister, e.getExpr());
+        Load load = newLoad(resultRegister, e.getAddress(), Tag.Linux.MO_ACQUIRE);
         load.addFilters(C11.PTHREAD);
         
         return eventSequence(
         		load,
-        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit()),
-        		Linux.newMemoryBarrier()
+        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit())
         );
 	}
 
-	@Override
+    @Override
 	public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
         Load load = newLoad(resultRegister, e.getAddress(), Tag.Linux.MO_ACQUIRE);
@@ -70,9 +65,8 @@ public class VisitorLKMM extends VisitorBase {
 
         return eventSequence(
         		load,
-				super.visitStart(e),
-        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit()),
-            	Linux.newMemoryBarrier()
+			super.visitStart(e),
+        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit())
         );
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -64,7 +64,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-		Local load = newLocal(resultRegister, e.getExpr());
+		Load load = newLoad(resultRegister, e.getAddress(), "");
         load.addFilters(C11.PTHREAD);
         Label label = newLabel("Jump_" + e.getOId());
         CondJump fakeCtrlDep = newFakeCtrlDep(resultRegister, label);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -24,49 +24,45 @@ class VisitorTso extends VisitorBase {
                 super(forceStart);
         }
 
-	@Override
-	public List<Event> visitCreate(Create e) {
-        Store store = newStore(e.getAddress(), e.getMemValue(), e.getMo());
-        store.addFilters(C11.PTHREAD);
-        
-        return eventSequence(
-                store,
-                X86.newMemoryFence()
-        );
-	}
+        @Override
+        public List<Event> visitCreate(Create e) {
+                Store store = newStore(e.getAddress(), e.getMemValue(), "");
+                store.addFilters(C11.PTHREAD);
 
-	@Override
-	public List<Event> visitEnd(End e) {
-        return eventSequence(
-        		newStore(e.getAddress(), IValue.ZERO, e.getMo()),
-                X86.newMemoryFence()
-        );
-	}
+                return eventSequence(
+                                store,
+                                X86.newMemoryFence());
+        }
 
-	@Override
-	public List<Event> visitJoin(Join e) {
-        Register resultRegister = e.getResultRegister();
-	Local load = newLocal(resultRegister, e.getExpr());
-        load.addFilters(C11.PTHREAD);
-        
-        return eventSequence(
-        		load,
-        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit())
-        );
-	}
+        @Override
+        public List<Event> visitEnd(End e) {
+                return eventSequence(
+                                newStore(e.getAddress(), IValue.ZERO, ""),
+                                X86.newMemoryFence());
+        }
 
-	@Override
-	public List<Event> visitStart(Start e) {
-        Register resultRegister = e.getResultRegister();
-        Load load = newLoad(resultRegister, e.getAddress(), e.getMo());
-        load.addFilters(Tag.STARTLOAD);
-        
-        return eventSequence(
-        		load,
-				super.visitStart(e),
-				newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit())
-        );
-	}
+        @Override
+        public List<Event> visitJoin(Join e) {
+                Register resultRegister = e.getResultRegister();
+                Load load = newLoad(resultRegister, e.getAddress(), "");
+                load.addFilters(C11.PTHREAD);
+
+                return eventSequence(
+                                load,
+                                newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit()));
+        }
+
+        @Override
+        public List<Event> visitStart(Start e) {
+                Register resultRegister = e.getResultRegister();
+                Load load = newLoad(resultRegister, e.getAddress(), "");
+                load.addFilters(Tag.STARTLOAD);
+
+                return eventSequence(
+                                load,
+                                super.visitStart(e),
+                                newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit()));
+        }
 
 	@Override
 	public List<Event> visitXchg(Xchg e) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -30,15 +30,13 @@ class VisitorTso extends VisitorBase {
                 store.addFilters(C11.PTHREAD);
 
                 return eventSequence(
-                                store,
-                                X86.newMemoryFence());
+                                store);
         }
 
         @Override
         public List<Event> visitEnd(End e) {
                 return eventSequence(
-                                newStore(e.getAddress(), IValue.ZERO, ""),
-                                X86.newMemoryFence());
+                                newStore(e.getAddress(), IValue.ZERO, ""));
         }
 
         @Override


### PR DESCRIPTION
With #332 we broke the acquire semantics of loads related to joins under LKMM.
This is because we were always using `C11.ACQ` as a tag which LKMM does not understand.
I also simplified the compilation of create/start/end/join events: we don't need that many fences / `SC` semantics ... `ACQ/REL` is enough.