### PR TITLE
Addresses must be even

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Memory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Memory.java
@@ -55,7 +55,11 @@ public class Memory {
             BigInteger i = BigInteger.ONE;
             for(MemoryObject a : program.getMemory().objects) {
                 a.address = i;
-                i = i.add(BigInteger.valueOf(a.size()));
+                // Addresses are tipically at least two byte aligned
+                //      https://stackoverflow.com/questions/23315939/why-2-lsbs-of-32-bit-arm-instruction-address-not-used
+                // Many algorithms rely on this assumption for correctness
+                int padding = (a.size() % 2);
+                i = i.add(BigInteger.valueOf(a.size() + padding));
             }
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Memory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Memory.java
@@ -52,7 +52,7 @@ public class Memory {
 
         @Override
         public void run(Program program) {
-            BigInteger i = BigInteger.ONE;
+            BigInteger i = BigInteger.TWO;
             for(MemoryObject a : program.getMemory().objects) {
                 a.address = i;
                 // Addresses are tipically at least two byte aligned

--- a/dartagnan/src/test/resources/arrays/ok/C-array-ok-17.litmus
+++ b/dartagnan/src/test/resources/arrays/ok/C-array-ok-17.litmus
@@ -15,4 +15,4 @@ P0(atomic_t* arr2) {
   WRITE_ONCE(*(r1 + 1), 5);
 }
 
-forall (0:r0 = 4 /\ 0:r1 = arr1[0] /\ 0:r2 = 1 /\ arr1[1] = 5);
+forall (0:r0 = 4 /\ 0:r1 = arr1 /\ 0:r2 = 1 /\ arr1[1] = 5);

--- a/dartagnan/src/test/resources/arrays/ok/C-array-ok-18.litmus
+++ b/dartagnan/src/test/resources/arrays/ok/C-array-ok-18.litmus
@@ -14,4 +14,4 @@ P0(atomic_t* arr2) {
   int r2 = READ_ONCE(*(arr2 + 1));
 }
 
-forall (0:r0 = a /\ 0:r1 = 1 /\ 0:r2 = 2);
+forall (0:r0 = a /\ 0:r1 = 1 /\ 0:r2 = b);

--- a/dartagnan/src/test/resources/arrays/ok/C-array-ok-19.litmus
+++ b/dartagnan/src/test/resources/arrays/ok/C-array-ok-19.litmus
@@ -10,4 +10,4 @@ P0(atomic_t* a) {
   int r2 = READ_ONCE(*(r1 + 2));
 }
 
-forall (0:r0 = arr[0] /\ 0:r1 = arr[0] /\ 0:r2 = 3);
+forall (0:r0 = arr /\ 0:r1 = arr /\ 0:r2 = 3);


### PR DESCRIPTION
[Most hardware architectures use even values for addresses](https://stackoverflow.com/questions/23315939/why-2-lsbs-of-32-bit-arm-instruction-address-not-used). This allows certain algorithms to make use (i.e., their correctness depends on this) of the least significant bit as a flag.

This PR modifies our fixed allocation to comply with such assumption.