### PR TITLE
[Rework] ExprInterface.getType()

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.encoding;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.COpBin;
+import com.dat3m.dartagnan.expression.type.*;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.analysis.BranchEquivalence;
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
@@ -276,11 +277,16 @@ public final class EncodingContext {
             if (e instanceof RegWriter) {
                 Register register = ((RegWriter) e).getResultRegister();
                 String name = register.getName() + "(" + e.getGlobalId() + "_result)";
-                int precision = register.getPrecision();
-                if (precision > 0) {
-                    r = formulaManager.getBitvectorFormulaManager().makeVariable(precision, name);
+                Type type = register.getType();
+                if (type instanceof IntegerType integerType) {
+                    if (integerType.isMathematical()) {
+                        r = formulaManager.getIntegerFormulaManager().makeVariable(name);
+                    } else {
+                        int bitWidth = integerType.getBitWidth();
+                        r = formulaManager.getBitvectorFormulaManager().makeVariable(bitWidth, name);
+                    }
                 } else {
-                    r = formulaManager.getIntegerFormulaManager().makeVariable(name);
+                    throw new UnsupportedOperationException(String.format("Encoding result of type %s.", type));
                 }
             } else {
                 r = null;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -479,7 +479,7 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
 
     @Override
     public Formula visit(INonDet iNonDet) {
-        String name = Integer.toString(iNonDet.hashCode());
+        String name = iNonDet.getName();
         Type type = iNonDet.getType();
         return makeVariable(type, name);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -512,7 +512,7 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
                 return integerFormulaManager().makeVariable(name);
             }
             int bitWidth = integerType.getBitWidth();
-            bitvectorFormulaManager().makeVariable(bitWidth, name);
+            return bitvectorFormulaManager().makeVariable(bitWidth, name);
         }
         throw new UnsupportedOperationException(String.format("Encoding variable of type %s.", type));
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExpr.java
@@ -1,6 +1,14 @@
 package com.dat3m.dartagnan.expression;
 
+import com.dat3m.dartagnan.expression.type.BooleanType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
+
 public abstract class BExpr implements ExprInterface {
+
+    @Override
+    public BooleanType getType() {
+        return TypeFactory.getInstance().getBooleanType();
+    }
 
     public boolean isTrue() {
 		return this.equals(BConst.TRUE);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExprInterface.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExprInterface.java
@@ -1,17 +1,22 @@
 package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
+import com.dat3m.dartagnan.expression.type.Type;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
 import com.google.common.collect.ImmutableSet;
 
 public interface ExprInterface {
 
+    default Type getType() {
+        return TypeFactory.getInstance().getBooleanType();
+    }
+
     default ImmutableSet<Register> getRegs() {
-    	return ImmutableSet.of();
+        return ImmutableSet.of();
     }
 
     <T> T visit(ExpressionVisitor<T> visitor);
 
     //default ExprInterface simplify() { return visit(ExprSimplifier.SIMPLIFIER); }
-    
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExprInterface.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExprInterface.java
@@ -2,15 +2,12 @@ package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
 import com.dat3m.dartagnan.expression.type.Type;
-import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
 import com.google.common.collect.ImmutableSet;
 
 public interface ExprInterface {
 
-    default Type getType() {
-        return TypeFactory.getInstance().getBooleanType();
-    }
+    Type getType();
 
     default ImmutableSet<Register> getRegs() {
         return ImmutableSet.of();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IConst.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IConst.java
@@ -1,11 +1,17 @@
 package com.dat3m.dartagnan.expression;
 
+import com.dat3m.dartagnan.expression.type.IntegerType;
+
 import java.math.BigInteger;
 
 /**
  * Expressions whose results are known before an execution starts.
  */
 public abstract class IConst extends IExpr {
+
+	protected IConst(IntegerType type) {
+		super(type);
+	}
 
     /**
      * @return

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
@@ -1,11 +1,15 @@
 package com.dat3m.dartagnan.expression;
 
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
+
 public abstract class IExpr implements Reducible {
 
 	public IExpr getBase() {
 		throw new UnsupportedOperationException("getBase() not supported for " + this);
 	}
 	
+	@Deprecated
 	public int getPrecision() {
 		throw new UnsupportedOperationException("getPrecision() not supported for " + this);
 	}
@@ -17,4 +21,11 @@ public abstract class IExpr implements Reducible {
 
 	public boolean isBV() { return getPrecision() > 0; }
 	public boolean isInteger() { return getPrecision() <= 0; }
+
+	@Override
+	public IntegerType getType() {
+		TypeFactory types = TypeFactory.getInstance();
+		int precision = getPrecision();
+		return precision < 0 ? types.getIntegerType() : types.getIntegerType(precision);
+	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
@@ -26,8 +26,13 @@ public abstract class IExpr implements Reducible {
 		throw new UnsupportedOperationException("Reduce not supported for " + this);
 	}
 
-	public boolean isBV() { return getPrecision() > 0; }
-	public boolean isInteger() { return getPrecision() <= 0; }
+	public boolean isBV() {
+		return !getType().isMathematical();
+	}
+
+	public boolean isInteger() {
+		return getType().isMathematical();
+	}
 
 	@Override
 	public final IntegerType getType() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
@@ -1,9 +1,16 @@
 package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.type.IntegerType;
-import com.dat3m.dartagnan.expression.type.TypeFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public abstract class IExpr implements Reducible {
+
+	private final IntegerType type;
+
+	protected IExpr(IntegerType type) {
+		this.type = checkNotNull(type);
+	}
 
 	public IExpr getBase() {
 		throw new UnsupportedOperationException("getBase() not supported for " + this);
@@ -11,7 +18,7 @@ public abstract class IExpr implements Reducible {
 	
 	@Deprecated
 	public int getPrecision() {
-		throw new UnsupportedOperationException("getPrecision() not supported for " + this);
+		return type.isMathematical() ? -1 : type.getBitWidth();
 	}
 	
 	@Override
@@ -23,9 +30,7 @@ public abstract class IExpr implements Reducible {
 	public boolean isInteger() { return getPrecision() <= 0; }
 
 	@Override
-	public IntegerType getType() {
-		TypeFactory types = TypeFactory.getInstance();
-		int precision = getPrecision();
-		return precision < 0 ? types.getIntegerType() : types.getIntegerType(precision);
+	public final IntegerType getType() {
+		return type;
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
+import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
@@ -15,7 +16,9 @@ public class IExprBin extends IExpr {
     private final IOpBin op;
 
     public IExprBin(IExpr lhs, IOpBin op, IExpr rhs) {
-    	Preconditions.checkArgument(lhs.getPrecision() == rhs.getPrecision(), "The type of " + lhs + " and " + rhs + " does not match");
+        super(lhs.getType());
+    	Preconditions.checkArgument(lhs.getType().equals(rhs.getType()),
+                "The types of %s and %s do not match.", lhs, rhs);
         this.lhs = lhs;
         this.rhs = rhs;
         this.op = op;
@@ -36,11 +39,6 @@ public class IExprBin extends IExpr {
     	BigInteger v1 = lhs.reduce().getValue();
     	BigInteger v2 = rhs.reduce().getValue();
 		return new IValue(op.combine(v1, v2), lhs.getPrecision());
-	}
-
-	@Override
-	public int getPrecision() {
-		return lhs.getPrecision();
 	}
 	
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
-import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
@@ -15,7 +15,7 @@ public class INonDet extends IExpr {
         this.precision = precision;
     }
 
-    public INonDetTypes getType() {
+    public INonDetTypes getNonDetType() {
         return type;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
@@ -6,22 +6,19 @@ import com.dat3m.dartagnan.expression.type.IntegerType;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 // TODO why is INonDet not a IConst?
 public class INonDet extends IExpr {
 
     private final String id;
-    private final IntegerType type;
     private final boolean signed;
     private final BigInteger min;
     private final BigInteger max;
 
     // Should only be accessed from Program
     public INonDet(int id, IntegerType type, boolean signed, BigInteger min, BigInteger max) {
+        super(type);
         this.id = Integer.toString(id);
         this.signed = signed;
-        this.type = checkNotNull(type);
         this.min = min;
         this.max = max;
     }
@@ -43,22 +40,13 @@ public class INonDet extends IExpr {
     }
 
     @Override
-    public IntegerType getType() {
-        return type;
-    }
-
-    @Override
-    public int getPrecision() {
-        return type.isMathematical() ? -1 : type.getBitWidth();
-    }
-
-    @Override
     public <T> T visit(ExpressionVisitor<T> visitor) {
         return visitor.visit(this);
     }
 
     @Override
     public String toString() {
+        IntegerType type = getType();
         if (type.isMathematical()) {
             return String.format("nondet_int(%d,%s,%s)", id, min, max);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDet.java
@@ -1,22 +1,55 @@
 package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
-import com.google.common.primitives.UnsignedInteger;
-import com.google.common.primitives.UnsignedLong;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 // TODO why is INonDet not a IConst?
 public class INonDet extends IExpr {
 
-    private final INonDetTypes type;
-    private final int precision;
+    private final String id;
+    private final IntegerType type;
+    private final boolean signed;
+    private final BigInteger min;
+    private final BigInteger max;
 
-    public INonDet(INonDetTypes type, int precision) {
-        this.type = type;
-        this.precision = precision;
+    // Should only be accessed from Program
+    public INonDet(int id, IntegerType type, boolean signed, BigInteger min, BigInteger max) {
+        this.id = Integer.toString(id);
+        this.signed = signed;
+        this.type = checkNotNull(type);
+        this.min = min;
+        this.max = max;
     }
 
-    public INonDetTypes getNonDetType() {
+    public String getName() {
+        return id;
+    }
+
+    public boolean isSigned() {
+        return signed;
+    }
+
+    public Optional<BigInteger> getMin() {
+        return Optional.ofNullable(min);
+    }
+
+    public Optional<BigInteger> getMax() {
+        return Optional.ofNullable(max);
+    }
+
+    @Override
+    public IntegerType getType() {
         return type;
+    }
+
+    @Override
+    public int getPrecision() {
+        return type.isMathematical() ? -1 : type.getBitWidth();
     }
 
     @Override
@@ -26,70 +59,9 @@ public class INonDet extends IExpr {
 
     @Override
     public String toString() {
-        switch(type){
-            case INT:
-                return "nondet_int()";
-            case UINT:
-                return "nondet_uint()";
-            case LONG:
-                return "nondet_long()";
-            case ULONG:
-                return "nondet_ulong()";
-            case SHORT:
-                return "nondet_short()";
-            case USHORT:
-                return "nondet_ushort()";
-            case CHAR:
-                return "nondet_char()";
-            case UCHAR:
-                return "nondet_uchar()";
+        if (type.isMathematical()) {
+            return String.format("nondet_int(%d,%s,%s)", id, min, max);
         }
-        throw new UnsupportedOperationException("toString() not supported for " + this);
-    }
-
-    public long getMin() {
-        switch(type){
-            case UINT:
-            case ULONG:
-            case USHORT:
-            case UCHAR:
-                return 0;
-            case INT:
-                return Integer.MIN_VALUE;
-            case LONG:
-                return Long.MIN_VALUE;
-            case SHORT:
-                return Short.MIN_VALUE;
-            case CHAR:
-                return -128;
-        }
-        throw new UnsupportedOperationException("getMin() not supported for " + this);
-    }
-
-    public long getMax() {
-        switch(type){
-            case INT:
-                return Integer.MAX_VALUE;
-            case UINT:
-                return UnsignedInteger.MAX_VALUE.longValue();
-            case LONG:
-                return Long.MAX_VALUE;
-            case ULONG:
-                return UnsignedLong.MAX_VALUE.longValue();
-            case SHORT:
-                return Short.MAX_VALUE;
-            case USHORT:
-                return 65535;
-            case CHAR:
-                return 127;
-            case UCHAR:
-                return 255;
-        }
-        throw new UnsupportedOperationException("getMax() not supported for " + this);
-    }
-
-    @Override
-    public int getPrecision() {
-        return precision;
+        return String.format("nondet_%c%d(%d,%s,%s)", signed ? 's' : 'u', type.getBitWidth(), id, min, max);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDetTypes.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/INonDetTypes.java
@@ -1,5 +1,0 @@
-package com.dat3m.dartagnan.expression;
-
-public enum INonDetTypes {
-	INT, UINT, SHORT, USHORT, LONG, ULONG, CHAR, UCHAR
-}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
@@ -18,17 +18,17 @@ public final class IValue extends IConst {
     // However, it is impossible to define general constants, we need a function that produces
     // a constant for each precision degree
     // HP: agree. I assume you wanted this to improve code readability, but having one constant per precision won't help.
-    public static IConst ZERO = new IValue(types.getArchType(), BigInteger.ZERO);
-    public static IConst ONE = new IValue(types.getArchType(), BigInteger.ONE);
+    public static IConst ZERO = new IValue(BigInteger.ZERO, types.getArchType());
+    public static IConst ONE = new IValue(BigInteger.ONE, types.getArchType());
 
     private final BigInteger value;
 
     @Deprecated
     public IValue(BigInteger v, int p) {
-        this(p == -1 ? types.getIntegerType() : types.getIntegerType(p), v);
+        this(v, p == -1 ? types.getIntegerType() : types.getIntegerType(p));
     }
 
-    public IValue(IntegerType type, BigInteger value) {
+    public IValue(BigInteger value, IntegerType type) {
         super(type);
         this.value = value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
@@ -22,26 +22,20 @@ public final class IValue extends IConst {
     public static IConst ONE = new IValue(types.getArchType(), BigInteger.ONE);
 
     private final BigInteger value;
-    private final IntegerType type;
 
     @Deprecated
     public IValue(BigInteger v, int p) {
         this(p == -1 ? types.getIntegerType() : types.getIntegerType(p), v);
     }
 
-    public IValue(IntegerType t, BigInteger v) {
-        type = t;
-        value = v;
+    public IValue(IntegerType type, BigInteger value) {
+        super(type);
+        this.value = value;
     }
 
     @Override
     public BigInteger getValue() {
         return value;
-    }
-
-    @Override
-    public int getPrecision() {
-        return type.isMathematical() ? -1 : type.getBitWidth();
     }
 
     @Override
@@ -51,16 +45,17 @@ public final class IValue extends IConst {
 
     @Override
     public int hashCode() {
-        return type.hashCode() ^ 0xa185f6b3 + value.hashCode();
+        return getType().hashCode() ^ 0xa185f6b3 + value.hashCode();
     }
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o instanceof IValue && type.equals(((IValue) o).type) && value.equals(((IValue) o).value);
+        return this == o ||
+                o instanceof IValue && getType().equals(((IValue) o).getType()) && value.equals(((IValue) o).value);
     }
 
     @Override
     public String toString() {
-        return value.toString() + type.toString();
+        return value.toString() + getType().toString();
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
@@ -1,8 +1,8 @@
 package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
-
-import static com.dat3m.dartagnan.GlobalSettings.*;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 
 import java.math.BigInteger;
 
@@ -11,20 +11,27 @@ import java.math.BigInteger;
  */
 public final class IValue extends IConst {
 
+    private static final TypeFactory types = TypeFactory.getInstance();
+
     // TODO(TH): not sure where this are used, but why do you set the precision to 0?
     // TH: This was a temporary try for integer logic only
     // However, it is impossible to define general constants, we need a function that produces
     // a constant for each precision degree
     // HP: agree. I assume you wanted this to improve code readability, but having one constant per precision won't help.
-    public static IConst ZERO = new IValue(BigInteger.ZERO, getArchPrecision());
-    public static IConst ONE = new IValue(BigInteger.ONE, getArchPrecision());
+    public static IConst ZERO = new IValue(types.getArchType(), BigInteger.ZERO);
+    public static IConst ONE = new IValue(types.getArchType(), BigInteger.ONE);
 
     private final BigInteger value;
-    private final int precision;
+    private final IntegerType type;
 
+    @Deprecated
     public IValue(BigInteger v, int p) {
+        this(p == -1 ? types.getIntegerType() : types.getIntegerType(p), v);
+    }
+
+    public IValue(IntegerType t, BigInteger v) {
+        type = t;
         value = v;
-        precision = p;
     }
 
     @Override
@@ -34,7 +41,7 @@ public final class IValue extends IConst {
 
     @Override
     public int getPrecision() {
-        return precision;
+        return type.isMathematical() ? -1 : type.getBitWidth();
     }
 
     @Override
@@ -44,16 +51,16 @@ public final class IValue extends IConst {
 
     @Override
     public int hashCode() {
-        return value.hashCode() + (precision > 0 ? 0 : precision);
+        return type.hashCode() ^ 0xa185f6b3 + value.hashCode();
     }
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o instanceof IValue && value.equals(((IValue)o).value) && precision == ((IValue)o).precision;
+        return this == o || o instanceof IValue && type.equals(((IValue) o).type) && value.equals(((IValue) o).value);
     }
 
     @Override
     public String toString() {
-        return value.toString();
+        return value.toString() + type.toString();
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
@@ -50,8 +50,7 @@ public final class IValue extends IConst {
 
     @Override
     public boolean equals(Object o) {
-        return this == o ||
-                o instanceof IValue && getType().equals(((IValue) o).getType()) && value.equals(((IValue) o).value);
+        return this == o || o instanceof IValue val && getType().equals(val.getType()) && value.equals(val.value);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
@@ -12,8 +12,9 @@ public class IfExpr extends IExpr {
 	private final IExpr fbranch;
 	
 	public IfExpr(BExpr guard, IExpr tbranch, IExpr fbranch) {
-    	Preconditions.checkArgument(tbranch.getPrecision() == fbranch.getPrecision(), 
-    			"The type of " + tbranch + " and " + fbranch + " does not match");
+		super(tbranch.getType());
+    	Preconditions.checkArgument(tbranch.getType().equals(fbranch.getType()),
+    			"The types of %s and %s do not match.", tbranch, fbranch);
 		this.guard =  guard;
 		this.tbranch = tbranch;
 		this.fbranch = fbranch;
@@ -39,11 +40,6 @@ public class IfExpr extends IExpr {
 
 	public IExpr getFalseBranch() {
 		return fbranch;
-	}
-
-	@Override
-	public int getPrecision() {
-		return tbranch.getPrecision();
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/BooleanType.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/BooleanType.java
@@ -1,0 +1,11 @@
+package com.dat3m.dartagnan.expression.type;
+
+public final class BooleanType implements Type {
+
+    BooleanType() {}
+
+    @Override
+    public String toString() {
+        return "bool";
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/IntegerType.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/IntegerType.java
@@ -23,6 +23,6 @@ public final class IntegerType implements Type {
 
     @Override
     public String toString() {
-        return "bv" + bitWidth;
+        return isMathematical() ? "int" : "bv" + bitWidth;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/IntegerType.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/IntegerType.java
@@ -1,0 +1,28 @@
+package com.dat3m.dartagnan.expression.type;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public final class IntegerType implements Type {
+
+    final static int MATHEMATICAL = -1;
+
+    private final int bitWidth;
+
+    IntegerType(int bitWidth) {
+        this.bitWidth = bitWidth;
+    }
+
+    public boolean isMathematical() {
+        return bitWidth == MATHEMATICAL;
+    }
+
+    public int getBitWidth() {
+        checkState(bitWidth > 0, "Invalid integer bound %s", bitWidth);
+        return bitWidth;
+    }
+
+    @Override
+    public String toString() {
+        return "bv" + bitWidth;
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/Type.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/Type.java
@@ -1,0 +1,4 @@
+package com.dat3m.dartagnan.expression.type;
+
+public interface Type {
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
@@ -1,0 +1,41 @@
+package com.dat3m.dartagnan.expression.type;
+
+import com.dat3m.dartagnan.GlobalSettings;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class TypeFactory {
+
+    private static TypeFactory instance = new TypeFactory();
+    private final BooleanType booleanType = new BooleanType();
+    private final Map<Integer, IntegerType> integerTypeMap = new HashMap<>();
+    private final IntegerType mathematicalIntegerType = new IntegerType(IntegerType.MATHEMATICAL);
+
+    private TypeFactory() {}
+
+    //TODO make this part of the program.
+    public static TypeFactory getInstance() {
+        return instance;
+    }
+
+    public BooleanType getBooleanType() {
+        return booleanType;
+    }
+
+    public IntegerType getIntegerType() {
+        return mathematicalIntegerType;
+    }
+
+    public IntegerType getIntegerType(int bitWidth) {
+        checkArgument(bitWidth >= 0, "Negative bit width %s.", bitWidth);
+        return integerTypeMap.computeIfAbsent(bitWidth, IntegerType::new);
+    }
+
+    public IntegerType getArchType() {
+        int archPrecision = GlobalSettings.getArchPrecision();
+        return archPrecision < 0 ? getIntegerType() : getIntegerType(archPrecision);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -2,6 +2,8 @@ package com.dat3m.dartagnan.parsers.program.utils;
 
 import com.dat3m.dartagnan.exception.MalformedProgramException;
 import com.dat3m.dartagnan.expression.IConst;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.Register;
@@ -28,6 +30,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class ProgramBuilder {
 
+    private static final TypeFactory types = TypeFactory.getInstance();
     private final Map<Integer, Thread> threads = new HashMap<>();
 
     private final Map<String,MemoryObject> locations = new HashMap<>();
@@ -156,15 +159,21 @@ public class ProgramBuilder {
         return null;
     }
 
-    public Register getOrCreateRegister(int threadId, String name, int precision){
+    @Deprecated
+    public Register getOrCreateRegister(int threadId, String name, int precision) {
+        IntegerType type = precision < 0 ? types.getIntegerType() : types.getIntegerType(precision);
+        return getOrNewRegister(threadId, name, type);
+    }
+
+    public Register getOrNewRegister(int threadId, String name, IntegerType type) {
         initThread(threadId);
         Thread thread = threads.get(threadId);
         if(name == null) {
-            return thread.newRegister(precision);
+            return thread.newRegister(type);
         }
         Register register = thread.getRegister(name);
         if(register == null){
-            return thread.newRegister(name, precision);
+            return thread.newRegister(name, type);
         }
         return register;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
@@ -6,7 +6,10 @@ import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.parsers.BoogieParser.Call_cmdContext;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventFactory;
+import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 
@@ -97,45 +100,41 @@ public class SvcompProcedures {
 		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Svcomp.newEndAtomic(visitor.currentBeginAtomic));
 		visitor.currentBeginAtomic = null;
 	}
-	
+
+	//TODO this should restart for each program.
+	private static int nondetCount;
+
 	private static void __VERIFIER_nondet(VisitorBoogie visitor, Call_cmdContext ctx, String name) {
-		INonDetTypes type = null;
-		switch (name) {
-			case "__VERIFIER_nondet_int":
-				type = INonDetTypes.INT;
-				break;
-			case "__VERIFIER_nondet_uint":
-			case "__VERIFIER_nondet_unsigned_int":
-				type = INonDetTypes.UINT;
-				break;
-			case "__VERIFIER_nondet_short":
-				type = INonDetTypes.SHORT;
-				break;
-			case "__VERIFIER_nondet_ushort":
-			case "__VERIFIER_nondet_unsigned_short":
-				type = INonDetTypes.USHORT;
-				break;
-			case "__VERIFIER_nondet_long":
-				type = INonDetTypes.LONG;
-				break;
-			case "__VERIFIER_nondet_ulong":
-				type = INonDetTypes.ULONG;
-				break;
-			case "__VERIFIER_nondet_char":
-				type = INonDetTypes.CHAR;
-				break;
-			case "__VERIFIER_nondet_uchar":
-				type = INonDetTypes.UCHAR;
-				break;
-			default:
-				throw new ParsingException(name + " is not supported");
-		}
+		String suffix = name.substring("__VERIFIER_nondet_".length());
+		boolean signed = switch (suffix) {
+			case "int", "short", "long", "char" -> true;
+			default -> false;
+		};
+		BigInteger min = switch (suffix) {
+			case "long" -> BigInteger.valueOf(Long.MIN_VALUE);
+			case "int" -> BigInteger.valueOf(Integer.MIN_VALUE);
+			case "short" -> BigInteger.valueOf(Short.MIN_VALUE);
+			case "char" -> BigInteger.valueOf(-128);
+			default -> BigInteger.ZERO;
+		};
+		BigInteger max = switch (suffix) {
+			case "int" -> BigInteger.valueOf(Integer.MAX_VALUE);
+			case "uint", "unsigned_int" -> UnsignedInteger.MAX_VALUE.bigIntegerValue();
+			case "short" -> BigInteger.valueOf(Short.MAX_VALUE);
+			case "ushort", "unsigned_short" -> BigInteger.valueOf(65535);
+			case "long" -> BigInteger.valueOf(Long.MAX_VALUE);
+			case "ulong" -> UnsignedLong.MAX_VALUE.bigIntegerValue();
+			case "char" -> BigInteger.valueOf(127);
+			case "uchar" -> BigInteger.valueOf(255);
+			default -> throw new ParsingException(name + " is not supported");
+		};
 		String registerName = ctx.call_params().Ident(0).getText();
 		Register register = visitor.programBuilder.getRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + registerName);
-	    if(register != null){
-			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(register, new INonDet(type, register.getPrecision())))
+		if (register != null) {
+			INonDet expression = new INonDet(nondetCount++, register.getType(), signed, min, max);
+			visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(register, expression))
 					.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
-	    }
+		}
 	}
 
 	private static void __VERIFIER_nondet_bool(VisitorBoogie visitor, Call_cmdContext ctx) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
@@ -114,7 +114,7 @@ public class SvcompProcedures {
 			case "long" -> BigInteger.valueOf(Long.MIN_VALUE);
 			case "int" -> BigInteger.valueOf(Integer.MIN_VALUE);
 			case "short" -> BigInteger.valueOf(Short.MIN_VALUE);
-			case "char" -> BigInteger.valueOf(-128);
+			case "char" -> BigInteger.valueOf(Byte.MIN_VALUE);
 			default -> BigInteger.ZERO;
 		};
 		BigInteger max = switch (suffix) {
@@ -124,7 +124,7 @@ public class SvcompProcedures {
 			case "ushort", "unsigned_short" -> BigInteger.valueOf(65535);
 			case "long" -> BigInteger.valueOf(Long.MAX_VALUE);
 			case "ulong" -> UnsignedLong.MAX_VALUE.bigIntegerValue();
-			case "char" -> BigInteger.valueOf(127);
+			case "char" -> BigInteger.valueOf(Byte.MAX_VALUE);
 			case "uchar" -> BigInteger.valueOf(255);
 			default -> throw new ParsingException(name + " is not supported");
 		};

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.expression.op.IOpUn;
 import com.dat3m.dartagnan.expression.processing.ExprSimplifier;
+import com.dat3m.dartagnan.expression.type.*;
 import com.dat3m.dartagnan.parsers.BoogieBaseVisitor;
 import com.dat3m.dartagnan.parsers.BoogieParser;
 import com.dat3m.dartagnan.parsers.BoogieParser.*;
@@ -56,7 +57,7 @@ import static com.dat3m.dartagnan.parsers.program.visitors.boogie.SvcompProcedur
 public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 
     private static final Logger logger = LogManager.getLogger(VisitorBoogie.class);
-	
+	private static final TypeFactory types = TypeFactory.getInstance();
 	protected ProgramBuilder programBuilder;
 	protected int threadCount = 0;
 	protected int currentThread = 0;
@@ -640,7 +641,9 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 		}
 		if(constantsTypeMap.containsKey(name)) {
 			// Dummy register needed to parse axioms
-			return new Register(name, Register.NO_THREAD, constantsTypeMap.get(name));
+			int precision = constantsTypeMap.get(name);
+			IntegerType type = precision < 0 ? types.getIntegerType() : types.getIntegerType(precision);
+			return new Register(name, Register.NO_THREAD, type);
 		}
         Register register = programBuilder.getRegister(threadCount, currentScope.getID() + ":" + name);
         if(register != null){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
@@ -14,12 +14,11 @@ public class Register extends IExpr {
 	private final String name;
 	private String cVar;
     private final int threadId;
-    private final IntegerType type;
 
 	public Register(String name, int threadId, IntegerType type) {
+		super(type);
 		this.name = checkNotNull(name);
 		this.threadId = threadId;
-		this.type = type;
 	}
 	
 	public String getName() {
@@ -61,11 +60,6 @@ public class Register extends IExpr {
     }
 
 	@Override
-	public IntegerType getType() {
-		return type;
-	}
-
-	@Override
 	public ImmutableSet<Register> getRegs() {
 		return ImmutableSet.of(this);
 	}
@@ -74,11 +68,6 @@ public class Register extends IExpr {
 	public <T> T visit(ExpressionVisitor<T> visitor) {
 		return visitor.visit(this);
 	}
-
-	@Override
-	public int getPrecision() {
-    	return type.isMathematical() ? -1 : type.getBitWidth();
-    }
 
 	@Override
 	public IExpr getBase() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
@@ -2,7 +2,10 @@ package com.dat3m.dartagnan.program;
 
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
+import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.google.common.collect.ImmutableSet;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Register extends IExpr {
 
@@ -11,13 +14,12 @@ public class Register extends IExpr {
 	private final String name;
 	private String cVar;
     private final int threadId;
+    private final IntegerType type;
 
-    private final int precision;
-
-	public Register(String name, int threadId, int precision) {
-		this.name = name;
+	public Register(String name, int threadId, IntegerType type) {
+		this.name = checkNotNull(name);
 		this.threadId = threadId;
-		this.precision = precision;
+		this.type = type;
 	}
 	
 	public String getName() {
@@ -59,6 +61,11 @@ public class Register extends IExpr {
     }
 
 	@Override
+	public IntegerType getType() {
+		return type;
+	}
+
+	@Override
 	public ImmutableSet<Register> getRegs() {
 		return ImmutableSet.of(this);
 	}
@@ -70,7 +77,7 @@ public class Register extends IExpr {
 
 	@Override
 	public int getPrecision() {
-    	return precision;
+    	return type.isMathematical() ? -1 : type.getBitWidth();
     }
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
@@ -1,6 +1,8 @@
 package com.dat3m.dartagnan.program;
 
 import com.dat3m.dartagnan.exception.MalformedProgramException;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.google.common.base.Preconditions;
 
@@ -12,7 +14,8 @@ import java.util.stream.Collectors;
 
 public class Thread {
 
-	private String name;
+    private static final TypeFactory types = TypeFactory.getInstance();
+    private String name;
     private final int id;
     private final Event entry;
     private Event exit;
@@ -79,16 +82,27 @@ public class Thread {
         return registers.get(name);
     }
 
+    @Deprecated
     public Register newRegister(int precision) {
-        return newRegister("DUMMY_REG_" + dummyCount++, precision);
+        return newRegister(precision < 0 ? types.getIntegerType() : types.getIntegerType(precision));
     }
 
-    public Register newRegister(String name, int precision){
-        if(registers.containsKey(name)){
+    public Register newRegister(IntegerType type) {
+        return newRegister("DUMMY_REG_" + dummyCount++, type);
+    }
+
+    @Deprecated
+    public Register newRegister(String name, int precision) {
+        IntegerType type = precision < 0 ? types.getIntegerType() : types.getIntegerType(precision);
+        return newRegister(name, type);
+    }
+
+    public Register newRegister(String name, IntegerType type) {
+        if (registers.containsKey(name)) {
             throw new MalformedProgramException("Register " + id + ":" + name + " already exists");
         }
-        Register register = new Register(name, id, precision);
-        registers.put(register.getName(), register);
+        Register register = new Register(name, id, type);
+        registers.put(name, register);
         return register;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
@@ -67,7 +67,7 @@ public class Local extends Event implements RegWriter, RegReaderData {
             long min = nonDet.getMin();
             long max = nonDet.getMax();
             if (expression instanceof BitvectorFormula) {
-                INonDetTypes type = nonDet.getType();
+                INonDetTypes type = nonDet.getNonDetType();
                 boolean signed = type.equals(INT) || type.equals(LONG) || type.equals(SHORT) || type.equals(CHAR);
                 BitvectorFormulaManager bvmgr = context.getFormulaManager().getBitvectorFormulaManager();
                 enc = bmgr.and(enc,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
@@ -66,13 +66,14 @@ public class Local extends Event implements RegWriter, RegReaderData {
             INonDet nonDet = (INonDet) expr;
             long min = nonDet.getMin();
             long max = nonDet.getMax();
-            if (expression instanceof BitvectorFormula) {
+            if (expression instanceof BitvectorFormula bitvector) {
                 INonDetTypes type = nonDet.getNonDetType();
                 boolean signed = type.equals(INT) || type.equals(LONG) || type.equals(SHORT) || type.equals(CHAR);
                 BitvectorFormulaManager bvmgr = context.getFormulaManager().getBitvectorFormulaManager();
+                int bitWidth = bvmgr.getLength(bitvector);
                 enc = bmgr.and(enc,
-                        bvmgr.greaterOrEquals((BitvectorFormula) expression, bvmgr.makeBitvector(nonDet.getPrecision(), min), signed),
-                        bvmgr.lessOrEquals((BitvectorFormula) expression, bvmgr.makeBitvector(nonDet.getPrecision(), max), signed));
+                        bvmgr.greaterOrEquals(bitvector, bvmgr.makeBitvector(bitWidth, min), signed),
+                        bvmgr.lessOrEquals(bitvector, bvmgr.makeBitvector(bitWidth, max), signed));
             } else {
                 IntegerFormulaManager imgr = context.getFormulaManager().getIntegerFormulaManager();
                 enc = bmgr.and(enc,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.program.event.core;
 import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.INonDet;
-import com.dat3m.dartagnan.expression.INonDetTypes;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
@@ -11,8 +10,6 @@ import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.collect.ImmutableSet;
 import org.sosy_lab.java_smt.api.*;
-
-import static com.dat3m.dartagnan.expression.INonDetTypes.*;
 
 public class Local extends Event implements RegWriter, RegReaderData {
 
@@ -64,21 +61,18 @@ public class Local extends Event implements RegWriter, RegReaderData {
         Formula expression = context.encodeIntegerExpressionAt(expr, this);
         if (expr instanceof INonDet) {
             INonDet nonDet = (INonDet) expr;
-            long min = nonDet.getMin();
-            long max = nonDet.getMax();
             if (expression instanceof BitvectorFormula bitvector) {
-                INonDetTypes type = nonDet.getNonDetType();
-                boolean signed = type.equals(INT) || type.equals(LONG) || type.equals(SHORT) || type.equals(CHAR);
+                boolean signed = nonDet.isSigned();
                 BitvectorFormulaManager bvmgr = context.getFormulaManager().getBitvectorFormulaManager();
                 int bitWidth = bvmgr.getLength(bitvector);
                 enc = bmgr.and(enc,
-                        bvmgr.greaterOrEquals(bitvector, bvmgr.makeBitvector(bitWidth, min), signed),
-                        bvmgr.lessOrEquals(bitvector, bvmgr.makeBitvector(bitWidth, max), signed));
+                        nonDet.getMin().map(min -> bvmgr.greaterOrEquals(bitvector, bvmgr.makeBitvector(bitWidth, min), signed)).orElseGet(bmgr::makeTrue),
+                        nonDet.getMax().map(max -> bvmgr.lessOrEquals(bitvector, bvmgr.makeBitvector(bitWidth, max), signed)).orElseGet(bmgr::makeTrue));
             } else {
                 IntegerFormulaManager imgr = context.getFormulaManager().getIntegerFormulaManager();
                 enc = bmgr.and(enc,
-                        imgr.greaterOrEquals((NumeralFormula.IntegerFormula) expression, imgr.makeNumber(min)),
-                        imgr.lessOrEquals((NumeralFormula.IntegerFormula) expression, imgr.makeNumber(max)));
+                        nonDet.getMin().map(min -> imgr.greaterOrEquals((NumeralFormula.IntegerFormula) expression, imgr.makeNumber(min))).orElseGet(bmgr::makeTrue),
+                        nonDet.getMax().map(max -> imgr.lessOrEquals((NumeralFormula.IntegerFormula) expression, imgr.makeNumber(max))).orElseGet(bmgr::makeTrue));
             }
         }
         return bmgr.and(enc, context.equal(context.result(this), expression));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Location.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/Location.java
@@ -1,8 +1,8 @@
 package com.dat3m.dartagnan.program.memory;
 
-import com.dat3m.dartagnan.GlobalSettings;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 
 public class Location extends IExpr {
 
@@ -11,6 +11,7 @@ public class Location extends IExpr {
 	private final int offset;
 
 	public Location(String name, MemoryObject b, int o) {
+		super(TypeFactory.getInstance().getArchType());
 		this.name = name;
 		base = b;
 		offset = o;
@@ -31,11 +32,6 @@ public class Location extends IExpr {
 	@Override
 	public <T> T visit(ExpressionVisitor<T> visitor) {
 		return visitor.visit(this);
-	}
-
-	@Override
-	public int getPrecision() {
-		return GlobalSettings.getArchPrecision();
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
@@ -5,12 +5,12 @@ import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IExprBin;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Set;
 
-import static com.dat3m.dartagnan.GlobalSettings.getArchPrecision;
 import static com.dat3m.dartagnan.expression.op.IOpBin.PLUS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -35,6 +35,7 @@ public class MemoryObject extends IConst {
     private final HashMap<Integer, IConst> initialValues = new HashMap<>();
 
     MemoryObject(int index, int size, boolean isStaticallyAllocated) {
+        super(TypeFactory.getInstance().getArchType());
         this.index = index;
         this.size = size;
         this.isStatic = isStaticallyAllocated;
@@ -125,11 +126,6 @@ public class MemoryObject extends IConst {
     @Override
     public BigInteger getValue() {
         return address != null ? address : BigInteger.valueOf(index);
-    }
-
-    @Override
-    public int getPrecision() {
-        return getArchPrecision();
     }
 
     @Override

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan.exceptions;
 import com.dat3m.dartagnan.exception.MalformedProgramException;
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
@@ -21,6 +22,8 @@ import org.sosy_lab.common.configuration.Configuration;
 import java.io.File;
 
 public class ExceptionsTest {
+
+    private static final TypeFactory types = TypeFactory.getInstance();
 
     @Test(expected = MalformedProgramException.class)
     public void noThread() throws Exception {
@@ -62,7 +65,9 @@ public class ExceptionsTest {
     @Test(expected = IllegalArgumentException.class)
     public void diffPrecisionInt() throws Exception {
         // Both arguments should have same precision
-        new IExprBin(new Register("a", 0, 32), IOpBin.PLUS, new Register("b", 0, 64));
+        Register a = new Register("a", 0, types.getIntegerType(32));
+        Register b = new Register("b", 0, types.getIntegerType(64));
+        new IExprBin(a, IOpBin.PLUS, b);
     }
 
     @Test(expected = NullPointerException.class)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan.miscellaneous;
 import com.dat3m.dartagnan.configuration.Alias;
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.BOpBin;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Program.SourceLanguage;
@@ -46,6 +47,8 @@ public class AnalysisTest {
     private static final Result NONE = Result.NONE;
     private static final Result MAY = Result.MAY;
     private static final Result MUST = Result.MUST;
+
+    private static final TypeFactory types = TypeFactory.getInstance();
 
     @Test
     public void dependencyMustOverride() throws InvalidConfigurationException {
@@ -210,7 +213,7 @@ public class AnalysisTest {
 
         b.initThread(0);
         Register r0 = b.getOrCreateRegister(0, "r0", getArchPrecision());
-        b.addChild(0, newLocal(r0, new INonDet(INonDetTypes.INT, getArchPrecision())));
+        b.addChild(0, newLocal(r0, new INonDet(0, types.getArchType(), true, null, null)));
         Label l0 = b.getOrCreateLabel("l0");
         b.addChild(0, newJump(new BExprBin(new Atom(r0, GT, ONE), BOpBin.OR, new Atom(r0, LT, ZERO)), l0));
         Store e0 = newStore(x);


### PR DESCRIPTION
Introduces the `Type` class, which extends the `IExpr.getPrecision()` property.  It will replace it  Currently, the supported types are `BooleanType` and `IntegerType`.  Due to name conflicts, the `INonDetTypes` class is also replaced here.