### PR TITLE
Add support for llvm.ctlz

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
@@ -62,6 +62,19 @@ public class IExprUn extends IExpr {
 			case ZEXT18: case ZEXT116: case ZEXT132: case ZEXT164: case ZEXT816: case ZEXT832: case ZEXT864: case ZEXT1632: case ZEXT1664: case ZEXT3264: 
 			case SEXT18: case SEXT116: case SEXT132: case SEXT164: case SEXT816: case SEXT832: case SEXT864: case SEXT1632: case SEXT1664: case SEXT3264:
 				return inner;
+			case CTLZ:
+				int leading;
+				switch(inner.getPrecision()) {
+					case 32:
+						leading = Integer.numberOfLeadingZeros(inner.getValueAsInt());
+						break;
+					case 64:
+						leading = Long.numberOfLeadingZeros(inner.getValueAsInt());
+						break;
+					default:
+						throw new UnsupportedOperationException("Reduce not supported for " + this + " with precision " + inner.getPrecision());
+				}
+				return new IValue(BigInteger.valueOf(leading), inner.getPrecision());
 			default:
 		        throw new UnsupportedOperationException("Reduce not supported for " + this);				
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
@@ -18,10 +18,10 @@ public class IExprUn extends IExpr {
 	private final IExpr b;
 	private final IOpUn op;
 
-    public IExprUn(IOpUn op, IExpr b) {
-        this.b = b;
-        this.op = op;
-    }
+	public IExprUn(IOpUn op, IExpr b) {
+		this.b = b;
+		this.op = op;
+	}
 
 	public IOpUn getOp() {
 		return op;
@@ -38,22 +38,23 @@ public class IExprUn extends IExpr {
 
 	@Override
 	public BigInteger getIntValue(Event e, Model model, FormulaManager m) {
-        return b.getIntValue(e, model, m).negate();
+		return b.getIntValue(e, model, m).negate();
 	}
 
 	@Override
 	public ImmutableSet<Register> getRegs() {
-        return b.getRegs();
+		return b.getRegs();
 	}
-    @Override
-    public String toString() {
-        return "(" + op + b + ")";
-    }
 
-    @Override
+	@Override
+	public String toString() {
+		return "(" + op + b + ")";
+	}
+
+	@Override
 	public IConst reduce() {
 		IConst inner = b.reduce();
-        switch(op){
+		switch (op) {
 			case MINUS:
 			return new IValue(inner.getValue().negate(), b.getPrecision());
 			case BV2UINT: case BV2INT:
@@ -65,25 +66,26 @@ public class IExprUn extends IExpr {
 			case CTLZ:
 				int leading;
 				int precision = inner.getPrecision();
-				switch(precision) {
-				case 32:
-					leading = Integer.numberOfLeadingZeros(inner.getValueAsInt());
-					break;
-				case 64:
-					leading = Long.numberOfLeadingZeros(inner.getValueAsInt());
-					break;
-				default:
-					throw new UnsupportedOperationException("Reduce not supported for " + this + " with precision " + precision);
+				switch (precision) {
+					case 32:
+						leading = Integer.numberOfLeadingZeros(inner.getValueAsInt());
+						break;
+					case 64:
+						leading = Long.numberOfLeadingZeros(inner.getValueAsInt());
+						break;
+					default:
+						throw new UnsupportedOperationException(
+								"Reduce not supported for " + this + " with precision " + precision);
 				}
 				return new IValue(BigInteger.valueOf(leading), precision);
 			default:
-		        throw new UnsupportedOperationException("Reduce not supported for " + this);				
-        }
+				throw new UnsupportedOperationException("Reduce not supported for " + this);
+		}
 	}
 
 	@Override
 	public int getPrecision() {
-        switch(op){
+		switch (op) {
 			case MINUS:
 				return b.getPrecision();
 			case BV2UINT: case BV2INT:
@@ -99,10 +101,10 @@ public class IExprUn extends IExpr {
 			case INT2BV64: case ZEXT164: case ZEXT864: case ZEXT1664: case ZEXT3264: case SEXT164: case SEXT864: case SEXT1664: case SEXT3264:
 				return 64;
 			default:
-		        throw new UnsupportedOperationException("getPrecision not supported for " + this);				
-        }
+				throw new UnsupportedOperationException("getPrecision not supported for " + this);
+		}
 	}
-	
+
 	@Override
 	public <T> T visit(ExpressionVisitor<T> visitor) {
 		return visitor.visit(this);
@@ -115,8 +117,8 @@ public class IExprUn extends IExpr {
 
 	@Override
 	public boolean equals(Object obj) {
-    	if (obj == this) {
-    		return true;
+		if (obj == this) {
+			return true;
 		} else if (obj == null || obj.getClass() != getClass()) {
 			return false;
 		}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
@@ -15,114 +15,114 @@ import java.math.BigInteger;
 
 public class IExprUn extends IExpr {
 
-	private final IExpr b;
-	private final IOpUn op;
+    private final IExpr b;
+    private final IOpUn op;
 
-	public IExprUn(IOpUn op, IExpr b) {
-		this.b = b;
-		this.op = op;
-	}
+    public IExprUn(IOpUn op, IExpr b) {
+        this.b = b;
+        this.op = op;
+    }
 
-	public IOpUn getOp() {
-		return op;
-	}
+    public IOpUn getOp() {
+        return op;
+    }
 
-	public IExpr getInner() {
-		return b;
-	}
+    public IExpr getInner() {
+        return b;
+    }
 
-	@Override
-	public Formula toIntFormula(Event e, FormulaManager m) {
-		return op.encode(b.toIntFormula(e, m), m);
-	}
+    @Override
+    public Formula toIntFormula(Event e, FormulaManager m) {
+        return op.encode(b.toIntFormula(e, m), m);
+    }
 
-	@Override
-	public BigInteger getIntValue(Event e, Model model, FormulaManager m) {
-		return b.getIntValue(e, model, m).negate();
-	}
+    @Override
+    public BigInteger getIntValue(Event e, Model model, FormulaManager m) {
+        return b.getIntValue(e, model, m).negate();
+    }
 
-	@Override
-	public ImmutableSet<Register> getRegs() {
-		return b.getRegs();
-	}
+    @Override
+    public ImmutableSet<Register> getRegs() {
+        return b.getRegs();
+    }
 
-	@Override
-	public String toString() {
-		return "(" + op + b + ")";
-	}
+    @Override
+    public String toString() {
+        return "(" + op + b + ")";
+    }
 
-	@Override
-	public IConst reduce() {
-		IConst inner = b.reduce();
-		switch (op) {
-			case MINUS:
-			return new IValue(inner.getValue().negate(), b.getPrecision());
-			case BV2UINT: case BV2INT:
-			case INT2BV1: case INT2BV8: case INT2BV16: case INT2BV32: case INT2BV64: 
-			case TRUNC6432: case TRUNC6416: case TRUNC648: case TRUNC641: case TRUNC3216: case TRUNC328: case TRUNC321: case TRUNC168: case TRUNC161: case TRUNC81:
-			case ZEXT18: case ZEXT116: case ZEXT132: case ZEXT164: case ZEXT816: case ZEXT832: case ZEXT864: case ZEXT1632: case ZEXT1664: case ZEXT3264: 
-			case SEXT18: case SEXT116: case SEXT132: case SEXT164: case SEXT816: case SEXT832: case SEXT864: case SEXT1632: case SEXT1664: case SEXT3264:
-				return inner;
-			case CTLZ:
-				int leading;
-				int precision = inner.getPrecision();
-				switch (precision) {
-					case 32:
-						leading = Integer.numberOfLeadingZeros(inner.getValueAsInt());
-						break;
-					case 64:
-						leading = Long.numberOfLeadingZeros(inner.getValueAsInt());
-						break;
-					default:
-						throw new UnsupportedOperationException(
-								"Reduce not supported for " + this + " with precision " + precision);
-				}
-				return new IValue(BigInteger.valueOf(leading), precision);
-			default:
-				throw new UnsupportedOperationException("Reduce not supported for " + this);
-		}
-	}
+    @Override
+    public IConst reduce() {
+        IConst inner = b.reduce();
+        switch (op) {
+            case MINUS:
+            return new IValue(inner.getValue().negate(), b.getPrecision());
+            case BV2UINT: case BV2INT:
+            case INT2BV1: case INT2BV8: case INT2BV16: case INT2BV32: case INT2BV64: 
+            case TRUNC6432: case TRUNC6416: case TRUNC648: case TRUNC641: case TRUNC3216: case TRUNC328: case TRUNC321: case TRUNC168: case TRUNC161: case TRUNC81:
+            case ZEXT18: case ZEXT116: case ZEXT132: case ZEXT164: case ZEXT816: case ZEXT832: case ZEXT864: case ZEXT1632: case ZEXT1664: case ZEXT3264: 
+            case SEXT18: case SEXT116: case SEXT132: case SEXT164: case SEXT816: case SEXT832: case SEXT864: case SEXT1632: case SEXT1664: case SEXT3264:
+                return inner;
+            case CTLZ:
+                int leading;
+                int precision = inner.getPrecision();
+                switch (precision) {
+                    case 32:
+                        leading = Integer.numberOfLeadingZeros(inner.getValueAsInt());
+                        break;
+                    case 64:
+                        leading = Long.numberOfLeadingZeros(inner.getValueAsInt());
+                        break;
+                    default:
+                        throw new UnsupportedOperationException(
+                                "Reduce not supported for " + this + " with precision " + precision);
+                }
+                return new IValue(BigInteger.valueOf(leading), precision);
+            default:
+                throw new UnsupportedOperationException("Reduce not supported for " + this);
+        }
+    }
 
-	@Override
-	public int getPrecision() {
-		switch (op) {
-			case MINUS:
-				return b.getPrecision();
-			case BV2UINT: case BV2INT:
-				return ARCH_PRECISION;
-			case INT2BV1: case TRUNC321: case TRUNC641: case TRUNC161: case TRUNC81:
-				return 1;
-			case INT2BV8: case TRUNC648: case TRUNC328: case TRUNC168: case ZEXT18: case SEXT18:
-				return 8;
-			case INT2BV16: case TRUNC6416: case TRUNC3216: case ZEXT116: case ZEXT816: case SEXT116: case SEXT816:
-				return 16;
-			case INT2BV32: case TRUNC6432: case ZEXT132: case ZEXT832: case ZEXT1632: case SEXT132: case SEXT832: case SEXT1632:
-				return 32;
-			case INT2BV64: case ZEXT164: case ZEXT864: case ZEXT1664: case ZEXT3264: case SEXT164: case SEXT864: case SEXT1664: case SEXT3264:
-				return 64;
-			default:
-				throw new UnsupportedOperationException("getPrecision not supported for " + this);
-		}
-	}
+    @Override
+    public int getPrecision() {
+        switch (op) {
+            case MINUS:
+                return b.getPrecision();
+            case BV2UINT: case BV2INT:
+                return ARCH_PRECISION;
+            case INT2BV1: case TRUNC321: case TRUNC641: case TRUNC161: case TRUNC81:
+                return 1;
+            case INT2BV8: case TRUNC648: case TRUNC328: case TRUNC168: case ZEXT18: case SEXT18:
+                return 8;
+            case INT2BV16: case TRUNC6416: case TRUNC3216: case ZEXT116: case ZEXT816: case SEXT116: case SEXT816:
+                return 16;
+            case INT2BV32: case TRUNC6432: case ZEXT132: case ZEXT832: case ZEXT1632: case SEXT132: case SEXT832: case SEXT1632:
+                return 32;
+            case INT2BV64: case ZEXT164: case ZEXT864: case ZEXT1664: case ZEXT3264: case SEXT164: case SEXT864: case SEXT1664: case SEXT3264:
+                return 64;
+            default:
+                throw new UnsupportedOperationException("getPrecision not supported for " + this);
+        }
+    }
 
-	@Override
-	public <T> T visit(ExpressionVisitor<T> visitor) {
-		return visitor.visit(this);
-	}
+    @Override
+    public <T> T visit(ExpressionVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
 
-	@Override
-	public int hashCode() {
-		return op.hashCode() ^ b.hashCode();
-	}
+    @Override
+    public int hashCode() {
+        return op.hashCode() ^ b.hashCode();
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (obj == this) {
-			return true;
-		} else if (obj == null || obj.getClass() != getClass()) {
-			return false;
-		}
-		IExprUn expr = (IExprUn) obj;
-		return expr.op == op && expr.b.equals(b);
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (obj == null || obj.getClass() != getClass()) {
+            return false;
+        }
+        IExprUn expr = (IExprUn) obj;
+        return expr.op == op && expr.b.equals(b);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
@@ -64,17 +64,18 @@ public class IExprUn extends IExpr {
 				return inner;
 			case CTLZ:
 				int leading;
-				switch(inner.getPrecision()) {
-					case 32:
-						leading = Integer.numberOfLeadingZeros(inner.getValueAsInt());
-						break;
-					case 64:
-						leading = Long.numberOfLeadingZeros(inner.getValueAsInt());
-						break;
-					default:
-						throw new UnsupportedOperationException("Reduce not supported for " + this + " with precision " + inner.getPrecision());
+				int precision = inner.getPrecision();
+				switch(precision) {
+				case 32:
+					leading = Integer.numberOfLeadingZeros(inner.getValueAsInt());
+					break;
+				case 64:
+					leading = Long.numberOfLeadingZeros(inner.getValueAsInt());
+					break;
+				default:
+					throw new UnsupportedOperationException("Reduce not supported for " + this + " with precision " + precision);
 				}
-				return new IValue(BigInteger.valueOf(leading), inner.getPrecision());
+				return new IValue(BigInteger.valueOf(leading), precision);
 			default:
 		        throw new UnsupportedOperationException("Reduce not supported for " + this);				
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -8,163 +8,167 @@ import static com.dat3m.dartagnan.GlobalSettings.ARCH_PRECISION;
 import java.math.BigInteger;
 
 public enum IOpUn {
-    MINUS, 
-    BV2UINT, BV2INT, 
-    INT2BV1, INT2BV8, INT2BV16, INT2BV32, INT2BV64, 
-    TRUNC6432, TRUNC6416,TRUNC648, TRUNC641, TRUNC3216, TRUNC328, TRUNC321, TRUNC168, TRUNC161, TRUNC81,    
-    ZEXT18, ZEXT116, ZEXT132, ZEXT164, ZEXT816, ZEXT832, ZEXT864, ZEXT1632, ZEXT1664, ZEXT3264, 
-    SEXT18, SEXT116, SEXT132, SEXT164, SEXT816, SEXT832, SEXT864, SEXT1632, SEXT1664, SEXT3264,
+	MINUS,
+	BV2UINT, BV2INT,
+	INT2BV1, INT2BV8, INT2BV16, INT2BV32, INT2BV64,
+	TRUNC6432, TRUNC6416, TRUNC648, TRUNC641, TRUNC3216, TRUNC328, TRUNC321, TRUNC168, TRUNC161, TRUNC81,
+	ZEXT18, ZEXT116, ZEXT132, ZEXT164, ZEXT816, ZEXT832, ZEXT864, ZEXT1632, ZEXT1664, ZEXT3264,
+	SEXT18, SEXT116, SEXT132, SEXT164, SEXT816, SEXT832, SEXT864, SEXT1632, SEXT1664, SEXT3264,
 	CTLZ;
-	
-    @Override
-    public String toString() {
-		switch(this) {
-		case MINUS:
-			return "-";
-		case CTLZ:
-			return "ctlz ";
-		default:
-    		return "";
+
+	@Override
+	public String toString() {
+		switch (this) {
+			case MINUS:
+				return "-";
+			case CTLZ:
+				return "ctlz ";
+			default:
+				return "";
 		}
 	}
 
-    public Formula encode(Formula e, FormulaManager m) {
-		if(e instanceof IntegerFormula) {
+	public Formula encode(Formula e, FormulaManager m) {
+		if (e instanceof IntegerFormula) {
 			IntegerFormulaManager imgr = m.getIntegerFormulaManager();
-			IntegerFormula i = (IntegerFormula)e;
-			switch(this) {
-    		case MINUS:
-    			return imgr.subtract(imgr.makeNumber(BigInteger.ZERO), i);
-    		case BV2UINT:
-    		case BV2INT:
-    			return e; 
-    		// ============ INT2BV ============
-    		case INT2BV1:
-    			return m.getBitvectorFormulaManager().makeBitvector(1, i);
-    		case INT2BV8:
-    			return m.getBitvectorFormulaManager().makeBitvector(8, i);
-    		case INT2BV16:
-    			return m.getBitvectorFormulaManager().makeBitvector(16, i);
-    		case INT2BV32:
-    			return m.getBitvectorFormulaManager().makeBitvector(32, i);
-    		case INT2BV64:
-   				return m.getBitvectorFormulaManager().makeBitvector(64, i);
-        	// ============ TRUNC ============    		
-    		case TRUNC6432:
-    		case TRUNC6416:
-    		case TRUNC3216:
-    		case TRUNC648:
-    		case TRUNC328:
-    		case TRUNC168:
-    		case TRUNC641:
-    		case TRUNC321:
-    		case TRUNC161:
-    		case TRUNC81:
-        	// ============ ZEXT ============    		
-    		case ZEXT18:
-    		case ZEXT116:
-    		case ZEXT132:
-    		case ZEXT164:
-    		case ZEXT816:
-    		case ZEXT832:
-    		case ZEXT864:
-    		case ZEXT1632:
-    		case ZEXT1664:
-    		case ZEXT3264:
-        	// ============ SEXT ============
-    		case SEXT18:
-    		case SEXT116:
-    		case SEXT132:
-    		case SEXT164:
-    		case SEXT816:
-    		case SEXT832:
-    		case SEXT864:
-    		case SEXT1632:
-    		case SEXT1664:
-    		case SEXT3264:
-    			return e;
-			default:
-				// TODO add support for CTLZ. Right now we assume constant propagation gor rid of such instructions
-				throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on integer formulas.");
+			IntegerFormula i = (IntegerFormula) e;
+			switch (this) {
+				case MINUS:
+					return imgr.subtract(imgr.makeNumber(BigInteger.ZERO), i);
+				case BV2UINT:
+				case BV2INT:
+					return e;
+				// ============ INT2BV ============
+				case INT2BV1:
+					return m.getBitvectorFormulaManager().makeBitvector(1, i);
+				case INT2BV8:
+					return m.getBitvectorFormulaManager().makeBitvector(8, i);
+				case INT2BV16:
+					return m.getBitvectorFormulaManager().makeBitvector(16, i);
+				case INT2BV32:
+					return m.getBitvectorFormulaManager().makeBitvector(32, i);
+				case INT2BV64:
+					return m.getBitvectorFormulaManager().makeBitvector(64, i);
+				// ============ TRUNC ============
+				case TRUNC6432:
+				case TRUNC6416:
+				case TRUNC3216:
+				case TRUNC648:
+				case TRUNC328:
+				case TRUNC168:
+				case TRUNC641:
+				case TRUNC321:
+				case TRUNC161:
+				case TRUNC81:
+				// ============ ZEXT ============
+				case ZEXT18:
+				case ZEXT116:
+				case ZEXT132:
+				case ZEXT164:
+				case ZEXT816:
+				case ZEXT832:
+				case ZEXT864:
+				case ZEXT1632:
+				case ZEXT1664:
+				case ZEXT3264:
+				// ============ SEXT ============
+				case SEXT18:
+				case SEXT116:
+				case SEXT132:
+				case SEXT164:
+				case SEXT816:
+				case SEXT832:
+				case SEXT864:
+				case SEXT1632:
+				case SEXT1664:
+				case SEXT3264:
+					return e;
+				default:
+					// TODO add support for CTLZ. Right now we assume constant propagation gor rid
+					// of such instructions
+					throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on integer formulas.");
 			}
 		} else {
 			BitvectorFormulaManager bvmgr = m.getBitvectorFormulaManager();
-			BitvectorFormula bv = (BitvectorFormula)e;
-	    	switch(this) {
-    		case MINUS:
-    			return bvmgr.negate(bv);
-    		case BV2UINT:
-    			return ARCH_PRECISION > -1 ? bvmgr.extend(bv, ARCH_PRECISION - bvmgr.getLength(bv), false) : bvmgr.toIntegerFormula(bv, false);
-    		case BV2INT:
-    			return ARCH_PRECISION > -1 ? bvmgr.extend(bv, ARCH_PRECISION - bvmgr.getLength(bv), true) : bvmgr.toIntegerFormula(bv, true);
-    		// ============ INT2BV ============
-    		case INT2BV1:
-    		case INT2BV8:
-    		case INT2BV16:
-    		case INT2BV32:
-    		case INT2BV64:
-    			return e;
-        	// ============ TRUNC ============    		
-    		case TRUNC6432:
-    			return bvmgr.extract(bv, 31, 0);
-    		case TRUNC6416:
-    		case TRUNC3216:
-    			return bvmgr.extract(bv, 15, 0);
-    		case TRUNC648:
-    		case TRUNC328:
-    		case TRUNC168:
-    			return bvmgr.extract(bv, 7, 0);
-    		case TRUNC641:
-    		case TRUNC321:
-    		case TRUNC161:
-    		case TRUNC81:
-    			return bvmgr.extract(bv, 1, 0);
-        	// ============ ZEXT ============    		
-    		case ZEXT18:
-    			return bvmgr.extend(bv, 7, false);
-    		case ZEXT116:
-    			return bvmgr.extend(bv, 15, false);
-    		case ZEXT132:
-    			return bvmgr.extend(bv, 31, false);
-    		case ZEXT164:
-    			return bvmgr.extend(bv, 63, false);
-    		case ZEXT816:
-    			return bvmgr.extend(bv, 8, false);
-    		case ZEXT832:
-    			return bvmgr.extend(bv, 24, false);
-    		case ZEXT864:
-    			return bvmgr.extend(bv, 56, false);
-    		case ZEXT1632:
-    			return bvmgr.extend(bv, 16, false);
-    		case ZEXT1664:
-    			return bvmgr.extend(bv, 48, false);
-    		case ZEXT3264:
-    			return bvmgr.extend(bv, 32, false);
-        	// ============ SEXT ============
-    		case SEXT18:
-    			return bvmgr.extend(bv, 7, true);
-    		case SEXT116:
-    			return bvmgr.extend(bv, 15, true);
-    		case SEXT132:
-    			return bvmgr.extend(bv, 31, true);
-    		case SEXT164:
-    			return bvmgr.extend(bv, 63, true);
-    		case SEXT816:
-    			return bvmgr.extend(bv, 8, true);
-    		case SEXT832:
-    			return bvmgr.extend(bv, 24, true);
-    		case SEXT864:
-    			return bvmgr.extend(bv, 56, true);
-    		case SEXT1632:
-    			return bvmgr.extend(bv, 16, true);
-    		case SEXT1664:
-    			return bvmgr.extend(bv, 48, true);
-    		case SEXT3264:
-    			return bvmgr.extend(bv, 32, true);
-			default:
-				// TODO add support for CTLZ. Right now we assume constant propagation gor rid of such instructions
-				throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on bitvector formulas.");
-	    	}
+			BitvectorFormula bv = (BitvectorFormula) e;
+			switch (this) {
+				case MINUS:
+					return bvmgr.negate(bv);
+				case BV2UINT:
+					return ARCH_PRECISION > -1 ? bvmgr.extend(bv, ARCH_PRECISION - bvmgr.getLength(bv), false)
+							: bvmgr.toIntegerFormula(bv, false);
+				case BV2INT:
+					return ARCH_PRECISION > -1 ? bvmgr.extend(bv, ARCH_PRECISION - bvmgr.getLength(bv), true)
+							: bvmgr.toIntegerFormula(bv, true);
+				// ============ INT2BV ============
+				case INT2BV1:
+				case INT2BV8:
+				case INT2BV16:
+				case INT2BV32:
+				case INT2BV64:
+					return e;
+				// ============ TRUNC ============
+				case TRUNC6432:
+					return bvmgr.extract(bv, 31, 0);
+				case TRUNC6416:
+				case TRUNC3216:
+					return bvmgr.extract(bv, 15, 0);
+				case TRUNC648:
+				case TRUNC328:
+				case TRUNC168:
+					return bvmgr.extract(bv, 7, 0);
+				case TRUNC641:
+				case TRUNC321:
+				case TRUNC161:
+				case TRUNC81:
+					return bvmgr.extract(bv, 1, 0);
+				// ============ ZEXT ============
+				case ZEXT18:
+					return bvmgr.extend(bv, 7, false);
+				case ZEXT116:
+					return bvmgr.extend(bv, 15, false);
+				case ZEXT132:
+					return bvmgr.extend(bv, 31, false);
+				case ZEXT164:
+					return bvmgr.extend(bv, 63, false);
+				case ZEXT816:
+					return bvmgr.extend(bv, 8, false);
+				case ZEXT832:
+					return bvmgr.extend(bv, 24, false);
+				case ZEXT864:
+					return bvmgr.extend(bv, 56, false);
+				case ZEXT1632:
+					return bvmgr.extend(bv, 16, false);
+				case ZEXT1664:
+					return bvmgr.extend(bv, 48, false);
+				case ZEXT3264:
+					return bvmgr.extend(bv, 32, false);
+				// ============ SEXT ============
+				case SEXT18:
+					return bvmgr.extend(bv, 7, true);
+				case SEXT116:
+					return bvmgr.extend(bv, 15, true);
+				case SEXT132:
+					return bvmgr.extend(bv, 31, true);
+				case SEXT164:
+					return bvmgr.extend(bv, 63, true);
+				case SEXT816:
+					return bvmgr.extend(bv, 8, true);
+				case SEXT832:
+					return bvmgr.extend(bv, 24, true);
+				case SEXT864:
+					return bvmgr.extend(bv, 56, true);
+				case SEXT1632:
+					return bvmgr.extend(bv, 16, true);
+				case SEXT1664:
+					return bvmgr.extend(bv, 48, true);
+				case SEXT3264:
+					return bvmgr.extend(bv, 32, true);
+				default:
+					// TODO add support for CTLZ. Right now we assume constant propagation gor rid
+					// of such instructions
+					throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on bitvector formulas.");
+			}
 		}
-    }
+	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -13,7 +13,8 @@ public enum IOpUn {
     INT2BV1, INT2BV8, INT2BV16, INT2BV32, INT2BV64, 
     TRUNC6432, TRUNC6416,TRUNC648, TRUNC641, TRUNC3216, TRUNC328, TRUNC321, TRUNC168, TRUNC161, TRUNC81,    
     ZEXT18, ZEXT116, ZEXT132, ZEXT164, ZEXT816, ZEXT832, ZEXT864, ZEXT1632, ZEXT1664, ZEXT3264, 
-    SEXT18, SEXT116, SEXT132, SEXT164, SEXT816, SEXT832, SEXT864, SEXT1632, SEXT1664, SEXT3264;
+    SEXT18, SEXT116, SEXT132, SEXT164, SEXT816, SEXT832, SEXT864, SEXT1632, SEXT1664, SEXT3264,
+	CTLZ;
 	
     @Override
     public String toString() {
@@ -75,6 +76,8 @@ public enum IOpUn {
     		case SEXT1664:
     		case SEXT3264:
     			return e;
+			case CTLZ:
+				throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on integer formulas.");
 			}
 			throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on integer formulas.");
 		} else {
@@ -151,6 +154,8 @@ public enum IOpUn {
     			return bvmgr.extend(bv, 48, true);
     		case SEXT3264:
     			return bvmgr.extend(bv, 32, true);
+			case CTLZ:
+				throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on bitvector formulas.");
 	    	}
 			throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on bitvector formulas.");
 		}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -18,8 +18,15 @@ public enum IOpUn {
 	
     @Override
     public String toString() {
-    	return this.equals(MINUS) ? "-" : "";
-    }
+		switch(this) {
+			case MINUS:
+				return "-";
+			case CTLZ:
+				return "ctlz ";
+			default:
+    			return "";
+		}
+	}
 
     public Formula encode(Formula e, FormulaManager m) {
 		if(e instanceof IntegerFormula) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -83,10 +83,10 @@ public enum IOpUn {
     		case SEXT1664:
     		case SEXT3264:
     			return e;
-			case CTLZ:
+			default:
+				// TODO add support for CTLZ. Right now we assume constant propagation gor rid of such instructions
 				throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on integer formulas.");
 			}
-			throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on integer formulas.");
 		} else {
 			BitvectorFormulaManager bvmgr = m.getBitvectorFormulaManager();
 			BitvectorFormula bv = (BitvectorFormula)e;
@@ -161,10 +161,10 @@ public enum IOpUn {
     			return bvmgr.extend(bv, 48, true);
     		case SEXT3264:
     			return bvmgr.extend(bv, 32, true);
-			case CTLZ:
+			default:
+				// TODO add support for CTLZ. Right now we assume constant propagation gor rid of such instructions
 				throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on bitvector formulas.");
 	    	}
-			throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on bitvector formulas.");
 		}
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -19,12 +19,12 @@ public enum IOpUn {
     @Override
     public String toString() {
 		switch(this) {
-			case MINUS:
-				return "-";
-			case CTLZ:
-				return "ctlz ";
-			default:
-    			return "";
+		case MINUS:
+			return "-";
+		case CTLZ:
+			return "ctlz ";
+		default:
+    		return "";
 		}
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -8,167 +8,167 @@ import static com.dat3m.dartagnan.GlobalSettings.ARCH_PRECISION;
 import java.math.BigInteger;
 
 public enum IOpUn {
-	MINUS,
-	BV2UINT, BV2INT,
-	INT2BV1, INT2BV8, INT2BV16, INT2BV32, INT2BV64,
-	TRUNC6432, TRUNC6416, TRUNC648, TRUNC641, TRUNC3216, TRUNC328, TRUNC321, TRUNC168, TRUNC161, TRUNC81,
-	ZEXT18, ZEXT116, ZEXT132, ZEXT164, ZEXT816, ZEXT832, ZEXT864, ZEXT1632, ZEXT1664, ZEXT3264,
-	SEXT18, SEXT116, SEXT132, SEXT164, SEXT816, SEXT832, SEXT864, SEXT1632, SEXT1664, SEXT3264,
-	CTLZ;
+    MINUS,
+    BV2UINT, BV2INT,
+    INT2BV1, INT2BV8, INT2BV16, INT2BV32, INT2BV64,
+    TRUNC6432, TRUNC6416, TRUNC648, TRUNC641, TRUNC3216, TRUNC328, TRUNC321, TRUNC168, TRUNC161, TRUNC81,
+    ZEXT18, ZEXT116, ZEXT132, ZEXT164, ZEXT816, ZEXT832, ZEXT864, ZEXT1632, ZEXT1664, ZEXT3264,
+    SEXT18, SEXT116, SEXT132, SEXT164, SEXT816, SEXT832, SEXT864, SEXT1632, SEXT1664, SEXT3264,
+    CTLZ;
 
-	@Override
-	public String toString() {
-		switch (this) {
-			case MINUS:
-				return "-";
-			case CTLZ:
-				return "ctlz ";
-			default:
-				return "";
-		}
-	}
+    @Override
+    public String toString() {
+        switch (this) {
+            case MINUS:
+                return "-";
+            case CTLZ:
+                return "ctlz ";
+            default:
+                return "";
+        }
+    }
 
-	public Formula encode(Formula e, FormulaManager m) {
-		if (e instanceof IntegerFormula) {
-			IntegerFormulaManager imgr = m.getIntegerFormulaManager();
-			IntegerFormula i = (IntegerFormula) e;
-			switch (this) {
-				case MINUS:
-					return imgr.subtract(imgr.makeNumber(BigInteger.ZERO), i);
-				case BV2UINT:
-				case BV2INT:
-					return e;
-				// ============ INT2BV ============
-				case INT2BV1:
-					return m.getBitvectorFormulaManager().makeBitvector(1, i);
-				case INT2BV8:
-					return m.getBitvectorFormulaManager().makeBitvector(8, i);
-				case INT2BV16:
-					return m.getBitvectorFormulaManager().makeBitvector(16, i);
-				case INT2BV32:
-					return m.getBitvectorFormulaManager().makeBitvector(32, i);
-				case INT2BV64:
-					return m.getBitvectorFormulaManager().makeBitvector(64, i);
-				// ============ TRUNC ============
-				case TRUNC6432:
-				case TRUNC6416:
-				case TRUNC3216:
-				case TRUNC648:
-				case TRUNC328:
-				case TRUNC168:
-				case TRUNC641:
-				case TRUNC321:
-				case TRUNC161:
-				case TRUNC81:
-				// ============ ZEXT ============
-				case ZEXT18:
-				case ZEXT116:
-				case ZEXT132:
-				case ZEXT164:
-				case ZEXT816:
-				case ZEXT832:
-				case ZEXT864:
-				case ZEXT1632:
-				case ZEXT1664:
-				case ZEXT3264:
-				// ============ SEXT ============
-				case SEXT18:
-				case SEXT116:
-				case SEXT132:
-				case SEXT164:
-				case SEXT816:
-				case SEXT832:
-				case SEXT864:
-				case SEXT1632:
-				case SEXT1664:
-				case SEXT3264:
-					return e;
-				default:
-					// TODO add support for CTLZ. Right now we assume constant propagation gor rid
-					// of such instructions
-					throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on integer formulas.");
-			}
-		} else {
-			BitvectorFormulaManager bvmgr = m.getBitvectorFormulaManager();
-			BitvectorFormula bv = (BitvectorFormula) e;
-			switch (this) {
-				case MINUS:
-					return bvmgr.negate(bv);
-				case BV2UINT:
-					return ARCH_PRECISION > -1 ? bvmgr.extend(bv, ARCH_PRECISION - bvmgr.getLength(bv), false)
-							: bvmgr.toIntegerFormula(bv, false);
-				case BV2INT:
-					return ARCH_PRECISION > -1 ? bvmgr.extend(bv, ARCH_PRECISION - bvmgr.getLength(bv), true)
-							: bvmgr.toIntegerFormula(bv, true);
-				// ============ INT2BV ============
-				case INT2BV1:
-				case INT2BV8:
-				case INT2BV16:
-				case INT2BV32:
-				case INT2BV64:
-					return e;
-				// ============ TRUNC ============
-				case TRUNC6432:
-					return bvmgr.extract(bv, 31, 0);
-				case TRUNC6416:
-				case TRUNC3216:
-					return bvmgr.extract(bv, 15, 0);
-				case TRUNC648:
-				case TRUNC328:
-				case TRUNC168:
-					return bvmgr.extract(bv, 7, 0);
-				case TRUNC641:
-				case TRUNC321:
-				case TRUNC161:
-				case TRUNC81:
-					return bvmgr.extract(bv, 1, 0);
-				// ============ ZEXT ============
-				case ZEXT18:
-					return bvmgr.extend(bv, 7, false);
-				case ZEXT116:
-					return bvmgr.extend(bv, 15, false);
-				case ZEXT132:
-					return bvmgr.extend(bv, 31, false);
-				case ZEXT164:
-					return bvmgr.extend(bv, 63, false);
-				case ZEXT816:
-					return bvmgr.extend(bv, 8, false);
-				case ZEXT832:
-					return bvmgr.extend(bv, 24, false);
-				case ZEXT864:
-					return bvmgr.extend(bv, 56, false);
-				case ZEXT1632:
-					return bvmgr.extend(bv, 16, false);
-				case ZEXT1664:
-					return bvmgr.extend(bv, 48, false);
-				case ZEXT3264:
-					return bvmgr.extend(bv, 32, false);
-				// ============ SEXT ============
-				case SEXT18:
-					return bvmgr.extend(bv, 7, true);
-				case SEXT116:
-					return bvmgr.extend(bv, 15, true);
-				case SEXT132:
-					return bvmgr.extend(bv, 31, true);
-				case SEXT164:
-					return bvmgr.extend(bv, 63, true);
-				case SEXT816:
-					return bvmgr.extend(bv, 8, true);
-				case SEXT832:
-					return bvmgr.extend(bv, 24, true);
-				case SEXT864:
-					return bvmgr.extend(bv, 56, true);
-				case SEXT1632:
-					return bvmgr.extend(bv, 16, true);
-				case SEXT1664:
-					return bvmgr.extend(bv, 48, true);
-				case SEXT3264:
-					return bvmgr.extend(bv, 32, true);
-				default:
-					// TODO add support for CTLZ. Right now we assume constant propagation gor rid
-					// of such instructions
-					throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on bitvector formulas.");
-			}
-		}
-	}
+    public Formula encode(Formula e, FormulaManager m) {
+        if (e instanceof IntegerFormula) {
+            IntegerFormulaManager imgr = m.getIntegerFormulaManager();
+            IntegerFormula i = (IntegerFormula) e;
+            switch (this) {
+                case MINUS:
+                    return imgr.subtract(imgr.makeNumber(BigInteger.ZERO), i);
+                case BV2UINT:
+                case BV2INT:
+                    return e;
+                // ============ INT2BV ============
+                case INT2BV1:
+                    return m.getBitvectorFormulaManager().makeBitvector(1, i);
+                case INT2BV8:
+                    return m.getBitvectorFormulaManager().makeBitvector(8, i);
+                case INT2BV16:
+                    return m.getBitvectorFormulaManager().makeBitvector(16, i);
+                case INT2BV32:
+                    return m.getBitvectorFormulaManager().makeBitvector(32, i);
+                case INT2BV64:
+                    return m.getBitvectorFormulaManager().makeBitvector(64, i);
+                // ============ TRUNC ============
+                case TRUNC6432:
+                case TRUNC6416:
+                case TRUNC3216:
+                case TRUNC648:
+                case TRUNC328:
+                case TRUNC168:
+                case TRUNC641:
+                case TRUNC321:
+                case TRUNC161:
+                case TRUNC81:
+                // ============ ZEXT ============
+                case ZEXT18:
+                case ZEXT116:
+                case ZEXT132:
+                case ZEXT164:
+                case ZEXT816:
+                case ZEXT832:
+                case ZEXT864:
+                case ZEXT1632:
+                case ZEXT1664:
+                case ZEXT3264:
+                // ============ SEXT ============
+                case SEXT18:
+                case SEXT116:
+                case SEXT132:
+                case SEXT164:
+                case SEXT816:
+                case SEXT832:
+                case SEXT864:
+                case SEXT1632:
+                case SEXT1664:
+                case SEXT3264:
+                    return e;
+                default:
+                    // TODO add support for CTLZ. Right now we assume constant propagation gor rid
+                    // of such instructions
+                    throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on integer formulas.");
+            }
+        } else {
+            BitvectorFormulaManager bvmgr = m.getBitvectorFormulaManager();
+            BitvectorFormula bv = (BitvectorFormula) e;
+            switch (this) {
+                case MINUS:
+                    return bvmgr.negate(bv);
+                case BV2UINT:
+                    return ARCH_PRECISION > -1 ? bvmgr.extend(bv, ARCH_PRECISION - bvmgr.getLength(bv), false)
+                            : bvmgr.toIntegerFormula(bv, false);
+                case BV2INT:
+                    return ARCH_PRECISION > -1 ? bvmgr.extend(bv, ARCH_PRECISION - bvmgr.getLength(bv), true)
+                            : bvmgr.toIntegerFormula(bv, true);
+                // ============ INT2BV ============
+                case INT2BV1:
+                case INT2BV8:
+                case INT2BV16:
+                case INT2BV32:
+                case INT2BV64:
+                    return e;
+                // ============ TRUNC ============
+                case TRUNC6432:
+                    return bvmgr.extract(bv, 31, 0);
+                case TRUNC6416:
+                case TRUNC3216:
+                    return bvmgr.extract(bv, 15, 0);
+                case TRUNC648:
+                case TRUNC328:
+                case TRUNC168:
+                    return bvmgr.extract(bv, 7, 0);
+                case TRUNC641:
+                case TRUNC321:
+                case TRUNC161:
+                case TRUNC81:
+                    return bvmgr.extract(bv, 1, 0);
+                // ============ ZEXT ============
+                case ZEXT18:
+                    return bvmgr.extend(bv, 7, false);
+                case ZEXT116:
+                    return bvmgr.extend(bv, 15, false);
+                case ZEXT132:
+                    return bvmgr.extend(bv, 31, false);
+                case ZEXT164:
+                    return bvmgr.extend(bv, 63, false);
+                case ZEXT816:
+                    return bvmgr.extend(bv, 8, false);
+                case ZEXT832:
+                    return bvmgr.extend(bv, 24, false);
+                case ZEXT864:
+                    return bvmgr.extend(bv, 56, false);
+                case ZEXT1632:
+                    return bvmgr.extend(bv, 16, false);
+                case ZEXT1664:
+                    return bvmgr.extend(bv, 48, false);
+                case ZEXT3264:
+                    return bvmgr.extend(bv, 32, false);
+                // ============ SEXT ============
+                case SEXT18:
+                    return bvmgr.extend(bv, 7, true);
+                case SEXT116:
+                    return bvmgr.extend(bv, 15, true);
+                case SEXT132:
+                    return bvmgr.extend(bv, 31, true);
+                case SEXT164:
+                    return bvmgr.extend(bv, 63, true);
+                case SEXT816:
+                    return bvmgr.extend(bv, 8, true);
+                case SEXT832:
+                    return bvmgr.extend(bv, 24, true);
+                case SEXT864:
+                    return bvmgr.extend(bv, 56, true);
+                case SEXT1632:
+                    return bvmgr.extend(bv, 16, true);
+                case SEXT1664:
+                    return bvmgr.extend(bv, 48, true);
+                case SEXT3264:
+                    return bvmgr.extend(bv, 32, true);
+                default:
+                    // TODO add support for CTLZ. Right now we assume constant propagation gor rid
+                    // of such instructions
+                    throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on bitvector formulas.");
+            }
+        }
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
@@ -5,9 +5,11 @@ import com.dat3m.dartagnan.expression.Atom;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.IExprUn;
 import com.dat3m.dartagnan.expression.IfExpr;
 import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.expression.op.IOpUn;
 import com.dat3m.dartagnan.parsers.BoogieParser;
 import com.dat3m.dartagnan.parsers.BoogieParser.Call_cmdContext;
 import com.dat3m.dartagnan.program.Register;
@@ -34,7 +36,9 @@ public class LlvmProcedures {
 			"llvm.smax.i32",
 			"llvm.smax.i64",
 			"llvm.smin.i32",
-			"llvm.smin.i64"
+			"llvm.smin.i64",
+			"llvm.ctlz.i32",
+			"llvm.ctlz.i64"
 			);
 
 	public static void handleLlvmFunction(VisitorBoogie visitor, Call_cmdContext ctx) {
@@ -125,6 +129,13 @@ public class LlvmProcedures {
 				i2 = (IExpr)p1;
 				cond = name.contains("max") ? new Atom(i1, COpBin.GTE, i2) : new Atom(i1, COpBin.LTE, i2);
 				visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(reg, new IfExpr(cond, i1, i2)))
+						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
+			return;
+				case "llvm.ctlz.i32":
+				case "llvm.ctlz.i64":
+			i1 = (IExpr)p0;
+				i2 = (IExpr)p1;
+				visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(reg, new IExprUn(IOpUn.CTLZ, i1)))
 						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 				return;
 			default:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
@@ -21,131 +21,131 @@ import java.util.List;
 
 public class LlvmProcedures {
 
-	public static List<String> LLVMPROCEDURES = Arrays.asList(
-			// Atomic operations
-			"__llvm_atomic32_load",
-			"__llvm_atomic64_load",
-			"__llvm_atomic32_store",
-			"__llvm_atomic64_store",
-			"__llvm_atomic32_cmpxchg",
-			"__llvm_atomic64_cmpxchg",
-			"__llvm_atomic32_rmw",
-			"__llvm_atomic64_rmw",
-			"__llvm_atomic_fence",
-			// Intrinsics
-			"llvm.smax.i32",
-			"llvm.smax.i64",
-			"llvm.smin.i32",
-			"llvm.smin.i64",
-			"llvm.ctlz.i32",
-			"llvm.ctlz.i64");
+    public static List<String> LLVMPROCEDURES = Arrays.asList(
+            // Atomic operations
+            "__llvm_atomic32_load",
+            "__llvm_atomic64_load",
+            "__llvm_atomic32_store",
+            "__llvm_atomic64_store",
+            "__llvm_atomic32_cmpxchg",
+            "__llvm_atomic64_cmpxchg",
+            "__llvm_atomic32_rmw",
+            "__llvm_atomic64_rmw",
+            "__llvm_atomic_fence",
+            // Intrinsics
+            "llvm.smax.i32",
+            "llvm.smax.i64",
+            "llvm.smin.i32",
+            "llvm.smin.i64",
+            "llvm.ctlz.i32",
+            "llvm.ctlz.i64");
 
-	public static void handleLlvmFunction(VisitorBoogie visitor, Call_cmdContext ctx) {
-		String name = ctx.call_params().Define() == null ? ctx.call_params().Ident(0).getText() : ctx.call_params().Ident(1).getText();
-		List<BoogieParser.ExprContext> params = ctx.call_params().exprs().expr();
+    public static void handleLlvmFunction(VisitorBoogie visitor, Call_cmdContext ctx) {
+        String name = ctx.call_params().Define() == null ? ctx.call_params().Ident(0).getText() : ctx.call_params().Ident(1).getText();
+        List<BoogieParser.ExprContext> params = ctx.call_params().exprs().expr();
 
-		String regName = visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText();
-		Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, regName, GlobalSettings.ARCH_PRECISION);
+        String regName = visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText();
+        Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, regName, GlobalSettings.ARCH_PRECISION);
 
-		Object p0 = params.get(0).accept(visitor);
-		Object p1 = params.size() > 1 ? params.get(1).accept(visitor) : null;
-		Object p2 = params.size() > 2 ? params.get(2).accept(visitor) : null;
-		Object p3 = params.size() > 3 ? params.get(3).accept(visitor) : null;
+        Object p0 = params.get(0).accept(visitor);
+        Object p1 = params.size() > 1 ? params.get(1).accept(visitor) : null;
+        Object p2 = params.size() > 2 ? params.get(2).accept(visitor) : null;
+        Object p3 = params.size() > 3 ? params.get(3).accept(visitor) : null;
 
-		String mo;
+        String mo;
 
-		// For intrinsics
-		IExpr i1;
-		IExpr i2;
-		Atom cond;
+        // For intrinsics
+        IExpr i1;
+        IExpr i2;
+        Atom cond;
 
-		switch (name) {
-			case "__llvm_atomic32_load":
-			case "__llvm_atomic64_load":
-				mo = C11.intToMo(((IConst) p1).getValueAsInt());
-				visitor.programBuilder.addChild(visitor.threadCount, Llvm.newLoad(reg, (IExpr) p0, mo))
-						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-				return;
-			case "__llvm_atomic32_store":
-			case "__llvm_atomic64_store":
-				mo = C11.intToMo(((IConst) p2).getValueAsInt());
-				visitor.programBuilder.addChild(visitor.threadCount, Llvm.newStore((IExpr) p0, (ExprInterface) p1, mo))
-						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-				return;
-			case "__llvm_atomic_fence":
-				mo = C11.intToMo(((IConst) p0).getValueAsInt());
-				visitor.programBuilder.addChild(visitor.threadCount, Llvm.newFence(mo))
-						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-				return;
-			case "__llvm_atomic32_cmpxchg":
-			case "__llvm_atomic64_cmpxchg":
-				// Since we don't support struct types, we instead model each member as a
-				// register.
-				// It is the responsibility of each LLVM istruction creating a structure to
-				// create such registers,
-				// then when calling "extractvalue" we can check if the member was properly
-				// initialized
-				Register oldValueRegister = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, regName + "(0)", GlobalSettings.ARCH_PRECISION);
-				Register cmpRegister = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, regName + "(1)", GlobalSettings.ARCH_PRECISION);
-				// The compilation of Llvm.newCompareExchange will
-				// assign the correct values to the registers above
-				mo = C11.intToMo(((IConst) p3).getValueAsInt());
-				visitor.programBuilder
-						.addChild(visitor.threadCount, Llvm.newCompareExchange(oldValueRegister, cmpRegister, (IExpr) p0, (IExpr) p1, (IExpr) p2, mo, true))
-						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-				return;
-			case "__llvm_atomic32_rmw":
-			case "__llvm_atomic64_rmw":
-				mo = C11.intToMo(((IConst) p2).getValueAsInt());
-				IOpBin op;
-				switch (((IConst) p3).getValueAsInt()) {
-					case 0:
-						visitor.programBuilder
-								.addChild(visitor.threadCount, Llvm.newExchange(reg, (IExpr) p0, (IExpr) p1, mo))
-								.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-						return;
-					case 1:
-						op = IOpBin.PLUS;
-						break;
-					case 2:
-						op = IOpBin.MINUS;
-						break;
-					case 3:
-						op = IOpBin.AND;
-						break;
-					case 4:
-						op = IOpBin.OR;
-						break;
-					case 5:
-						op = IOpBin.XOR;
-						break;
-					default:
-						throw new UnsupportedOperationException("Operation " + params.get(3).getText() + " is not recognized.");
-				}
-				visitor.programBuilder.addChild(visitor.threadCount, Llvm.newRMW(reg, (IExpr) p0, (IExpr) p1, op, mo))
-						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-				return;
-			case "llvm.smax.i32":
-			case "llvm.smax.i64":
-			case "llvm.smin.i32":
-			case "llvm.smin.i64":
-				i1 = (IExpr) p0;
-				i2 = (IExpr) p1;
-				cond = name.contains("max") ? new Atom(i1, COpBin.GTE, i2) : new Atom(i1, COpBin.LTE, i2);
-				visitor.programBuilder
-						.addChild(visitor.threadCount, EventFactory.newLocal(reg, new IfExpr(cond, i1, i2)))
-						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-				return;
-			case "llvm.ctlz.i32":
-			case "llvm.ctlz.i64":
-				i1 = (IExpr) p0;
-				i2 = (IExpr) p1;
-				visitor.programBuilder
-						.addChild(visitor.threadCount, EventFactory.newLocal(reg, new IExprUn(IOpUn.CTLZ, i1)))
-						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-				return;
-			default:
-				throw new UnsupportedOperationException(name + " procedure is not part of LLVMPROCEDURES");
-		}
-	}
+        switch (name) {
+            case "__llvm_atomic32_load":
+            case "__llvm_atomic64_load":
+                mo = C11.intToMo(((IConst) p1).getValueAsInt());
+                visitor.programBuilder.addChild(visitor.threadCount, Llvm.newLoad(reg, (IExpr) p0, mo))
+                        .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
+                return;
+            case "__llvm_atomic32_store":
+            case "__llvm_atomic64_store":
+                mo = C11.intToMo(((IConst) p2).getValueAsInt());
+                visitor.programBuilder.addChild(visitor.threadCount, Llvm.newStore((IExpr) p0, (ExprInterface) p1, mo))
+                        .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
+                return;
+            case "__llvm_atomic_fence":
+                mo = C11.intToMo(((IConst) p0).getValueAsInt());
+                visitor.programBuilder.addChild(visitor.threadCount, Llvm.newFence(mo))
+                        .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
+                return;
+            case "__llvm_atomic32_cmpxchg":
+            case "__llvm_atomic64_cmpxchg":
+                // Since we don't support struct types, we instead model each member as a
+                // register.
+                // It is the responsibility of each LLVM istruction creating a structure to
+                // create such registers,
+                // then when calling "extractvalue" we can check if the member was properly
+                // initialized
+                Register oldValueRegister = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, regName + "(0)", GlobalSettings.ARCH_PRECISION);
+                Register cmpRegister = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, regName + "(1)", GlobalSettings.ARCH_PRECISION);
+                // The compilation of Llvm.newCompareExchange will
+                // assign the correct values to the registers above
+                mo = C11.intToMo(((IConst) p3).getValueAsInt());
+                visitor.programBuilder
+                        .addChild(visitor.threadCount, Llvm.newCompareExchange(oldValueRegister, cmpRegister, (IExpr) p0, (IExpr) p1, (IExpr) p2, mo, true))
+                        .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
+                return;
+            case "__llvm_atomic32_rmw":
+            case "__llvm_atomic64_rmw":
+                mo = C11.intToMo(((IConst) p2).getValueAsInt());
+                IOpBin op;
+                switch (((IConst) p3).getValueAsInt()) {
+                    case 0:
+                        visitor.programBuilder
+                                .addChild(visitor.threadCount, Llvm.newExchange(reg, (IExpr) p0, (IExpr) p1, mo))
+                                .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
+                        return;
+                    case 1:
+                        op = IOpBin.PLUS;
+                        break;
+                    case 2:
+                        op = IOpBin.MINUS;
+                        break;
+                    case 3:
+                        op = IOpBin.AND;
+                        break;
+                    case 4:
+                        op = IOpBin.OR;
+                        break;
+                    case 5:
+                        op = IOpBin.XOR;
+                        break;
+                    default:
+                        throw new UnsupportedOperationException("Operation " + params.get(3).getText() + " is not recognized.");
+                }
+                visitor.programBuilder.addChild(visitor.threadCount, Llvm.newRMW(reg, (IExpr) p0, (IExpr) p1, op, mo))
+                        .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
+                return;
+            case "llvm.smax.i32":
+            case "llvm.smax.i64":
+            case "llvm.smin.i32":
+            case "llvm.smin.i64":
+                i1 = (IExpr) p0;
+                i2 = (IExpr) p1;
+                cond = name.contains("max") ? new Atom(i1, COpBin.GTE, i2) : new Atom(i1, COpBin.LTE, i2);
+                visitor.programBuilder
+                        .addChild(visitor.threadCount, EventFactory.newLocal(reg, new IfExpr(cond, i1, i2)))
+                        .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
+                return;
+            case "llvm.ctlz.i32":
+            case "llvm.ctlz.i64":
+                i1 = (IExpr) p0;
+                i2 = (IExpr) p1;
+                visitor.programBuilder
+                        .addChild(visitor.threadCount, EventFactory.newLocal(reg, new IExprUn(IOpUn.CTLZ, i1)))
+                        .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
+                return;
+            default:
+                throw new UnsupportedOperationException(name + " procedure is not part of LLVMPROCEDURES");
+        }
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
@@ -130,10 +130,10 @@ public class LlvmProcedures {
 				cond = name.contains("max") ? new Atom(i1, COpBin.GTE, i2) : new Atom(i1, COpBin.LTE, i2);
 				visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(reg, new IfExpr(cond, i1, i2)))
 						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-			return;
-				case "llvm.ctlz.i32":
-				case "llvm.ctlz.i64":
-			i1 = (IExpr)p0;
+				return;
+			case "llvm.ctlz.i32":
+			case "llvm.ctlz.i64":
+				i1 = (IExpr)p0;
 				i2 = (IExpr)p1;
 				visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(reg, new IExprUn(IOpUn.CTLZ, i1)))
 						.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -41,13 +41,15 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
 
     // ====================================================================================
 
-    private SparseConditionalConstantPropagation() { }
+    private SparseConditionalConstantPropagation() {
+    }
 
     public static SparseConditionalConstantPropagation newInstance() {
         return new SparseConditionalConstantPropagation();
     }
 
-    public static SparseConditionalConstantPropagation fromConfig(Configuration config) throws InvalidConfigurationException {
+    public static SparseConditionalConstantPropagation fromConfig(Configuration config)
+            throws InvalidConfigurationException {
         SparseConditionalConstantPropagation instance = newInstance();
         config.inject(instance);
         return instance;
@@ -63,14 +65,16 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
 
     private void run(Thread thread) {
         final EventSimplifier simplifier = new EventSimplifier();
-        final Predicate<ExprInterface> checkDoPropagate = propagateCopyAssignments ?
-                (expr -> expr instanceof IConst || expr instanceof BConst || expr instanceof Register)
+        final Predicate<ExprInterface> checkDoPropagate = propagateCopyAssignments
+                ? (expr -> expr instanceof IConst || expr instanceof BConst || expr instanceof Register)
                 : (expr -> expr instanceof IConst || expr instanceof BConst);
 
         Set<Event> reachableEvents = new HashSet<>();
         Map<Label, Map<Register, ExprInterface>> inflowMap = new HashMap<>();
-        // NOTE: An absent key represents the TOP value of our lattice (we start from TOP everywhere)
-        //       BOT is not represented as it is never produced (we only ever join non-BOT values and hence never produce BOT).
+        // NOTE: An absent key represents the TOP value of our lattice (we start from
+        // TOP everywhere)
+        // BOT is not represented as it is never produced (we only ever join non-BOT
+        // values and hence never produce BOT).
         Map<Register, ExprInterface> propagationMap = new HashMap<>();
         boolean isTraversingDeadBranch = false;
 
@@ -102,15 +106,16 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
                     final CondJump jump = (CondJump) cur;
                     final Label target = jump.getLabel();
                     if (jump.isGoto()) {
-                        // The successor event is going to be dead (unless it is a label with other inflow).
+                        // The successor event is going to be dead (unless it is a label with other
+                        // inflow).
                         isTraversingDeadBranch = true;
                         propagationMap.clear();
                     }
                     if (!jump.isDead()) {
                         // Join current map with label-associated map
                         final Map<Register, ExprInterface> finalPropagationMap = propagationMap;
-                        inflowMap.compute(target, (k, v) -> v == null ?
-                                new HashMap<>(finalPropagationMap) : join(v, finalPropagationMap));
+                        inflowMap.compute(target, (k, v) -> v == null ? new HashMap<>(finalPropagationMap)
+                                : join(v, finalPropagationMap));
                     }
                 }
             }
@@ -122,10 +127,12 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
             if (reachableEvents.contains(e)) {
                 continue;
             } else if (e instanceof Label && e.is(Tag.NOOPT)) {
-                // FIXME: This check is just to avoid deleting loop-related labels (especially the loop end marker)
-                //  because those are used to find unrolled loops.
-                //  There should be better ways that do not retain such dead code: for example, we could
-                //  move the loop end marker into the last non-dead iteration.
+                // FIXME: This check is just to avoid deleting loop-related labels (especially
+                // the loop end marker)
+                // because those are used to find unrolled loops.
+                // There should be better ways that do not retain such dead code: for example,
+                // we could
+                // move the loop end marker into the last non-dead iteration.
                 continue;
             }
             e.delete();
@@ -144,7 +151,7 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
     }
 
     /*
-        Simplifies the expressions of events by inserting known constant values.
+     * Simplifies the expressions of events by inserting known constant values.
      */
     private static class EventSimplifier implements EventVisitor<Void> {
 
@@ -173,7 +180,7 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
 
         @Override
         public Void visitMemEvent(MemEvent e) {
-            e.setAddress((IExpr)e.getAddress().visit(propagator));
+            e.setAddress((IExpr) e.getAddress().visit(propagator));
             return null;
         }
 
@@ -185,19 +192,19 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
 
         @Override
         public Void visitMalloc(Malloc e) {
-            e.setSizeExpr((IExpr)e.getSizeExpr().visit(propagator));
+            e.setSizeExpr((IExpr) e.getSizeExpr().visit(propagator));
             return null;
         }
     }
 
-
     /*
-        A simple expression transformer that
-            - replaces regs by constant values (if known)
-            - simplifies constant (sub)expressions to a single constant
-        It does NOT
-            - use associativity to find more constant subexpressions
-            - simplify trivial expressions like "x == x" or "0*x" to avoid eliminating any dependencies
+     * A simple expression transformer that
+     * - replaces regs by constant values (if known)
+     * - simplifies constant (sub)expressions to a single constant
+     * It does NOT
+     * - use associativity to find more constant subexpressions
+     * - simplify trivial expressions like "x == x" or "0*x" to avoid eliminating
+     * any dependencies
      */
     private static class ConstantPropagator extends ExprTransformer {
 
@@ -207,7 +214,8 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
         public ExprInterface visit(Register reg) {
             final ExprInterface retVal = propagationMap.getOrDefault(reg, reg);
             if (retVal instanceof BConst) {
-                // We only have integral registers, so we need to implicitly convert booleans to integers.
+                // We only have integral registers, so we need to implicitly convert booleans to
+                // integers.
                 return retVal.equals(BConst.TRUE) ? IValue.ONE : IValue.ZERO;
             } else {
                 return retVal;
@@ -287,7 +295,8 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
             IExpr trueBranch = (IExpr) ifExpr.getTrueBranch().visit(this);
             IExpr falseBranch = (IExpr) ifExpr.getFalseBranch().visit(this);
             if (guard instanceof BConst && trueBranch instanceof IValue && falseBranch instanceof IValue) {
-                // We optimize ITEs only if all subexpressions are constant to avoid messing up data dependencies
+                // We optimize ITEs only if all subexpressions are constant to avoid messing up
+                // data dependencies
                 return guard.equals(BConst.TRUE) ? trueBranch : falseBranch;
             }
             return new IfExpr(guard, trueBranch, falseBranch);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -273,8 +273,9 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
         public IExpr visit(IExprUn iUn) {
             IExpr inner = (IExpr) iUn.getInner().visit(this);
             if (inner instanceof IValue && iUn.getOp() == IOpUn.MINUS) {
-                // We only optimize negation but no casting operations.
                 return new IValue(((IValue) inner).getValue().negate(), inner.getPrecision());
+            } else if (inner instanceof IValue && iUn.getOp() == IOpUn.CTLZ) {
+                return new IExprUn(iUn.getOp(), inner).reduce();
             } else {
                 return new IExprUn(iUn.getOp(), inner);
             }


### PR DESCRIPTION
This PR adds support for `llvm.ctlz` intrinsic which counts the leading zeros of a value. This resulted in a new `IOpUn` operator. While it might be possible to properly encode its semantics as a big ITE, in most of the cases I have seen, CP should completely remove such instructions so I currently do not see the need to implement this. 