### PR TITLE
Register reads (rework)

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
@@ -1,9 +1,12 @@
 package com.dat3m.dartagnan.program;
 
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -73,4 +76,25 @@ public class Register extends IExpr {
 	public IExpr getBase() {
     	return this;
     }
+
+
+	public static Set<Read> collectRegisterReads(ExprInterface expr, Register.UsageType usageType, Set<Read> collector) {
+		expr.getRegs().stream().map(r -> new Register.Read(r, usageType)).forEach(collector::add);
+		return collector;
+	}
+
+	public enum UsageType {
+		CTRL, DATA, ADDR, // The register value is used to determine control, data, or address.
+		OTHER;            // The register value is used for a different purpose.
+	}
+
+	/*
+        Describes for what purpose a register was read.
+    */
+	public record Read(Register register, UsageType usageType) {
+		@Override
+		public String toString() {
+			return String.format("RegRead[%s, %s]", register, usageType);
+		}
+	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
@@ -12,89 +12,96 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Register extends IExpr {
 
-	public static final int NO_THREAD = -1;
+    public static final int NO_THREAD = -1;
 
-	private final String name;
-	private String cVar;
+    private final String name;
+    private String cVar;
     private final int threadId;
 
-	public Register(String name, int threadId, IntegerType type) {
-		super(type);
-		this.name = checkNotNull(name);
-		this.threadId = threadId;
-	}
-	
-	public String getName() {
-		return name;
-	}
+    public Register(String name, int threadId, IntegerType type) {
+        super(type);
+        this.name = checkNotNull(name);
+        this.threadId = threadId;
+    }
 
-	public String getCVar() {
-		return cVar;
-	}
-
-	public void setCVar(String name) {
-		this.cVar = name;
-	}
-
-	public int getThreadId(){
-		return threadId;
-	}
-
-	@Override
-	public String toString() {
+    public String getName() {
         return name;
-	}
+    }
+
+    public String getCVar() {
+        return cVar;
+    }
+
+    public void setCVar(String name) {
+        this.cVar = name;
+    }
+
+    public int getThreadId() {
+        return threadId;
+    }
 
     @Override
-    public int hashCode(){
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
         return name.hashCode() + threadId;
     }
 
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
-			return true;
-		} else if (obj == null || getClass() != obj.getClass()) {
-			return false;
-		}
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
 
         Register rObj = (Register) obj;
         return name.equals(rObj.name) && threadId == rObj.threadId;
     }
 
-	@Override
-	public ImmutableSet<Register> getRegs() {
-		return ImmutableSet.of(this);
-	}
-
-	@Override
-	public <T> T visit(ExpressionVisitor<T> visitor) {
-		return visitor.visit(this);
-	}
-
-	@Override
-	public IExpr getBase() {
-    	return this;
+    @Override
+    public ImmutableSet<Register> getRegs() {
+        return ImmutableSet.of(this);
     }
 
+    @Override
+    public <T> T visit(ExpressionVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
 
-	public static Set<Read> collectRegisterReads(ExprInterface expr, Register.UsageType usageType, Set<Read> collector) {
-		expr.getRegs().stream().map(r -> new Register.Read(r, usageType)).forEach(collector::add);
-		return collector;
-	}
+    @Override
+    public IExpr getBase() {
+        return this;
+    }
 
-	public enum UsageType {
-		CTRL, DATA, ADDR, // The register value is used to determine control, data, or address.
-		OTHER;            // The register value is used for a different purpose.
-	}
+    // ============================== Static utility =============================
 
-	/*
+    public static Set<Read> collectRegisterReads(ExprInterface expr, Register.UsageType usageType, Set<Read> collector) {
+        expr.getRegs().stream().map(r -> new Register.Read(r, usageType)).forEach(collector::add);
+        return collector;
+    }
+
+    // ==========================================================================
+    // ==========================================================================
+    // ============================== Inner classes =============================
+    // ==========================================================================
+    // ==========================================================================
+
+    public enum UsageType {
+        CTRL, DATA, ADDR, // The register value is used to determine control, data, or address.
+        OTHER;            // The register value is used for a different purpose.
+    }
+
+    /*
         Describes for what purpose a register was read.
     */
-	public record Read(Register register, UsageType usageType) {
-		@Override
-		public String toString() {
-			return String.format("RegRead[%s, %s]", register, usageType);
-		}
-	}
+    public record Read(Register register, UsageType usageType) {
+        @Override
+        public String toString() {
+            return String.format("RegRead[%s, %s]", register, usageType);
+        }
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/Dependency.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/Dependency.java
@@ -100,15 +100,12 @@ public final class Dependency {
             if (j != null) {
                 state.addAll(j);
             }
-            //collecting dependencies, mixing 'data' and 'addr'
+            //collecting all register dependencies
             Set<Register> registers = new HashSet<>();
             if (event instanceof RegReader regReader) {
-                Set<Register.Read> regReads = regReader.getRegisterReads();
                 regReader.getRegisterReads().forEach( read -> registers.add(read.register()));
             }
-            /*if (event instanceof MemEvent) {
-                registers.addAll(((MemEvent) event).getAddress().getRegs());
-            }*/
+
             if (!registers.isEmpty()) {
                 Map<Register, State> result = new HashMap<>();
                 for (Register register : registers) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/Dependency.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/Dependency.java
@@ -5,8 +5,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.verification.Context;
 import org.apache.logging.log4j.LogManager;
@@ -103,12 +102,13 @@ public final class Dependency {
             }
             //collecting dependencies, mixing 'data' and 'addr'
             Set<Register> registers = new HashSet<>();
-            if (event instanceof RegReaderData) {
-                registers.addAll(((RegReaderData) event).getDataRegs());
+            if (event instanceof RegReader regReader) {
+                Set<Register.Read> regReads = regReader.getRegisterReads();
+                regReader.getRegisterReads().forEach( read -> registers.add(read.register()));
             }
-            if (event instanceof MemEvent) {
+            /*if (event instanceof MemEvent) {
                 registers.addAll(((MemEvent) event).getAddress().getRegs());
-            }
+            }*/
             if (!registers.isEmpty()) {
                 Map<Register, State> result = new HashMap<>();
                 for (Register register : registers) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
@@ -4,15 +4,15 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.RMW;
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public class RMW extends MemEvent implements RegWriter, RegReaderData {
+public class RMW extends MemEvent implements RegWriter {
 
     private final Register resultRegister;
     private final IExpr value;
@@ -40,10 +40,10 @@ public class RMW extends MemEvent implements RegWriter, RegReaderData {
         return value;
     }
 
-	@Override
-	public ImmutableSet<Register> getDataRegs() {
-		return value.getRegs();
-	}
+    @Override
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
+    }
 
 	@Override
 	public Register getResultRegister() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.program.event.arch.tso;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -12,7 +11,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public class Xchg extends MemEvent implements RegWriter, RegReader {
+public class Xchg extends MemEvent implements RegWriter {
 
     private final Register resultRegister;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -3,15 +3,16 @@ package com.dat3m.dartagnan.program.event.arch.tso;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public class Xchg extends MemEvent implements RegWriter, RegReaderData {
+public class Xchg extends MemEvent implements RegWriter, RegReader {
 
     private final Register resultRegister;
 
@@ -32,8 +33,8 @@ public class Xchg extends MemEvent implements RegWriter, RegReaderData {
     }
 
     @Override
-    public ImmutableSet<Register> getDataRegs(){
-        return ImmutableSet.of(resultRegister);
+    public Set<Register.Read> getRegisterReads(){
+        return Set.of(new Register.Read(resultRegister, Register.UsageType.DATA));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -33,7 +33,7 @@ public class Xchg extends MemEvent implements RegWriter {
 
     @Override
     public Set<Register.Read> getRegisterReads(){
-        return Set.of(new Register.Read(resultRegister, Register.UsageType.DATA));
+        return Register.collectRegisterReads(resultRegister, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
@@ -3,13 +3,15 @@ package com.dat3m.dartagnan.program.event.core;
 import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
-import com.google.common.collect.ImmutableSet;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 
-public class Assume extends Event implements RegReaderData {
+import java.util.HashSet;
+import java.util.Set;
+
+public class Assume extends Event implements RegReader {
 
 	protected final ExprInterface expr;
 
@@ -30,8 +32,8 @@ public class Assume extends Event implements RegReaderData {
 
 
 	@Override
-	public ImmutableSet<Register> getDataRegs(){
-		return expr.getRegs();
+	public Set<Register.Read> getRegisterReads() {
+		return Register.collectRegisterReads(expr, Register.UsageType.OTHER, new HashSet<>());
 	}
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
@@ -4,48 +4,49 @@ import com.dat3m.dartagnan.expression.BExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
-public class CondJump extends Event implements RegReaderData {
+public class CondJump extends Event implements RegReader {
 
     private Label label;
-    private BExpr expr;
+    private BExpr guard;
 
-    public CondJump(BExpr expr, Label label){
+    public CondJump(BExpr guard, Label label){
     	Preconditions.checkNotNull(label, "CondJump event requires non null label event");
-    	Preconditions.checkNotNull(expr, "CondJump event requires non null expression");
+    	Preconditions.checkNotNull(guard, "CondJump event requires non null expression");
         this.label = label;
         this.label.getJumpSet().add(this);
         this.thread = label.getThread();
-        this.expr = expr;
+        this.guard = guard;
     }
 
     protected CondJump(CondJump other) {
 		super(other);
 		this.label = other.label;;
-		this.expr = other.expr;
+		this.guard = other.guard;
         this.label.getJumpSet().add(this);
     }
     
     public boolean isGoto() {
-    	return expr.isTrue();
+    	return guard.isTrue();
     }
-    public boolean isDead() {return expr.isFalse(); }
+    public boolean isDead() {return guard.isFalse(); }
     
     public Label getLabel(){
         return label;
     }
 
     public BExpr getGuard(){
-        return expr;
+        return guard;
     }
     public void setGuard(BExpr guard){
-        this.expr = guard;
+        this.guard = guard;
     }
 
     @Override
@@ -57,8 +58,8 @@ public class CondJump extends Event implements RegReaderData {
     }
 
     @Override
-    public ImmutableSet<Register> getDataRegs(){
-        return expr.getRegs();
+    public Set<Register.Read> getRegisterReads(){
+        return Register.collectRegisterReads(guard, Register.UsageType.CTRL, new HashSet<>());
     }
 
     @Override
@@ -67,7 +68,7 @@ public class CondJump extends Event implements RegReaderData {
     	if(isGoto()) {
             output = "goto " + label.getName();
     	} else {
-            output = "if(" + expr + "); then goto " + label.getName();    		
+            output = "if(" + guard + "); then goto " + label.getName();
     	}
         output = hasTag(Tag.BOUND) ? String.format("%1$-" + Event.PRINT_PAD_EXTRA + "s", output) + "\t### BOUND" : output;
         output = hasTag(Tag.SPINLOOP) ? String.format("%1$-" + Event.PRINT_PAD_EXTRA + "s", output) + "\t### SPINLOOP" : output;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -16,14 +16,14 @@ public class Load extends MemEvent implements RegWriter {
         this.resultRegister = register;
         addTags(Tag.READ);
     }
-    
-    protected Load(Load other){
+
+    protected Load(Load other) {
         super(other);
         this.resultRegister = other.resultRegister;
     }
 
     @Override
-    public Register getResultRegister(){
+    public Register getResultRegister() {
         return resultRegister;
     }
 
@@ -33,7 +33,7 @@ public class Load extends MemEvent implements RegWriter {
     }
 
     @Override
-    public ExprInterface getMemValue(){
+    public ExprInterface getMemValue() {
         return resultRegister;
     }
 
@@ -41,15 +41,15 @@ public class Load extends MemEvent implements RegWriter {
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public Load getCopy(){
+    public Load getCopy() {
         return new Load(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitLoad(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitLoad(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
@@ -5,13 +5,15 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.INonDet;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
-import com.google.common.collect.ImmutableSet;
 import org.sosy_lab.java_smt.api.*;
 
-public class Local extends Event implements RegWriter, RegReaderData {
+import java.util.HashSet;
+import java.util.Set;
+
+public class Local extends Event implements RegWriter, RegReader {
 
     protected final Register register;
     protected ExprInterface expr;
@@ -41,8 +43,8 @@ public class Local extends Event implements RegWriter, RegReaderData {
     }
 
     @Override
-    public ImmutableSet<Register> getDataRegs() {
-        return expr.getRegs();
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(expr, Register.UsageType.DATA, new HashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemEvent.java
@@ -2,12 +2,17 @@ package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class MemEvent extends Event {
+public abstract class MemEvent extends Event implements RegReader {
 
     protected IExpr address;
     protected String mo;
@@ -31,6 +36,11 @@ public abstract class MemEvent extends Event {
 
     public IExpr getAddress() { return address; }
     public void setAddress(IExpr address) { this.address = address; }
+
+    @Override
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(address, Register.UsageType.ADDR, new HashSet<>());
+    }
 
     public ExprInterface getMemValue() {
         throw new RuntimeException("MemValue is not available for event " + this.getClass().getName());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -4,11 +4,12 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
-import com.google.common.collect.ImmutableSet;
 
-public class Store extends MemEvent implements RegReaderData {
+import java.util.Set;
+
+public class Store extends MemEvent implements RegReader {
 
     protected ExprInterface value;
 
@@ -24,8 +25,8 @@ public class Store extends MemEvent implements RegReaderData {
     }
 
     @Override
-    public ImmutableSet<Register> getDataRegs(){
-        return value.getRegs();
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -4,22 +4,21 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import java.util.Set;
 
-public class Store extends MemEvent implements RegReader {
+public class Store extends MemEvent {
 
     protected ExprInterface value;
 
-    public Store(IExpr address, ExprInterface value, String mo){
-    	super(address, mo);
+    public Store(IExpr address, ExprInterface value, String mo) {
+        super(address, mo);
         this.value = value;
         addTags(Tag.WRITE);
     }
-    
-    protected Store(Store other){
+
+    protected Store(Store other) {
         super(other);
         this.value = other.value;
     }
@@ -35,12 +34,12 @@ public class Store extends MemEvent implements RegReader {
     }
 
     @Override
-    public ExprInterface getMemValue(){
+    public ExprInterface getMemValue() {
         return value;
     }
 
     @Override
-    public void setMemValue(ExprInterface value){
+    public void setMemValue(ExprInterface value) {
         this.value = value;
     }
 
@@ -48,15 +47,15 @@ public class Store extends MemEvent implements RegReader {
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public Store getCopy(){
+    public Store getCopy() {
         return new Store(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitStore(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitStore(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/utils/RegReader.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/utils/RegReader.java
@@ -1,0 +1,9 @@
+package com.dat3m.dartagnan.program.event.core.utils;
+
+import com.dat3m.dartagnan.program.Register;
+
+import java.util.Set;
+
+public interface RegReader {
+    Set<Register.Read> getRegisterReads();
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/utils/RegReaderData.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/utils/RegReaderData.java
@@ -1,9 +1,0 @@
-package com.dat3m.dartagnan.program.event.core.utils;
-
-import com.dat3m.dartagnan.program.Register;
-import com.google.common.collect.ImmutableSet;
-
-public interface RegReaderData {
-
-    ImmutableSet<Register> getDataRegs();
-}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -4,15 +4,15 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class AtomicAbstract extends MemEvent implements RegWriter, RegReaderData {
+public abstract class AtomicAbstract extends MemEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;
@@ -37,8 +37,8 @@ public abstract class AtomicAbstract extends MemEvent implements RegWriter, RegR
     }
 
     @Override
-    public ImmutableSet<Register> getDataRegs() {
-        return value.getRegs();
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -4,16 +4,16 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
 
-public class AtomicStore extends MemEvent implements RegReaderData {
+public class AtomicStore extends MemEvent {
 
     private ExprInterface value;
 
@@ -32,8 +32,8 @@ public class AtomicStore extends MemEvent implements RegReaderData {
     }
 
     @Override
-    public ImmutableSet<Register> getDataRegs(){
-        return value.getRegs();
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -4,14 +4,14 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class RMWAbstract extends MemEvent implements RegWriter, RegReaderData {
+public abstract class RMWAbstract extends MemEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;
@@ -35,8 +35,8 @@ public abstract class RMWAbstract extends MemEvent implements RegWriter, RegRead
     }
 
     @Override
-    public ImmutableSet<Register> getDataRegs(){
-        return value.getRegs();
+    public Set<Register.Read> getRegisterReads(){
+        return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAddUnless.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAddUnless.java
@@ -5,7 +5,8 @@ import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 public class RMWAddUnless extends RMWAbstract {
 
@@ -31,8 +32,8 @@ public class RMWAddUnless extends RMWAbstract {
     }
     
     @Override
-    public ImmutableSet<Register> getDataRegs(){
-        return new ImmutableSet.Builder<Register>().addAll(value.getRegs()).addAll(cmp.getRegs()).build();
+    public Set<Register.Read> getRegisterReads(){
+        return Register.collectRegisterReads(cmp, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWCmpXchg.java
@@ -5,7 +5,8 @@ import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 public class RMWCmpXchg extends RMWAbstract {
 
@@ -29,10 +30,10 @@ public class RMWCmpXchg extends RMWAbstract {
     public ExprInterface getCmp() {
     	return cmp;
     }
-    
+
     @Override
-    public ImmutableSet<Register> getDataRegs(){
-        return new ImmutableSet.Builder<Register>().addAll(value.getRegs()).addAll(cmp.getRegs()).build();
+    public Set<Register.Read> getRegisterReads(){
+        return Register.collectRegisterReads(cmp, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -4,15 +4,15 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class LlvmAbstractRMW extends MemEvent implements RegWriter, RegReaderData {
+public abstract class LlvmAbstractRMW extends MemEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;
@@ -37,8 +37,8 @@ public abstract class LlvmAbstractRMW extends MemEvent implements RegWriter, Reg
     }
 
     @Override
-    public ImmutableSet<Register> getDataRegs() {
-        return value.getRegs();
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
@@ -4,9 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
-import com.google.common.collect.ImmutableSet;
 
-import java.util.HashSet;
 import java.util.Set;
 
 public class LlvmCmpXchg extends LlvmAbstractRMW {
@@ -60,11 +58,11 @@ public class LlvmCmpXchg extends LlvmAbstractRMW {
     }
     
     @Override
-    public ImmutableSet<Register> getDataRegs() {
-        Set<Register> registers = new HashSet<>();
-        registers.addAll(value.getRegs());
-        registers.addAll(expectedValue.getRegs());
-        return ImmutableSet.copyOf(registers);
+    public Set<Register.Read> getRegisterReads() {
+        final Set<Register.Read> regReads = super.getRegisterReads();
+        Register.collectRegisterReads(value, Register.UsageType.DATA, regReads);
+        Register.collectRegisterReads(expectedValue, Register.UsageType.DATA, regReads);
+        return regReads;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -4,16 +4,16 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
 
-public class LlvmStore extends MemEvent implements RegReaderData {
+public class LlvmStore extends MemEvent {
 
     private ExprInterface value;
 
@@ -32,8 +32,8 @@ public class LlvmStore extends MemEvent implements RegReaderData {
     }
 
     @Override
-    public ImmutableSet<Register> getDataRegs(){
-        return value.getRegs();
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
@@ -20,7 +20,7 @@ public class Join extends Load {
 
     @Override
     public String toString() {
-        return "pthread_join(" + getAddress() + ")";
+        return resultRegister + " <- pthread_join(" + getAddress() + ")";
     }
 
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/std/Malloc.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/std/Malloc.java
@@ -5,11 +5,13 @@ import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
-import com.google.common.collect.ImmutableSet;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /*
     NOTE: Although this event is no core event, it does not get compiled in the compilation pass.
@@ -17,7 +19,7 @@ import org.sosy_lab.java_smt.api.BooleanFormula;
     FIXME: Possibly make this event "core" due to the absence of compilation?
            A better alternative would be to reuse 'Local' but with a malloc expression as its right-hand side.
  */
-public class Malloc extends Event implements RegWriter, RegReaderData {
+public class Malloc extends Event implements RegWriter, RegReader {
 
     protected final Register register;
     protected IExpr sizeExpr;
@@ -41,7 +43,10 @@ public class Malloc extends Event implements RegWriter, RegReaderData {
     public Register getResultRegister() { return register; }
 
     @Override
-    public ImmutableSet<Register> getDataRegs() { return sizeExpr.getRegs(); }
+    public Set<Register.Read> getRegisterReads() {
+        // TODO: Should this technically be an addr-dependency? Maybe an "other" dependency?
+        return Register.collectRegisterReads(sizeExpr, Register.UsageType.DATA, new HashSet<>());
+    }
 
     @Override
     public String toString() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadAssignmentElimination.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadAssignmentElimination.java
@@ -4,8 +4,7 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
-import com.dat3m.dartagnan.program.event.core.utils.RegReaderData;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
@@ -62,12 +61,12 @@ public class DeadAssignmentElimination implements ProgramProcessor {
                 .forEach(usedRegs::add);
         programEvents.stream()
                 .filter(e -> !e.getThread().equals(thread))
-                .filter(RegReaderData.class::isInstance).map(RegReaderData.class::cast)
-                .forEach(e -> usedRegs.addAll(e.getDataRegs()));
-        programEvents.stream()
+                .filter(RegReader.class::isInstance).map(RegReader.class::cast)
+                .forEach(e -> e.getRegisterReads().stream().map(Register.Read::register).forEach(usedRegs::add));
+        /*programEvents.stream()
                 .filter(e -> !e.getThread().equals(thread))
                 .filter(MemEvent.class::isInstance).map(MemEvent.class::cast)
-                .forEach(e -> usedRegs.addAll(e.getAddress().getRegs()));
+                .forEach(e -> usedRegs.addAll(e.getAddress().getRegs()));*/
 
 
         // Compute events to be removed (removal is delayed)
@@ -78,16 +77,9 @@ public class DeadAssignmentElimination implements ProgramProcessor {
                 // TODO (TH): Can we also remove loads to unused registers here?
                 // Invisible RegWriters that write to an unused reg can get removed
                 toBeRemoved.add(e);
-            } else {
+            } else if (e instanceof RegReader regReader) {
                 // An event that was not removed adds its dependencies to the used registers
-                if (e instanceof RegReaderData) {
-                    // Data & Ctrl dependencies
-                    usedRegs.addAll(((RegReaderData) e).getDataRegs());
-                }
-                if (e instanceof MemEvent) {
-                    // Address dependencies
-                    usedRegs.addAll(((MemEvent) e).getAddress().getRegs());
-                }
+                regReader.getRegisterReads().stream().map(Register.Read::register).forEach(usedRegs::add);
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadAssignmentElimination.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadAssignmentElimination.java
@@ -63,10 +63,6 @@ public class DeadAssignmentElimination implements ProgramProcessor {
                 .filter(e -> !e.getThread().equals(thread))
                 .filter(RegReader.class::isInstance).map(RegReader.class::cast)
                 .forEach(e -> e.getRegisterReads().stream().map(Register.Read::register).forEach(usedRegs::add));
-        /*programEvents.stream()
-                .filter(e -> !e.getThread().equals(thread))
-                .filter(MemEvent.class::isInstance).map(MemEvent.class::cast)
-                .forEach(e -> usedRegs.addAll(e.getAddress().getRegs()));*/
 
 
         // Compute events to be removed (removal is delayed)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadAssignmentElimination.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DeadAssignmentElimination.java
@@ -69,7 +69,8 @@ public class DeadAssignmentElimination implements ProgramProcessor {
         final List<Event> threadEvents = thread.getEvents();
         final Set<Event> toBeRemoved = new HashSet<>();
         for(Event e : Lists.reverse(threadEvents)) {
-            if (e instanceof RegWriter && !e.hasTag(NOOPT) && !e.hasTag(VISIBLE) && !usedRegs.contains(((RegWriter)e).getResultRegister())) {
+            if (!e.hasTag(NOOPT) && !e.hasTag(VISIBLE)
+                    && e instanceof RegWriter regWriter && !usedRegs.contains(regWriter.getResultRegister())) {
                 // TODO (TH): Can we also remove loads to unused registers here?
                 // Invisible RegWriters that write to an unused reg can get removed
                 toBeRemoved.add(e);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -13,7 +13,6 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Label;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.metadata.UnrollingId;
@@ -180,14 +179,9 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
 
         Event cur = iterStart;
         do {
-            if (cur instanceof MemEvent memEvent) {
-                if (cur.hasTag(Tag.WRITE)) {
-                    sideEffects.add(cur); // Writes always cause side effects
-                    continue;
-                } else {
-                    final Set<Register> addrRegs = memEvent.getAddress().getRegs();
-                    unsafeRegisters.addAll(Sets.difference(addrRegs, safeRegisters));
-                }
+            if (cur.hasTag(Tag.WRITE)) {
+                sideEffects.add(cur); // Writes always cause side effects
+                continue;
             }
 
             if (cur instanceof RegReader regReader) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SimpleSpinLoopDetection.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SimpleSpinLoopDetection.java
@@ -55,13 +55,13 @@ public class SimpleSpinLoopDetection implements ProgramProcessor {
     private int detectAndMarkSpinLoops(Thread thread) {
         final List<Label> unmarkedLabels = thread.getEvents().stream()
                 .filter(e -> e instanceof Label && !e.hasTag(Tag.SPINLOOP))
-                .map(Label.class::cast).collect(Collectors.toList());
+                .map(Label.class::cast).toList();
 
         int spinloopCounter = 0;
         for (final Label label : unmarkedLabels) {
             final List<CondJump> backjumps = label.getJumpSet()
                     .stream().filter(x -> x.getGlobalId() > label.getGlobalId())
-                    .collect(Collectors.toList());
+                    .toList();
             final boolean isLoop = !backjumps.isEmpty();
 
             if (isLoop) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -401,6 +401,10 @@ public class ExecutionModel {
             for (Register.Read regRead : regReader.getRegisterReads()) {
                 final Register reg = regRead.register();
                 final Set<EventData> visibleRootDependencies = lastRegWrites.get(reg);
+                if (visibleRootDependencies == null) {
+                    // FIXME: This should never happen, but our parser is buggy and produces ill-formed code.
+                    continue;
+                }
                 switch (regRead.usageType()) {
                     case DATA -> dataDeps.addAll(visibleRootDependencies);
                     case ADDR -> addrDeps.addAll(visibleRootDependencies);
@@ -443,6 +447,10 @@ public class ExecutionModel {
                 for (Register.Read regRead : local.getRegisterReads()) {
                     final Register reg = regRead.register();
                     final Set<EventData> visibleRootDependencies = lastRegWrites.get(reg);
+                    if (visibleRootDependencies == null) {
+                        // FIXME: This should never happen, but our parser is buggy and produces ill-formed code.
+                        continue;
+                    }
                     assert regRead.usageType() == Register.UsageType.DATA;
                     dataDeps.addAll(visibleRootDependencies);
                 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -280,14 +280,11 @@ public class ExecutionModel {
                 }
                 // =========================
 
-                if (e instanceof CondJump) {
-                    CondJump jump = (CondJump) e;
-                    if (isTrue(encodingContext.jumpCondition(jump))) {
-                        e = jump.getLabel();
-                        continue;
-                    }
+                if (e instanceof CondJump jump && isTrue(encodingContext.jumpCondition(jump))) {
+                    e = jump.getLabel();
+                } else {
+                    e = e.getSuccessor();
                 }
-                e = e.getSuccessor();
 
             } while (e != null);
             // We have a BeginAtomic without EndAtomic since the program terminated within the block
@@ -452,50 +449,6 @@ public class ExecutionModel {
                 lastRegWrites.put(local.getResultRegister(), dataDeps);
             }
         }
-
-        // TODO: Check below code
-
-        /*if (e instanceof ExecutionStatus status) {
-            // ---- Track data dependency due to execution tracking ----
-            Event tracked = status.getStatusEvent();
-            HashSet<EventData> deps = new HashSet<>();
-            if (eventExists(tracked) && status.doesTrackDep()) {
-                deps.add(eventMap.get(tracked));
-            }
-            lastRegWrites.put(status.getResultRegister(), deps);
-        }
-
-        if (e instanceof RegReader reader) {
-            // ---- Track data dependency ----
-            HashSet<EventData> deps = new HashSet<>();
-            for (Register r : reader.getRegisterReads()) {
-                deps.addAll(lastRegWrites.getOrDefault(r, Collections.emptySet()));
-            }
-
-            if (e instanceof Store) {
-                // ---- visible data dependency ----
-                dataDepMap.put(eventMap.get(e), deps);
-            }
-            if (e instanceof RegWriter writer) {
-                // ---- internal data dependency ----
-                lastRegWrites.put(writer.getResultRegister(), deps);
-            }
-            if (e instanceof CondJump) {
-                if (e instanceof IfAsJump) {
-                    // Remember what dependencies were added when entering the If so we can remove them when exiting
-                    HashSet<EventData> addedDeps = new HashSet<>(Sets.difference(deps, curCtrlDeps));
-                    ifCtrlDeps.push(addedDeps);
-                    endIfs.push(((IfAsJump)e).getEndIf());
-                }
-                // Jumps add all dependencies
-                curCtrlDeps.addAll(deps);
-            }
-        }
-
-        if (e instanceof Load load) {
-            // ---- Update lastRegWrites ----
-            lastRegWrites.compute(load.getResultRegister(), (k, v) -> new HashSet<>()).add(eventMap.get(e));
-        }*/
     }
 
     // ===================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -18,6 +18,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.FormulaManager;
@@ -38,6 +40,8 @@ The ExecutionModel wraps a Model and extracts data from it in a more workable ma
 //TODO: Add the capability to remove unnecessary init events from a model
 // i.e. those that init some address which no read nor write accesses.
 public class ExecutionModel {
+
+    private static final Logger logger = LogManager.getLogger(ExecutionModel.class);
 
     private final EncodingContext encodingContext;
 
@@ -403,6 +407,7 @@ public class ExecutionModel {
                 final Set<EventData> visibleRootDependencies = lastRegWrites.get(reg);
                 if (visibleRootDependencies == null) {
                     // FIXME: This should never happen, but our parser is buggy and produces ill-formed code.
+                    logger.warn("Encountered uninitialized register {} read by {} in an execution.", reg, e);
                     continue;
                 }
                 switch (regRead.usageType()) {
@@ -449,6 +454,7 @@ public class ExecutionModel {
                     final Set<EventData> visibleRootDependencies = lastRegWrites.get(reg);
                     if (visibleRootDependencies == null) {
                         // FIXME: This should never happen, but our parser is buggy and produces ill-formed code.
+                        logger.warn("Encountered uninitialized register {} read by {} in an execution.", reg, e);
                         continue;
                     }
                     assert regRead.usageType() == Register.UsageType.DATA;


### PR DESCRIPTION
This PR introduces the `Register.Read` class which allows events to specify *why* they read from a register (via a `UsageType`).
As a consequence, the `RegReaderData` has been updated to a more general `RegReader` interface that returns a set of this new `Register.Read` objects.
`MemEvent` is now also a `RegReader` as it reads from registers to determine its address (it has `UsageType=ADDR`).
All the user code of the old `RegReaderData` interface were updated accordingly.