### PR TITLE
Add race definition to RC11

### DIFF
--- a/benchmarks/locks/mutex.h
+++ b/benchmarks/locks/mutex.h
@@ -1,4 +1,4 @@
-#include <futex.h>
+#include "futex.h"
 #include <stdatomic.h>
 
 #ifdef ACQ2RX

--- a/benchmarks/locks/mutex_musl.h
+++ b/benchmarks/locks/mutex_musl.h
@@ -1,4 +1,4 @@
-#include <futex.h>
+#include "futex.h"
 #include <stdatomic.h>
 
 #ifdef ACQ2RX

--- a/cat/rc11.cat
+++ b/cat/rc11.cat
@@ -30,3 +30,10 @@ irreflexive (myrmw; eco) as coherencermw
 empty (myrmw & (fr; co)) as atomicity
 acyclic psc as SC
 acyclic (po | rf) as no-thin-air
+
+(* data_races *)
+let conflict = (((W * _) | (_ * W)) & loc)
+// We treat initial events as non-atomic thus we need to explicit remove them
+let race = ext & (conflict \ hb \ (hb^-1) \ (A * A) \ ((IW * _) | (_ * IW)))
+
+flag ~empty race as racy 

--- a/cat/rc11.cat
+++ b/cat/rc11.cat
@@ -32,8 +32,8 @@ acyclic psc as SC
 acyclic (po | rf) as no-thin-air
 
 (* data_races *)
-let conflict = (((W * _) | (_ * W)) & loc)
 // We treat initial events as non-atomic thus we need to explicit remove them
-let race = ext & (conflict \ hb \ (hb^-1) \ (A * A) \ ((IW * _) | (_ * IW)))
+let conflict = ext & ((((W * _) | (_ * W)) & loc) \ ((IW * _) | (_ * IW)))
+let race = conflict \ (A * A) \ hb \ (hb^-1) 
 
 flag ~empty race as racy 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -145,8 +145,12 @@ public abstract class ModelChecker {
                 logger.debug("Flag " + Optional.ofNullable(ax.getName()).orElse(ax.getRelation().getNameOrTerm()));
                 StringBuilder violatingPairs = new StringBuilder("\n ===== The following pairs belong to the relation ===== \n");
                 for(Tuple tuple : encoder.getTuples(ax.getRelation(), model)) {
-                    violatingPairs.append("\t").append(tuple.getFirst().getGlobalId())
-                            .append(" -> ").append(tuple.getSecond().getGlobalId());
+                    violatingPairs
+                        .append("\t").append(tuple.getFirst().getGlobalId())
+                        .append(" -> ").append(tuple.getSecond().getGlobalId())
+                        .append("\t(").append(tuple.getFirst().getSourceCodeFile()).append("#").append(tuple.getFirst().getCLine())
+                        .append(" -> ").append(tuple.getSecond().getSourceCodeFile()).append("#").append(tuple.getSecond().getCLine())
+                        .append(")\n");
                 }
                 logger.debug(violatingPairs.toString());
             }


### PR DESCRIPTION
This PR adds the data-race axiom to RC11 as defined in the cat file [here](https://plv.mpi-sws.org/scfix/) (with minimal modifications due to the fact that we treat init events as non-atomic).

Signed-off-by: Hernan Ponce de Leon <hernanl.leon@huawei.com>