### PR TITLE
Propagate oId, cId, uId to freshly created events

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.analysis;
 
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.core.annotations.FunCall;
 import com.dat3m.dartagnan.program.event.core.annotations.FunRet;
@@ -14,55 +15,59 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Stack;
 
-public class CallStackComputation  {
-	
-	private Map<Event, String> callStackMapping = new HashMap<>(); 
+public class CallStackComputation {
 
-    private CallStackComputation () { }
+    private Map<Event, Stack<FunCall>> callStackMapping = new HashMap<>();
 
-    public static CallStackComputation  fromConfig(Configuration config) throws InvalidConfigurationException {
+    private CallStackComputation() {
+    }
+
+    public static CallStackComputation fromConfig(Configuration config) throws InvalidConfigurationException {
         return newInstance();
     }
 
-    public static CallStackComputation  newInstance() {
-        return new CallStackComputation ();
+    public static CallStackComputation newInstance() {
+        return new CallStackComputation();
     }
 
-	public Map<Event, String> getCallStackMapping() {
-		return callStackMapping;
-	}
+    public Map<Event, Stack<FunCall>> getCallStackMapping() {
+        return callStackMapping;
+    }
 
     public void run(Program program) {
 
-        for(Thread thread : program.getThreads()) {
-			Stack<String> callStack = new Stack<>();
-			Event current = thread.getEntry();
-			while (current != null) {
-				if(current instanceof FunCall) {
-					FunCall call = (FunCall)current;
-					callStack.push(call.getFunctionName());
-				}
-				if(current instanceof FunRet) {
-					callStack.pop();
-				}
-				if(current instanceof MemEvent) {
-					callStackMapping.put(current, stackToString(callStack));
-				}
-				current = current.getSuccessor();
-			}       
-		}
+        for (Thread thread : program.getThreads()) {
+            Stack<FunCall> callStack = new Stack<>();
+            Event current = thread.getEntry();
+            while (current != null) {
+                if (current instanceof FunCall) {
+                    FunCall call = (FunCall) current;
+                    callStack.push(call);
+                }
+                if (current instanceof FunRet) {
+                    callStack.pop();
+                }
+                if ((current instanceof MemEvent || current.is(Tag.ASSERTION) || current.is(Tag.SPINLOOP))
+                        && !callStack.isEmpty()) {
+                    Stack<FunCall> newStack = new Stack<>();
+                    newStack.addAll(callStack);
+                    callStackMapping.put(current, newStack);
+                }
+                current = current.getSuccessor();
+            }
+        }
     }
 
-	private String stackToString(Stack<String> s) {
-		StringBuilder strB = new StringBuilder();
-		Iterator<String> it = s.iterator();
-		while(it.hasNext()) {
-			String next = it.next();
-			strB.append(next);
-			if(it.hasNext()) {
-				strB.append(" -> \\n");
-			}
-		}
-		return strB.toString();
-	}
+    public String getStackAsString(Event e, String callsSeparator) {
+        StringBuilder strB = new StringBuilder();
+        Iterator<FunCall> it = callStackMapping.get(e).iterator();
+        while (it.hasNext()) {
+            FunCall next = it.next();
+            strB.append(String.format("%s (%s#%s)", next.getFunctionName(), next.getSourceCodeFileName(), next.getCLine()));
+            if (it.hasNext()) {
+                strB.append(" -> " + callsSeparator);
+            }
+        }
+        return strB.toString();
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
@@ -24,8 +24,8 @@ public abstract class Event implements Encoder, Comparable<Event> {
 	protected int uId = -1;		// Global ID right before unrolling
 	protected int cId = -1;		// Global ID right before compilation
 
-	protected int cLine = -1;				// line in the original C program
-	protected String sourceCodeFile = "";	// filename of the original C program
+	protected int cLine = -1;				    // line in the original C program
+	protected String sourceCodeFilePath  = "";	// path of the original C program
 
 	protected Thread thread; // The thread this event belongs to
 
@@ -49,7 +49,7 @@ public abstract class Event implements Encoder, Comparable<Event> {
 		this.uId = other.uId;
 		this.cId = other.cId;
 		this.cLine = other.cLine;
-		this.sourceCodeFile = other.sourceCodeFile;
+		this.sourceCodeFilePath = other.sourceCodeFilePath;
 	}
 
 	public int getGlobalId() { return globalId; }
@@ -68,13 +68,18 @@ public abstract class Event implements Encoder, Comparable<Event> {
 		return cLine;
 	}
 	
-	public String getSourceCodeFile() {
-		return sourceCodeFile;
+	public String getSourceCodeFilePath() {
+		return sourceCodeFilePath ;
 	}
 
-	public Event setCFileInformation(int line, String file) {
+	public String getSourceCodeFileName() {
+        return sourceCodeFilePath.contains("/") ? sourceCodeFilePath.substring(sourceCodeFilePath.lastIndexOf("/") + 1)
+                : sourceCodeFilePath;
+	}
+
+	public Event setCFileInformation(int line, String sourceCodeFilePath) {
 		this.cLine = line;
-		this.sourceCodeFile = file;
+		this.sourceCodeFilePath  = sourceCodeFilePath ;
 		return this;
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
@@ -64,6 +64,12 @@ public abstract class Event implements Encoder, Comparable<Event> {
 	public int getCId() { return cId; }
 	public void setCId(int id) { this.cId = id; }
 
+    public void copyIds(Event other) {
+        this.oId = other.oId;
+        this.cId = other.cId;
+        this.uId = other.uId;
+    }
+
 	public int getCLine() {
 		return cLine;
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
@@ -64,12 +64,6 @@ public abstract class Event implements Encoder, Comparable<Event> {
 	public int getCId() { return cId; }
 	public void setCId(int id) { this.cId = id; }
 
-    public void copyIds(Event other) {
-        this.oId = other.oId;
-        this.cId = other.cId;
-        this.uId = other.uId;
-    }
-
 	public int getCLine() {
 		return cLine;
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
@@ -54,20 +54,23 @@ public abstract class Event implements Encoder, Comparable<Event> {
 
 	public int getGlobalId() { return globalId; }
 	public void setGlobalId(int id) { this.globalId = id; }
+	public boolean hasGlobalId() { return globalId != -1; }
 
 	public int getOId() { return oId; }
 	public void setOId(int id) { this.oId = id; }
+	public boolean hasOId() { return oId != -1; }
 
 	public int getUId(){ return uId; }
 	public void setUId(int id) { this.uId = id; }
+	public boolean hasUId() { return uId != -1; }
 
 	public int getCId() { return cId; }
 	public void setCId(int id) { this.cId = id; }
+	public boolean hasCId() { return cId != -1; }
 
-	public int getCLine() {
-		return cLine;
-	}
-	
+	public int getCLine() { return cLine; }
+    public boolean hasCLine() { return cLine != -1; }
+
 	public String getSourceCodeFilePath() {
 		return sourceCodeFilePath ;
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ComplexBlockSplitting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ComplexBlockSplitting.java
@@ -64,8 +64,8 @@ public class ComplexBlockSplitting implements ProgramProcessor {
             final Label blockLabel = EventFactory.newLabel(newLabelName);
             final CondJump gotoLabel = EventFactory.newGoto(blockLabel);
 
-            blockLabel.copyIds(condJump);
-            gotoLabel.copyIds(condJump);
+            blockLabel.copyMetadataFrom(condJump);
+            gotoLabel.copyMetadataFrom(condJump);
 
             condJump.insertAfter(gotoLabel);
             gotoLabel.insertAfter(blockLabel);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ComplexBlockSplitting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ComplexBlockSplitting.java
@@ -43,9 +43,6 @@ public class ComplexBlockSplitting implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
-        // This might not a strong requirement, but if it is weaken, then events created by
-        // this class need to not only get the corresponding oId, but also cId.
-        Preconditions.checkArgument(!program.isCompiled(), "ComplexBlockSplitting should be run before compilation.");
         final int numBlockSplittings = program.getThreads().stream().mapToInt(this::run).sum();
 
         logger.info("Split {} complex blocks.", numBlockSplittings);
@@ -67,9 +64,8 @@ public class ComplexBlockSplitting implements ProgramProcessor {
             final Label blockLabel = EventFactory.newLabel(newLabelName);
             final CondJump gotoLabel = EventFactory.newGoto(blockLabel);
 
-            // ComplexBlockSplitting is run before compilation, thus we only need to assign oId
-            blockLabel.setOId(condJump.getOId());
-            gotoLabel.setOId(condJump.getOId());
+            blockLabel.copyIds(condJump);
+            gotoLabel.copyIds(condJump);
 
             condJump.insertAfter(gotoLabel);
             gotoLabel.insertAfter(blockLabel);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ComplexBlockSplitting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ComplexBlockSplitting.java
@@ -5,8 +5,6 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Label;
-import com.google.common.base.Preconditions;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,9 +41,6 @@ public class ComplexBlockSplitting implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
-        // This might not a strong requirement, but if it is weaken, then events created by
-        // this class need to not only get the corresponding oId, but also cId.
-        Preconditions.checkArgument(!program.isCompiled(), "ComplexBlockSplitting should be run before compilation.");
         final int numBlockSplittings = program.getThreads().stream().mapToInt(this::run).sum();
 
         logger.info("Split {} complex blocks.", numBlockSplittings);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ComplexBlockSplitting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ComplexBlockSplitting.java
@@ -5,8 +5,6 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Label;
-import com.google.common.base.Preconditions;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -72,8 +72,11 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
-        Preconditions.checkArgument(program.isCompiled(),
-                "DynamicPureLoopCutting can only be run on compiled programs.");
+        // This is not a strong requirement, but if it is weaken, events created by this
+        // class do not need to get the corresponding uId. This check is in place to
+        // catch such situations.
+        Preconditions.checkArgument(program.isUnrolled(),
+                "DynamicPureLoopCutting can only be run on unrolled programs.");
 
         AnalysisStats stats = new AnalysisStats(0, 0);
         final LoopAnalysis loopAnalysis = LoopAnalysis.newInstance(program);
@@ -130,6 +133,11 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
             trackingRegs.add(trackingReg);
 
             final Event execCheck = EventFactory.newExecutionStatus(trackingReg, sideEffect);
+            // DynamicPureLoopCutting is run after unrolling, thus we need to assign all
+            // three of oId, cId and uId.
+            execCheck.setOId(insertionPoint.getOId());
+            execCheck.setCId(insertionPoint.getCId());
+            execCheck.setUId(insertionPoint.getUId());
             insertionPoint.insertAfter(execCheck);
             insertionPoint = execCheck;
         }
@@ -141,6 +149,11 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
         assumeSideEffect.addFilters(Tag.SPINLOOP, Tag.EARLYTERMINATION, Tag.NOOPT);
         final Event spinloopStart = iterInfo.getIterationStart();
         assumeSideEffect.setCFileInformation(spinloopStart.getCLine(), spinloopStart.getSourceCodeFilePath());
+        // DynamicPureLoopCutting is run after unrolling, thus we need to assign all
+        // three of oId, cId and uId.
+        assumeSideEffect.setOId(spinloopStart.getOId());
+        assumeSideEffect.setCId(spinloopStart.getCId());
+        assumeSideEffect.setUId(spinloopStart.getUId());
         insertionPoint.insertAfter(assumeSideEffect);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -72,11 +72,8 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
-        // This is not a strong requirement, but if it is weaken, events created by this
-        // class do not need to get the corresponding uId. This check is in place to
-        // catch such situations.
-        Preconditions.checkArgument(program.isUnrolled(),
-                "DynamicPureLoopCutting can only be run on unrolled programs.");
+        Preconditions.checkArgument(program.isCompiled(),
+                "DynamicPureLoopCutting can only be run on compiled programs.");
 
         AnalysisStats stats = new AnalysisStats(0, 0);
         final LoopAnalysis loopAnalysis = LoopAnalysis.newInstance(program);
@@ -133,11 +130,6 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
             trackingRegs.add(trackingReg);
 
             final Event execCheck = EventFactory.newExecutionStatus(trackingReg, sideEffect);
-            // DynamicPureLoopCutting is run after unrolling, thus we need to assign all
-            // three of oId, cId and uId.
-            execCheck.setOId(insertionPoint.getOId());
-            execCheck.setCId(insertionPoint.getCId());
-            execCheck.setUId(insertionPoint.getUId());
             insertionPoint.insertAfter(execCheck);
             insertionPoint = execCheck;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -72,11 +72,8 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
-        // This is not a strong requirement, but if it is weaken, events created by this
-        // class do not need to get the corresponding uId. This check is in place to
-        // catch such situations.
-        Preconditions.checkArgument(program.isUnrolled(),
-                "DynamicPureLoopCutting can only be run on unrolled programs.");
+        Preconditions.checkArgument(program.isCompiled(),
+                "DynamicPureLoopCutting can only be run on compiled programs.");
 
         AnalysisStats stats = new AnalysisStats(0, 0);
         final LoopAnalysis loopAnalysis = LoopAnalysis.newInstance(program);
@@ -133,11 +130,6 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
             trackingRegs.add(trackingReg);
 
             final Event execCheck = EventFactory.newExecutionStatus(trackingReg, sideEffect);
-            // DynamicPureLoopCutting is run after unrolling, thus we need to assign all
-            // three of oId, cId and uId.
-            execCheck.setOId(insertionPoint.getOId());
-            execCheck.setCId(insertionPoint.getCId());
-            execCheck.setUId(insertionPoint.getUId());
             insertionPoint.insertAfter(execCheck);
             insertionPoint = execCheck;
         }
@@ -149,11 +141,7 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
         assumeSideEffect.addFilters(Tag.SPINLOOP, Tag.EARLYTERMINATION, Tag.NOOPT);
         final Event spinloopStart = iterInfo.getIterationStart();
         assumeSideEffect.setCFileInformation(spinloopStart.getCLine(), spinloopStart.getSourceCodeFilePath());
-        // DynamicPureLoopCutting is run after unrolling, thus we need to assign all
-        // three of oId, cId and uId.
-        assumeSideEffect.setOId(spinloopStart.getOId());
-        assumeSideEffect.setCId(spinloopStart.getCId());
-        assumeSideEffect.setUId(spinloopStart.getUId());
+        assumeSideEffect.copyIds(spinloopStart);
         insertionPoint.insertAfter(assumeSideEffect);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -140,8 +140,7 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
         final CondJump assumeSideEffect = EventFactory.newJumpUnless(atLeastOneSideEffect, (Label) thread.getExit());
         assumeSideEffect.addFilters(Tag.SPINLOOP, Tag.EARLYTERMINATION, Tag.NOOPT);
         final Event spinloopStart = iterInfo.getIterationStart();
-        assumeSideEffect.setCFileInformation(spinloopStart.getCLine(), spinloopStart.getSourceCodeFilePath());
-        assumeSideEffect.copyIds(spinloopStart);
+        assumeSideEffect.copyMetadataFrom(spinloopStart);
         insertionPoint.insertAfter(assumeSideEffect);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -140,7 +140,7 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
         final CondJump assumeSideEffect = EventFactory.newJumpUnless(atLeastOneSideEffect, (Label) thread.getExit());
         assumeSideEffect.addFilters(Tag.SPINLOOP, Tag.EARLYTERMINATION, Tag.NOOPT);
         final Event spinloopStart = iterInfo.getIterationStart();
-        assumeSideEffect.setCFileInformation(spinloopStart.getCLine(), spinloopStart.getSourceCodeFile());
+        assumeSideEffect.setCFileInformation(spinloopStart.getCLine(), spinloopStart.getSourceCodeFilePath());
         insertionPoint.insertAfter(assumeSideEffect);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -137,8 +137,8 @@ public class LoopUnrolling implements ProgramProcessor {
                 endOfLoopMarker.addFilters(Tag.NOOPT);
                 boundEvent.getPredecessor().insertAfter(endOfLoopMarker);
 
-                boundEvent.copyIds(loopBackJump);
-                endOfLoopMarker.copyIds(loopBackJump);    
+                boundEvent.copyMetadataFrom(loopBackJump);
+                endOfLoopMarker.copyMetadataFrom(loopBackJump);    
 
             } else {
                 final Map<Event, Event> copyCtx = new HashMap<>();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -62,10 +62,6 @@ public class LoopUnrolling implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
-        // This is not a strong requirement, but if it is weaken, events created by this
-        // class do not need to get the corresponding cId. This check is in place to
-        // catch such situations.
-        Preconditions.checkArgument(program.isCompiled(), "LoopUnrolling should be run after compilation.");
         if (program.isUnrolled()) {
             logger.warn("Skipped unrolling: Program is already unrolled.");
             return;
@@ -141,12 +137,8 @@ public class LoopUnrolling implements ProgramProcessor {
                 endOfLoopMarker.addFilters(Tag.NOOPT);
                 boundEvent.getPredecessor().insertAfter(endOfLoopMarker);
 
-                // Unrolling is currently run after compilation, thus we need to assign both oId and cId.
-                // The final step of run takes care of assigning uId.
-                for(Event e : Arrays.asList(threadExit, boundEvent, endOfLoopMarker)) {
-                    e.setOId(loopBackJump.getOId());
-                    e.setCId(loopBackJump.getCId());    
-                }
+                boundEvent.copyIds(loopBackJump);
+                endOfLoopMarker.copyIds(loopBackJump);    
 
             } else {
                 final Map<Event, Event> copyCtx = new HashMap<>();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -62,10 +62,6 @@ public class LoopUnrolling implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
-        // This is not a strong requirement, but if it is weaken, events created by this
-        // class do not need to get the corresponding cId. This check is in place to
-        // catch such situations.
-        Preconditions.checkArgument(program.isCompiled(), "LoopUnrolling should be run after compilation.");
         if (program.isUnrolled()) {
             logger.warn("Skipped unrolling: Program is already unrolled.");
             return;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
@@ -10,7 +10,6 @@ import com.dat3m.dartagnan.program.event.core.Local;
 import com.dat3m.dartagnan.program.event.lang.std.Malloc;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
-import com.google.common.base.Preconditions;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -31,11 +30,6 @@ public class MemoryAllocation implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
-        // This is not a strong requirement, but if it is weaken, events created by this
-        // class do not need to get the corresponding uId. This check is in place to
-        // catch such situations.
-        Preconditions.checkArgument(program.isUnrolled(),
-                "MemoryAllocation can only be run on unrolled programs.");
         processMallocs(program);
         moveAndAlignMemoryObjects(program.getMemory());
         createInitEvents(program);
@@ -46,11 +40,7 @@ public class MemoryAllocation implements ProgramProcessor {
             final MemoryObject allocatedObject = program.getMemory().allocate(getSize(malloc), false);
             final Local local = EventFactory.newLocal(malloc.getResultRegister(), allocatedObject);
             local.addFilters(Tag.Std.MALLOC);
-            // MemoryAllocation is run after unrolling, thus we need to assign all
-            // three of oId, cId and uId.
-            local.setOId(malloc.getOId());
-            local.setCId(malloc.getCId());
-            local.setUId(malloc.getUId());
+            local.copyIds(malloc);
             malloc.replaceBy(local);
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
@@ -40,7 +40,7 @@ public class MemoryAllocation implements ProgramProcessor {
             final MemoryObject allocatedObject = program.getMemory().allocate(getSize(malloc), false);
             final Local local = EventFactory.newLocal(malloc.getResultRegister(), allocatedObject);
             local.addFilters(Tag.Std.MALLOC);
-            local.copyIds(malloc);
+            local.copyMetadataFrom(malloc);
             malloc.replaceBy(local);
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
@@ -10,6 +10,7 @@ import com.dat3m.dartagnan.program.event.core.Local;
 import com.dat3m.dartagnan.program.event.lang.std.Malloc;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
+import com.google.common.base.Preconditions;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -30,6 +31,11 @@ public class MemoryAllocation implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
+        // This is not a strong requirement, but if it is weaken, events created by this
+        // class do not need to get the corresponding uId. This check is in place to
+        // catch such situations.
+        Preconditions.checkArgument(program.isUnrolled(),
+                "MemoryAllocation can only be run on unrolled programs.");
         processMallocs(program);
         moveAndAlignMemoryObjects(program.getMemory());
         createInitEvents(program);
@@ -40,6 +46,11 @@ public class MemoryAllocation implements ProgramProcessor {
             final MemoryObject allocatedObject = program.getMemory().allocate(getSize(malloc), false);
             final Local local = EventFactory.newLocal(malloc.getResultRegister(), allocatedObject);
             local.addFilters(Tag.Std.MALLOC);
+            // MemoryAllocation is run after unrolling, thus we need to assign all
+            // three of oId, cId and uId.
+            local.setOId(malloc.getOId());
+            local.setCId(malloc.getCId());
+            local.setUId(malloc.getUId());
             malloc.replaceBy(local);
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
@@ -10,7 +10,6 @@ import com.dat3m.dartagnan.program.event.core.Local;
 import com.dat3m.dartagnan.program.event.lang.std.Malloc;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
-import com.google.common.base.Preconditions;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -31,11 +30,6 @@ public class MemoryAllocation implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
-        // This is not a strong requirement, but if it is weaken, events created by this
-        // class do not need to get the corresponding uId. This check is in place to
-        // catch such situations.
-        Preconditions.checkArgument(program.isUnrolled(),
-                "MemoryAllocation can only be run on unrolled programs.");
         processMallocs(program);
         moveAndAlignMemoryObjects(program.getMemory());
         createInitEvents(program);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -3,8 +3,8 @@ package com.dat3m.dartagnan.utils.visualization;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.analysis.CallStackComputation;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.verification.model.EventData;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
@@ -33,7 +33,7 @@ public class ExecutionGraphVisualizer {
     private static final Logger logger = LogManager.getLogger(ExecutionGraphVisualizer.class);
 	
     private final Graphviz graphviz;
-    private Map<Event, String> callStackMapping;
+    private CallStackComputation csc;
     // By default we do not filter anything
     private BiPredicate<EventData, EventData> rfFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> frFilter = (x, y) -> true;
@@ -44,8 +44,8 @@ public class ExecutionGraphVisualizer {
         this.graphviz = new Graphviz();
     }
 
-    public ExecutionGraphVisualizer setCallStackMapping(Map<Event, String> callStackMapping) {
-        this.callStackMapping = callStackMapping;
+    public ExecutionGraphVisualizer setCallStackMapping(CallStackComputation csc) {
+        this.csc = csc;
         return this;
     }
 
@@ -210,14 +210,14 @@ public class ExecutionGraphVisualizer {
             mo = mo.isEmpty() ? mo : ", " + mo;
             tag = e.isWrite() ?
             		String.format("W(%s, %d%s)", address, value, mo) :
-            		String.format("%d = R(%s%s)", value, address, mo);
+            		String.format("%s = R(%s%s)", value, address, mo);
         }
-        return String.format("\"T%d:E%s (%s:L%d)\\n%s%s\"", 
+        return String.format("\"T%s:E%s\\n%s%s#%s\n%s\"", 
         				e.getThread().getId(), 
         				e.getEvent().getGlobalId(),
-        				e.getEvent().getSourceCodeFile(), 
+                        csc.getCallStackMapping().containsKey(e.getEvent()) ? (csc.getStackAsString(e.getEvent(), "\\n") + " -> \n") : "", 
+        				e.getEvent().getSourceCodeFileName(), 
         				e.getEvent().getCLine(),
-                        callStackMapping.containsKey(e.getEvent()) ? callStackMapping.get(e.getEvent()) + "\\n" : "", 
         				tag);
     }
 
@@ -228,13 +228,13 @@ public class ExecutionGraphVisualizer {
     public static void generateGraphvizFile(ExecutionModel model, int iterationCount,
             BiPredicate<EventData, EventData> rfFilter, BiPredicate<EventData, EventData> frFilter,
             BiPredicate<EventData, EventData> coFilter, String directoryName, String fileNameBase,
-            Map<Event, String> callStackMapping) {
+            CallStackComputation csc) {
         File fileVio = new File(directoryName + fileNameBase + ".dot");
         fileVio.getParentFile().mkdirs();
         try (FileWriter writer = new FileWriter(fileVio)) {
             // Create .dot file
             new ExecutionGraphVisualizer()
-                    .setCallStackMapping(callStackMapping)
+                    .setCallStackMapping(csc)
                     .setReadFromFilter(rfFilter)
                     .setFromReadFilter(frFilter)
                     .setCoherenceFilter(coFilter)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -85,7 +85,7 @@ public class ExecutionGraphVisualizer {
     }
 
     private boolean ignore(EventData e) {
-        return e.getEvent().getCLine() == -1 && !e.isInit();
+        return !e.getEvent().hasCLine() && !e.isInit();
     }
 
 
@@ -192,7 +192,7 @@ public class ExecutionGraphVisualizer {
     private String eventToNode(EventData e, ExecutionModel model) {
         if (e.isInit()) {
             return String.format("\"I(%s, %d)\"", addresses.get(e.getAccessedAddress()), e.getValue());
-        } else if (e.getEvent().getCLine() == -1) {
+        } else if (!e.getEvent().hasCLine()) {
             // Special write of each thread
             int threadSize = model.getThreadEventsMap().get(e.getThread()).size();
             if (e.getLocalId() <= threadSize / 2) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -75,7 +75,7 @@ public class AssumeSolver extends ModelChecker {
             res = prover.isUnsat()? PASS : Result.UNKNOWN;
         } else {
             res = FAIL;
-            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context);
+            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context, task.getProgram());
         }
 
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -72,7 +72,7 @@ public class IncrementalSolver extends ModelChecker {
             res = prover.isUnsat()? PASS : UNKNOWN;
         } else {
         	res = FAIL;
-            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context);
+            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context, task.getProgram());
         }
         
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -502,7 +502,7 @@ public class RefinementSolver extends ModelChecker {
                 .append(String.format("%s (%s / %s)", df.format(branchCoveragePercentage), coveredBranches.size(),
                         branches.size()))
                 .append("\n");
-            if (eventCoveragePercentage < 1d) {
+        if (eventCoveragePercentage < 1d) {
             report.append("\t-- Missing events: \n");
             messageSet.forEach(s -> report.append("\t\t").append(s).append("\n"));
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -10,7 +10,6 @@ import com.dat3m.dartagnan.program.analysis.CallStackComputation;
 import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.annotations.FunCall;
 import com.dat3m.dartagnan.program.filter.FilterAbstract;
 import com.dat3m.dartagnan.solver.caat.CAATSolver;
 import com.dat3m.dartagnan.solver.caat4wmm.Refiner;
@@ -444,12 +443,13 @@ public class RefinementSolver extends ModelChecker {
         final Set<Integer> coveredOIds = new HashSet<>();
         final Set<Integer> coveredBranches = new HashSet<>();
         for (Event e : coveredEvents) {
-            if (e.getCLine() > 0 && e.getOId() != 1) {
+            if (e.getCLine() > 0 && e.getOId() != -1) {
                 Event symmRep = symm.map(e, symm.getRepresentative(e.getThread()));
-                // e.getOId() != 1 guarantees symmRep.getOId() != 1
+                // e.getOId() != -1 guarantees symmRep.getOId() != -1
                 coveredOIds.add(symmRep.getOId());
-                // symmRep \in cf.getEquivalenceClass(symmRep), thus symmRep.getOId() != 1 guarantees findAny succeeds
-                Event cfRep = cf.getEquivalenceClass(symmRep).stream().filter(f -> f.getOId() != -1).findAny().get();
+                // symmRep \in cf.getEquivalenceClass(symmRep), thus symmRep.getOId() != -1 guarantees findFirst succeeds.
+                // We need to use findFirst which guarantees determinism.
+                Event cfRep = cf.getEquivalenceClass(symmRep).stream().filter(f -> f.getOId() != -1).findFirst().get();
                 coveredBranches.add(cfRep.getOId());
             }
         }
@@ -458,7 +458,7 @@ public class RefinementSolver extends ModelChecker {
         csc.run(program);
 
         final Set<Event> programEvents = program.getEvents(MemEvent.class).stream()
-                .filter(e -> e.getCLine() > 0 && e.getOId() != 1).collect(Collectors.toSet());
+                .filter(e -> e.getCLine() > 0 && e.getOId() != -1).collect(Collectors.toSet());
         final Set<String> messageSet = new TreeSet<>(); // TreeSet to keep strings in order
         for (Event e : programEvents) {
             EquivalenceClass<Thread> clazz = symm.getEquivalenceClass(e.getThread());
@@ -479,8 +479,9 @@ public class RefinementSolver extends ModelChecker {
             // Since coveredEvents only containes MemEvents, we only count those branches
             // containig at least one such event
             if (cf.getEquivalenceClass(symmRep).stream().anyMatch(f -> f instanceof MemEvent)) {
-                // symmRep \in cf.getEquivalenceClass(symmRep), thus symmRep.getOId() != 1 guarantees findAny succeeds
-                Event cfRep = cf.getEquivalenceClass(symmRep).stream().filter(f -> f.getOId() != -1).findAny().get();
+                // symmRep \in cf.getEquivalenceClass(symmRep), thus symmRep.getOId() != -1 guarantees findFirst succeeds.
+                // We need to use findFirst which guarantees determinism.
+                Event cfRep = cf.getEquivalenceClass(symmRep).stream().filter(f -> f.getOId() != -1).findFirst().get();
                 branches.add(cfRep.getOId());
             }
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -443,13 +443,13 @@ public class RefinementSolver extends ModelChecker {
         final Set<Integer> coveredOIds = new HashSet<>();
         final Set<Integer> coveredBranches = new HashSet<>();
         for (Event e : coveredEvents) {
-            if (e.getCLine() > 0 && e.getOId() != -1) {
+            if (e.hasCLine() && e.hasOId()) {
                 Event symmRep = symm.map(e, symm.getRepresentative(e.getThread()));
                 // e.getOId() != -1 guarantees symmRep.getOId() != -1
                 coveredOIds.add(symmRep.getOId());
                 // symmRep \in cf.getEquivalenceClass(symmRep), thus symmRep.getOId() != -1 guarantees findFirst succeeds.
                 // We need to use findFirst which guarantees determinism.
-                Event cfRep = cf.getEquivalenceClass(symmRep).stream().filter(f -> f.getOId() != -1).findFirst().get();
+                Event cfRep = cf.getEquivalenceClass(symmRep).stream().filter(f -> f.hasOId()).findFirst().get();
                 coveredBranches.add(cfRep.getOId());
             }
         }
@@ -458,7 +458,7 @@ public class RefinementSolver extends ModelChecker {
         csc.run(program);
 
         final Set<Event> programEvents = program.getEvents(MemEvent.class).stream()
-                .filter(e -> e.getCLine() > 0 && e.getOId() != -1).collect(Collectors.toSet());
+                .filter(e -> e.hasCLine() && e.hasOId()).collect(Collectors.toSet());
         final Set<String> messageSet = new TreeSet<>(); // TreeSet to keep strings in order
         for (Event e : programEvents) {
             EquivalenceClass<Thread> clazz = symm.getEquivalenceClass(e.getThread());
@@ -481,7 +481,7 @@ public class RefinementSolver extends ModelChecker {
             if (cf.getEquivalenceClass(symmRep).stream().anyMatch(f -> f instanceof MemEvent)) {
                 // symmRep \in cf.getEquivalenceClass(symmRep), thus symmRep.getOId() != -1 guarantees findFirst succeeds.
                 // We need to use findFirst which guarantees determinism.
-                Event cfRep = cf.getEquivalenceClass(symmRep).stream().filter(f -> f.getOId() != -1).findFirst().get();
+                Event cfRep = cf.getEquivalenceClass(symmRep).stream().filter(f -> f.hasOId()).findFirst().get();
                 branches.add(cfRep.getOId());
             }
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -83,7 +83,7 @@ public class TwoSolvers extends ModelChecker {
             res = prover2.isUnsat() ? PASS : UNKNOWN;
         } else {
         	res = FAIL;
-            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover1, context);
+            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover1, context, task.getProgram());
         }
 
         if(logger.isDebugEnabled()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
@@ -166,7 +166,7 @@ public class WitnessBuilder {
 	private List<Event> getSCExecutionOrder(Model model) {
 		List<Event> execEvents = new ArrayList<>();
 		// TODO: we recently added many cline to many events and this might affect the witness generation.
-		Predicate<Event> executedCEvents = e -> Boolean.TRUE.equals(model.evaluate(context.execution(e))) &&  e.getCLine() > - 1;
+		Predicate<Event> executedCEvents = e -> Boolean.TRUE.equals(model.evaluate(context.execution(e))) &&  e.hasCLine();
 		execEvents.addAll(context.getTask().getProgram().getEvents(Init.class).stream().filter(executedCEvents).collect(Collectors.toList()));
 		execEvents.addAll(context.getTask().getProgram().getEvents().stream().filter(executedCEvents).collect(Collectors.toList()));
 		Map<Integer, List<Event>> map = new HashMap<>();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -73,8 +73,8 @@ public class AnalysisTest {
         b.addChild(0, e5);
 
         Program program = b.build();
-        LoopUnrolling.newInstance().run(program);
         Compilation.newInstance().run(program);
+        LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         Configuration config = Configuration.defaultConfiguration();
         Context context = Context.create();
@@ -132,6 +132,8 @@ public class AnalysisTest {
         b.addChild(0, e3);
 
         Program program = b.build();
+        Compilation.newInstance().run(program);
+        LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
         MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
@@ -174,6 +176,8 @@ public class AnalysisTest {
         b.addChild(0, e3);
 
         Program program = b.build();
+        Compilation.newInstance().run(program);
+        LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
         MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
@@ -221,6 +225,8 @@ public class AnalysisTest {
         b.addChild(0, l0);
 
         Program program = b.build();
+        Compilation.newInstance().run(program);
+        LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
         MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
@@ -263,6 +269,8 @@ public class AnalysisTest {
         b.addChild(0, e3);
 
         Program program = b.build();
+        Compilation.newInstance().run(program);
+        LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
         MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
@@ -391,8 +399,8 @@ public class AnalysisTest {
     }
 
     private AliasAnalysis analyze(Program program, Alias method) throws InvalidConfigurationException {
-        LoopUnrolling.newInstance().run(program);
         Compilation.newInstance().run(program);
+        LoopUnrolling.newInstance().run(program);
         return AliasAnalysis.fromConfig(program, Configuration.builder().setOption(ALIAS_METHOD, method.asStringOption()).build());
     }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/LoopTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/LoopTest.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan.miscellaneous;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.processing.LoopUnrolling;
+import com.dat3m.dartagnan.program.processing.compilation.Compilation;
 import com.dat3m.dartagnan.utils.ResourceHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +40,7 @@ public class LoopTest {
     @Test
     public void test() throws Exception {
         Program p = new ProgramParser().parse(new File(path));
+        Compilation.newInstance().run(p);
         LoopUnrolling.newInstance().run(p);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/PrinterTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/PrinterTest.java
@@ -22,8 +22,8 @@ public class PrinterTest {
     public void PrintBpl1() throws Exception {
         Program p = new ProgramParser().parse(new File(ResourceHelper.TEST_RESOURCE_PATH + "boogie/concurrency/fib_bench-1-O0.bpl"));
         assertNotNull(new Printer().print(p));
-        LoopUnrolling.newInstance().run(p);
         Compilation.newInstance().run(p);
+        LoopUnrolling.newInstance().run(p);
         assertNotNull(new Printer().print(p));
     }
 
@@ -31,8 +31,8 @@ public class PrinterTest {
     public void PrintBpl2() throws Exception {
         Program p = new ProgramParser().parse(new File(ResourceHelper.TEST_RESOURCE_PATH + "locks/linuxrwlock.bpl"));
         assertNotNull(new Printer().print(p));
-        LoopUnrolling.newInstance().run(p);
         Compilation.newInstance().run(p);
+        LoopUnrolling.newInstance().run(p);
         assertNotNull(new Printer().print(p));
     }
 

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -1,13 +1,10 @@
 package com.dat3m.ui.result;
 
 import com.dat3m.dartagnan.Dartagnan;
-import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.program.Program;
-import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.*;
 import com.dat3m.dartagnan.wmm.Wmm;
-import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.ui.utils.UiOptions;
@@ -16,22 +13,10 @@ import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
-import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
-import org.sosy_lab.java_smt.api.SolverException;
-
-import java.util.Optional;
-
 import static com.dat3m.dartagnan.configuration.OptionNames.PHANTOM_REFERENCES;
-import static com.dat3m.dartagnan.configuration.Property.CAT_SPEC;
-import static com.dat3m.dartagnan.configuration.Property.PROGRAM_SPEC;
-import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
-import static com.dat3m.dartagnan.utils.Result.FAIL;
-import static com.dat3m.dartagnan.utils.Result.PASS;
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 
 public class ReachabilityResult {
 


### PR DESCRIPTION
Some of our code (e.g. the coverage report) relies on the assumption that events have a proper ` oId, cId, uId` (i.e. different than `-1`) . This PR guarantees that this assumption is fulfilled by coping (from where depends on the pass) those ids when new events are created.