### PR TITLE
Improved memory allocation

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -46,9 +46,8 @@ public class ProgramBuilder {
     
     public Program build(){
         Program program = new Program(memory, format);
-        buildInitThreads();
         for(Thread thread : threads.values()){
-        	addChild(thread.getId(), getOrCreateLabel("END_OF_T" + thread.getId()));
+            addChild(thread.getId(), getOrCreateLabel("END_OF_T" + thread.getId()));
             validateLabels(thread);
             program.add(thread);
             thread.setProgram(program);
@@ -190,27 +189,6 @@ public class ProgramBuilder {
 
     // ----------------------------------------------------------------------------------------------------------------
     // Private utility
-
-    private int nextThreadId(){
-        int maxId = -1;
-        for(int key : threads.keySet()){
-            maxId = Integer.max(maxId, key);
-        }
-        return maxId + 1;
-    }
-
-    private void buildInitThreads(){
-        int nextThreadId = nextThreadId();
-        for(MemoryObject memObj : memory.getObjects()) {
-            assert memObj.isStaticallyAllocated();
-            for (Integer field : memObj.getInitializedFields()) {
-                Event init = EventFactory.newInit(memObj, field);
-                Thread thread = new Thread(nextThreadId, init);
-                threads.put(nextThreadId,thread);
-                nextThreadId++;
-            }
-        }
-    }
 
     private void validateLabels(Thread thread) throws MalformedProgramException {
         Map<String, Label> threadLabels = new HashMap<>();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -113,7 +113,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 			return true;
 		}
 		// We also ignore all kinds of strings for now.
-		if (varName.contains(".str")) {
+		if (varName.startsWith(".str")) {
 			return true;
 		}
 		return false;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -116,6 +116,10 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 		if (varName.startsWith(".str")) {
 			return true;
 		}
+		// These are special strings containing function names.
+		if (varName.startsWith("__PRETTY_FUNCTION")) {
+			return true;
+		}
 		return false;
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Memory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Memory.java
@@ -6,7 +6,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
 
 public class Memory {
 
@@ -19,9 +19,9 @@ public class Memory {
      * @return
      * Points to the created location.
      */
-    public MemoryObject allocate(int size) {
+    public MemoryObject allocate(int size, boolean isStatic) {
         Preconditions.checkArgument(size > 0, "Illegal malloc. Size must be positive");
-        MemoryObject address = new MemoryObject(nextIndex++,size);
+        MemoryObject address = new MemoryObject(nextIndex++, size, isStatic);
         objects.add(address);
         return address;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Memory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Memory.java
@@ -1,11 +1,8 @@
 package com.dat3m.dartagnan.program.memory;
 
-import com.dat3m.dartagnan.program.Program;
-import com.dat3m.dartagnan.program.processing.ProgramProcessor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
-import java.math.BigInteger;
 import java.util.ArrayList;
 
 public class Memory {
@@ -35,32 +32,4 @@ public class Memory {
         return ImmutableSet.copyOf(objects);
     }
 
-    /**
-     * Creates a new processing primitive that recalculates addresses.
-     * @return
-     * When provided a program, repositions its allocated objects.
-     */
-    public static FixateMemoryValues fixateMemoryValues() {
-        return new FixateMemoryValues();
-    }
-
-    /**
-     * Recomputes the values for all objects,
-     * so that their arrays do not overlap.
-     */
-    public static final class FixateMemoryValues implements ProgramProcessor {
-
-        @Override
-        public void run(Program program) {
-            BigInteger i = BigInteger.TWO;
-            for(MemoryObject a : program.getMemory().objects) {
-                a.address = i;
-                // Addresses are tipically at least two byte aligned
-                //      https://stackoverflow.com/questions/23315939/why-2-lsbs-of-32-bit-arm-instruction-address-not-used
-                // Many algorithms rely on this assumption for correctness
-                int padding = (a.size() % 2);
-                i = i.add(BigInteger.valueOf(a.size() + padding));
-            }
-        }
-    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
@@ -59,6 +59,9 @@ public class MemoryObject extends IConst {
         return initialValues.keySet();
     }
 
+    public BigInteger getAddress() { return this.address; }
+    public void setAddress(BigInteger addr) { this.address = addr; }
+
     /**
      * @return Number of fields in this array.
      */

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import static com.dat3m.dartagnan.GlobalSettings.getArchPrecision;
 import static com.dat3m.dartagnan.expression.op.IOpBin.PLUS;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Associated with an array of memory locations.
@@ -55,7 +56,8 @@ public class MemoryObject extends IConst {
     public boolean isDynamicallyAllocated() { return !isStatic; }
 
     // Should only be called for statically allocated objects.
-    public Set<Integer> getInitializedFields() {
+    public Set<Integer> getStaticallyInitializedFields() {
+        checkState(this.isStaticallyAllocated());
         return initialValues.keySet();
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LogProgramStatistics.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LogProgramStatistics.java
@@ -44,7 +44,11 @@ public class LogProgramStatistics implements ProgramProcessor {
             // TODO: Why do we do this?
         }
 
-        int addressSpaceSize = program.getMemory().getObjects().stream().mapToInt(MemoryObject::size).sum();
+        int staticAddressSpaceSize = program.getMemory().getObjects().stream()
+                .filter(MemoryObject::isStaticallyAllocated).mapToInt(MemoryObject::size).sum();
+        int dynamicAddressSpaceSize = program.getMemory().getObjects().stream()
+                .filter(MemoryObject::isDynamicallyAllocated).mapToInt(MemoryObject::size).sum();
+        int totalAddressSpaceSize = dynamicAddressSpaceSize + staticAddressSpaceSize;
 
         StringBuilder output = new StringBuilder();
         output.append("\n======== Program statistics ========").append("\n");
@@ -54,7 +58,9 @@ public class LogProgramStatistics implements ProgramProcessor {
                 .append("\t#Loads: ").append(loadCount).append("\n")
                 .append("\t#Fences: ").append(fenceCount).append("\n")
                 .append("\t#Init: ").append(initCount).append("\n")
-                .append("#Allocated bytes: ").append(addressSpaceSize).append("\n");
+                .append("#Allocated bytes: ").append(totalAddressSpaceSize).append("\n")
+                .append("\tStatically allocated: ").append(staticAddressSpaceSize).append("\n")
+                .append("\tDynamically allocated: ").append(dynamicAddressSpaceSize).append("\n");
         output.append("========================================");
         logger.info(output);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LogProgramStatistics.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LogProgramStatistics.java
@@ -1,0 +1,61 @@
+package com.dat3m.dartagnan.program.processing;
+
+import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.memory.MemoryObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class LogProgramStatistics implements ProgramProcessor {
+
+    private static final Logger logger = LogManager.getLogger(LogProgramStatistics.class);
+
+    private LogProgramStatistics() { }
+
+    public static LogProgramStatistics newInstance() { return new LogProgramStatistics(); }
+
+    @Override
+    public void run(Program program) {
+        if (!logger.isInfoEnabled()) {
+            return;
+        }
+
+        int totalEventCount = 0;
+        int storeCount = 0;
+        int loadCount = 0;
+        int initCount = 0;
+        int fenceCount = 0;
+        for (Event e : program.getEvents()) {
+            totalEventCount++;
+            if (e instanceof Store) {
+                storeCount++;
+            } else if (e instanceof Load) {
+                loadCount++;
+            } else if (e instanceof Init) {
+                initCount++;
+            } else if (e instanceof Fence) {
+                fenceCount++;
+            }
+        }
+
+        int numNonInitThreads = (int)program.getThreads().stream().filter(t -> !(t.getEntry() instanceof Init)).count();
+        if (program.getFormat() == Program.SourceLanguage.BOOGIE) {
+            numNonInitThreads--; // We subtract 1, because for Boogie code we always create an extra empty thread
+            // TODO: Why do we do this?
+        }
+
+        int addressSpaceSize = program.getMemory().getObjects().stream().mapToInt(MemoryObject::size).sum();
+
+        StringBuilder output = new StringBuilder();
+        output.append("\n======== Program statistics ========").append("\n");
+        output.append("#Threads: ").append(numNonInitThreads).append("\n")
+                .append("#Events: ").append(totalEventCount).append("\n")
+                .append("\t#Stores: ").append(storeCount).append("\n")
+                .append("\t#Loads: ").append(loadCount).append("\n")
+                .append("\t#Fences: ").append(fenceCount).append("\n")
+                .append("\t#Init: ").append(initCount).append("\n")
+                .append("#Allocated bytes: ").append(addressSpaceSize).append("\n");
+        output.append("========================================");
+        logger.info(output);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
@@ -32,7 +32,7 @@ public class MemoryAllocation implements ProgramProcessor {
 
         final List<MemoryObject> memObjs = new ArrayList<>();
         for (Malloc malloc : program.getEvents(Malloc.class)) {
-            final MemoryObject memoryObject = program.getMemory().allocate(getSize(malloc));
+            final MemoryObject memoryObject = program.getMemory().allocate(getSize(malloc), false);
             memObjs.add(memoryObject);
 
             final Local local = EventFactory.newLocal(malloc.getResultRegister(), memoryObject);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
@@ -80,9 +80,9 @@ public class MemoryAllocation implements ProgramProcessor {
             // we expect at least every 8 bytes to be initialized.
             final boolean isStaticallyInitialized = !isLitmus
                     && memObj.isStaticallyAllocated()
-                    && (memObj.getInitializedFields().size() >= memObj.size() / 8);
+                    && (memObj.getStaticallyInitializedFields().size() >= memObj.size() / 8);
             final Iterable<Integer> fieldsToInit = isStaticallyInitialized ?
-                    memObj.getInitializedFields() : IntStream.range(0, memObj.size()).boxed()::iterator;
+                    memObj.getStaticallyInitializedFields() : IntStream.range(0, memObj.size()).boxed()::iterator;
 
             for(int i : fieldsToInit) {
                 final Event init = EventFactory.newInit(memObj, i);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
@@ -63,10 +63,14 @@ public class MemoryAllocation implements ProgramProcessor {
         for(MemoryObject memObj : memory.getObjects()) {
             memObj.setAddress(nextAddr);
 
-            // nextAddr += memObjSize + ((-memObjSize) mod alignment)
+            // Compute next aligned address as follows:
+            //  nextAddr = curAddr + size + padding = k*alignment   // Alignment requirement
+            //  => padding = k*alignment - curAddr - size
+            //  => padding mod alignment = (-size) mod alignment    // k*alignment and curAddr are 0 mod alignment.
+            //  => padding = (-size) mod alignment                  // Because padding < alignment
             final BigInteger memObjSize = BigInteger.valueOf(memObj.size());
-            nextAddr = nextAddr.add(memObjSize)
-                    .add(memObjSize.negate().mod(alignment));
+            final BigInteger padding = memObjSize.negate().mod(alignment);
+            nextAddr = nextAddr.add(memObjSize).add(padding);
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -94,7 +94,8 @@ public class ProcessingManager implements ProgramProcessor {
                 reduceSymmetry ? SymmetryReduction.fromConfig(config) : null,
                 MemoryAllocation.newInstance(),
                 EventIdReassignment.newInstance(), // Normalize used Ids (remove any gaps)
-                printAfterProcessing ? DebugPrint.withHeader("After processing") : null
+                printAfterProcessing ? DebugPrint.withHeader("After processing") : null,
+                LogProgramStatistics.newInstance()
         ));
         programProcessors.removeIf(Objects::isNull);
     }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -15,6 +15,7 @@ import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.processing.LoopUnrolling;
+import com.dat3m.dartagnan.program.processing.MemoryAllocation;
 import com.dat3m.dartagnan.program.processing.compilation.Compilation;
 import com.dat3m.dartagnan.verification.Context;
 import org.junit.Test;
@@ -74,6 +75,7 @@ public class AnalysisTest {
         Program program = b.build();
         LoopUnrolling.newInstance().run(program);
         Compilation.newInstance().run(program);
+        MemoryAllocation.newInstance().run(program);
         Configuration config = Configuration.defaultConfiguration();
         Context context = Context.create();
         context.register(BranchEquivalence.class, BranchEquivalence.fromConfig(program, config));
@@ -130,6 +132,7 @@ public class AnalysisTest {
         b.addChild(0, e3);
 
         Program program = b.build();
+        MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
         MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
         MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);
@@ -171,6 +174,7 @@ public class AnalysisTest {
         b.addChild(0, e3);
 
         Program program = b.build();
+        MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
         MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
         MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);
@@ -217,6 +221,7 @@ public class AnalysisTest {
         b.addChild(0, l0);
 
         Program program = b.build();
+        MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
         MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
         MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);
@@ -258,6 +263,7 @@ public class AnalysisTest {
         b.addChild(0, e3);
 
         Program program = b.build();
+        MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
         MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
         MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);


### PR DESCRIPTION
This PR allows us to distinguish between statically and dynamically allocated memory.
For statically allocated memory, we exploit the static initialization generated by Smack to create `Init` events for only a subset of the statically allocated address space.