### PR TITLE
Fix Maven settings to also load native libraries from default locations

### DIFF
--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.dependency.relativepath>dependency</project.dependency.relativepath>
     <project.dependency.path>${project.build.directory}/${project.dependency.relativepath}</project.dependency.path>
-    <argLine>-Djava.library.path=${project.dependency.path}</argLine>
+    <argLine>-Djava.library.path=${project.dependency.path}:${java.library.path}</argLine>
   </properties>
 
   <!--

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -2,11 +2,14 @@ package com.dat3m.dartagnan.parsers.program.utils;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+
 import static java.util.Arrays.asList;
 
 public class Compilation {
@@ -14,42 +17,40 @@ public class Compilation {
 	private static final Logger logger = LogManager.getLogger(Compilation.class);
 	
 	public static File compileWithClang(File file, String cflags) throws Exception {
-		String output = getOutputName(file, ".ll");		
-		
-		ArrayList<String> cmd = new ArrayList<String>();
-		cmd.addAll(asList("clang", "-Xclang", "-disable-O0-optnone", "-S", 
-			"-emit-llvm", "-g", "-gcolumn-info", "-o", output));
+		final String outputFileName = getOutputName(file, ".ll");
+
+		ArrayList<String> cmd = new ArrayList<>(
+				asList("clang", "-Xclang", "-disable-O0-optnone", "-S",
+				"-emit-llvm", "-g", "-gcolumn-info", "-o", outputFileName));
 		// We use cflags when using the UI and fallback top CFLAGS otherwise
 		cflags = cflags.isEmpty() ? System.getenv().getOrDefault("CFLAGS", "") : cflags;
 		// Needed to handle more than one flag in CFLAGS
-		for(String option : cflags.split(" ")) {
-			cmd.add(option);
-		}
+		Collections.addAll(cmd, cflags.split(" "));
 		cmd.add(file.getAbsolutePath());
-		
-		return runCmd(cmd, output);
+
+		runCmd(cmd);
+		return new File(outputFileName);
 	}
 
 	public static File applyLlvmPasses(File file) throws Exception {
-		ArrayList<String> cmd = new ArrayList<String>();
-		String output = getOutputName(file, "-opt.ll");		
-		cmd.addAll(asList("atomic-replace", file.getAbsolutePath(), output));
-		return runCmd(cmd, output);
+		final String outputFileName = getOutputName(file, "-opt.ll");
+		ArrayList<String> cmd = new ArrayList<>(asList("atomic-replace", file.getAbsolutePath(), outputFileName));
+		runCmd(cmd);
+		return new File(outputFileName);
 	}
 
 	public static File compileWithSmack(File file, String cflags) throws Exception {
-		String output = getOutputName(file, ".bpl");
+		final String outputFileName = getOutputName(file, ".bpl");
 
-    	ArrayList<String> cmd = new ArrayList<String>();
+    	ArrayList<String> cmd = new ArrayList<>();
     	cmd.add("smack");
     	// Needed to handle more than one flag in SMACK_FLAGS
-    	for(String option : System.getenv().getOrDefault("SMACK_FLAGS", "").split(" ")) {
-    		cmd.add(option);
-    	}
+		Collections.addAll(cmd, System.getenv().getOrDefault("SMACK_FLAGS", "").split(" "));
 		cmd.add("--clang-options=" + cflags);
-    	cmd.addAll(asList("-bpl", output, file.getAbsolutePath()));
+    	cmd.addAll(asList("-bpl", outputFileName, file.getAbsolutePath()));
     	
-		return runCmd(cmd, output);
+		runCmd(cmd);
+		return new File(outputFileName);
 	}	
 
 	private static String getOutputName(File file, String postfix) {
@@ -57,7 +58,7 @@ public class Compilation {
 			file.getName().substring(0, file.getName().lastIndexOf('.')) + postfix;
 	}
 
-	private static File runCmd(ArrayList<String> cmd, String outputFileName) throws Exception {
+	private static void runCmd(ArrayList<String> cmd) throws Exception {
     	logger.debug(String.join(" ", cmd));
 		ProcessBuilder processBuilder = new ProcessBuilder(cmd);
 		// "Unless the standard input and output streams are promptly written and read respectively 
@@ -69,10 +70,9 @@ public class Compilation {
 		processBuilder.redirectOutput(log);
     	Process proc = processBuilder.start();
     	proc.waitFor();
-    	if(proc.exitValue() == 1) {
+    	if(proc.exitValue() != 0) {
 			String errorString =  Files.asCharSource(log, Charsets.UTF_8).read();
-			throw new Exception(errorString);
+			throw new IOException(errorString);
     	}
-		return new File(outputFileName);	
 	}
 }


### PR DESCRIPTION
Our pom.xml was configured to set `java.library.path` to `${project.dependency.path}`, overwriting the default value of `java.library.path`.
This PR simply prepends `${project.dependency.path}` (instead of overwriting), so that default locations are still included for externally downloaded binaries (e.g. Z3 ARM binaries).

I also refactored `Compilation` slightly and changed a conditional to properly detect errors produced when calling `Clang` and `Smack`.