### PR TITLE
Avoid ConcurrentModificationException in Label.delete()

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Label.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Label.java
@@ -30,9 +30,11 @@ public class Label extends Event {
 
     @Override
     public void delete() {
-        // We delete all jumps that target this label to avoid
-        // broken jumps.
-        getJumpSet().forEach(CondJump::delete);
+        // We delete all jumps that target this label to avoid broken jumps.
+        // We iterate over a snapshot to avoid probles due to the jumpSet being modified
+        // during the iteration.
+        Set<CondJump> copyJumpSet = new HashSet<>(jumpSet);
+        copyJumpSet.forEach(CondJump::delete);
         super.delete();
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -128,11 +128,9 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
                 continue;
             } else if (e instanceof Label && e.is(Tag.NOOPT)) {
                 // FIXME: This check is just to avoid deleting loop-related labels (especially
-                // the loop end marker)
-                // because those are used to find unrolled loops.
+                // the loop end marker) because those are used to find unrolled loops.
                 // There should be better ways that do not retain such dead code: for example,
-                // we could
-                // move the loop end marker into the last non-dead iteration.
+                // we could move the loop end marker into the last non-dead iteration.
                 continue;
             }
             e.delete();


### PR DESCRIPTION
When calling `Label.delete()`, it was possible that the `jumpSet` was modified while iterating over it, resulting in a `ConcurrentModificationException`.

This PR solves the problem by iterating over a snapshot of the set.  