### PR TITLE
Avoid deadlock in Compilation.runCmd

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -62,8 +62,14 @@ public class Compilation {
 	}
 
 	private static File runCmd(ArrayList<String> cmd, String outputFileName) throws Exception {
-		ProcessBuilder processBuilder = new ProcessBuilder(cmd);
     	logger.debug(String.join(" ", cmd));
+		ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+		// "Unless the standard input and output streams are promptly written and read respectively 
+		// of the sub process, it may block or deadlock the sub process."
+		//		https://www.developer.com/design/understanding-java-process-and-java-processbuilder/
+		// The lines below take care of this.
+		processBuilder.redirectErrorStream(true);
+		processBuilder.redirectOutput(File.createTempFile("log", null));		
     	Process proc = processBuilder.start();
     	proc.waitFor();
     	if(proc.exitValue() == 1) {


### PR DESCRIPTION
I was experiencing a deadlock when creating a process to take care of compiling the file. I found out that this is possible when the input and output streams are promptly written and read respectively of the sub process (which seems to happen when trying to compile large files).

This PR solves this problem.