### PR TITLE
Show fr edges in witness

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -178,7 +178,13 @@ public class Dartagnan extends BaseOptions {
                     CallStackComputation csc = CallStackComputation.fromConfig(config);
                     csc.run(p);
                     String name = task.getProgram().getName().substring(0, task.getProgram().getName().lastIndexOf('.'));
-                    generateGraphvizFile(m, 1, (x, y) -> true, System.getenv("DAT3M_OUTPUT") + "/", name, csc.getCallStackMapping());
+                    // RF edges give both ordering and data flow information, thus even when the pair is in PO
+                    // we get some data flow information by observing the edge
+                    // FR edges only give ordering information which is known if the pair is also in PO
+                    // CO edges only give ordering information which is known if the pair is also in PO
+                    generateGraphvizFile(m, 1, (x, y) -> false, (x, y) -> x.getThread().equals(y.getThread()),
+                            (x, y) -> x.getThread().equals(y.getThread()), System.getenv("DAT3M_OUTPUT") + "/", name,
+                            csc.getCallStackMapping());
                 }
 
                 long endTime = System.currentTimeMillis();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -182,8 +182,8 @@ public class Dartagnan extends BaseOptions {
                     // we get some data flow information by observing the edge
                     // FR edges only give ordering information which is known if the pair is also in PO
                     // CO edges only give ordering information which is known if the pair is also in PO
-                    generateGraphvizFile(m, 1, (x, y) -> false, (x, y) -> x.getThread().equals(y.getThread()),
-                            (x, y) -> x.getThread().equals(y.getThread()), System.getenv("DAT3M_OUTPUT") + "/", name,
+                    generateGraphvizFile(m, 1, (x, y) -> true, (x, y) -> !x.getThread().equals(y.getThread()),
+                            (x, y) -> !x.getThread().equals(y.getThread()), System.getenv("DAT3M_OUTPUT") + "/", name,
                             csc.getCallStackMapping());
                 }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -426,9 +426,11 @@ public class RefinementSolver extends ModelChecker {
         String directoryName = String.format("%s/refinement/%s-%s-debug/", System.getenv("DAT3M_OUTPUT"), programName, task.getProgram().getArch());
         String fileNameBase = String.format("%s-%d", programName, iterationCount);
         // File with reason edges only
-        generateGraphvizFile(model, iterationCount, edgeFilter, directoryName, fileNameBase, new HashMap<>());
+        generateGraphvizFile(model, iterationCount, edgeFilter, edgeFilter, edgeFilter, directoryName, fileNameBase,
+                new HashMap<>());
         // File with all edges
-        generateGraphvizFile(model, iterationCount, (x,y) -> true, directoryName, fileNameBase + "-full", new HashMap<>());
+        generateGraphvizFile(model, iterationCount, (x, y) -> true, (x, y) -> true, (x, y) -> true, directoryName,
+                fileNameBase + "-full", new HashMap<>());
     }
 
     private Wmm createDefaultWmm() {


### PR DESCRIPTION
This PR adds `fr` edges to the graph witness (which is useful to understand the scheduling points). Both `fr` and `co` edges only bring information about ordering in general. This is not needed between events of the same thread (since the ordering is given by `po`) and thus we filter some edges in the graph. However, `rf` edges also explain how the data flows, and thus keeping `rfi` edges is valuable.