### PR TITLE
Use call stack for everything we report to the user

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -250,7 +250,7 @@ public class Dartagnan extends BaseOptions {
                                     .append("\tE").append(e.getGlobalId())
                                     .append(":\t")
                                     .append(callStackMapping.containsKey(e) ? (csc.getStackAsString(e, "") + " -> ") : "")
-                                    .append(e.getSourceCodeFile()).append("#").append(e.getCLine())
+                                    .append(e.getSourceCodeFileName()).append("#").append(e.getCLine())
                                     .append("\n");
                         }
                     }
@@ -265,7 +265,7 @@ public class Dartagnan extends BaseOptions {
                                     .append("\tE").append(e.getGlobalId())
                                     .append(":\t")
                                     .append(callStackMapping.containsKey(e) ? (csc.getStackAsString(e, "") + " -> ") : "")
-                                    .append(e.getSourceCodeFile()).append("#").append(e.getCLine())
+                                    .append(e.getSourceCodeFileName()).append("#").append(e.getCLine())
                                     .append("\n");
                         }
                     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
@@ -63,7 +63,7 @@ public class CallStackComputation {
         Iterator<FunCall> it = callStackMapping.get(e).iterator();
         while (it.hasNext()) {
             FunCall next = it.next();
-            strB.append(String.format("%s (%s#%s)", next.getFunctionName(), next.getSourceCodeFile(), next.getCLine()));
+            strB.append(String.format("%s (%s#%s)", next.getFunctionName(), next.getSourceCodeFileName(), next.getCLine()));
             if (it.hasNext()) {
                 strB.append(" -> " + callsSeparator);
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
@@ -41,7 +41,7 @@ public class CallStackComputation  {
 			while (current != null) {
  				if(current instanceof FunCall) {
 					FunCall call = (FunCall)current;
-					callStack.push(call.getFunctionName());
+					callStack.push(String.format("%s (%s#%s)", call.getFunctionName(), call.getSourceCodeFile(), call.getCLine()));
 				}
 				if(current instanceof FunRet) {
 					callStack.pop();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/CallStackComputation.java
@@ -15,62 +15,59 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Stack;
 
-public class CallStackComputation  {
-	
-	private Map<Event, String> callStackMapping = new HashMap<>(); 
+public class CallStackComputation {
 
-    private CallStackComputation () { }
+    private Map<Event, Stack<FunCall>> callStackMapping = new HashMap<>();
 
-    public static CallStackComputation  fromConfig(Configuration config) throws InvalidConfigurationException {
+    private CallStackComputation() {
+    }
+
+    public static CallStackComputation fromConfig(Configuration config) throws InvalidConfigurationException {
         return newInstance();
     }
 
-    public static CallStackComputation  newInstance() {
-        return new CallStackComputation ();
+    public static CallStackComputation newInstance() {
+        return new CallStackComputation();
     }
 
-	public Map<Event, String> getCallStackMapping() {
-		return callStackMapping;
-	}
-
-    public void run(Program program, String callsSeparator) {
-
-        for(Thread thread : program.getThreads()) {
-			Stack<String> callStack = new Stack<>();
-			Event current = thread.getEntry();
-			while (current != null) {
- 				if(current instanceof FunCall) {
-					FunCall call = (FunCall)current;
-					callStack.push(String.format("%s (%s#%s)", call.getFunctionName(), call.getSourceCodeFile(), call.getCLine()));
-				}
-				if(current instanceof FunRet) {
-					callStack.pop();
-				}
-                String stack = stackToString(callStack, callsSeparator);
-				if(current instanceof MemEvent && !stack.isEmpty()) {
-					callStackMapping.put(current, stack);
-				}
-				if(current.is(Tag.ASSERTION) && !stack.isEmpty()) {
-					callStackMapping.put(current, stack);
-				}
-				if(current.is(Tag.SPINLOOP) && !stack.isEmpty()) {
-					callStackMapping.put(current, stack);
-				}
-				current = current.getSuccessor();
-			}       
-		}
+    public Map<Event, Stack<FunCall>> getCallStackMapping() {
+        return callStackMapping;
     }
 
-	private String stackToString(Stack<String> s, String callsSeparator) {
-		StringBuilder strB = new StringBuilder();
-		Iterator<String> it = s.iterator();
-		while(it.hasNext()) {
-			String next = it.next();
-			strB.append(next);
-			if(it.hasNext()) {
-				strB.append(" -> " + callsSeparator);
-			}
-		}
-		return strB.toString();
-	}
+    public void run(Program program) {
+
+        for (Thread thread : program.getThreads()) {
+            Stack<FunCall> callStack = new Stack<>();
+            Event current = thread.getEntry();
+            while (current != null) {
+                if (current instanceof FunCall) {
+                    FunCall call = (FunCall) current;
+                    callStack.push(call);
+                }
+                if (current instanceof FunRet) {
+                    callStack.pop();
+                }
+                if ((current instanceof MemEvent || current.is(Tag.ASSERTION) || current.is(Tag.SPINLOOP))
+                        && !callStack.isEmpty()) {
+                    Stack<FunCall> newStack = new Stack<>();
+                    newStack.addAll(callStack);
+                    callStackMapping.put(current, newStack);
+                }
+                current = current.getSuccessor();
+            }
+        }
+    }
+
+    public String getStackAsString(Event e, String callsSeparator) {
+        StringBuilder strB = new StringBuilder();
+        Iterator<FunCall> it = callStackMapping.get(e).iterator();
+        while (it.hasNext()) {
+            FunCall next = it.next();
+            strB.append(String.format("%s (%s#%s)", next.getFunctionName(), next.getSourceCodeFile(), next.getCLine()));
+            if (it.hasNext()) {
+                strB.append(" -> " + callsSeparator);
+            }
+        }
+        return strB.toString();
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
@@ -24,8 +24,8 @@ public abstract class Event implements Encoder, Comparable<Event> {
 	protected int uId = -1;		// Global ID right before unrolling
 	protected int cId = -1;		// Global ID right before compilation
 
-	protected int cLine = -1;				// line in the original C program
-	protected String sourceCodeFile = "";	// filename of the original C program
+	protected int cLine = -1;				    // line in the original C program
+	protected String sourceCodeFilePath  = "";	// path of the original C program
 
 	protected Thread thread; // The thread this event belongs to
 
@@ -49,7 +49,7 @@ public abstract class Event implements Encoder, Comparable<Event> {
 		this.uId = other.uId;
 		this.cId = other.cId;
 		this.cLine = other.cLine;
-		this.sourceCodeFile = other.sourceCodeFile;
+		this.sourceCodeFilePath = other.sourceCodeFilePath;
 	}
 
 	public int getGlobalId() { return globalId; }
@@ -68,13 +68,18 @@ public abstract class Event implements Encoder, Comparable<Event> {
 		return cLine;
 	}
 	
-	public String getSourceCodeFile() {
-		return sourceCodeFile;
+	public String getSourceCodeFilePath() {
+		return sourceCodeFilePath ;
 	}
 
-	public Event setCFileInformation(int line, String file) {
+	public String getSourceCodeFileName() {
+        return sourceCodeFilePath.contains("/") ? sourceCodeFilePath.substring(sourceCodeFilePath.lastIndexOf("/") + 1)
+                : sourceCodeFilePath;
+	}
+
+	public Event setCFileInformation(int line, String sourceCodeFilePath) {
 		this.cLine = line;
-		this.sourceCodeFile = file.contains("/") ? file.substring(file.lastIndexOf("/") + 1) : file;
+		this.sourceCodeFilePath  = sourceCodeFilePath ;
 		return this;
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Event.java
@@ -74,7 +74,7 @@ public abstract class Event implements Encoder, Comparable<Event> {
 
 	public Event setCFileInformation(int line, String file) {
 		this.cLine = line;
-		this.sourceCodeFile = file;
+		this.sourceCodeFile = file.contains("/") ? file.substring(file.lastIndexOf("/") + 1) : file;
 		return this;
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -140,7 +140,7 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
         final CondJump assumeSideEffect = EventFactory.newJumpUnless(atLeastOneSideEffect, (Label) thread.getExit());
         assumeSideEffect.addFilters(Tag.SPINLOOP, Tag.EARLYTERMINATION, Tag.NOOPT);
         final Event spinloopStart = iterInfo.getIterationStart();
-        assumeSideEffect.setCFileInformation(spinloopStart.getCLine(), spinloopStart.getSourceCodeFile());
+        assumeSideEffect.setCFileInformation(spinloopStart.getCLine(), spinloopStart.getSourceCodeFilePath());
         insertionPoint.insertAfter(assumeSideEffect);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -216,7 +216,7 @@ public class ExecutionGraphVisualizer {
         				e.getThread().getId(), 
         				e.getEvent().getGlobalId(),
                         csc.getCallStackMapping().containsKey(e.getEvent()) ? (csc.getStackAsString(e.getEvent(), "\\n") + " -> \n") : "", 
-        				e.getEvent().getSourceCodeFile(), 
+        				e.getEvent().getSourceCodeFileName(), 
         				e.getEvent().getCLine(),
         				tag);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -212,10 +212,10 @@ public class ExecutionGraphVisualizer {
             		String.format("W(%s, %d%s)", address, value, mo) :
             		String.format("%s = R(%s%s)", value, address, mo);
         }
-        return String.format("\"T%s:E%s\\n%s ->\n%s#%s\n%s\"", 
+        return String.format("\"T%s:E%s\\n%s%s#%s\n%s\"", 
         				e.getThread().getId(), 
         				e.getEvent().getGlobalId(),
-                        callStackMapping.containsKey(e.getEvent()) ? callStackMapping.get(e.getEvent()) : "", 
+                        callStackMapping.containsKey(e.getEvent()) ? (callStackMapping.get(e.getEvent()) + " -> \n") : "", 
         				e.getEvent().getSourceCodeFile(), 
         				e.getEvent().getCLine(),
         				tag);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -210,14 +210,14 @@ public class ExecutionGraphVisualizer {
             mo = mo.isEmpty() ? mo : ", " + mo;
             tag = e.isWrite() ?
             		String.format("W(%s, %d%s)", address, value, mo) :
-            		String.format("%d = R(%s%s)", value, address, mo);
+            		String.format("%s = R(%s%s)", value, address, mo);
         }
-        return String.format("\"T%d:E%s (%s:L%d)\\n%s%s\"", 
+        return String.format("\"T%s:E%s\\n%s ->\n%s#%s\n%s\"", 
         				e.getThread().getId(), 
         				e.getEvent().getGlobalId(),
+                        callStackMapping.containsKey(e.getEvent()) ? callStackMapping.get(e.getEvent()) : "", 
         				e.getEvent().getSourceCodeFile(), 
         				e.getEvent().getCLine(),
-                        callStackMapping.containsKey(e.getEvent()) ? callStackMapping.get(e.getEvent()) + "\\n" : "", 
         				tag);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -75,7 +75,7 @@ public class AssumeSolver extends ModelChecker {
             res = prover.isUnsat()? PASS : Result.UNKNOWN;
         } else {
             res = FAIL;
-            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context);
+            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context, task.getProgram());
         }
 
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -72,7 +72,7 @@ public class IncrementalSolver extends ModelChecker {
             res = prover.isUnsat()? PASS : UNKNOWN;
         } else {
         	res = FAIL;
-            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context);
+            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context, task.getProgram());
         }
         
         if(logger.isDebugEnabled()) {        	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -159,9 +159,9 @@ public abstract class ModelChecker {
                         .append("\tE").append(tuple.getFirst().getGlobalId())
                         .append(" / E").append(tuple.getSecond().getGlobalId())
                         .append("\t").append(csc.getCallStackMapping().containsKey(tuple.getFirst()) ? (csc.getStackAsString(tuple.getFirst(), "") + " -> ") : "")
-                        .append(tuple.getFirst().getSourceCodeFile()).append("#").append(tuple.getFirst().getCLine())
+                        .append(tuple.getFirst().getSourceCodeFileName()).append("#").append(tuple.getFirst().getCLine())
                         .append(" / ").append(csc.getCallStackMapping().containsKey(tuple.getSecond()) ? (csc.getStackAsString(tuple.getSecond(), "") + " -> ") : "")
-                        .append(tuple.getSecond().getSourceCodeFile()).append("#").append(tuple.getSecond().getCLine())
+                        .append(tuple.getSecond().getSourceCodeFileName()).append("#").append(tuple.getSecond().getCLine())
                         .append("\n");
                 }
                 flaggedPairsOutput += violatingPairs.toString();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -14,6 +14,7 @@ import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Local;
+import com.dat3m.dartagnan.program.event.core.annotations.FunCall;
 import com.dat3m.dartagnan.program.processing.ProcessingManager;
 import com.dat3m.dartagnan.program.specification.AbstractAssert;
 import com.dat3m.dartagnan.program.specification.AssertCompositeAnd;
@@ -36,6 +37,7 @@ import org.sosy_lab.java_smt.api.SolverException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Stack;
 
 import static com.dat3m.dartagnan.configuration.Property.*;
 import static com.dat3m.dartagnan.program.event.Tag.ASSERTION;
@@ -149,17 +151,16 @@ public abstract class ModelChecker {
             if(ax.isFlagged() && FALSE.equals(model.evaluate(CAT_SPEC.getSMTVariable(ax, ctx)))) {
 
                 CallStackComputation csc = CallStackComputation.newInstance();
-                csc.run(program, "");
-                Map<Event, String> callStackMapping = csc.getCallStackMapping();
+                csc.run(program);
     
                 StringBuilder violatingPairs = new StringBuilder("Flag " + Optional.ofNullable(ax.getName()).orElse(ax.getRelation().getNameOrTerm())).append("\n");
                 for(Tuple tuple : encoder.getTuples(ax.getRelation(), model)) {
                     violatingPairs
                         .append("\tE").append(tuple.getFirst().getGlobalId())
                         .append(" / E").append(tuple.getSecond().getGlobalId())
-                        .append("\t").append(callStackMapping.containsKey(tuple.getFirst()) ? (callStackMapping.get(tuple.getFirst()) + " -> ") : "")
+                        .append("\t").append(csc.getCallStackMapping().containsKey(tuple.getFirst()) ? (csc.getStackAsString(tuple.getFirst(), "") + " -> ") : "")
                         .append(tuple.getFirst().getSourceCodeFile()).append("#").append(tuple.getFirst().getCLine())
-                        .append(" / ").append(callStackMapping.containsKey(tuple.getSecond()) ? (callStackMapping.get(tuple.getSecond()) + " -> ") : "")
+                        .append(" / ").append(csc.getCallStackMapping().containsKey(tuple.getSecond()) ? (csc.getStackAsString(tuple.getSecond(), "") + " -> ") : "")
                         .append(tuple.getSecond().getSourceCodeFile()).append("#").append(tuple.getSecond().getCLine())
                         .append("\n");
                 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -465,7 +465,7 @@ public class RefinementSolver extends ModelChecker {
                 // Events not executed in any violating execution
                 final String threads = clazz.stream().map(t -> "T" + t.getId())
                         .collect(Collectors.joining(" / "));
-                messageSet.add(String.format("%s: %s -> %s#%s", threads, callStackMapping.containsKey(rep) ? callStackMapping.get(rep): "", e.getSourceCodeFile(), rep.getCLine()));
+                messageSet.add(String.format("%s: %s%s#%s", threads, callStackMapping.containsKey(rep) ? (callStackMapping.get(e) + " -> ") : "", e.getSourceCodeFile(), rep.getCLine()));
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -465,7 +465,9 @@ public class RefinementSolver extends ModelChecker {
                 // Events not executed in any violating execution
                 final String threads = clazz.stream().map(t -> "T" + t.getId())
                         .collect(Collectors.joining(" / "));
-                messageSet.add(String.format("%s: %s%s#%s", threads, csc.getCallStackMapping().containsKey(rep) ? (csc.getStackAsString(rep, "") + " -> ") : "", e.getSourceCodeFile(), rep.getCLine()));
+                messageSet.add(String.format("%s: %s%s#%s", threads,
+                        csc.getCallStackMapping().containsKey(rep) ? (csc.getStackAsString(rep, "") + " -> ") : "",
+                        e.getSourceCodeFileName(), rep.getCLine()));
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.encoding.*;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.BranchEquivalence;
+import com.dat3m.dartagnan.program.analysis.CallStackComputation;
 import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
@@ -450,6 +451,10 @@ public class RefinementSolver extends ModelChecker {
             }
         }
 
+        CallStackComputation csc = CallStackComputation.newInstance();
+        csc.run(program, "");
+        Map<Event, String> callStackMapping = csc.getCallStackMapping();
+
         final Set<Event> programEvents = program.getEvents(MemEvent.class).stream()
                 .filter(e -> e.getCLine() > 0).collect(Collectors.toSet());
         final Set<String> messageSet = new TreeSet<>(); // TreeSet to keep strings in order
@@ -460,7 +465,7 @@ public class RefinementSolver extends ModelChecker {
                 // Events not executed in any violating execution
                 final String threads = clazz.stream().map(t -> "T" + t.getId())
                         .collect(Collectors.joining(" / "));
-                messageSet.add(String.format("%s -> %s#%s", threads, e.getSourceCodeFile(), rep.getCLine()));
+                messageSet.add(String.format("%s: %s -> %s#%s", threads, callStackMapping.containsKey(rep) ? callStackMapping.get(rep): "", e.getSourceCodeFile(), rep.getCLine()));
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -496,7 +496,7 @@ public class RefinementSolver extends ModelChecker {
                 .append(String.format("%s (%s / %s)", df.format(branchCoveragePercentage), coveredBranches.size(),
                         branches.size()))
                 .append("\n");
-        if (programEvents.size() != messageSet.size()) {
+            if (eventCoveragePercentage < 1d) {
             report.append("\t-- Missing events: \n");
             messageSet.forEach(s -> report.append("\t\t").append(s).append("\n"));
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -10,6 +10,7 @@ import com.dat3m.dartagnan.program.analysis.CallStackComputation;
 import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.annotations.FunCall;
 import com.dat3m.dartagnan.program.filter.FilterAbstract;
 import com.dat3m.dartagnan.solver.caat.CAATSolver;
 import com.dat3m.dartagnan.solver.caat4wmm.Refiner;
@@ -452,8 +453,7 @@ public class RefinementSolver extends ModelChecker {
         }
 
         CallStackComputation csc = CallStackComputation.newInstance();
-        csc.run(program, "");
-        Map<Event, String> callStackMapping = csc.getCallStackMapping();
+        csc.run(program);
 
         final Set<Event> programEvents = program.getEvents(MemEvent.class).stream()
                 .filter(e -> e.getCLine() > 0).collect(Collectors.toSet());
@@ -465,7 +465,7 @@ public class RefinementSolver extends ModelChecker {
                 // Events not executed in any violating execution
                 final String threads = clazz.stream().map(t -> "T" + t.getId())
                         .collect(Collectors.joining(" / "));
-                messageSet.add(String.format("%s: %s%s#%s", threads, callStackMapping.containsKey(rep) ? (callStackMapping.get(e) + " -> ") : "", e.getSourceCodeFile(), rep.getCLine()));
+                messageSet.add(String.format("%s: %s%s#%s", threads, csc.getCallStackMapping().containsKey(rep) ? (csc.getStackAsString(rep, "") + " -> ") : "", e.getSourceCodeFile(), rep.getCLine()));
             }
         }
 
@@ -533,10 +533,10 @@ public class RefinementSolver extends ModelChecker {
         String fileNameBase = String.format("%s-%d", programName, iterationCount);
         // File with reason edges only
         generateGraphvizFile(model, iterationCount, edgeFilter, edgeFilter, edgeFilter, directoryName, fileNameBase,
-                new HashMap<>());
+                CallStackComputation.newInstance());
         // File with all edges
         generateGraphvizFile(model, iterationCount, (x, y) -> true, (x, y) -> true, (x, y) -> true, directoryName,
-                fileNameBase + "-full", new HashMap<>());
+                fileNameBase + "-full", CallStackComputation.newInstance());
     }
 
     private Wmm createDefaultWmm() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -83,7 +83,7 @@ public class TwoSolvers extends ModelChecker {
             res = prover2.isUnsat() ? PASS : UNKNOWN;
         } else {
         	res = FAIL;
-            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover1, context);
+            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover1, context, task.getProgram());
         }
 
         if(logger.isDebugEnabled()) {

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -1,13 +1,10 @@
 package com.dat3m.ui.result;
 
 import com.dat3m.dartagnan.Dartagnan;
-import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.program.Program;
-import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.*;
 import com.dat3m.dartagnan.wmm.Wmm;
-import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.ui.utils.UiOptions;
@@ -16,22 +13,10 @@ import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
-import org.sosy_lab.java_smt.api.Model;
 import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
-import org.sosy_lab.java_smt.api.SolverException;
-
-import java.util.Optional;
-
 import static com.dat3m.dartagnan.configuration.OptionNames.PHANTOM_REFERENCES;
-import static com.dat3m.dartagnan.configuration.Property.CAT_SPEC;
-import static com.dat3m.dartagnan.configuration.Property.PROGRAM_SPEC;
-import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
-import static com.dat3m.dartagnan.utils.Result.FAIL;
-import static com.dat3m.dartagnan.utils.Result.PASS;
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 
 public class ReachabilityResult {
 


### PR DESCRIPTION
This PR makes sure we consistently report the same kind of information (something link `event: callStack -> file#line`) whenever we report anything to the user (witness graph / violation found / coverage report).