### PR TITLE
Read error msg from log file

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -1,16 +1,12 @@
 package com.dat3m.dartagnan.parsers.program.utils;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
+import com.google.common.io.Files;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import java.io.File;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import static java.util.Arrays.asList;
 
 public class Compilation {
@@ -68,12 +64,13 @@ public class Compilation {
 		// of the sub process, it may block or deadlock the sub process."
 		//		https://www.developer.com/design/understanding-java-process-and-java-processbuilder/
 		// The lines below take care of this.
+		File log = File.createTempFile("log", null);
 		processBuilder.redirectErrorStream(true);
-		processBuilder.redirectOutput(File.createTempFile("log", null));		
+		processBuilder.redirectOutput(log);
     	Process proc = processBuilder.start();
     	proc.waitFor();
     	if(proc.exitValue() == 1) {
-    		String errorString = CharStreams.toString(new InputStreamReader(proc.getErrorStream(), Charsets.UTF_8));
+			String errorString =  Files.asCharSource(log, Charsets.UTF_8).read();
 			throw new Exception(errorString);
     	}
 		return new File(outputFileName);	


### PR DESCRIPTION
The changes in #343 redirect the error msg to the log file. This makes the input stream (from which we used to read the error msg) empty, thus making it hard to understand from the console what the problem was.

This PR makes the error msg be read from the log file.