### PR TITLE
getModel() as a local variable

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -29,6 +29,7 @@ import com.dat3m.dartagnan.wmm.utils.Tuple;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverException;
@@ -121,14 +122,15 @@ public abstract class ModelChecker {
 
     protected void logFlaggedPairs(Wmm wmm, ProverEnvironment prover, Logger logger, 
         EncodingContext eCtx, SolverContext sCtx) throws SolverException {
+        Model model = prover.getModel();
         for(Axiom ax : wmm.getAxioms()) {
-            if(ax.isFlagged() && TRUE.equals(prover.getModel().evaluate(CAT.getSMTVariable(ax, sCtx)))) {
+            if(ax.isFlagged() && TRUE.equals(model.evaluate(CAT.getSMTVariable(ax, sCtx)))) {
                 System.out.println("Flag " + (ax.getName() != null ? ax.getName() : ax.getRelation().getName()));
                 if(logger.isDebugEnabled()) {
                     StringBuilder violatingPairs = new StringBuilder("\n ===== The following pairs belong to the relation ===== \n");
                     for(Tuple tuple : ax.getRelation().getEncodeTupleSet()) {
-                        if(TRUE.equals(prover.getModel().evaluate(eCtx.edge(ax.getRelation(), tuple)))) {
-                            violatingPairs.append("\t" + tuple.getFirst() + " -> " + tuple.getSecond());
+                        if(TRUE.equals(model.evaluate(eCtx.edge(ax.getRelation(), tuple)))) {
+                            violatingPairs.append("\t" + tuple.getFirst().getCId() + " -> " + tuple.getSecond().getCId());
                         }
                     }
                     logger.debug(violatingPairs.toString());


### PR DESCRIPTION
I was consistently experiencing some library crashes when trying to extract the model after a data race was found. I assume that from the JavaSMT side, calling twice `prover.getModel()` should be safe. However, when I avoid the double call (by saving the model in a local variable), the crash disappears.