### PR TITLE
MemoryEvent as interface

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -11,7 +11,7 @@ import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Load;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
@@ -193,15 +193,15 @@ public final class EncodingContext {
         }
     }
 
-    public BooleanFormula sameAddress(MemEvent first, MemEvent second) {
+    public BooleanFormula sameAddress(MemoryEvent first, MemoryEvent second) {
         return aliasAnalysis.mustAlias(first, second) ? booleanFormulaManager.makeTrue() : equal(address(first), address(second));
     }
 
-    public Formula address(MemEvent event) {
+    public Formula address(MemoryEvent event) {
         return addresses.get(event);
     }
 
-    public Formula value(MemEvent event) {
+    public Formula value(MemoryEvent event) {
         return values.get(event);
     }
 
@@ -292,9 +292,9 @@ public final class EncodingContext {
             } else {
                 r = null;
             }
-            if (e instanceof MemEvent) {
-                addresses.put(e, encodeIntegerExpressionAt(((MemEvent) e).getAddress(), e));
-                values.put(e, e instanceof Load ? r : encodeIntegerExpressionAt(((MemEvent) e).getMemValue(), e));
+            if (e instanceof MemoryEvent memEvent) {
+                addresses.put(e, encodeIntegerExpressionAt(memEvent.getAddress(), e));
+                values.put(e, e instanceof Load ? r : encodeIntegerExpressionAt(memEvent.getMemValue(), e));
             }
             if (r != null) {
                 results.put(e, r);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
@@ -176,7 +176,7 @@ public class PropertyEncoder implements Encoder {
             if (!writeEvent.hasTag(Tag.WRITE)) {
                 continue;
             }
-            MemEvent w1 = (MemEvent) writeEvent;
+            MemoryEvent w1 = (MemoryEvent) writeEvent;
             if (dominatedWrites.contains(w1)) {
                 enc.add(bmgr.not(lastCoVar(w1)));
                 continue;
@@ -318,7 +318,7 @@ public class PropertyEncoder implements Encoder {
                     if (!e1.hasTag(Tag.WRITE) || e1.hasTag(Tag.INIT)) {
                         continue;
                     }
-                    MemEvent w = (MemEvent)e1;
+                    MemoryEvent w = (MemoryEvent)e1;
                     if (!w.canRace()) {
                         continue;
                     }
@@ -326,7 +326,7 @@ public class PropertyEncoder implements Encoder {
                         if (!e2.hasTag(Tag.MEMORY) || e2.hasTag(Tag.INIT)) {
                             continue;
                         }
-                        MemEvent m = (MemEvent)e2;
+                        MemoryEvent m = (MemoryEvent)e2;
                         if((w.hasTag(Tag.RMW) && m.hasTag(Tag.RMW)) || !m.canRace() || !alias.mayAlias(m, w)) {
                             continue;
                         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AliasAnalysis.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.analysis.alias;
 
 import com.dat3m.dartagnan.configuration.Alias;
 import com.dat3m.dartagnan.program.Program;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
@@ -16,8 +16,8 @@ public interface AliasAnalysis {
 
     Logger logger = LogManager.getLogger(AliasAnalysis.class);
 
-    boolean mustAlias(MemEvent a, MemEvent b);
-    boolean mayAlias(MemEvent a, MemEvent b);
+    boolean mustAlias(MemoryEvent a, MemoryEvent b);
+    boolean mayAlias(MemoryEvent a, MemoryEvent b);
 
     static AliasAnalysis fromConfig(Program program, Configuration config) throws InvalidConfigurationException {
         Config c = new Config(config);
@@ -63,12 +63,12 @@ public interface AliasAnalysis {
         }
 
         @Override
-        public boolean mustAlias(MemEvent a, MemEvent b) {
+        public boolean mustAlias(MemoryEvent a, MemoryEvent b) {
             return a1.mustAlias(a, b) || a2.mustAlias(a, b);
         }
 
         @Override
-        public boolean mayAlias(MemEvent a, MemEvent b) {
+        public boolean mayAlias(MemoryEvent a, MemoryEvent b) {
             return a1.mayAlias(a, b) && a2.mayAlias(a, b);
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/EqualityAliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/EqualityAliasAnalysis.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.analysis.alias;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import org.sosy_lab.common.configuration.Configuration;
@@ -29,7 +29,7 @@ public class EqualityAliasAnalysis implements AliasAnalysis {
     }
 
     @Override
-    public boolean mustAlias(MemEvent a, MemEvent b) {
+    public boolean mustAlias(MemoryEvent a, MemoryEvent b) {
         if (a.getThread() != b.getThread() || !a.getAddress().equals(b.getAddress())) {
             return false;
         } else if (a == b) {
@@ -37,7 +37,7 @@ public class EqualityAliasAnalysis implements AliasAnalysis {
         }
         // Normalize direction
         if (a.getGlobalId() > b.getGlobalId()) {
-            MemEvent temp = a;
+            MemoryEvent temp = a;
             a = b;
             b = temp;
         }
@@ -63,7 +63,7 @@ public class EqualityAliasAnalysis implements AliasAnalysis {
     }
 
     @Override
-    public boolean mayAlias(MemEvent a, MemEvent b) {
+    public boolean mayAlias(MemoryEvent a, MemoryEvent b) {
         return true;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.arch.lisa;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -12,7 +12,7 @@ import java.util.Set;
 import static com.dat3m.dartagnan.program.event.Tag.RMW;
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public class RMW extends MemEvent implements RegWriter {
+public class RMW extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
     private final IExpr value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.event.arch.tso;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -11,7 +11,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public class Xchg extends MemEvent implements RegWriter {
+public class Xchg extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryEvent.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.program.event.core;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
@@ -12,13 +11,13 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class MemEvent extends AbstractEvent implements RegReader {
+public abstract class AbstractMemoryEvent extends AbstractEvent implements MemoryEvent {
 
     protected IExpr address;
     protected String mo;
 
     // The empty string means no memory order 
-    public MemEvent(IExpr address, String mo) {
+    public AbstractMemoryEvent(IExpr address, String mo) {
         Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;
         this.mo = mo;
@@ -28,13 +27,15 @@ public abstract class MemEvent extends AbstractEvent implements RegReader {
         }
     }
 
-    protected MemEvent(MemEvent other) {
+    protected AbstractMemoryEvent(AbstractMemoryEvent other) {
         super(other);
         this.address = other.address;
         this.mo = other.mo;
     }
 
+    @Override
     public IExpr getAddress() { return address; }
+    @Override
     public void setAddress(IExpr address) { this.address = address; }
 
     @Override
@@ -42,16 +43,20 @@ public abstract class MemEvent extends AbstractEvent implements RegReader {
         return Register.collectRegisterReads(address, Register.UsageType.ADDR, new HashSet<>());
     }
 
+    @Override
     public ExprInterface getMemValue() {
         throw new RuntimeException("MemValue is not available for event " + this.getClass().getName());
     }
 
+    @Override
     public void setMemValue(ExprInterface value) {
         throw new RuntimeException("SetValue is not available for event " + this.getClass().getName());
     }
 
+    @Override
     public String getMo() { return mo; }
 
+    @Override
     public void setMo(String mo) {
         Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         if (!this.mo.isEmpty()) {
@@ -64,6 +69,7 @@ public abstract class MemEvent extends AbstractEvent implements RegReader {
         }
     }
 
+    @Override
     public boolean canRace() { return mo.isEmpty() || mo.equals(C11.NONATOMIC); }
 
     // Visitor

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryEvent.java
@@ -2,14 +2,10 @@ package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import static com.dat3m.dartagnan.program.event.Tag.*;
+import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
+import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 
 public abstract class AbstractMemoryEvent extends AbstractEvent implements MemoryEvent {
 
@@ -34,13 +30,13 @@ public abstract class AbstractMemoryEvent extends AbstractEvent implements Memor
     }
 
     @Override
-    public IExpr getAddress() { return address; }
-    @Override
-    public void setAddress(IExpr address) { this.address = address; }
+    public IExpr getAddress() {
+        return address;
+    }
 
     @Override
-    public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(address, Register.UsageType.ADDR, new HashSet<>());
+    public void setAddress(IExpr address) {
+        this.address = address;
     }
 
     @Override
@@ -54,7 +50,9 @@ public abstract class AbstractMemoryEvent extends AbstractEvent implements Memor
     }
 
     @Override
-    public String getMo() { return mo; }
+    public String getMo() {
+        return mo;
+    }
 
     @Override
     public void setMo(String mo) {
@@ -69,14 +67,5 @@ public abstract class AbstractMemoryEvent extends AbstractEvent implements Memor
         }
     }
 
-    @Override
-    public boolean canRace() { return mo.isEmpty() || mo.equals(C11.NONATOMIC); }
-
-    // Visitor
-    // -----------------------------------------------------------------------------------------------------------------
-
-    @Override
-    public <T> T accept(EventVisitor<T> visitor) {
-        return visitor.visitMemEvent(this);
-    }
 }
+

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -10,7 +10,7 @@ import com.dat3m.dartagnan.program.memory.MemoryObject;
  * It is exposed to the memory consistency model as a visible event.
  * It acts like a regular store, such that load events may read from it and other stores may overwrite it.
  */
-public class Init extends MemEvent {
+public class Init extends AbstractMemoryEvent {
 
 	private final MemoryObject base;
 	private final int offset;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -7,7 +7,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class Load extends MemEvent implements RegWriter {
+public class Load extends AbstractMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -1,0 +1,29 @@
+package com.dat3m.dartagnan.program.event.core;
+
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
+import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
+
+import java.util.Set;
+
+public interface MemoryEvent extends Event, RegReader {
+
+    IExpr getAddress();
+    void setAddress(IExpr address);
+
+    ExprInterface getMemValue();
+    void setMemValue(ExprInterface value);
+
+    String getMo();
+    void setMo(String mo);
+
+    @Override
+    Set<Register.Read> getRegisterReads();
+
+    boolean canRace();
+
+    @Override
+    <T> T accept(EventVisitor<T> visitor);
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
+import java.util.HashSet;
 import java.util.Set;
 
 public interface MemoryEvent extends Event, RegReader {
@@ -20,10 +21,12 @@ public interface MemoryEvent extends Event, RegReader {
     void setMo(String mo);
 
     @Override
-    Set<Register.Read> getRegisterReads();
-
-    boolean canRace();
+    default Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(getAddress(), Register.UsageType.ADDR, new HashSet<>());
+    }
 
     @Override
-    <T> T accept(EventVisitor<T> visitor);
+    default <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitMemEvent(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -8,7 +8,7 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import java.util.Set;
 
-public class Store extends MemEvent {
+public class Store extends AbstractMemoryEvent {
 
     protected ExprInterface value;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,7 +12,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class AtomicAbstract extends MemEvent implements RegWriter {
+public abstract class AtomicAbstract extends AbstractMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,7 +12,7 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.READ;
 
-public class AtomicLoad extends MemEvent implements RegWriter {
+public class AtomicLoad extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
@@ -13,7 +13,7 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
 
-public class AtomicStore extends MemEvent {
+public class AtomicStore extends AbstractMemoryEvent {
 
     private ExprInterface value;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
@@ -1,10 +1,10 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class LKMMLock extends MemEvent {
+public class LKMMLock extends AbstractMemoryEvent {
 
 	public LKMMLock(IExpr lock) {
 		// This event will be compiled to LKMMLockRead + LKMMLockWrite 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.linux;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -11,7 +11,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class RMWAbstract extends MemEvent implements RegWriter {
+public abstract class RMWAbstract extends AbstractMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
@@ -4,10 +4,10 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class SrcuSync extends MemEvent {
+public class SrcuSync extends AbstractMemoryEvent {
 
 	public SrcuSync(IExpr address) {
 		super(address, Tag.Linux.SRCU_SYNC);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.llvm;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,7 +12,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class LlvmAbstractRMW extends MemEvent implements RegWriter {
+public abstract class LlvmAbstractRMW extends AbstractMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.llvm;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,7 +12,7 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.READ;
 
-public class LlvmLoad extends MemEvent implements RegWriter {
+public class LlvmLoad extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.llvm;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
@@ -13,7 +13,7 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
 
-public class LlvmStore extends MemEvent {
+public class LlvmStore extends AbstractMemoryEvent {
 
     private ExprInterface value;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
@@ -29,7 +29,7 @@ public interface EventVisitor<T> {
 	default T visitLabel(Label e) { return visitEvent(e); }
 	default T visitLoad(Load e) { return visitMemEvent(e); }
 	default T visitLocal(Local e) { return visitEvent(e); }
-	default T visitMemEvent(MemEvent e) { return visitEvent(e); }
+	default T visitMemEvent(MemoryEvent e) { return visitEvent(e); }
 	default T visitSkip(Skip e) { return visitEvent(e); }
 	default T visitStore(Store e) { return visitMemEvent(e); }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -177,7 +177,7 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
         }
 
         @Override
-        public Void visitMemEvent(MemEvent e) {
+        public Void visitMemEvent(MemoryEvent e) {
             e.setAddress((IExpr) e.getAddress().visit(propagator));
             return null;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -255,8 +255,8 @@ public class VisitorC11 extends VisitorBase {
     }
 
     private void tagEvent(Event e) {
-        if(e instanceof MemEvent) {
-                e.addTags(((MemEvent)e).canRace() ? C11.NONATOMIC : C11.ATOMIC);
+        if(e instanceof MemoryEvent memEvent) {
+            e.addTags(memEvent.canRace() ? C11.NONATOMIC : C11.ATOMIC);
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -256,7 +256,8 @@ public class VisitorC11 extends VisitorBase {
 
     private void tagEvent(Event e) {
         if(e instanceof MemoryEvent memEvent) {
-            e.addTags(memEvent.canRace() ? C11.NONATOMIC : C11.ATOMIC);
+            final boolean canRace = (memEvent.getMo().isEmpty() || memEvent.getMo().equals(C11.NONATOMIC));
+            e.addTags(canRace ? C11.NONATOMIC : C11.ATOMIC);
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -211,16 +211,16 @@ class VisitorTso extends VisitorBase {
                 Store storeExpected = newStore(expectedAddr, regValue, "");
 
                 return tagList(eventSequence(
-                                // Indentation shows the branching structure
-                                loadExpected,
-                                loadValue,
-                                casCmpResult,
-                                branchOnCasCmpResult,
-                                        storeValue,
-                                        gotoCasEnd,
-                                casFail,
-                                        storeExpected,
-                                casEnd));
+                        // Indentation shows the branching structure
+                        loadExpected,
+                        loadValue,
+                        casCmpResult,
+                        branchOnCasCmpResult,
+                                storeValue,
+                                gotoCasEnd,
+                        casFail,
+                                storeExpected,
+                        casEnd));
         }
 
         @Override
@@ -250,38 +250,37 @@ class VisitorTso extends VisitorBase {
                 Fence optionalMFence = mo.equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
 
                 return eventSequence(
-                                newStore(e.getAddress(), e.getMemValue(), mo),
-                                optionalMFence);
+                        newStore(e.getAddress(), e.getMemValue(), mo),
+                        optionalMFence);
         }
 
         @Override
         public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
                 Fence optionalFence = e.getMo().equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
 
-                return eventSequence(
-                                optionalFence);
+                return eventSequence(optionalFence);
         }
 
         @Override
         public List<Event> visitAtomicXchg(AtomicXchg e) {
-                IExpr address = e.getAddress();
-                String mo = e.getMo();
-                Load load = newRMWLoad(e.getResultRegister(), address, mo);
+            IExpr address = e.getAddress();
+            String mo = e.getMo();
+            Load load = newRMWLoad(e.getResultRegister(), address, mo);
 
-                return tagList(eventSequence(
-                                load,
-                                newRMWStore(load, address, e.getMemValue(), mo)));
+            return tagList(eventSequence(
+                    load,
+                    newRMWStore(load, address, e.getMemValue(), mo)));
         }
 
         private List<Event> tagList(List<Event> in) {
-                in.forEach(this::tagEvent);
-                return in;
+            in.forEach(this::tagEvent);
+            return in;
         }
 
         private void tagEvent(Event e) {
-                if (e instanceof MemEvent) {
-                        e.addTags(Tag.TSO.ATOM);
-                }
+            if (e instanceof MemoryEvent) {
+                e.addTags(Tag.TSO.ATOM);
+            }
         }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/Refiner.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/Refiner.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.AddressLiteral;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreLiteral;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.ExecLiteral;
@@ -124,8 +124,8 @@ public class Refiner {
             enc = encoder.execution(perm.apply(lit.getData()));
         } else if (literal instanceof AddressLiteral) {
             AddressLiteral loc = (AddressLiteral) literal;
-            MemEvent e1 = (MemEvent) perm.apply(loc.getFirst());
-            MemEvent e2 = (MemEvent) perm.apply(loc.getSecond());
+            MemoryEvent e1 = (MemoryEvent) perm.apply(loc.getFirst());
+            MemoryEvent e2 = (MemoryEvent) perm.apply(loc.getSecond());
             enc = encoder.sameAddress(e1, e2);
         } else if (literal instanceof RelLiteral) {
             RelLiteral lit = (RelLiteral) literal;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -5,7 +5,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.dat3m.dartagnan.verification.model.EventData;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
@@ -70,7 +70,7 @@ public class ExecutionGraphVisualizer {
     public void generateGraphOfExecutionModel(Writer writer, String graphName, ExecutionModel model) throws IOException {
         for (EventData data : model.getEventList()) {
             if (data.isMemoryEvent()) {
-                MemEvent m = (MemEvent) data.getEvent();
+                MemoryEvent m = (MemoryEvent) data.getEvent();
                 if (!(m.getAddress() instanceof Register)) {
                     addresses.putIfAbsent(data.getAccessedAddress(), m.getAddress());
                 }
@@ -207,7 +207,7 @@ public class ExecutionGraphVisualizer {
         if (e.isMemoryEvent()) {
             Object address = addresses.get(e.getAccessedAddress());
             BigInteger value = e.getValue();
-            String mo = ((MemEvent) e.getEvent()).getMo();
+            String mo = ((MemoryEvent) e.getEvent()).getMo();
             mo = mo.isEmpty() ? mo : ", " + mo;
             tag = e.isWrite() ?
                     String.format("W(%s, %d%s)", address, value, mo) :

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -327,7 +327,7 @@ public class ExecutionModel {
         data.setWasExecuted(true);
         if (data.isMemoryEvent()) {
             // ===== Memory Events =====
-            Object addressObject = checkNotNull(model.evaluate(encodingContext.address((MemEvent) e)));
+            Object addressObject = checkNotNull(model.evaluate(encodingContext.address((MemoryEvent) e)));
             BigInteger address = new BigInteger(addressObject.toString());
             data.setAccessedAddress(address);
             if (!addressReadsMap.containsKey(address)) {
@@ -339,7 +339,7 @@ public class ExecutionModel {
                 data.setValue(new BigInteger(model.evaluate(encodingContext.result((RegWriter) e)).toString()));
                 addressReadsMap.get(address).add(data);
             } else if (data.isWrite()) {
-                Object valueObject = checkNotNull(model.evaluate(encodingContext.value((MemEvent) e)));
+                Object valueObject = checkNotNull(model.evaluate(encodingContext.value((MemoryEvent) e)));
                 data.setValue(new BigInteger(valueObject.toString()));
                 addressWritesMap.get(address).add(data);
                 writeReadsMap.put(data, new HashSet<>());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -8,8 +8,8 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.BranchEquivalence;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
 import com.dat3m.dartagnan.program.event.metadata.OriginalId;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.dat3m.dartagnan.program.filter.Filter;
@@ -442,7 +442,7 @@ public class RefinementSolver extends ModelChecker {
         final ThreadSymmetry symm = analysisContext.requires(ThreadSymmetry.class);
         final BranchEquivalence cf = analysisContext.requires(BranchEquivalence.class);
 
-        final Set<Event> programEvents = program.getEvents(MemEvent.class).stream()
+        final Set<Event> programEvents = program.getEvents(AbstractMemoryEvent.class).stream()
                 // TODO: Can we have events with source information but without parse id?
                 .filter(e -> e.hasMetadata(SourceLocation.class) && e.hasMetadata(OriginalId.class))
                 .collect(Collectors.toSet());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Load;
-import com.dat3m.dartagnan.program.event.core.MemEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.google.common.collect.Lists;
@@ -80,8 +80,8 @@ public class WitnessGraph extends ElemWithAttributes {
 		IntegerFormulaManager imgr = context.getFormulaManager().getIntegerFormulaManager();
 		List<BooleanFormula> enc = new ArrayList<>();
 		List<Event> previous = new ArrayList<>();
-		for(Edge edge : edges.stream().filter(Edge::hasCline).collect(Collectors.toList())) {
-			List<Event> events = program.getEvents(MemEvent.class).stream()
+		for(Edge edge : edges.stream().filter(Edge::hasCline).toList()) {
+			List<Event> events = program.getEvents(MemoryEvent.class).stream()
 					.filter(e -> e.hasMetadata(SourceLocation.class))
 					.filter(e -> e.getMetadata(SourceLocation.class).getLineNumber() == edge.getCline())
 					.collect(Collectors.toList());

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -140,10 +140,10 @@ public class AnalysisTest {
         LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
-        MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
-        MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);
-        MemEvent me2 = (MemEvent) findMatchingEventAfterProcessing(program, e2);
-        MemEvent me3 = (MemEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);//precisely no
         assertAlias(expect[1], a, me0, me2);
@@ -184,10 +184,10 @@ public class AnalysisTest {
         LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
-        MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
-        MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);
-        MemEvent me2 = (MemEvent) findMatchingEventAfterProcessing(program, e2);
-        MemEvent me3 = (MemEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);
         assertAlias(expect[1], a, me0, me2);
@@ -233,10 +233,10 @@ public class AnalysisTest {
         LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
-        MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
-        MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);
-        MemEvent me2 = (MemEvent) findMatchingEventAfterProcessing(program, e2);
-        MemEvent me3 = (MemEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);
         assertAlias(expect[1], a, me0, me2);
@@ -277,10 +277,10 @@ public class AnalysisTest {
         LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
-        MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
-        MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);
-        MemEvent me2 = (MemEvent) findMatchingEventAfterProcessing(program, e2);
-        MemEvent me3 = (MemEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);
         assertAlias(expect[1], a, me0, me2);
@@ -321,10 +321,10 @@ public class AnalysisTest {
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
-        MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
-        MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);
-        MemEvent me2 = (MemEvent) findMatchingEventAfterProcessing(program, e2);
-        MemEvent me3 = (MemEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);//precisely no
         assertAlias(expect[1], a, me0, me2);//precisely must
@@ -365,10 +365,10 @@ public class AnalysisTest {
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
-        MemEvent me0 = (MemEvent) findMatchingEventAfterProcessing(program, e0);
-        MemEvent me1 = (MemEvent) findMatchingEventAfterProcessing(program, e1);
-        MemEvent me2 = (MemEvent) findMatchingEventAfterProcessing(program, e2);
-        MemEvent me3 = (MemEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);//precisely no
         assertAlias(expect[1], a, me0, me2);//precisely must
@@ -408,7 +408,7 @@ public class AnalysisTest {
         return AliasAnalysis.fromConfig(program, Configuration.builder().setOption(ALIAS_METHOD, method.asStringOption()).build());
     }
 
-    private void assertAlias(Result expect, AliasAnalysis a, MemEvent x, MemEvent y) {
+    private void assertAlias(Result expect, AliasAnalysis a, MemoryEvent x, MemoryEvent y) {
         switch (expect) {
             case NONE:
                 assertFalse(a.mayAlias(x, y));


### PR DESCRIPTION
This PR renames `MemEvent` to `AbstractMemoryEvent` and introduces an interface `MemoryEvent`.
The method `MemEvent.canRace()` was removed (it had two very specific use-cases, so I inlined the method there).
