### PR TITLE
Log program spec violation

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -243,9 +243,9 @@ public class Dartagnan extends BaseOptions {
                 }
                 if (props.contains(LIVENESS) && FALSE.equals(model.evaluate(LIVENESS.getSMTVariable(encCtx)))) {
                     summary.append("============ Liveness violation found ============\n");
-                    for(Event e : p.getEvents(CondJump.class)) {
+                    for(CondJump e : p.getEvents(CondJump.class)) {
                         if(e.is(Tag.SPINLOOP) && TRUE.equals(model.evaluate(encCtx.execution(e)))
-                            && TRUE.equals(model.evaluate(encCtx.jumpCondition((CondJump)e)))) {
+                            && TRUE.equals(model.evaluate(encCtx.jumpCondition(e)))) {
                             summary
                                 .append("\t").append(e.getGlobalId())
                                 .append(":\t(").append(e.getSourceCodeFile()).append("#").append(e.getCLine())

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -11,6 +11,7 @@ import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.analysis.CallStackComputation;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.core.Local;
 import com.dat3m.dartagnan.utils.Result;
@@ -241,8 +242,15 @@ public class Dartagnan extends BaseOptions {
                     summary.append(" ================================================= \n");
                 }
                 if (props.contains(LIVENESS) && FALSE.equals(model.evaluate(LIVENESS.getSMTVariable(encCtx)))) {
-                    summary.append(" ===== Liveness violation found ===== \n");
-                    // TODO
+                    summary.append("============ Liveness violation found ============ \n");
+                    for(Event e : p.getEvents(Label.class)) {
+                        if(e.is(Tag.SPINLOOP) && TRUE.equals(model.evaluate(encCtx.execution(e)))) {
+                            summary
+                                .append("\t").append(e.getGlobalId())
+                                .append(":\t(").append(e.getSourceCodeFile()).append("#").append(e.getCLine())
+                                .append(")\n");
+                        }
+                    }
                     summary.append(" ================================================= \n");
                 }
                 final List<Axiom> violatedCATSpecs = task.getMemoryModel().getAxioms().stream()
@@ -250,7 +258,7 @@ public class Dartagnan extends BaseOptions {
                         .filter(ax -> props.contains(CAT_SPEC) && FALSE.equals(model.evaluate(CAT_SPEC.getSMTVariable(ax, encCtx))))
                         .collect(Collectors.toList());
                 if (!violatedCATSpecs.isEmpty()) {
-                    summary.append(" ===== CAT specification violation found ===== \n");
+                    summary.append(" ======= CAT specification violation found ======= \n");
                     // Computed by the model checker since it needs access to the WmmEncoder
                     summary.append(modelChecker.getFlaggedPairsOutput());
                     summary.append(" ================================================= \n");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -10,8 +10,8 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.analysis.CallStackComputation;
 import com.dat3m.dartagnan.program.event.Tag;
+import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.core.Local;
 import com.dat3m.dartagnan.utils.Result;
@@ -243,8 +243,9 @@ public class Dartagnan extends BaseOptions {
                 }
                 if (props.contains(LIVENESS) && FALSE.equals(model.evaluate(LIVENESS.getSMTVariable(encCtx)))) {
                     summary.append("============ Liveness violation found ============\n");
-                    for(Event e : p.getEvents(Label.class)) {
-                        if(e.is(Tag.SPINLOOP) && TRUE.equals(model.evaluate(encCtx.execution(e)))) {
+                    for(Event e : p.getEvents(CondJump.class)) {
+                        if(e.is(Tag.SPINLOOP) && TRUE.equals(model.evaluate(encCtx.execution(e)))
+                            && TRUE.equals(model.evaluate(encCtx.jumpCondition((CondJump)e)))) {
                             summary
                                 .append("\t").append(e.getGlobalId())
                                 .append(":\t(").append(e.getSourceCodeFile()).append("#").append(e.getCLine())

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -242,6 +242,8 @@ public class Dartagnan extends BaseOptions {
                 }
                 if (props.contains(LIVENESS) && FALSE.equals(model.evaluate(LIVENESS.getSMTVariable(encCtx)))) {
                     summary.append(" ===== Liveness violation found ===== \n");
+                    // TODO
+                    summary.append(" ================================================= \n");
                 }
                 final List<Axiom> violatedCATSpecs = task.getMemoryModel().getAxioms().stream()
                         .filter(Axiom::isFlagged)
@@ -249,11 +251,9 @@ public class Dartagnan extends BaseOptions {
                         .collect(Collectors.toList());
                 if (!violatedCATSpecs.isEmpty()) {
                     summary.append(" ===== CAT specification violation found ===== \n");
-                    for (Axiom violatedAx : violatedCATSpecs) {
-                        summary.append("Flag ")
-                                .append(Optional.ofNullable(violatedAx.getName()).orElse(violatedAx.getNameOrTerm()))
-                                .append("\n");
-                    }
+                    // Computed by the model checker since it needs access to the WmmEncoder
+                    summary.append(modelChecker.getFlaggedPairsOutput());
+                    summary.append(" ================================================= \n");
                 }
             } else if (hasPositiveWitnesses) {
                 if (props.contains(PROGRAM_SPEC) && TRUE.equals(model.evaluate(PROGRAM_SPEC.getSMTVariable(encCtx)))) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -230,7 +230,7 @@ public class Dartagnan extends BaseOptions {
             if (hasViolations) {
                 printWarningIfThreadStartFailed(p, encCtx, prover);
                 if (props.contains(PROGRAM_SPEC) && FALSE.equals(model.evaluate(PROGRAM_SPEC.getSMTVariable(encCtx)))) {
-                    summary.append(" ===== Program specification violation found ===== \n");
+                    summary.append("===== Program specification violation found =====\n");
                     for(Event e : p.getEvents(Local.class)) {
                         if(e.is(Tag.ASSERTION) && TRUE.equals(model.evaluate(encCtx.execution(e)))) {
                             summary
@@ -239,10 +239,10 @@ public class Dartagnan extends BaseOptions {
                                 .append(")\n");
                         }
                     }
-                    summary.append(" ================================================= \n");
+                    summary.append("=================================================\n");
                 }
                 if (props.contains(LIVENESS) && FALSE.equals(model.evaluate(LIVENESS.getSMTVariable(encCtx)))) {
-                    summary.append("============ Liveness violation found ============ \n");
+                    summary.append("============ Liveness violation found ============\n");
                     for(Event e : p.getEvents(Label.class)) {
                         if(e.is(Tag.SPINLOOP) && TRUE.equals(model.evaluate(encCtx.execution(e)))) {
                             summary
@@ -251,17 +251,17 @@ public class Dartagnan extends BaseOptions {
                                 .append(")\n");
                         }
                     }
-                    summary.append(" ================================================= \n");
+                    summary.append("=================================================\n");
                 }
                 final List<Axiom> violatedCATSpecs = task.getMemoryModel().getAxioms().stream()
                         .filter(Axiom::isFlagged)
                         .filter(ax -> props.contains(CAT_SPEC) && FALSE.equals(model.evaluate(CAT_SPEC.getSMTVariable(ax, encCtx))))
                         .collect(Collectors.toList());
                 if (!violatedCATSpecs.isEmpty()) {
-                    summary.append(" ======= CAT specification violation found ======= \n");
+                    summary.append("======= CAT specification violation found =======\n");
                     // Computed by the model checker since it needs access to the WmmEncoder
                     summary.append(modelChecker.getFlaggedPairsOutput());
-                    summary.append(" ================================================= \n");
+                    summary.append("=================================================\n");
                 }
             } else if (hasPositiveWitnesses) {
                 if (props.contains(PROGRAM_SPEC) && TRUE.equals(model.evaluate(PROGRAM_SPEC.getSMTVariable(encCtx)))) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -504,7 +504,8 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 		// Since we "inline" procedures, label names might clash
 		// thus we use currentScope.getID() + ":"
 		String labelName = currentScope.getID() + ":" + ctx.children.get(0).getText();
-		Label label = programBuilder.getOrCreateLabel(labelName);
+		Label label = (Label)programBuilder.getOrCreateLabel(labelName)
+			.setCFileInformation(currentLine, sourceCodeFile);
         programBuilder.addChild(threadCount, label);
         currentLabel = label;
         return null;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -139,6 +139,8 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
                 .reduce(BConst.FALSE, (x, y) -> new BExprBin(x, BOpBin.OR, y));
         final CondJump assumeSideEffect = EventFactory.newJumpUnless(atLeastOneSideEffect, (Label) thread.getExit());
         assumeSideEffect.addFilters(Tag.SPINLOOP, Tag.EARLYTERMINATION, Tag.NOOPT);
+        final Event spinloopStart = iterInfo.getIterationStart();
+        assumeSideEffect.setCFileInformation(spinloopStart.getCLine(), spinloopStart.getSourceCodeFile());
         insertionPoint.insertAfter(assumeSideEffect);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -76,7 +76,6 @@ public class AssumeSolver extends ModelChecker {
         } else {
             res = FAIL;
             logFlaggedPairs(memoryModel, wmmEncoder, prover, logger, context);
-            logProgramSpecViolation(task.getProgram(), prover, logger, context);
         }
 
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -76,6 +76,7 @@ public class AssumeSolver extends ModelChecker {
         } else {
             res = FAIL;
             logFlaggedPairs(memoryModel, wmmEncoder, prover, logger, context);
+            logProgramSpecViolation(task.getProgram(), prover, logger, context);
         }
 
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -75,7 +75,7 @@ public class AssumeSolver extends ModelChecker {
             res = prover.isUnsat()? PASS : Result.UNKNOWN;
         } else {
             res = FAIL;
-            logFlaggedPairs(memoryModel, wmmEncoder, prover, logger, context);
+            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context);
         }
 
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -73,7 +73,6 @@ public class IncrementalSolver extends ModelChecker {
         } else {
         	res = FAIL;
             logFlaggedPairs(memoryModel, wmmEncoder, prover, logger, context);
-            logProgramSpecViolation(task.getProgram(), prover, logger, context);
         }
         
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -73,6 +73,7 @@ public class IncrementalSolver extends ModelChecker {
         } else {
         	res = FAIL;
             logFlaggedPairs(memoryModel, wmmEncoder, prover, logger, context);
+            logProgramSpecViolation(task.getProgram(), prover, logger, context);
         }
         
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -72,7 +72,7 @@ public class IncrementalSolver extends ModelChecker {
             res = prover.isUnsat()? PASS : UNKNOWN;
         } else {
         	res = FAIL;
-            logFlaggedPairs(memoryModel, wmmEncoder, prover, logger, context);
+            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context);
         }
         
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -157,23 +157,4 @@ public abstract class ModelChecker {
         }
     }
 
-    protected void logProgramSpecViolation(Program program, ProverEnvironment prover, Logger logger, EncodingContext ctx) throws SolverException {
-        if (!logger.isDebugEnabled() || !ctx.getTask().getProperty().contains(PROGRAM_SPEC)) {
-            return;
-        }
-        Model model = prover.getModel();
-        if(FALSE.equals(model.evaluate(PROGRAM_SPEC.getSMTVariable(ctx)))) {
-            StringBuilder violatingPairs = new StringBuilder("\n ===== The following assertions are violated ===== \n");
-            for(Event e : program.getEvents(Local.class)) {
-                if(e.is(ASSERTION) && TRUE.equals(model.evaluate(ctx.execution(e)))) {
-                    violatingPairs
-                        .append("\t").append(e.getGlobalId())
-                        .append("\t(").append(e.getSourceCodeFile()).append("#").append(e.getCLine())
-                        .append(")\n");
-                }
-            }            
-            logger.debug(violatingPairs.toString());
-        }
-    }
-
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -26,7 +26,6 @@ import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.analysis.WmmAnalysis;
 import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
-import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.api.Model;
@@ -47,12 +46,16 @@ public abstract class ModelChecker {
 
     protected Result res = Result.UNKNOWN;
     protected EncodingContext context;
+    private String flaggedPairsOutput = "";
 
     public final Result getResult() {
         return res;
     }
     public EncodingContext getEncodingContext() {
         return context;
+    }
+    public final String getFlaggedPairsOutput() {
+        return flaggedPairsOutput;
     }
 
     public boolean hasModel() {
@@ -135,15 +138,14 @@ public abstract class ModelChecker {
         program.setSpecification(spec);
     }
 
-    protected void logFlaggedPairs(Wmm wmm, WmmEncoder encoder, ProverEnvironment prover, Logger logger, EncodingContext ctx) throws SolverException {
-        if (!logger.isDebugEnabled() || !ctx.getTask().getProperty().contains(CAT_SPEC)) {
+    protected void saveFlaggedPairsOutput(Wmm wmm, WmmEncoder encoder, ProverEnvironment prover, EncodingContext ctx) throws SolverException {
+        if (!ctx.getTask().getProperty().contains(CAT_SPEC)) {
             return;
         }
         Model model = prover.getModel();
         for(Axiom ax : wmm.getAxioms()) {
             if(ax.isFlagged() && FALSE.equals(model.evaluate(CAT_SPEC.getSMTVariable(ax, ctx)))) {
-                logger.debug("Flag " + Optional.ofNullable(ax.getName()).orElse(ax.getRelation().getNameOrTerm()));
-                StringBuilder violatingPairs = new StringBuilder("\n ===== The following pairs belong to the relation ===== \n");
+                StringBuilder violatingPairs = new StringBuilder("Flag " + Optional.ofNullable(ax.getName()).orElse(ax.getRelation().getNameOrTerm())).append("\n");
                 for(Tuple tuple : encoder.getTuples(ax.getRelation(), model)) {
                     violatingPairs
                         .append("\t").append(tuple.getFirst().getGlobalId())
@@ -152,7 +154,7 @@ public abstract class ModelChecker {
                         .append(" -> ").append(tuple.getSecond().getSourceCodeFile()).append("#").append(tuple.getSecond().getCLine())
                         .append(")\n");
                 }
-                logger.debug(violatingPairs.toString());
+                flaggedPairsOutput += violatingPairs.toString();
             }
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -36,11 +36,11 @@ import org.sosy_lab.java_smt.api.SolverException;
 import java.util.List;
 import java.util.Optional;
 
-import static com.dat3m.dartagnan.configuration.Property.CAT_SPEC;
+import static com.dat3m.dartagnan.configuration.Property.*;
 import static com.dat3m.dartagnan.program.event.Tag.ASSERTION;
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
-import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.*;
 import static java.util.stream.Collectors.toList;
 
 public abstract class ModelChecker {
@@ -154,6 +154,25 @@ public abstract class ModelChecker {
                 }
                 logger.debug(violatingPairs.toString());
             }
+        }
+    }
+
+    protected void logProgramSpecViolation(Program program, ProverEnvironment prover, Logger logger, EncodingContext ctx) throws SolverException {
+        if (!logger.isDebugEnabled() || !ctx.getTask().getProperty().contains(PROGRAM_SPEC)) {
+            return;
+        }
+        Model model = prover.getModel();
+        if(FALSE.equals(model.evaluate(PROGRAM_SPEC.getSMTVariable(ctx)))) {
+            StringBuilder violatingPairs = new StringBuilder("\n ===== The following assertions are violated ===== \n");
+            for(Event e : program.getEvents(Local.class)) {
+                if(e.is(ASSERTION) && TRUE.equals(model.evaluate(ctx.execution(e)))) {
+                    violatingPairs
+                        .append("\t").append(e.getGlobalId())
+                        .append("\t(").append(e.getSourceCodeFile()).append("#").append(e.getCLine())
+                        .append(")\n");
+                }
+            }            
+            logger.debug(violatingPairs.toString());
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -262,6 +262,7 @@ public class RefinementSolver extends ModelChecker {
             boundCheckTime = System.currentTimeMillis() - lastTime;
         } else {
             res = FAIL;
+            logProgramSpecViolation(program, prover, logger, context);
         }
 
         if (logger.isInfoEnabled()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -262,7 +262,6 @@ public class RefinementSolver extends ModelChecker {
             boundCheckTime = System.currentTimeMillis() - lastTime;
         } else {
             res = FAIL;
-            logProgramSpecViolation(program, prover, logger, context);
         }
 
         if (logger.isInfoEnabled()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -84,6 +84,7 @@ public class TwoSolvers extends ModelChecker {
         } else {
         	res = FAIL;
             logFlaggedPairs(memoryModel, wmmEncoder, prover1, logger, context);
+            logProgramSpecViolation(task.getProgram(), prover1, logger, context);
         }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -83,7 +83,7 @@ public class TwoSolvers extends ModelChecker {
             res = prover2.isUnsat() ? PASS : UNKNOWN;
         } else {
         	res = FAIL;
-            logFlaggedPairs(memoryModel, wmmEncoder, prover1, logger, context);
+            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover1, context);
         }
 
         if(logger.isDebugEnabled()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -84,9 +84,7 @@ public class TwoSolvers extends ModelChecker {
         } else {
         	res = FAIL;
             logFlaggedPairs(memoryModel, wmmEncoder, prover1, logger, context);
-            logProgramSpecViolation(task.getProgram(), prover1, logger, context);
         }
-
 
         if(logger.isDebugEnabled()) {
     		String smtStatistics = "\n ===== SMT Statistics ===== \n";


### PR DESCRIPTION
This PR logs the concreate assertions (event + file / line) that is violated one the program specification is not guaranteed. I marked as a DRAFT because there are several things we might want to improve
- do we want to log this or printed in the console as the rest of the result output we give?
- if we log, do we want to do it only at the debug level (not only for program_spec violations but also for flagged axioms)?
- I guess we don't want this information for litmus tests