### PR TITLE
Add bit-vector encoding for CTLZ

### DIFF
--- a/benchmarks/c/miscellaneous/ctlz.c
+++ b/benchmarks/c/miscellaneous/ctlz.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+#include <assert.h>
+
+volatile int32_t x = 1;
+volatile int32_t y = INT32_MAX;
+volatile int32_t z = INT32_MAX+1;
+volatile int32_t u;
+
+int main()
+{
+    // x = 0000 0000 0000 0000 0000 0000 0000 0001 
+    u = __builtin_clz(x);
+	assert(u == 31);
+    // y = 0111 1111 1111 1111 1111 1111 1111 1111 
+    u = __builtin_clz(y);
+	assert(u == 1);
+    // z = 1000 0000 0000 0000 0000 0000 0000 0000 
+    u = __builtin_clz(z);
+	assert(u == 0);
+
+	return 0;
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -28,8 +28,8 @@ public enum IOpUn {
     }
 
     public Formula encode(Formula e, FormulaManager m) {
-        IntegerFormulaManager imgr = m.getIntegerFormulaManager();
         if (e instanceof IntegerFormula) {
+            IntegerFormulaManager imgr = m.getIntegerFormulaManager();
             IntegerFormula i = (IntegerFormula) e;
             switch (this) {
                 case MINUS:
@@ -165,7 +165,7 @@ public enum IOpUn {
                     return bvmgr.extend(bv, 32, true);
                 case CTLZ:
                     // enc = extract(bv, 63, 63) == 1 ? 0 : (extract(bv, 62, 62) == 1 ? 1 : extract ... extract(bv, 0, 0) ? 63 : 64)
-                    IntegerFormula enc = imgr.makeNumber(bvmgr.getLength(bv));
+                    BitvectorFormula enc = bvmgr.makeBitvector(bvmgr.getLength(bv), bvmgr.getLength(bv));
                     for(int i = bvmgr.getLength(bv); i >= 0; i--) {
                         enc = ctlzEncodingAtIndex(i, bv, enc, m);
                     }
@@ -176,13 +176,12 @@ public enum IOpUn {
         }
     }
 
-    private IntegerFormula ctlzEncodingAtIndex(int i, BitvectorFormula bv, IntegerFormula rest, FormulaManager m) {
-        IntegerFormulaManager imgr = m.getIntegerFormulaManager();
+    private BitvectorFormula ctlzEncodingAtIndex(int i, BitvectorFormula bv, BitvectorFormula rest, FormulaManager m) {
         BitvectorFormulaManager bvmgr = m.getBitvectorFormulaManager();
         int bvLength = bvmgr.getLength(bv);
         if(i == bvLength) {
             return rest;
         }
-        return m.getBooleanFormulaManager().ifThenElse(bvmgr.equal(bvmgr.extract(bv, bvLength - (i + 1), bvLength - (i + 1)), bvmgr.makeBitvector(1, 1)), imgr.makeNumber(i), rest);
+        return m.getBooleanFormulaManager().ifThenElse(bvmgr.equal(bvmgr.extract(bv, bvLength - (i + 1), bvLength - (i + 1)), bvmgr.makeBitvector(1, 1)), bvmgr.makeBitvector(bvLength, i), rest);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -165,23 +165,18 @@ public enum IOpUn {
                     return bvmgr.extend(bv, 32, true);
                 case CTLZ:
                     // enc = extract(bv, 63, 63) == 1 ? 0 : (extract(bv, 62, 62) == 1 ? 1 : extract ... extract(bv, 0, 0) ? 63 : 64)
-                    BitvectorFormula enc = bvmgr.makeBitvector(bvmgr.getLength(bv), bvmgr.getLength(bv));
-                    for(int i = bvmgr.getLength(bv); i >= 0; i--) {
-                        enc = ctlzEncodingAtIndex(i, bv, enc, m);
+                    int bvLength = bvmgr.getLength(bv);
+                    BitvectorFormula bv1 = bvmgr.makeBitvector(1, 1);
+                    BitvectorFormula enc = bvmgr.makeBitvector(bvLength, bvLength);
+                    for(int i = bvmgr.getLength(bv) - 1; i >= 0; i--) {
+                        BitvectorFormula bvi = bvmgr.makeBitvector(bvLength, i);
+                        BitvectorFormula bvbit = bvmgr.extract(bv, bvLength - (i + 1), bvLength - (i + 1));
+                        enc = m.getBooleanFormulaManager().ifThenElse(bvmgr.equal(bvbit, bv1), bvi, enc);
                     }
                     return enc;
                 default:
                     throw new UnsupportedOperationException("Encoding of IOpUn operation " + this + " not supported on bitvector formulas.");
             }
         }
-    }
-
-    private BitvectorFormula ctlzEncodingAtIndex(int i, BitvectorFormula bv, BitvectorFormula rest, FormulaManager m) {
-        BitvectorFormulaManager bvmgr = m.getBitvectorFormulaManager();
-        int bvLength = bvmgr.getLength(bv);
-        if(i == bvLength) {
-            return rest;
-        }
-        return m.getBooleanFormulaManager().ifThenElse(bvmgr.equal(bvmgr.extract(bv, bvLength - (i + 1), bvLength - (i + 1)), bvmgr.makeBitvector(1, 1)), bvmgr.makeBitvector(bvLength, i), rest);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -164,9 +164,9 @@ public enum IOpUn {
                 case SEXT3264:
                     return bvmgr.extend(bv, 32, true);
                 case CTLZ:
-                    // enc = extract(bv, 63, 63) == 1 ? 0 : (1 + extract(bv, 62, 62) == 1 ? 0 : 1 + extract ...)
-                    IntegerFormula enc = imgr.makeNumber(0);
-                    for(int i = 0; i < bvmgr.getLength(bv) ; i++) {
+                    // enc = extract(bv, 63, 63) == 1 ? 0 : (extract(bv, 62, 62) == 1 ? 1 : extract ... extract(bv, 0, 0) ? 63 : 64)
+                    IntegerFormula enc = imgr.makeNumber(bvmgr.getLength(bv));
+                    for(int i = bvmgr.getLength(bv); i >= 0; i--) {
                         enc = ctlzEncodingAtIndex(i, bv, enc, m);
                     }
                     return enc;
@@ -179,7 +179,10 @@ public enum IOpUn {
     private IntegerFormula ctlzEncodingAtIndex(int i, BitvectorFormula bv, IntegerFormula rest, FormulaManager m) {
         IntegerFormulaManager imgr = m.getIntegerFormulaManager();
         BitvectorFormulaManager bvmgr = m.getBitvectorFormulaManager();
-        IntegerFormula elseCase = i == 0 ? imgr.makeNumber(1) : imgr.add(imgr.makeNumber(1), rest);
-        return m.getBooleanFormulaManager().ifThenElse(bvmgr.equal(bvmgr.extract(bv, i, i), bvmgr.makeBitvector(1, 1)), imgr.makeNumber(0), elseCase);
+        int bvLength = bvmgr.getLength(bv);
+        if(i == bvLength) {
+            return rest;
+        }
+        return m.getBooleanFormulaManager().ifThenElse(bvmgr.equal(bvmgr.extract(bv, bvLength - (i + 1), bvLength - (i + 1)), bvmgr.makeBitvector(1, 1)), imgr.makeNumber(i), rest);
     }
 }


### PR DESCRIPTION
This PR adds a the encoding of the ctlz instruction. I tested it with the following program
```
#include <stdint.h>
#include <assert.h>

volatile int32_t x = 1;
volatile int32_t y = INT32_MAX;
volatile int32_t z = INT32_MAX+1;
volatile int32_t u;

int main()
{
    // x = 0000 0000 0000 0000 0000 0000 0000 0001 
    u = __builtin_clz(x);
    assert(u == 31);

    // y = 0111 1111 1111 1111 1111 1111 1111 1111 
    u = __builtin_clz(y);
    assert(u == 1);

    // z = 1000 0000 0000 0000 0000 0000 0000 0000 
    u = __builtin_clz(z);
    assert(u == 0);

    return 0;
}
```
However, since we are still wrongly parsing types, testing this requires the following flag `--modeling.precision=32`