### PR TITLE
Improvements

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
@@ -42,7 +42,8 @@ public class PthreadsProcedures {
 			pthread_create(visitor, ctx);
 			break;
 		case "pthread_join":
-			pthread_join(visitor, ctx);
+			// VisitorBoogie already took care of creating the join event
+			// when it parsed the previous load.
 			break;
 		case "pthread_cond_init":
 		case "pthread_cond_wait":
@@ -87,13 +88,6 @@ public class PthreadsProcedures {
 		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(reg, IValue.ZERO));
 		}
 	
-	private static void pthread_join(VisitorBoogie visitor, Call_cmdContext ctx) {
-		Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText(), ARCH_PRECISION);
-		IExpr expr = (IExpr)ctx.call_params().exprs().expr().get(0).accept(visitor);
-        visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newJoin(reg, expr))
-				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-	}
-
 	private static void mutexInit(VisitorBoogie visitor, Call_cmdContext ctx) {
 		ExprContext lock = ctx.call_params().exprs().expr(0);
 		IExpr lockAddress = (IExpr)lock.accept(visitor);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -471,7 +471,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 	public Object visitAssume_cmd(Assume_cmdContext ctx) {
 		if(ctx.getText().contains("sourceloc")) {
 			String line = ctx.getText();
-			sourceCodeFile = line.substring(line.lastIndexOf('/') + 1, line.indexOf(',') - 1);
+			sourceCodeFile = line.substring(line.indexOf('\"') + 1, line.indexOf(',') - 1);
 			currentLine = Integer.parseInt(line.substring(line.indexOf(',') + 1, line.lastIndexOf(',')));
 		}
 		// We can get rid of all the "assume true" statements

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
@@ -22,7 +22,7 @@ public class RMW extends MemEvent implements RegWriter, RegReaderData {
         super(address, mo);
 		this.resultRegister = register;
         this.value = value;
-        addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, RMW, REG_WRITER, REG_READER);
+        addFilters(READ, WRITE, RMW, REG_WRITER, REG_READER);
     }
 
     private RMW(RMW other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -18,7 +18,7 @@ public class Xchg extends MemEvent implements RegWriter, RegReaderData {
     public Xchg(MemoryObject address, Register register) {
         super(address, "");
         this.resultRegister = register;
-        addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, TSO.ATOM, REG_WRITER, REG_READER);
+        addFilters(READ, WRITE, TSO.ATOM, REG_WRITER, REG_READER);
     }
 
     private Xchg(Xchg other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -19,7 +19,7 @@ public class Init extends MemEvent {
 		super(b.add(o), "");
 		base = b;
 		offset = o;
-		addFilters(Tag.ANY, Tag.VISIBLE, Tag.MEMORY, Tag.WRITE, Tag.INIT);
+		addFilters(Tag.WRITE, Tag.INIT);
 	}
 
 	/**

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -14,7 +14,7 @@ public class Load extends MemEvent implements RegWriter {
     public Load(Register register, IExpr address, String mo) {
         super(address, mo);
         this.resultRegister = register;
-        addFilters(Tag.ANY, Tag.VISIBLE, Tag.MEMORY, Tag.READ, Tag.REG_WRITER);
+        addFilters(Tag.READ, Tag.REG_WRITER);
     }
     
     protected Load(Load other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
@@ -6,6 +6,8 @@ import com.dat3m.dartagnan.program.event.Tag.C11;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
+import static com.dat3m.dartagnan.program.event.Tag.*;
+
 public abstract class MemEvent extends Event {
 
     protected IExpr address;
@@ -16,6 +18,7 @@ public abstract class MemEvent extends Event {
     	Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;
         this.mo = mo;
+        addFilters(ANY, VISIBLE, MEMORY);
         if(!mo.isEmpty()){
             addFilters(mo);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -15,7 +15,7 @@ public class Store extends MemEvent implements RegReaderData {
     public Store(IExpr address, ExprInterface value, String mo){
     	super(address, mo);
         this.value = value;
-        addFilters(Tag.ANY, Tag.VISIBLE, Tag.MEMORY, Tag.WRITE, Tag.REG_READER);
+        addFilters(Tag.WRITE, Tag.REG_READER);
     }
     
     protected Store(Store other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -22,7 +22,7 @@ public abstract class AtomicAbstract extends MemEvent implements RegWriter, RegR
         Preconditions.checkArgument(!mo.isEmpty(), "Atomic events cannot have empty memory order");
         this.resultRegister = register;
         this.value = value;
-        addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, RMW, REG_WRITER, REG_READER);
+        addFilters(READ, WRITE, RMW, REG_WRITER, REG_READER);
     }
 
     AtomicAbstract(AtomicAbstract other) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -20,7 +20,7 @@ public class AtomicLoad extends MemEvent implements RegWriter {
     	Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),
     			getClass().getName() + " can not have memory order: " + mo);
         this.resultRegister = register;
-        addFilters(ANY, VISIBLE, MEMORY, READ, REG_WRITER);
+        addFilters(READ, REG_WRITER);
     }
 
     private AtomicLoad(AtomicLoad other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -22,7 +22,7 @@ public class AtomicStore extends MemEvent implements RegReaderData {
         Preconditions.checkArgument(!mo.equals(MO_ACQUIRE) && !mo.equals(MO_ACQUIRE_RELEASE),
         		getClass().getName() + " can not have memory order: " + mo);
         this.value = value;
-        addFilters(ANY, VISIBLE, MEMORY, WRITE, REG_READER);
+        addFilters(WRITE, REG_READER);
     }
 
     private AtomicStore(AtomicStore other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -20,7 +20,7 @@ public abstract class RMWAbstract extends MemEvent implements RegWriter, RegRead
         super(address, mo);
         this.resultRegister = register;
         this.value = value;
-        addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, RMW, REG_WRITER, REG_READER);
+        addFilters(READ, WRITE, RMW, REG_WRITER, REG_READER);
     }
 
     RMWAbstract(RMWAbstract other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -22,7 +22,7 @@ public abstract class LlvmAbstractRMW extends MemEvent implements RegWriter, Reg
         Preconditions.checkArgument(!mo.isEmpty(), "LLVM events cannot have empty memory order");
         this.resultRegister = register;
         this.value = value;
-        addFilters(ANY, VISIBLE, MEMORY, READ, WRITE, RMW, REG_WRITER, REG_READER);
+        addFilters(READ, WRITE, RMW, REG_WRITER, REG_READER);
     }
 
     LlvmAbstractRMW(LlvmAbstractRMW other) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -20,7 +20,7 @@ public class LlvmLoad extends MemEvent implements RegWriter {
     	Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),
     			getClass().getName() + " cannot have memory order: " + mo);
         this.resultRegister = register;
-        addFilters(ANY, VISIBLE, MEMORY, READ, REG_WRITER);
+        addFilters(READ, REG_WRITER);
     }
 
     private LlvmLoad(LlvmLoad other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -22,7 +22,7 @@ public class LlvmStore extends MemEvent implements RegReaderData {
         Preconditions.checkArgument(!mo.equals(MO_ACQUIRE) && !mo.equals(MO_ACQUIRE_RELEASE),
         		getClass().getName() + " cannot have memory order: " + mo);
         this.value = value;
-        addFilters(ANY, VISIBLE, MEMORY, WRITE, REG_READER);
+        addFilters(WRITE, REG_READER);
     }
 
     private LlvmStore(LlvmStore other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan.utils.visualization;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.verification.model.EventData;
@@ -128,7 +129,7 @@ public class ExecutionGraphVisualizer {
 
     private ExecutionGraphVisualizer addThreadPo(Thread thread, ExecutionModel model) {
         List<EventData> threadEvents = model.getThreadEventsMap().get(thread)
-            .stream().filter(e -> e.isMemoryEvent() || e.isFence()).collect(Collectors.toList());
+            .stream().filter(e -> e.is(Tag.VISIBLE)).collect(Collectors.toList());
         if (threadEvents.size() <= 1) {
             return this;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -176,10 +176,11 @@ public class ExecutionGraphVisualizer {
         if(e.isMemoryEvent()) {
             Object address = addresses.get(e.getAccessedAddress());
             BigInteger value = e.getValue();
-        	String mo = ofNullable(((MemEvent)e.getEvent()).getMo()).orElse(C11.NONATOMIC);
+        	String mo = ((MemEvent)e.getEvent()).getMo();
+            mo = mo.isEmpty() ? mo : ", " + mo;
             tag = e.isWrite() ?
-            		String.format("W(%s, %d, %s)", address, value, mo) :
-            		String.format("%d = R(%s, %s)", value, address, mo);
+            		String.format("W(%s, %d%s)", address, value, mo) :
+            		String.format("%d = R(%s%s)", value, address, mo);
         }
         return String.format("\"T%d:E%s (%s:L%d)\\n%s%s\"", 
         				e.getThread().getId(), 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -3,13 +3,10 @@ package com.dat3m.dartagnan.utils.visualization;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
-import com.dat3m.dartagnan.program.event.Tag.C11;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.verification.model.EventData;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
-
-import static java.util.Optional.ofNullable;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -131,7 +128,7 @@ public class ExecutionGraphVisualizer {
 
     private ExecutionGraphVisualizer addThreadPo(Thread thread, ExecutionModel model) {
         List<EventData> threadEvents = model.getThreadEventsMap().get(thread)
-            .stream().filter(e -> e.isMemoryEvent()).collect(Collectors.toList());
+            .stream().filter(e -> e.isMemoryEvent() || e.isFence()).collect(Collectors.toList());
         if (threadEvents.size() <= 1) {
             return this;
         }


### PR DESCRIPTION
This PR makes some small improvements
- After #341, we ended up with two `Load` events for each `pthread_join`, one created in `VisitorBoogie` and the other in `PthreadProcedures`. I removed the later.
- Nodes from non-atomic events in witnesses where having labels like `W(x, 1, )`. Now we use `W(x,1)`. 
- Barriers should be visible in witness graphs
- When setting the `sourceCFile`, we assumed that there was a path containing `/` rather than simply a file name. This is now fixed