### PR TITLE
Coverage

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -10,6 +10,7 @@ public class OptionNames {
 	public static final String SOLVER = "solver";
 	public static final String TIMEOUT = "timeout";
 	public static final String VALIDATE = "validate";
+	public static final String COVERAGE = "coverage";
 
 	// Modeling Options
 	public static final String THREAD_CREATE_ALWAYS_SUCCEEDS = "modeling.threadCreateAlwaysSucceeds";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.solver.caat4wmm;
 
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.solver.caat.CAATSolver;
 import com.dat3m.dartagnan.solver.caat.reasoning.CAATLiteral;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreLiteral;
@@ -10,6 +11,7 @@ import com.dat3m.dartagnan.utils.logic.Conjunction;
 import com.dat3m.dartagnan.utils.logic.DNF;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
+import com.dat3m.dartagnan.verification.model.EventData;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
 import com.dat3m.dartagnan.wmm.Relation;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
@@ -19,6 +21,7 @@ import org.sosy_lab.java_smt.api.Model;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /*
     This is our domain-specific bridging component that specializes the CAATSolver to the WMM setting.
@@ -63,6 +66,8 @@ public class WMMSolver {
         Statistics stats = result.stats;
         stats.modelExtractionTime = extractTime;
         stats.modelSize = executionGraph.getDomain().size();
+        stats.executedEvents = executionGraph.getDomain().getElements().stream().map(EventData::getEvent)
+                .collect(Collectors.toSet());
 
         if (result.getStatus() == CAATSolver.Status.INCONSISTENT) {
             // ============== Compute Core reasons ==============
@@ -119,6 +124,7 @@ public class WMMSolver {
         long modelExtractionTime;
         long coreReasonComputationTime;
         int modelSize;
+        Set<Event> executedEvents;
         int numComputedCoreReasons;
         int numComputedReducedCoreReasons;
 
@@ -128,6 +134,7 @@ public class WMMSolver {
         public long getCoreReasonComputationTime() { return coreReasonComputationTime; }
         public long getConsistencyCheckTime() { return caatStats.getConsistencyCheckTime(); }
         public int getModelSize() { return modelSize; }
+        public Set<Event> getExecutedEvents() { return executedEvents; }
         public int getNumComputedBaseReasons() { return caatStats.getNumComputedReasons(); }
         public int getNumComputedReducedBaseReasons() { return caatStats.getNumComputedReducedReasons(); }
         public int getNumComputedCoreReasons() { return numComputedCoreReasons; }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.solver.caat4wmm;
 
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.solver.caat.CAATSolver;
 import com.dat3m.dartagnan.solver.caat.reasoning.CAATLiteral;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreLiteral;
@@ -11,7 +10,6 @@ import com.dat3m.dartagnan.utils.logic.Conjunction;
 import com.dat3m.dartagnan.utils.logic.DNF;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
-import com.dat3m.dartagnan.verification.model.EventData;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
 import com.dat3m.dartagnan.wmm.Relation;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
@@ -21,7 +19,6 @@ import org.sosy_lab.java_smt.api.Model;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /*
     This is our domain-specific bridging component that specializes the CAATSolver to the WMM setting.
@@ -66,8 +63,6 @@ public class WMMSolver {
         Statistics stats = result.stats;
         stats.modelExtractionTime = extractTime;
         stats.modelSize = executionGraph.getDomain().size();
-        stats.executedEvents = executionGraph.getDomain().getElements().stream().map(EventData::getEvent)
-                .collect(Collectors.toSet());
 
         if (result.getStatus() == CAATSolver.Status.INCONSISTENT) {
             // ============== Compute Core reasons ==============
@@ -124,7 +119,6 @@ public class WMMSolver {
         long modelExtractionTime;
         long coreReasonComputationTime;
         int modelSize;
-        Set<Event> executedEvents;
         int numComputedCoreReasons;
         int numComputedReducedCoreReasons;
 
@@ -134,7 +128,6 @@ public class WMMSolver {
         public long getCoreReasonComputationTime() { return coreReasonComputationTime; }
         public long getConsistencyCheckTime() { return caatStats.getConsistencyCheckTime(); }
         public int getModelSize() { return modelSize; }
-        public Set<Event> getExecutedEvents() { return executedEvents; }
         public int getNumComputedBaseReasons() { return caatStats.getNumComputedReasons(); }
         public int getNumComputedReducedBaseReasons() { return caatStats.getNumComputedReducedReasons(); }
         public int getNumComputedCoreReasons() { return numComputedCoreReasons; }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -370,7 +370,6 @@ public class RefinementSolver extends ModelChecker {
     private static CharSequence generateSummary(List<WMMSolver.Statistics> statList, int iterationCount,
                                                 long totalNativeSolvingTime, long totalCaatTime,
                                                 long totalRefiningTime, long boundCheckTime) {
-        
         long totalModelExtractTime = 0;
         long totalPopulationTime = 0;
         long totalConsistencyCheckTime = 0;
@@ -421,10 +420,7 @@ public class RefinementSolver extends ModelChecker {
         ThreadSymmetry symm = analysisContext.requires(ThreadSymmetry.class);
 
         Set<Event> executed = new HashSet<>();
-
-        for (WMMSolver.Statistics stats : statList) {
-            executed.addAll(stats.getExecutedEvents());
-        }
+        statList.stream().map(WMMSolver.Statistics::getExecutedEvents).forEach(executed::addAll);
 
         // Track executed events (via oId) wrt the source code file (keys of the map)
         Map<String, Set<Integer>> eMap = new HashMap<>();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -85,7 +85,7 @@ public class RefinementSolver extends ModelChecker {
             description="Prints the coverage report (this option requires --method=caat).",
             secure=true,
             toUppercase=true)
-    private boolean printCovReport = true;
+    private boolean printCovReport = false;
 
     // ======================================================================
 


### PR DESCRIPTION
This PRs adds the option to print a verification coverage report (when `--method=assume`). 

The idea is to collect the events that were executed in any violating execution and compare those wrt the events of the program (before compilation / unrolling, i.e., by comparing `oId`). The report also shows which lines of code were not covered.

Here is a sample output
```
Property-based coverage: 
   -- Events executed by at least one property-violating behavior (including inconsistent behaviors): 99% 
   -- Missing events: 
        T2 / T3 / T4 -> ../cna-verification/kernel/locking/qspinlock.c#204
        T2 / T3 / T4 -> ../cna-verification/kernel/locking/qspinlock.c#335
        T2 / T3 / T4 -> ../cna-verification/kernel/locking/qspinlock.c#536
        T2 / T3 / T4 -> cna-verification/include/asm-generic/qspinlock.h#63
        T2 / T3 / T4 -> cna-verification/include/asm-generic/qspinlock.h#68
```
