### PR TITLE
Log flagged pairs

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -188,11 +188,6 @@ public class Dartagnan extends BaseOptions {
             		if(TRUE.equals(prover.getModel().evaluate(LIVENESS.getSMTVariable(ctx)))) {
             			System.out.println("Liveness violation found");
             		}
-            		for(Axiom ax : task.getMemoryModel().getAxioms()) {
-                		if(ax.isFlagged() && TRUE.equals(prover.getModel().evaluate(CAT.getSMTVariable(ax, ctx)))) {
-                			System.out.println("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName()));
-                		}                			
-            		}
                 }
                 if (p.getFormat().equals(SourceLanguage.LITMUS)) {
                     if (p.getAssFilter() != null) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -6,8 +6,6 @@ import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
-import com.dat3m.dartagnan.wmm.axiom.Axiom;
-import com.dat3m.dartagnan.wmm.utils.Tuple;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -17,8 +15,6 @@ import org.sosy_lab.java_smt.api.*;
 
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
-import static com.dat3m.dartagnan.configuration.Property.CAT;
-import static java.lang.Boolean.TRUE;
 import static java.util.Collections.singletonList;
 
 public class AssumeSolver extends ModelChecker {
@@ -85,20 +81,8 @@ public class AssumeSolver extends ModelChecker {
             res = prover.isUnsat()? PASS : Result.UNKNOWN;
         } else {
             res = FAIL;
-        }
-
-        for(Axiom ax : memoryModel.getAxioms()) {
-            if(ax.isFlagged() && TRUE.equals(prover.getModel().evaluate(CAT.getSMTVariable(ax, ctx)))) {
-                System.out.println("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName()));
-                if(logger.isDebugEnabled()) {
-                    StringBuilder violatingPairs = new StringBuilder("\n ===== The following pairs belong to the relation ===== \n");
-                    for(Tuple tuple : ax.getRelation().getEncodeTupleSet()) {
-                        if(TRUE.equals(prover.getModel().evaluate(context.edge(ax.getRelation(), tuple)))) {
-                            violatingPairs.append("\t" + tuple.getFirst() + " -> " + tuple.getSecond());
-                        }
-                    }
-                    logger.debug(violatingPairs.toString());
-                }
+            if(!program.getAss().getInvert()) {
+                logFlaggedPairs(memoryModel, prover, logger, context, ctx);
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -6,6 +6,9 @@ import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.wmm.axiom.Axiom;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
@@ -14,6 +17,8 @@ import org.sosy_lab.java_smt.api.*;
 
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
+import static com.dat3m.dartagnan.configuration.Property.CAT;
+import static java.lang.Boolean.TRUE;
 import static java.util.Collections.singletonList;
 
 public class AssumeSolver extends ModelChecker {
@@ -81,7 +86,22 @@ public class AssumeSolver extends ModelChecker {
         } else {
             res = FAIL;
         }
-    
+
+        for(Axiom ax : memoryModel.getAxioms()) {
+            if(ax.isFlagged() && TRUE.equals(prover.getModel().evaluate(CAT.getSMTVariable(ax, ctx)))) {
+                System.out.println("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName()));
+                if(logger.isDebugEnabled()) {
+                    StringBuilder violatingPairs = new StringBuilder("\n ===== The following pairs belong to the relation ===== \n");
+                    for(Tuple tuple : ax.getRelation().getEncodeTupleSet()) {
+                        if(TRUE.equals(prover.getModel().evaluate(context.edge(ax.getRelation(), tuple)))) {
+                            violatingPairs.append("\t" + tuple.getFirst() + " -> " + tuple.getSecond());
+                        }
+                    }
+                    logger.debug(violatingPairs.toString());
+                }
+            }
+        }
+
         if(logger.isDebugEnabled()) {        	
     		String smtStatistics = "\n ===== SMT Statistics ===== \n";
     		for(String key : prover.getStatistics().keySet()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -1,19 +1,22 @@
 package com.dat3m.dartagnan.verification.solving;
 
 import com.dat3m.dartagnan.encoding.*;
-import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.wmm.axiom.Axiom;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
-import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverException;
 
+import static com.dat3m.dartagnan.configuration.Property.CAT;
+import static java.lang.Boolean.TRUE;
 import static com.dat3m.dartagnan.utils.Result.*;
 
 public class IncrementalSolver extends ModelChecker {
@@ -38,7 +41,6 @@ public class IncrementalSolver extends ModelChecker {
     }
 
     private void run() throws InterruptedException, SolverException, InvalidConfigurationException {
-        Program program = task.getProgram();
         Wmm memoryModel = task.getMemoryModel();
         Context analysisContext = Context.create();
         Configuration config = task.getConfig();
@@ -80,6 +82,21 @@ public class IncrementalSolver extends ModelChecker {
         	res = FAIL;
         }
 
+        for(Axiom ax : memoryModel.getAxioms()) {
+            if(ax.isFlagged() && TRUE.equals(prover.getModel().evaluate(CAT.getSMTVariable(ax, ctx)))) {
+                System.out.println("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName()));
+                if(logger.isDebugEnabled()) {
+                    StringBuilder violatingPairs = new StringBuilder("\n ===== The following pairs belong to the relation ===== \n");
+                    for(Tuple tuple : ax.getRelation().getEncodeTupleSet()) {
+                        if(TRUE.equals(prover.getModel().evaluate(context.edge(ax.getRelation(), tuple)))) {
+                            violatingPairs.append("\t" + tuple.getFirst() + " -> " + tuple.getSecond());
+                        }
+                    }
+                    logger.debug(violatingPairs.toString());
+                }
+            }
+        }
+        
         if(logger.isDebugEnabled()) {        	
     		String smtStatistics = "\n ===== SMT Statistics ===== \n";
     		for(String key : prover.getStatistics().keySet()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.verification.solving;
 
 import com.dat3m.dartagnan.encoding.*;
-import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
@@ -13,8 +12,12 @@ import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverException;
+import com.dat3m.dartagnan.wmm.axiom.Axiom;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
 
 import static com.dat3m.dartagnan.utils.Result.*;
+import static com.dat3m.dartagnan.configuration.Property.CAT;
+import static java.lang.Boolean.TRUE;
 
 public class TwoSolvers extends ModelChecker {
 
@@ -39,7 +42,6 @@ public class TwoSolvers extends ModelChecker {
     }
 
     private void run() throws InterruptedException, SolverException, InvalidConfigurationException {
-    	Program program = task.getProgram();
         Wmm memoryModel = task.getMemoryModel();
         Context analysisContext = Context.create();
         Configuration config = task.getConfig();
@@ -90,6 +92,21 @@ public class TwoSolvers extends ModelChecker {
         	res = FAIL;
         }
 
+        for(Axiom ax : memoryModel.getAxioms()) {
+            if(ax.isFlagged() && TRUE.equals(prover1.getModel().evaluate(CAT.getSMTVariable(ax, ctx)))) {
+                System.out.println("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName()));
+                if(logger.isDebugEnabled()) {
+                    StringBuilder violatingPairs = new StringBuilder("\n ===== The following pairs belong to the relation ===== \n");
+                    for(Tuple tuple : ax.getRelation().getEncodeTupleSet()) {
+                        if(TRUE.equals(prover1.getModel().evaluate(context.edge(ax.getRelation(), tuple)))) {
+                            violatingPairs.append("\t" + tuple.getFirst() + " -> " + tuple.getSecond());
+                        }
+                    }
+                    logger.debug(violatingPairs.toString());
+                }
+            }
+        }
+        
         if(logger.isDebugEnabled()) {        	
     		String smtStatistics = "\n ===== SMT Statistics ===== \n";
     		for(String key : prover1.getStatistics().keySet()) {


### PR DESCRIPTION
When we flag an axiom (e.g., a data race was found), we only report that the axiom was violated, but we don't explain why.
This PR shows the user (via the log in debug mode) which are the pairs that belong to the relation of the axiom that was flagged.

Since I needed access to the `EncodingContext`, I moved the part that flags the violation from `Dartagnan` main class to each solver (`Refinement` cannot deal with such violations and thus it is omitted there). This results in some code duplication. I explored the idea of moving the logging part to `ModelChecker` (the common parent of all solvers), but this required moving there the logger and the `EncodingContext` so it did not look that much like an improvement to me. 