### PR TITLE
Fixed liveness encoding bug

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
@@ -182,7 +182,7 @@ public class PropertyEncoder implements Encoder {
                     for (Tuple rfEdge : rf.getMaxTupleSet().getBySecond(load)) {
                         coMaximalLoad = bmgr.or(coMaximalLoad, bmgr.and(context.edge(rf, rfEdge), lastCoVar(rfEdge.getFirst())));
                     }
-                    allCoMaximalLoad = bmgr.and(allCoMaximalLoad, coMaximalLoad);
+                    allCoMaximalLoad = bmgr.and(allCoMaximalLoad, bmgr.implication(context.execution(load), coMaximalLoad));
                 }
                 isStuck  = bmgr.or(isStuck, bmgr.and(context.execution(pair.bound), allCoMaximalLoad));
             }


### PR DESCRIPTION
Problem: Our liveness encoding forced all loads inside a loop body to read from co-maximal stores, even those loads that did not execute!

Fix: Only actually executed(!) loads need to read from co-maximal stores.