### PR TITLE
Missing changes from lkmm.2023.04.07a

### DIFF
--- a/cat/linux-kernel.cat
+++ b/cat/linux-kernel.cat
@@ -97,8 +97,8 @@ let dep = addr | data
 let rwdep = (dep | ctrl) ; [W]
 let overwrite = co | fr
 let to-w = rwdep | (overwrite & int) | (addr ; [Plain] ; wmb)
-let to-r = addr | (dep ; [Marked] ; rfi)
-let ppo = to-r | to-w | fence | (po-unlock-lock-po & int)
+let to-r = (addr ; [R]) | (dep ; [Marked] ; rfi)
+let ppo = to-r | to-w | (fence & int) | (po-unlock-lock-po & int)
 
 (* Propagation: Ordering from release operations and strong fences. *)
 let rmw-sequence = (rf ; rmw)*


### PR DESCRIPTION
This PR contains some missing changes to `to-r` and `ppo` from LKMM v6.4 in [here](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=406037351e08dea03735178bf11046da85f00125).