### PR TITLE
Set LD_LIBRARY_PATH in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,4 @@ ENV DAT3M_OUTPUT=$DAT3M_HOME/output
 ENV CFLAGS="-I$DAT3M_HOME/include"
 ENV SMACK_FLAGS="-q -t --no-memory-splitting"
 ENV ATOMIC_REPLACE_OPTS="-mem2reg -sroa -early-cse -indvars -loop-unroll -simplifycfg -gvn"
+ENV LD_LIBRARY_PATH=/usr/local/lib


### PR DESCRIPTION
The `atomic-replace` pass was not able to find the library in the docker container. This PR fixes the problem.
Since @ThomasHaas seems to have problems running docker, @xeren can you please test this? 