### PR TITLE
Fix symmetry breaking for Refinement

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -6,7 +6,6 @@ import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
@@ -53,7 +52,7 @@ public class AssumeSolver extends ModelChecker {
         ProgramEncoder programEncoder = ProgramEncoder.withContext(context);
         PropertyEncoder propertyEncoder = PropertyEncoder.withContext(context);
         WmmEncoder wmmEncoder = WmmEncoder.withContext(context);
-        SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context, memoryModel, analysisContext);
+        SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context);
 
         logger.info("Starting encoding using " + ctx.getVersion());
         prover.addConstraint(programEncoder.encodeFullProgram());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
@@ -56,7 +56,7 @@ public class DataRaceSolver extends ModelChecker {
 		ProgramEncoder programEncoder = ProgramEncoder.withContext(context);
 		PropertyEncoder propertyEncoder = PropertyEncoder.withContext(context);
 		WmmEncoder wmmEncoder = WmmEncoder.withContext(context);
-		SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context, memoryModel, analysisContext);
+		SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context);
 
         logger.info("Starting encoding using " + ctx.getVersion());
 		prover.addConstraint(programEncoder.encodeFullProgram());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -5,7 +5,6 @@ import com.dat3m.dartagnan.encoding.*;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
@@ -52,7 +51,7 @@ public class IncrementalSolver extends ModelChecker {
         ProgramEncoder programEncoder = ProgramEncoder.withContext(context);
         PropertyEncoder propertyEncoder = PropertyEncoder.withContext(context);
         WmmEncoder wmmEncoder = WmmEncoder.withContext(context);
-        SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context, memoryModel, analysisContext);
+        SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context);
 
         logger.info("Starting encoding using " + ctx.getVersion());
         prover.addConstraint(programEncoder.encodeFullProgram());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -129,7 +129,7 @@ public class RefinementSolver extends ModelChecker {
         PropertyEncoder propertyEncoder = PropertyEncoder.withContext(context);
         // We use the original memory model for symmetry breaking because we need axioms
         // to compute the breaking order.
-        SymmetryEncoder symmEncoder = SymmetryEncoder.withContext(context, memoryModel, analysisContext);
+        SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context);
         WmmEncoder baselineEncoder = WmmEncoder.withContext(context);
 
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
@@ -141,7 +141,7 @@ public class RefinementSolver extends ModelChecker {
         logger.info("Starting encoding using " + ctx.getVersion());
         prover.addConstraint(programEncoder.encodeFullProgram());
         prover.addConstraint(baselineEncoder.encodeFullMemoryModel());
-        prover.addConstraint(symmEncoder.encodeFullSymmetryBreaking());
+        prover.addConstraint(symmetryEncoder.encodeFullSymmetryBreaking());
 
         prover.push();
         prover.addConstraint(propertyEncoder.encodeProperties(task.getProperty()));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -53,7 +53,7 @@ public class TwoSolvers extends ModelChecker {
         ProgramEncoder programEncoder = ProgramEncoder.withContext(context);
         PropertyEncoder propertyEncoder = PropertyEncoder.withContext(context);
         WmmEncoder wmmEncoder = WmmEncoder.withContext(context);
-        SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context, memoryModel, analysisContext);
+        SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context);
 
         logger.info("Starting encoding using " + ctx.getVersion());
         BooleanFormula encodeProg = programEncoder.encodeFullProgram();


### PR DESCRIPTION
This PR addresses issue #376 by removing the feature of computing sync degrees over a different memory model than the one that gets encoded. In the case of Refinement, the sync degree is now computed over the baseline model.
If no biases are specified, then the baseline model will have no axioms which disabled the sync degree computation.