### PR TITLE
Add MemoryAccess and MemoryCoreEvents

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -293,7 +293,7 @@ public final class EncodingContext {
                 r = null;
             }
             if (e instanceof MemoryEvent memEvent) {
-                addresses.put(e, encodeIntegerExpressionAt(memEvent.getAddress(), e));
+                addresses.put(e, encodeIntegerExpressionAt(memEvent.getMemoryAccess().address(), e));
                 values.put(e, e instanceof Load ? r : encodeIntegerExpressionAt(memEvent.getMemValue(), e));
             }
             if (r != null) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -190,7 +190,7 @@ public final class EncodingContext {
         }
     }
 
-    public BooleanFormula sameAddress(MemoryEvent first, MemoryEvent second) {
+    public BooleanFormula sameAddress(MemoryCoreEvent first, MemoryCoreEvent second) {
         return aliasAnalysis.mustAlias(first, second) ? booleanFormulaManager.makeTrue() : equal(address(first), address(second));
     }
 
@@ -289,8 +289,8 @@ public final class EncodingContext {
             } else {
                 r = null;
             }
-            if (e instanceof MemoryEvent memEvent) {
-                addresses.put(e, encodeIntegerExpressionAt(memEvent.getMemoryAccess().address(), e));
+            if (e instanceof MemoryCoreEvent memEvent) {
+                addresses.put(e, encodeIntegerExpressionAt(memEvent.getAddress(), e));
                 if (e instanceof Load) {
                     values.put(e, r);
                 } else if (e instanceof Store store) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -8,10 +8,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.analysis.BranchEquivalence;
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
-import com.dat3m.dartagnan.program.event.core.CondJump;
-import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.Load;
-import com.dat3m.dartagnan.program.event.core.MemoryEvent;
+import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
@@ -294,7 +291,13 @@ public final class EncodingContext {
             }
             if (e instanceof MemoryEvent memEvent) {
                 addresses.put(e, encodeIntegerExpressionAt(memEvent.getMemoryAccess().address(), e));
-                values.put(e, e instanceof Load ? r : encodeIntegerExpressionAt(memEvent.getMemValue(), e));
+                if (e instanceof Load) {
+                    values.put(e, r);
+                } else if (e instanceof Store store) {
+                    values.put(e, encodeIntegerExpressionAt(store.getMemValue(), e));
+                } else if (e instanceof Init init) {
+                    values.put(e, encodeIntegerExpressionAt(init.getMemValue(), e));
+                }
             }
             if (r != null) {
                 results.put(e, r);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -295,8 +295,6 @@ public final class EncodingContext {
                     values.put(e, r);
                 } else if (e instanceof Store store) {
                     values.put(e, encodeIntegerExpressionAt(store.getMemValue(), e));
-                } else if (e instanceof Init init) {
-                    values.put(e, encodeIntegerExpressionAt(init.getMemValue(), e));
                 }
             }
             if (r != null) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
@@ -321,7 +321,7 @@ public class PropertyEncoder implements Encoder {
                     if (!e1.hasTag(Tag.WRITE) || e1.hasTag(Tag.INIT)) {
                         continue;
                     }
-                    MemoryEvent w = (MemoryEvent)e1;
+                    MemoryCoreEvent w = (MemoryCoreEvent)e1;
                     if (!canRace.test(w)) {
                         continue;
                     }
@@ -329,7 +329,7 @@ public class PropertyEncoder implements Encoder {
                         if (!e2.hasTag(Tag.MEMORY) || e2.hasTag(Tag.INIT)) {
                             continue;
                         }
-                        MemoryEvent m = (MemoryEvent)e2;
+                        MemoryCoreEvent m = (MemoryCoreEvent)e2;
                         if((w.hasTag(Tag.RMW) && m.hasTag(Tag.RMW)) || !canRace.test(m) || !alias.mayAlias(m, w)) {
                             continue;
                         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
@@ -8,6 +8,7 @@ import com.dat3m.dartagnan.program.analysis.LoopAnalysis;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.specification.AbstractAssert;
 import com.dat3m.dartagnan.wmm.Relation;
 import com.dat3m.dartagnan.wmm.Wmm;
@@ -305,7 +306,10 @@ public class PropertyEncoder implements Encoder {
         final Program program = this.program;
         final AliasAnalysis alias = this.alias;
 
-        final Predicate<MemoryEvent> canRace = (m -> m.getMo().isEmpty() || m.getMo().equals(Tag.C11.NONATOMIC));
+        final Predicate<MemoryEvent> canRace = (m -> {
+            final MemoryOrder mo = m.getMetadata(MemoryOrder.class);
+            return mo == null || mo.value().equals(Tag.C11.NONATOMIC);
+        });
 
         BooleanFormula hasRace = bmgr.makeFalse();
         for(Thread t1 : program.getThreads()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
@@ -173,11 +173,7 @@ public class PropertyEncoder implements Encoder {
         // ---- Construct encoding ----
         List<BooleanFormula> enc = new ArrayList<>();
         final Function<Event, Collection<Tuple>> out = knowledge.getMayOut();
-        for (Event writeEvent : program.getEvents()) {
-            if (!writeEvent.hasTag(Tag.WRITE)) {
-                continue;
-            }
-            MemoryEvent w1 = (MemoryEvent) writeEvent;
+        for (Store w1 : program.getEvents(Store.class)) {
             if (dominatedWrites.contains(w1)) {
                 enc.add(bmgr.not(lastCoVar(w1)));
                 continue;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -152,7 +152,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         if(ctx.offset() != null){
             address = visitOffset(ctx.offset(), address);
         }
-        return programBuilder.addChild(mainThread, EventFactory.newLoad(register, address, ctx.loadInstruction().mo));
+        return programBuilder.addChild(mainThread, EventFactory.newLoadWithMo(register, address, ctx.loadInstruction().mo));
     }
 
     @Override
@@ -162,7 +162,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         if(ctx.offset() != null){
             address = visitOffset(ctx.offset(), address);
         }
-        Load load = EventFactory.newRMWLoadExclusive(register, address, ctx.loadExclusiveInstruction().mo);
+        Load load = EventFactory.newRMWLoadExclusiveWithMo(register, address, ctx.loadExclusiveInstruction().mo);
         return programBuilder.addChild(mainThread, load);
     }
 
@@ -173,7 +173,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         if(ctx.offset() != null){
             address = visitOffset(ctx.offset(), address);
         }
-        return programBuilder.addChild(mainThread, EventFactory.newStore(address, register, ctx.storeInstruction().mo));
+        return programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(address, register, ctx.storeInstruction().mo));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -333,7 +333,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     @Override
     public IExpr visitReReadNa(LitmusCParser.ReReadNaContext ctx){
         Register register = getReturnRegister(true);
-        Event event = EventFactory.newLoad(register, getAddress(ctx.address), C11.NONATOMIC);
+        Event event = EventFactory.newLoadWithMo(register, getAddress(ctx.address), C11.NONATOMIC);
         programBuilder.addChild(currentThread, event);
         return register;
     }
@@ -463,7 +463,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
 
         ExprInterface value = (ExprInterface)ctx.re().accept(this);
         if(variable instanceof MemoryObject || variable instanceof Register){
-            Event event = EventFactory.newStore((IExpr) variable, value, C11.NONATOMIC);
+            Event event = EventFactory.newStoreWithMo((IExpr) variable, value, C11.NONATOMIC);
             return programBuilder.addChild(currentThread, event);
         }
         throw new ParsingException("Invalid syntax near " + ctx.getText());
@@ -521,14 +521,14 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
             MemoryObject object = programBuilder.getObject(ctx.getText());
             if(object != null){
                 register = programBuilder.getOrCreateRegister(scope, null, getArchPrecision());
-                programBuilder.addChild(currentThread, EventFactory.newLoad(register, object, C11.NONATOMIC));
+                programBuilder.addChild(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC));
                 return register;
             }
             return programBuilder.getOrCreateRegister(scope, ctx.getText(), getArchPrecision());
         }
         MemoryObject object = programBuilder.getOrNewObject(ctx.getText());
         Register register = programBuilder.getOrCreateRegister(scope, null, getArchPrecision());
-        programBuilder.addChild(currentThread, EventFactory.newLoad(register, object, C11.NONATOMIC));
+        programBuilder.addChild(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC));
         return register;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
@@ -108,7 +108,7 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
         Register reg = programBuilder.getOrCreateRegister(mainThread, ctx.register().getText(), getArchPrecision());
         IExpr address = (IExpr) ctx.expression().accept(this);
         String mo = ctx.mo() != null ? ctx.mo().getText() : "";
-		programBuilder.addChild(mainThread, EventFactory.newLoad(reg, address, mo));
+		programBuilder.addChild(mainThread, EventFactory.newLoadWithMo(reg, address, mo));
 		return null;
 	}
 
@@ -125,7 +125,7 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
 		IExpr value = (IExpr) ctx.value().accept(this);
         IExpr address = (IExpr) ctx.expression().accept(this);
         String mo = ctx.mo() != null ? ctx.mo().getText() : "";
-        programBuilder.addChild(mainThread, EventFactory.newStore(address, value, mo));
+        programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(address, value, mo));
 		return null;
 
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -137,7 +137,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
     public Object visitLwz(LitmusPPCParser.LwzContext ctx) {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLoadWithMo(r1, ra, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newLoad(r1, ra));
     }
 
     @Override
@@ -150,7 +150,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
     public Object visitStw(LitmusPPCParser.StwContext ctx) {
         Register r1 = programBuilder.getOrErrorRegister(mainThread, ctx.register(0).getText());
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(ra, r1, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newStore(ra, r1));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -134,7 +134,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
     public Object visitLwz(LitmusPPCParser.LwzContext ctx) {
         Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLoad(r1, ra, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newLoadWithMo(r1, ra, "_rx"));
     }
 
     @Override
@@ -147,7 +147,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
     public Object visitStw(LitmusPPCParser.StwContext ctx) {
         Register r1 = programBuilder.getOrErrorRegister(mainThread, ctx.register(0).getText());
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newStore(ra, r1, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(ra, r1, "_rx"));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -185,21 +185,21 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
 	public Object visitLw(LitmusRISCVParser.LwContext ctx) {
         Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLoad(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
+        return programBuilder.addChild(mainThread, EventFactory.newLoadWithMo(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
 	}
 
 	@Override
 	public Object visitSw(LitmusRISCVParser.SwContext ctx) {
         Register r1 = programBuilder.getOrErrorRegister(mainThread, ctx.register(0).getText());
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newStore(ra, r1, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
+        return programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(ra, r1, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
 	}
 	
 	@Override
 	public Object visitLr(LitmusRISCVParser.LrContext ctx) {
         Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newRMWLoadExclusive(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
+        return programBuilder.addChild(mainThread, EventFactory.newRMWLoadExclusiveWithMo(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
@@ -117,21 +117,21 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
     public Object visitLoadLocationToRegister(LitmusX86Parser.LoadLocationToRegisterContext ctx) {
         Register register = programBuilder.getOrCreateRegister(mainThread, ctx.register().getText(), getArchPrecision());
         MemoryObject object = programBuilder.getOrNewObject(ctx.location().getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLoad(register, object, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newLoadWithMo(register, object, "_rx"));
     }
 
     @Override
     public Object visitStoreValueToLocation(LitmusX86Parser.StoreValueToLocationContext ctx) {
         MemoryObject object = programBuilder.getOrNewObject(ctx.location().getText());
         IValue constant = new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision());
-        return programBuilder.addChild(mainThread, EventFactory.newStore(object, constant, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(object, constant, "_rx"));
     }
 
     @Override
     public Object visitStoreRegisterToLocation(LitmusX86Parser.StoreRegisterToLocationContext ctx) {
         Register register = programBuilder.getOrErrorRegister(mainThread, ctx.register().getText());
         MemoryObject object = programBuilder.getOrNewObject(ctx.location().getText());
-        return programBuilder.addChild(mainThread, EventFactory.newStore(object, register, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(object, register, "_rx"));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
@@ -122,21 +122,21 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
     public Object visitLoadLocationToRegister(LitmusX86Parser.LoadLocationToRegisterContext ctx) {
         Register register = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
         MemoryObject object = programBuilder.getOrNewObject(ctx.location().getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLoadWithMo(register, object, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newLoad(register, object));
     }
 
     @Override
     public Object visitStoreValueToLocation(LitmusX86Parser.StoreValueToLocationContext ctx) {
         MemoryObject object = programBuilder.getOrNewObject(ctx.location().getText());
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(object, constant, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newStore(object, constant));
     }
 
     @Override
     public Object visitStoreRegisterToLocation(LitmusX86Parser.StoreRegisterToLocationContext ctx) {
         Register register = programBuilder.getOrErrorRegister(mainThread, ctx.register().getText());
         MemoryObject object = programBuilder.getOrNewObject(ctx.location().getText());
-        return programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(object, register, "_rx"));
+        return programBuilder.addChild(mainThread, EventFactory.newStore(object, register));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -441,7 +441,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 						// These loads corresponding to pthread_joins
 						child = EventFactory.Pthread.newJoin(register, (IExpr)value);
 					} else {
-						child = EventFactory.newLoad(register, (IExpr)value, "");
+						child = EventFactory.newLoadWithMo(register, (IExpr)value, "");
 					}
 					programBuilder.addChild(threadCount, child)
 							.setCFileInformation(currentLine, sourceCodeFile);
@@ -455,7 +455,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
             MemoryObject object = programBuilder.getObject(name);
             if(object != null){
     			// These events are eventually compiled and we need to compare its mo, thus it cannot be null
-				programBuilder.addChild(threadCount, EventFactory.newStore(object, value, ""))
+				programBuilder.addChild(threadCount, EventFactory.newStoreWithMo(object, value, ""))
 						.setCFileInformation(currentLine, sourceCodeFile);
 	            continue;
 	        }
@@ -704,7 +704,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 				programBuilder.getOrNewObject(text).appendInitialValue(rhs,value.reduce());
 				return null;
 			}
-			programBuilder.addChild(threadCount, EventFactory.newStore(address, value, ""))
+			programBuilder.addChild(threadCount, EventFactory.newStoreWithMo(address, value, ""))
 					.setCFileInformation(currentLine, sourceCodeFile);
 			return null;
 		}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -1,22 +1,13 @@
 package com.dat3m.dartagnan.parsers.program.visitors.boogie;
 
 import com.dat3m.dartagnan.exception.ParsingException;
-import com.dat3m.dartagnan.expression.Atom;
-import com.dat3m.dartagnan.expression.Expression;
-import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IExprBin;
-import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.processing.ExprSimplifier;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.BoogieBaseVisitor;
 import com.dat3m.dartagnan.parsers.BoogieParser.*;
-import com.dat3m.dartagnan.parsers.program.boogie.Function;
-import com.dat3m.dartagnan.parsers.program.boogie.FunctionCall;
-import com.dat3m.dartagnan.parsers.program.boogie.PthreadPool;
-import com.dat3m.dartagnan.parsers.program.boogie.Scope;
-import com.dat3m.dartagnan.parsers.program.boogie.Types;
+import com.dat3m.dartagnan.parsers.program.boogie.*;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventFactory;
@@ -716,7 +707,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 				programBuilder.getOrNewObject(text).appendInitialValue(rhs,value.reduce());
 				return null;
 			}
-			programBuilder.addChild(threadCount, EventFactory.newStoreWithMo(address, value, ""))
+			programBuilder.addChild(threadCount, EventFactory.newStore(address, value))
 					.setCFileInformation(currentLine, sourceCodeFile);
 			return null;
 		}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.program.analysis;
 
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
-import com.dat3m.dartagnan.program.event.core.AbstractEvent;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Label;
@@ -506,7 +505,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
 
         @Override
         public boolean contains(Object o) {
-            if (!(o instanceof AbstractEvent)) {
+            if (!(o instanceof Event)) {
                 return false;
             }
             return classes.contains(classMap.get(o));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AliasAnalysis.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.analysis.alias;
 
 import com.dat3m.dartagnan.configuration.Alias;
 import com.dat3m.dartagnan.program.Program;
-import com.dat3m.dartagnan.program.event.core.MemoryEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
@@ -16,8 +16,8 @@ public interface AliasAnalysis {
 
     Logger logger = LogManager.getLogger(AliasAnalysis.class);
 
-    boolean mustAlias(MemoryEvent a, MemoryEvent b);
-    boolean mayAlias(MemoryEvent a, MemoryEvent b);
+    boolean mustAlias(MemoryCoreEvent a, MemoryCoreEvent b);
+    boolean mayAlias(MemoryCoreEvent a, MemoryCoreEvent b);
 
     static AliasAnalysis fromConfig(Program program, Configuration config) throws InvalidConfigurationException {
         Config c = new Config(config);
@@ -63,12 +63,12 @@ public interface AliasAnalysis {
         }
 
         @Override
-        public boolean mustAlias(MemoryEvent a, MemoryEvent b) {
+        public boolean mustAlias(MemoryCoreEvent a, MemoryCoreEvent b) {
             return a1.mustAlias(a, b) || a2.mustAlias(a, b);
         }
 
         @Override
-        public boolean mayAlias(MemoryEvent a, MemoryEvent b) {
+        public boolean mayAlias(MemoryCoreEvent a, MemoryCoreEvent b) {
             return a1.mayAlias(a, b) && a2.mayAlias(a, b);
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
@@ -6,7 +6,6 @@ import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IExprBin;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Local;
 import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import com.dat3m.dartagnan.program.event.core.Store;
@@ -132,8 +131,8 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
             return;
         }
         //event is a store operation
-        Verify.verify(e.hasTag(Tag.WRITE), "memory event that is neither tagged \"W\" nor a register writer");
-        ExprInterface value = e.getMemValue();
+        Verify.verify(e instanceof Store, "memory event that is neither store nor load.");
+        ExprInterface value = ((Store)e).getMemValue();
         if (value instanceof Register) {
             addEdge(value, location);
             return;
@@ -178,16 +177,12 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
                                 // Add location to variables if edge is new.
                                 variables.add(address);
                             }
-                        } else if (e instanceof Store) {
+                        } else if (e instanceof Store store && store.getMemValue() instanceof Register register) {
                             // *variable = register
-                            ExprInterface value = e.getMemValue();
-                            if (value instanceof Register) {
-                                Register register = (Register) value;
-                                // Add edge from register to location
-                                if (addEdge(register, address)) {
-                                    // Add register to variables if edge is new.
-                                    variables.add(register);
-                                }
+                            // Add edge from register to location
+                            if (addEdge(register, address)) {
+                                // Add register to variables if edge is new.
+                                variables.add(register);
                             }
                         }
                     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
@@ -103,7 +103,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
     }
 
     private void processLocs(MemoryEvent e) {
-        IExpr address = e.getAddress();
+        IExpr address = e.getMemoryAccess().address();
         // Collect for each v events of form: p = *v, *v = q
         if (address instanceof Register) {
             addEvent((Register) address, e);
@@ -242,7 +242,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
     }
 
     private void processResults(MemoryEvent e) {
-        IExpr address = e.getAddress();
+        IExpr address = e.getMemoryAccess().address();
         Set<Location> addresses;
         if (address instanceof Register) {
             Set<Location> target = targets.get(address);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.expression.IExprBin;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.Local;
+import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -68,12 +69,12 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
     // ================================ API ================================
 
     @Override
-    public boolean mayAlias(MemoryEvent x, MemoryEvent y) {
+    public boolean mayAlias(MemoryCoreEvent x, MemoryCoreEvent y) {
         return !Sets.intersection(getMaxAddressSet(x), getMaxAddressSet(y)).isEmpty();
     }
 
     @Override
-    public boolean mustAlias(MemoryEvent x, MemoryEvent y) {
+    public boolean mustAlias(MemoryCoreEvent x, MemoryCoreEvent y) {
         return getMaxAddressSet(x).size() == 1 && getMaxAddressSet(x).containsAll(getMaxAddressSet(y));
     }
 
@@ -84,9 +85,9 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
     // ================================ Processing ================================
 
     private void run(Program program) {
-        List<MemoryEvent> memEvents = program.getEvents(MemoryEvent.class);
+        List<MemoryCoreEvent> memEvents = program.getEvents(MemoryCoreEvent.class);
         List<Local> locals = program.getEvents(Local.class);
-        for (MemoryEvent e : memEvents) {
+        for (MemoryCoreEvent e : memEvents) {
             processLocs(e);
         }
         for (Local e : locals) {
@@ -96,13 +97,13 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
         for (Local e : locals) {
             processResults(e);
         }
-        for (MemoryEvent e : memEvents) {
+        for (MemoryCoreEvent e : memEvents) {
             processResults(e);
         }
     }
 
-    private void processLocs(MemoryEvent e) {
-        IExpr address = e.getMemoryAccess().address();
+    private void processLocs(MemoryCoreEvent e) {
+        IExpr address = e.getAddress();
         // Collect for each v events of form: p = *v, *v = q
         if (address instanceof Register) {
             addEvent((Register) address, e);
@@ -237,8 +238,8 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
         }
     }
 
-    private void processResults(MemoryEvent e) {
-        IExpr address = e.getMemoryAccess().address();
+    private void processResults(MemoryCoreEvent e) {
+        IExpr address = e.getAddress();
         Set<Location> addresses;
         if (address instanceof Register) {
             Set<Location> target = targets.get(address);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
@@ -131,7 +131,8 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
             return;
         }
         //event is a store operation
-        Verify.verify(e instanceof Store, "memory event that is neither store nor load.");
+        Verify.verify(e instanceof Store,
+                "Encountered memory event that is neither store nor load: {}", e);
         ExprInterface value = ((Store)e).getMemValue();
         if (value instanceof Register) {
             addEdge(value, location);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/EqualityAliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/EqualityAliasAnalysis.java
@@ -30,7 +30,8 @@ public class EqualityAliasAnalysis implements AliasAnalysis {
 
     @Override
     public boolean mustAlias(MemoryEvent a, MemoryEvent b) {
-        if (a.getThread() != b.getThread() || !a.getAddress().equals(b.getAddress())) {
+        if (a.getThread() != b.getThread()
+                || !a.getMemoryAccess().address().equals(b.getMemoryAccess().address())) {
             return false;
         } else if (a == b) {
             return true;
@@ -49,7 +50,7 @@ public class EqualityAliasAnalysis implements AliasAnalysis {
         }
 
         // Establish that address expression evaluates to same value at both events.
-        Set<Register> addrRegs = a.getAddress().getRegs();
+        Set<Register> addrRegs = a.getMemoryAccess().address().getRegs();
         Event e = a.getSuccessor();
         while (e != b) {
             if (e instanceof RegWriter && addrRegs.contains(((RegWriter)e).getResultRegister())) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/EqualityAliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/EqualityAliasAnalysis.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.analysis.alias;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.MemoryEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.wmm.utils.Tuple;
 import org.sosy_lab.common.configuration.Configuration;
@@ -29,16 +29,17 @@ public class EqualityAliasAnalysis implements AliasAnalysis {
     }
 
     @Override
-    public boolean mustAlias(MemoryEvent a, MemoryEvent b) {
+    public boolean mustAlias(MemoryCoreEvent a, MemoryCoreEvent b) {
+
         if (a.getThread() != b.getThread()
-                || !a.getMemoryAccess().address().equals(b.getMemoryAccess().address())) {
+                || !a.getAddress().equals(b.getAddress())) {
             return false;
         } else if (a == b) {
             return true;
         }
         // Normalize direction
         if (a.getGlobalId() > b.getGlobalId()) {
-            MemoryEvent temp = a;
+            MemoryCoreEvent temp = a;
             a = b;
             b = temp;
         }
@@ -50,7 +51,7 @@ public class EqualityAliasAnalysis implements AliasAnalysis {
         }
 
         // Establish that address expression evaluates to same value at both events.
-        Set<Register> addrRegs = a.getMemoryAccess().address().getRegs();
+        Set<Register> addrRegs = a.getAddress().getRegs();
         Event e = a.getSuccessor();
         while (e != b) {
             if (e instanceof RegWriter && addrRegs.contains(((RegWriter)e).getResultRegister())) {
@@ -64,7 +65,7 @@ public class EqualityAliasAnalysis implements AliasAnalysis {
     }
 
     @Override
-    public boolean mayAlias(MemoryEvent a, MemoryEvent b) {
+    public boolean mayAlias(MemoryCoreEvent a, MemoryCoreEvent b) {
         return true;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/FieldSensitiveAndersen.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/FieldSensitiveAndersen.java
@@ -101,7 +101,7 @@ public class FieldSensitiveAndersen implements AliasAnalysis {
     // ================================ Processing ================================
 
     protected void processLocs(MemoryEvent e) {
-        Collector collector = new Collector(e.getAddress());
+        Collector collector = new Collector(e.getMemoryAccess().address());
         if(e instanceof RegWriter) {
             Register result = ((RegWriter)e).getResultRegister();
             for(Offset<Register> r : collector.register()) {
@@ -163,7 +163,7 @@ public class FieldSensitiveAndersen implements AliasAnalysis {
 
     protected void processResults(MemoryEvent e) {
         ImmutableSet.Builder<Location> addresses = ImmutableSet.builder();
-        Collector collector = new Collector(e.getAddress());
+        Collector collector = new Collector(e.getMemoryAccess().address());
         addresses.addAll(collector.address());
         for(Offset<Register> r : collector.register()) {
             addresses.addAll(fields(getAddresses(r.base),r.offset,r.alignment));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/FieldSensitiveAndersen.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/FieldSensitiveAndersen.java
@@ -107,14 +107,8 @@ public class FieldSensitiveAndersen implements AliasAnalysis {
             for(Location f : collector.address()) {
                 addEdge(f,result,0,0);
             }
-        } else if (e instanceof Store || e instanceof Init) {
-            ExprInterface storeVal;
-            if (e instanceof Store store) {
-                storeVal = store.getMemValue();
-            } else {
-                storeVal = ((Init)e).getMemValue();
-            }
-            Collector value = new Collector(storeVal);
+        } else if (e instanceof Store store) {
+            Collector value = new Collector(store.getMemValue());
             for(Offset<Register> r : collector.register()) {
                 stores.computeIfAbsent(r.base,k->new LinkedList<>()).add(new Offset<>(value,r.offset,r.alignment));
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -20,6 +20,7 @@ import com.dat3m.dartagnan.program.event.lang.llvm.*;
 import com.dat3m.dartagnan.program.event.lang.pthread.*;
 import com.dat3m.dartagnan.program.event.lang.std.Malloc;
 import com.dat3m.dartagnan.program.event.lang.svcomp.*;
+import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 
 import java.util.*;
@@ -70,11 +71,21 @@ public class EventFactory {
     // ------------------------------------------ Memory events ------------------------------------------
 
     public static Load newLoad(Register register, IExpr address, String mo) {
-        return new Load(register, address, mo);
+        Load load = new Load(register, address);
+        if (mo != null && !mo.isEmpty()) {
+            load.setMetadata(new MemoryOrder(mo));
+            load.addTags(mo);
+        }
+        return load;
     }
 
     public static Store newStore(IExpr address, ExprInterface value, String mo) {
-        return new Store(address, value, mo);
+        Store store = new Store(address, value);
+        if (mo != null && !mo.isEmpty()) {
+            store.setMetadata(new MemoryOrder(mo));
+            store.addTags(mo);
+        }
+        return store;
     }
 
     public static Fence newFence(String name) {
@@ -159,17 +170,27 @@ public class EventFactory {
     }
 
     public static RMWStore newRMWStore(Load loadEvent, IExpr address, ExprInterface value, String mo) {
-        return new RMWStore(loadEvent, address, value, mo);
+        RMWStore store =  new RMWStore(loadEvent, address, value);
+        if (mo != null && !mo.isEmpty()) {
+            store.setMetadata(new MemoryOrder(mo));
+            store.addTags(mo);
+        }
+        return store;
     }
 
     public static Load newRMWLoadExclusive(Register reg, IExpr address, String mo) {
-        Load load = new Load(reg, address, mo);
+        Load load = newLoad(reg, address, mo);
         load.addTags(Tag.RMW, Tag.EXCL);
         return load;
     }
 
     public static RMWStoreExclusive newRMWStoreExclusive(IExpr address, ExprInterface value, String mo, boolean isStrong) {
-        return new RMWStoreExclusive(address, value, mo, isStrong, false);
+        RMWStoreExclusive store = new  RMWStoreExclusive(address, value, isStrong, false);
+        if (mo != null && !mo.isEmpty()) {
+            store.setMetadata(new MemoryOrder(mo));
+            store.addTags(mo);
+        }
+        return store;
     }
 
     public static RMWStoreExclusive newRMWStoreExclusive(IExpr address, ExprInterface value, String mo) {
@@ -516,8 +537,12 @@ public class EventFactory {
         }
 
         public static RMWStoreExclusive newRMWStoreConditional(IExpr address, ExprInterface value, String mo, boolean isStrong) {
-            RMWStoreExclusive store = new RMWStoreExclusive(address, value, mo, isStrong, true);
+            RMWStoreExclusive store = new RMWStoreExclusive(address, value, isStrong, true);
             store.addTags(Tag.RISCV.STCOND);
+            if (mo != null && !mo.isEmpty()) {
+                store.setMetadata(new MemoryOrder(mo));
+                store.addTags(mo);
+            }
             return store;
         }
 
@@ -588,7 +613,12 @@ public class EventFactory {
         }
 
         public static RMWStoreExclusive newRMWStoreConditional(IExpr address, ExprInterface value, String mo, boolean isStrong) {
-            return new RMWStoreExclusive(address, value, mo, isStrong, true);
+            RMWStoreExclusive store = new RMWStoreExclusive(address, value, isStrong, true);
+            if (mo != null && !mo.isEmpty()) {
+                store.setMetadata(new MemoryOrder(mo));
+                store.addTags(mo);
+            }
+            return store;
         }
 
         public static Fence newISyncBarrier() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -629,13 +629,8 @@ public class EventFactory {
         private Power() {
         }
 
-        public static RMWStoreExclusive newRMWStoreConditional(Expression address, Expression value, String mo, boolean isStrong) {
-            RMWStoreExclusive store = new RMWStoreExclusive(address, value, isStrong, true);
-            if (mo != null && !mo.isEmpty()) {
-                store.setMetadata(new MemoryOrder(mo));
-                store.addTags(mo);
-            }
-            return store;
+        public static RMWStoreExclusive newRMWStoreConditional(Expression address, Expression value, boolean isStrong) {
+            return new RMWStoreExclusive(address, value, isStrong, true);
         }
 
         public static Fence newISyncBarrier() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -51,7 +51,7 @@ public class EventFactory {
             if (obj == null) {
                 continue;
             }
-            if (obj instanceof AbstractEvent) {
+            if (obj instanceof Event) {
                 retVal.add((Event) obj);
             } else if (obj instanceof Collection<?>) {
                 retVal.addAll((Collection<? extends Event>) obj);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -21,7 +21,6 @@ import com.dat3m.dartagnan.program.event.lang.llvm.*;
 import com.dat3m.dartagnan.program.event.lang.pthread.*;
 import com.dat3m.dartagnan.program.event.lang.std.Malloc;
 import com.dat3m.dartagnan.program.event.lang.svcomp.*;
-import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 
 import java.math.BigInteger;
@@ -556,10 +555,7 @@ public class EventFactory {
         public static RMWStoreExclusive newRMWStoreConditional(Expression address, Expression value, String mo, boolean isStrong) {
             RMWStoreExclusive store = new RMWStoreExclusive(address, value, isStrong, true);
             store.addTags(Tag.RISCV.STCOND);
-            if (mo != null && !mo.isEmpty()) {
-                store.setMetadata(new MemoryOrder(mo));
-                store.addTags(mo);
-            }
+            store.setMemoryOrder(mo);
             return store;
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -70,21 +70,23 @@ public class EventFactory {
 
     // ------------------------------------------ Memory events ------------------------------------------
 
-    public static Load newLoad(Register register, IExpr address, String mo) {
-        Load load = new Load(register, address);
-        if (mo != null && !mo.isEmpty()) {
-            load.setMetadata(new MemoryOrder(mo));
-            load.addTags(mo);
-        }
+    public static Load newLoad(Register register, IExpr address) {
+        return new Load(register, address);
+    }
+
+    public static Load newLoadWithMo(Register register, IExpr address, String mo) {
+        Load load = newLoad(register, address);
+        load.setMemoryOrder(mo);
         return load;
     }
 
-    public static Store newStore(IExpr address, ExprInterface value, String mo) {
-        Store store = new Store(address, value);
-        if (mo != null && !mo.isEmpty()) {
-            store.setMetadata(new MemoryOrder(mo));
-            store.addTags(mo);
-        }
+    public static Store newStore(IExpr address, ExprInterface value) {
+        return new Store(address, value);
+    }
+
+    public static Store newStoreWithMo(IExpr address, ExprInterface value, String mo) {
+        Store store = newStore(address, value);
+        store.setMemoryOrder(mo);
         return store;
     }
 
@@ -163,38 +165,48 @@ public class EventFactory {
 
     // ------------------------------------------ RMW events ------------------------------------------
 
-    public static Load newRMWLoad(Register reg, IExpr address, String mo) {
-        Load load = newLoad(reg, address, mo);
+    public static Load newRMWLoad(Register reg, IExpr address) {
+        Load load = newLoad(reg, address);
         load.addTags(Tag.RMW);
         return load;
     }
 
-    public static RMWStore newRMWStore(Load loadEvent, IExpr address, ExprInterface value, String mo) {
-        RMWStore store =  new RMWStore(loadEvent, address, value);
-        if (mo != null && !mo.isEmpty()) {
-            store.setMetadata(new MemoryOrder(mo));
-            store.addTags(mo);
-        }
+    public static Load newRMWLoadWithMo(Register reg, IExpr address, String mo) {
+        Load load = newLoadWithMo(reg, address, mo);
+        load.addTags(Tag.RMW);
+        return load;
+    }
+
+    public static RMWStore newRMWStore(Load loadEvent, IExpr address, ExprInterface value) {
+        return new RMWStore(loadEvent, address, value);
+    }
+
+    public static RMWStore newRMWStoreWithMo(Load loadEvent, IExpr address, ExprInterface value, String mo) {
+        RMWStore store = newRMWStore(loadEvent, address, value);
+        store.setMemoryOrder(mo);
         return store;
     }
 
-    public static Load newRMWLoadExclusive(Register reg, IExpr address, String mo) {
-        Load load = newLoad(reg, address, mo);
+    public static Load newRMWLoadExclusive(Register reg, IExpr address) {
+        Load load = newLoad(reg, address);
         load.addTags(Tag.RMW, Tag.EXCL);
         return load;
     }
 
-    public static RMWStoreExclusive newRMWStoreExclusive(IExpr address, ExprInterface value, String mo, boolean isStrong) {
-        RMWStoreExclusive store = new  RMWStoreExclusive(address, value, isStrong, false);
-        if (mo != null && !mo.isEmpty()) {
-            store.setMetadata(new MemoryOrder(mo));
-            store.addTags(mo);
-        }
-        return store;
+    public static Load newRMWLoadExclusiveWithMo(Register reg, IExpr address, String mo) {
+        Load load = newRMWLoadExclusive(reg, address);
+        load.setMemoryOrder(mo);
+        return load;
     }
 
-    public static RMWStoreExclusive newRMWStoreExclusive(IExpr address, ExprInterface value, String mo) {
-        return newRMWStoreExclusive(address, value, mo, false);
+    public static RMWStoreExclusive newRMWStoreExclusive(IExpr address, ExprInterface value, boolean isStrong) {
+        return new RMWStoreExclusive(address, value, isStrong, false);
+    }
+
+    public static RMWStoreExclusive newRMWStoreExclusiveWithMo(IExpr address, ExprInterface value, boolean isStrong, String mo) {
+        RMWStoreExclusive store = newRMWStoreExclusive(address, value, isStrong);
+        store.setMemoryOrder(mo);
+        return store;
     }
 
     public static ExecutionStatus newExecutionStatus(Register register, Event event) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryAccess.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryAccess.java
@@ -8,12 +8,4 @@ public record MemoryAccess(IExpr address, Type accessType, Mode mode) {
         LOAD, STORE, OTHER;
     }
 
-    public MemoryAccess withAddress(IExpr address) {
-        return new MemoryAccess(address, accessType, mode);
-    }
-
-    public MemoryAccess withType(Type accessType) {
-        return new MemoryAccess(address, accessType, mode);
-    }
-
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryAccess.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryAccess.java
@@ -1,9 +1,9 @@
 package com.dat3m.dartagnan.program.event;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.type.Type;
 
-public record MemoryAccess(IExpr address, Type accessType, Mode mode) {
+public record MemoryAccess(Expression address, Type accessType, Mode mode) {
     public enum Mode {
         LOAD, STORE, RMW, OTHER;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryAccess.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryAccess.java
@@ -5,7 +5,7 @@ import com.dat3m.dartagnan.expression.type.Type;
 
 public record MemoryAccess(IExpr address, Type accessType, Mode mode) {
     public enum Mode {
-        LOAD, STORE, OTHER;
+        LOAD, STORE, RMW, OTHER;
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryAccess.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryAccess.java
@@ -1,0 +1,19 @@
+package com.dat3m.dartagnan.program.event;
+
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.type.Type;
+
+public record MemoryAccess(IExpr address, Type accessType, Mode mode) {
+    public enum Mode {
+        LOAD, STORE, OTHER;
+    }
+
+    public MemoryAccess withAddress(IExpr address) {
+        return new MemoryAccess(address, accessType, mode);
+    }
+
+    public MemoryAccess withType(Type accessType) {
+        return new MemoryAccess(address, accessType, mode);
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/StoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/StoreExclusive.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.Store;
+import com.dat3m.dartagnan.program.event.common.StoreBase;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -12,7 +12,7 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
     This event is common among ARMv8, RISCV, and PPC.
     It gets compiled down to a pair of RMWStoreExclusive + ExecutionStatus.
  */
-public class StoreExclusive extends Store implements RegWriter {
+public class StoreExclusive extends StoreBase implements RegWriter {
 
     private final Register register;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -13,7 +13,7 @@ import java.util.Set;
 import static com.dat3m.dartagnan.program.event.Tag.RMW;
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public class RMW extends SingleAddressMemoryEvent implements RegWriter {
+public class RMW extends SingleAccessMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
     private final IExpr value;
@@ -53,8 +53,7 @@ public class RMW extends SingleAddressMemoryEvent implements RegWriter {
 
     @Override
     public MemoryAccess getMemoryAccess() {
-        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.arch.tso;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -42,7 +42,6 @@ public class Xchg extends SingleAddressMemoryEvent implements RegWriter {
         return "xchg(*" + address + ", " + resultRegister + ")";
     }
 
-    @Override
     public ExprInterface getMemValue(){
         return resultRegister;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -2,7 +2,8 @@ package com.dat3m.dartagnan.program.event.arch.tso;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -11,7 +12,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public class Xchg extends AbstractMemoryEvent implements RegWriter {
+public class Xchg extends SingleAddressMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 
@@ -46,6 +47,12 @@ public class Xchg extends AbstractMemoryEvent implements RegWriter {
         return resultRegister;
     }
 
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        // TODO: Once we can return List<MemoryAccess>, we need to return both
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.LOAD);
+    }
+
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
@@ -54,11 +61,11 @@ public class Xchg extends AbstractMemoryEvent implements RegWriter {
         return new Xchg(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitXchg(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitXchg(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.arch.tso;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -12,7 +12,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public class Xchg extends SingleAddressMemoryEvent implements RegWriter {
+public class Xchg extends SingleAccessMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 
@@ -48,8 +48,7 @@ public class Xchg extends SingleAddressMemoryEvent implements RegWriter {
 
     @Override
     public MemoryAccess getMemoryAccess() {
-        // TODO: Once we can return List<MemoryAccess>, we need to return both
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.LOAD);
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/LoadBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/LoadBase.java
@@ -1,4 +1,4 @@
-package com.dat3m.dartagnan.program.event.core;
+package com.dat3m.dartagnan.program.event.common;
 
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
@@ -6,19 +6,19 @@ import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
-import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class Load extends AbstractMemoryCoreEvent implements RegWriter {
+@NoInterface
+public abstract class LoadBase extends SingleAddressMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
 
-    public Load(Register register, IExpr address) {
-        super(address);
+    public LoadBase(Register register, IExpr address, String mo) {
+        super(address, mo);
         this.resultRegister = register;
         addTags(Tag.READ);
     }
 
-    protected Load(Load other) {
+    protected LoadBase(LoadBase other) {
         super(other);
         this.resultRegister = other.resultRegister;
     }
@@ -38,20 +38,5 @@ public class Load extends AbstractMemoryCoreEvent implements RegWriter {
     public MemoryAccess getMemoryAccess() {
         return new MemoryAccess(address, accessType, MemoryAccess.Mode.LOAD);
     }
-
-    // Unrolling
-    // -----------------------------------------------------------------------------------------------------------------
-
-    @Override
-    public Load getCopy() {
-        return new Load(this);
-    }
-
-    // Visitor
-    // -----------------------------------------------------------------------------------------------------------------
-
-    @Override
-    public <T> T accept(EventVisitor<T> visitor) {
-        return visitor.visitLoad(this);
-    }
 }
+

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/LoadBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/LoadBase.java
@@ -8,7 +8,7 @@ import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 
 @NoInterface
-public abstract class LoadBase extends SingleAddressMemoryEvent implements RegWriter {
+public abstract class LoadBase extends SingleAccessMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/LoadBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/LoadBase.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.common;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -12,7 +12,7 @@ public abstract class LoadBase extends SingleAccessMemoryEvent implements RegWri
 
     protected final Register resultRegister;
 
-    public LoadBase(Register register, IExpr address, String mo) {
+    public LoadBase(Register register, Expression address, String mo) {
         super(address, mo);
         this.resultRegister = register;
         addTags(Tag.READ);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/NoInterface.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/NoInterface.java
@@ -1,0 +1,13 @@
+package com.dat3m.dartagnan.program.event.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/*
+    We use this annotation to mark abstract classes that should never be used as an interface. This means:
+    (1) there are no casts nor instanceof checks involving this class,
+    (2) the class is ONLY used to reduce implementation effort by providing a common implementation.
+ */
+@Target(ElementType.TYPE)
+public @interface NoInterface {
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/SingleAccessMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/SingleAccessMemoryEvent.java
@@ -14,21 +14,23 @@ import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
 import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 
 /*
-    A SingleAddressMemoryEvent may perform multiple memory accesses, but all of them are on the same address
-    with the same type.
+    A SingleAccessMemoryEvent is memory event that performs a single access to memory.
     This includes simple loads and stores but also RMW events or abstract events like SRCU.
     Complex events like MemCpy access two different addresses and hence are unable to
     reuse the implementation given by this class.
+
+    NOTE: This class is intended as a basis for language-level memory events which support a memory order (mo).
+
  */
 @NoInterface
-public abstract class SingleAddressMemoryEvent extends AbstractEvent implements MemoryEvent {
+public abstract class SingleAccessMemoryEvent extends AbstractEvent implements MemoryEvent {
 
     protected IExpr address;
     protected Type accessType;
     protected String mo;
 
     // The empty string means no memory order 
-    public SingleAddressMemoryEvent(IExpr address, String mo) {
+    public SingleAccessMemoryEvent(IExpr address, String mo) {
         Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;
         this.mo = mo;
@@ -40,7 +42,7 @@ public abstract class SingleAddressMemoryEvent extends AbstractEvent implements 
         }
     }
 
-    protected SingleAddressMemoryEvent(SingleAddressMemoryEvent other) {
+    protected SingleAccessMemoryEvent(SingleAccessMemoryEvent other) {
         super(other);
         this.address = other.address;
         this.mo = other.mo;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/SingleAccessMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/SingleAccessMemoryEvent.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.common;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.type.Type;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
@@ -25,12 +25,12 @@ import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 @NoInterface
 public abstract class SingleAccessMemoryEvent extends AbstractEvent implements MemoryEvent {
 
-    protected IExpr address;
+    protected Expression address;
     protected Type accessType;
     protected String mo;
 
     // The empty string means no memory order 
-    public SingleAccessMemoryEvent(IExpr address, String mo) {
+    public SingleAccessMemoryEvent(Expression address, String mo) {
         Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;
         this.mo = mo;
@@ -49,8 +49,8 @@ public abstract class SingleAccessMemoryEvent extends AbstractEvent implements M
         this.accessType = other.accessType;
     }
 
-    public IExpr getAddress() { return address; }
-    public void setAddress(IExpr address) { this.address = address; }
+    public Expression getAddress() { return address; }
+    public void setAddress(Expression address) { this.address = address; }
 
     public Type getAccessType() { return accessType; }
     public void setAccessType(Type type) { this.accessType = type; }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/SingleAddressMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/SingleAddressMemoryEvent.java
@@ -1,0 +1,58 @@
+package com.dat3m.dartagnan.program.event.common;
+
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.type.Type;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
+import com.dat3m.dartagnan.program.event.core.AbstractEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryEvent;
+import com.google.common.base.Preconditions;
+
+import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
+import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
+
+/*
+    A SingleAddressMemoryEvent may perform multiple memory accesses, but all of them are on the same address
+    with the same type.
+    This includes simple loads and stores but also RMW events or abstract events like SRCU.
+    Complex events like MemCpy access two different addresses and hence are unable to
+    reuse the implementation given by this class.
+ */
+@NoInterface
+public abstract class SingleAddressMemoryEvent extends AbstractEvent implements MemoryEvent {
+
+    protected IExpr address;
+    protected Type accessType;
+    protected String mo;
+
+    // The empty string means no memory order 
+    public SingleAddressMemoryEvent(IExpr address, String mo) {
+        Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
+        this.address = address;
+        this.mo = mo;
+        // TODO: Add proper typing.
+        this.accessType = TypeFactory.getInstance().getArchType();
+        addTags(VISIBLE, MEMORY);
+        if (!mo.isEmpty()) {
+            addTags(mo);
+        }
+    }
+
+    protected SingleAddressMemoryEvent(SingleAddressMemoryEvent other) {
+        super(other);
+        this.address = other.address;
+        this.mo = other.mo;
+        this.accessType = other.accessType;
+    }
+
+    public IExpr getAddress() { return address; }
+    public void setAddress(IExpr address) { this.address = address; }
+
+    public Type getAccessType() { return accessType; }
+    public void setAccessType(Type type) { this.accessType = type; }
+
+    public String getMo() {
+        return mo;
+    }
+
+}
+

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/SingleAddressMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/SingleAddressMemoryEvent.java
@@ -3,9 +3,12 @@ package com.dat3m.dartagnan.program.event.common;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.type.Type;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.core.AbstractEvent;
 import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import com.google.common.base.Preconditions;
+
+import java.util.List;
 
 import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
 import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
@@ -54,5 +57,11 @@ public abstract class SingleAddressMemoryEvent extends AbstractEvent implements 
         return mo;
     }
 
+    public abstract MemoryAccess getMemoryAccess();
+
+    @Override
+    public List<MemoryAccess> getMemoryAccesses() {
+        return List.of(getMemoryAccess());
+    }
 }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/StoreBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/StoreBase.java
@@ -1,0 +1,49 @@
+package com.dat3m.dartagnan.program.event.common;
+
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.Tag;
+
+import java.util.Set;
+
+@NoInterface
+public abstract class StoreBase extends SingleAddressMemoryEvent {
+
+    protected ExprInterface value;
+
+    public StoreBase(IExpr address, ExprInterface value, String mo) {
+        super(address, mo);
+        this.value = value;
+        addTags(Tag.WRITE);
+    }
+
+    protected StoreBase(StoreBase other) {
+        super(other);
+        this.value = other.value;
+    }
+
+    public ExprInterface getMemValue() {
+        return value;
+    }
+    public void setMemValue(ExprInterface value) {
+        this.value = value;
+    }
+
+    @Override
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
+    }
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("store(*%s, %s%s)", address, value, !mo.isEmpty() ? ", " + mo : "");
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/StoreBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/StoreBase.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.common;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -11,9 +10,9 @@ import java.util.Set;
 @NoInterface
 public abstract class StoreBase extends SingleAccessMemoryEvent {
 
-    protected ExprInterface value;
+    protected Expression value;
 
-    public StoreBase(IExpr address, ExprInterface value, String mo) {
+    public StoreBase(Expression address, Expression value, String mo) {
         super(address, mo);
         this.value = value;
         addTags(Tag.WRITE);
@@ -24,10 +23,10 @@ public abstract class StoreBase extends SingleAccessMemoryEvent {
         this.value = other.value;
     }
 
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
         return value;
     }
-    public void setMemValue(ExprInterface value) {
+    public void setMemValue(Expression value) {
         this.value = value;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/StoreBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/StoreBase.java
@@ -9,7 +9,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import java.util.Set;
 
 @NoInterface
-public abstract class StoreBase extends SingleAddressMemoryEvent {
+public abstract class StoreBase extends SingleAccessMemoryEvent {
 
     protected ExprInterface value;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryCoreEvent.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.program.event.core;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.type.Type;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
-import com.google.common.base.Preconditions;
 
 import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
 import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
@@ -11,36 +10,22 @@ import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 /*
     WARNING: This class is an implementation detail, i.e., it does NOT provide an interface
     and should ONLY be used to reduce boilerplate code by sharing common code.
-
-    A SingleAddressMemoryEvent may perform multiple memory accesses, but all of them are on the same address
-    with the same type.
-    This includes simple loads and stores but also RMW events or abstract events like SRCU.
-    Complex events like MemCpy access two different addresses and hence are unable to
-    reuse the implementation given by this class.
  */
-public abstract class SingleAddressMemoryEvent extends AbstractEvent implements MemoryEvent {
+public abstract class AbstractMemoryCoreEvent extends AbstractEvent implements MemoryCoreEvent {
 
     protected IExpr address;
     protected Type accessType;
-    protected String mo;
 
-    // The empty string means no memory order 
-    public SingleAddressMemoryEvent(IExpr address, String mo) {
-        Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
+    // The empty string means no memory order
+    public AbstractMemoryCoreEvent(IExpr address) {
         this.address = address;
-        this.mo = mo;
-        // TODO: Add proper typing.
         this.accessType = TypeFactory.getInstance().getArchType();
         addTags(VISIBLE, MEMORY);
-        if (!mo.isEmpty()) {
-            addTags(mo);
-        }
     }
 
-    protected SingleAddressMemoryEvent(SingleAddressMemoryEvent other) {
+    protected AbstractMemoryCoreEvent(AbstractMemoryCoreEvent other) {
         super(other);
         this.address = other.address;
-        this.mo = other.mo;
         this.accessType = other.accessType;
     }
 
@@ -50,9 +35,6 @@ public abstract class SingleAddressMemoryEvent extends AbstractEvent implements 
     public Type getAccessType() { return accessType; }
     public void setAccessType(Type type) { this.accessType = type; }
 
-    public String getMo() {
-        return mo;
-    }
 
 }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryCoreEvent.java
@@ -8,6 +8,9 @@ import com.dat3m.dartagnan.program.event.common.NoInterface;
 import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
 import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 
+/*
+    This class is similar to SingleAccessMemoryEvent, but without a memory order.
+ */
 @NoInterface
 public abstract class AbstractMemoryCoreEvent extends AbstractEvent implements MemoryCoreEvent {
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryCoreEvent.java
@@ -3,23 +3,20 @@ package com.dat3m.dartagnan.program.event.core;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.type.Type;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
+import com.dat3m.dartagnan.program.event.common.NoInterface;
 
 import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
 import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 
-/*
-    WARNING: This class is an implementation detail, i.e., it does NOT provide an interface
-    and should ONLY be used to reduce boilerplate code by sharing common code.
- */
+@NoInterface
 public abstract class AbstractMemoryCoreEvent extends AbstractEvent implements MemoryCoreEvent {
 
     protected IExpr address;
     protected Type accessType;
 
-    // The empty string means no memory order
     public AbstractMemoryCoreEvent(IExpr address) {
         this.address = address;
-        this.accessType = TypeFactory.getInstance().getArchType();
+        this.accessType = TypeFactory.getInstance().getArchType(); // TODO: Add proper typing
         addTags(VISIBLE, MEMORY);
     }
 
@@ -34,7 +31,5 @@ public abstract class AbstractMemoryCoreEvent extends AbstractEvent implements M
 
     public Type getAccessType() { return accessType; }
     public void setAccessType(Type type) { this.accessType = type; }
-
-
 }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryCoreEvent.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.type.Type;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.common.NoInterface;
@@ -14,10 +14,10 @@ import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 @NoInterface
 public abstract class AbstractMemoryCoreEvent extends AbstractEvent implements MemoryCoreEvent {
 
-    protected IExpr address;
+    protected Expression address;
     protected Type accessType;
 
-    public AbstractMemoryCoreEvent(IExpr address) {
+    public AbstractMemoryCoreEvent(Expression address) {
         this.address = address;
         this.accessType = TypeFactory.getInstance().getArchType(); // TODO: Add proper typing
         addTags(VISIBLE, MEMORY);
@@ -29,8 +29,8 @@ public abstract class AbstractMemoryCoreEvent extends AbstractEvent implements M
         this.accessType = other.accessType;
     }
 
-    public IExpr getAddress() { return address; }
-    public void setAddress(IExpr address) { this.address = address; }
+    public Expression getAddress() { return address; }
+    public void setAddress(Expression address) { this.address = address; }
 
     public Type getAccessType() { return accessType; }
     public void setAccessType(Type type) { this.accessType = type; }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.IConst;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -10,60 +11,63 @@ import com.dat3m.dartagnan.program.memory.MemoryObject;
  * It is exposed to the memory consistency model as a visible event.
  * It acts like a regular store, such that load events may read from it and other stores may overwrite it.
  */
-public class Init extends AbstractMemoryEvent {
+public class Init extends SingleAddressMemoryEvent {
 
-	private final MemoryObject base;
-	private final int offset;
-	
-	public Init(MemoryObject b, int o) {
-		super(b.add(o), "");
-		base = b;
-		offset = o;
-		addTags(Tag.WRITE, Tag.INIT);
-	}
+    private final MemoryObject base;
+    private final int offset;
 
-	/**
-	 * Partially identifies this instance in the program.
-	 * @return
-	 * Address of the array whose field is initialized in this event.
-	 */
-	public MemoryObject getBase() {
-		return base;
-	}
+    public Init(MemoryObject b, int o) {
+        super(b.add(o), "");
+        base = b;
+        offset = o;
+        addTags(Tag.WRITE, Tag.INIT);
+    }
 
-	/**
-	 * Partially identifies this instance in the program.
-	 * @return
-	 * Number of fields before the initialized location.
-	 */
-	public int getOffset() {
-		return offset;
-	}
+    /**
+     * Partially identifies this instance in the program.
+     *
+     * @return Address of the array whose field is initialized in this event.
+     */
+    public MemoryObject getBase() {
+        return base;
+    }
 
-	/**
-	 * Initial value at the associated field.
-	 * @return
-	 * Content of the location at the start of each execution.
-	 */
-	public IConst getValue(){
-		return base.getInitialValue(offset);
-	}
+    /**
+     * Partially identifies this instance in the program.
+     *
+     * @return Number of fields before the initialized location.
+     */
+    public int getOffset() {
+        return offset;
+    }
 
-	@Override
-	public String toString() {
-		return String.format("%s[%d] := %s",base,offset,getValue());
-	}
+    /**
+     * Initial value at the associated field.
+     *
+     * @return Content of the location at the start of each execution.
+     */
+    public IConst getValue() {
+        return base.getInitialValue(offset);
+    }
 
-	@Override
-	public IConst getMemValue(){
-		return getValue();
-	}
+    @Override
+    public String toString() {
+        return String.format("%s[%d] := %s", base, offset, getValue());
+    }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    @Override
+    public IConst getMemValue() { return getValue(); }
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitInit(this);
-	}
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+    }
+
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
+
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitInit(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -16,8 +16,7 @@ public class Init extends Store {
     private final int offset;
 
     public Init(MemoryObject b, int o) {
-        super(b.add(o), b.getInitialValue(o), "");
-        //super(b.add(o), "");
+        super(b.add(o), b.getInitialValue(o));
         base = b;
         offset = o;
         addTags(Tag.INIT);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -55,7 +55,6 @@ public class Init extends SingleAddressMemoryEvent {
         return String.format("%s[%d] := %s", base, offset, getValue());
     }
 
-    @Override
     public IConst getMemValue() { return getValue(); }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.IConst;
-import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -11,16 +10,17 @@ import com.dat3m.dartagnan.program.memory.MemoryObject;
  * It is exposed to the memory consistency model as a visible event.
  * It acts like a regular store, such that load events may read from it and other stores may overwrite it.
  */
-public class Init extends SingleAddressMemoryEvent {
+public class Init extends Store {
 
     private final MemoryObject base;
     private final int offset;
 
     public Init(MemoryObject b, int o) {
-        super(b.add(o), "");
+        super(b.add(o), b.getInitialValue(o), "");
+        //super(b.add(o), "");
         base = b;
         offset = o;
-        addTags(Tag.WRITE, Tag.INIT);
+        addTags(Tag.INIT);
     }
 
     /**
@@ -55,12 +55,9 @@ public class Init extends SingleAddressMemoryEvent {
         return String.format("%s[%d] := %s", base, offset, getValue());
     }
 
+    @Override
     public IConst getMemValue() { return getValue(); }
 
-    @Override
-    public MemoryAccess getMemoryAccess() {
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
-    }
 
     // Visitor
     // -----------------------------------------------------------------------------------------------------------------

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -3,11 +3,12 @@ package com.dat3m.dartagnan.program.event.core;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class Load extends AbstractMemoryEvent implements RegWriter {
+public class Load extends SingleAddressMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
 
@@ -35,6 +36,11 @@ public class Load extends AbstractMemoryEvent implements RegWriter {
     @Override
     public ExprInterface getMemValue() {
         return resultRegister;
+    }
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.LOAD);
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
@@ -31,11 +30,6 @@ public class Load extends SingleAddressMemoryEvent implements RegWriter {
     @Override
     public String toString() {
         return resultRegister + " = load(*" + address + (!mo.isEmpty() ? ", " + mo : "") + ")";
-    }
-
-    @Override
-    public ExprInterface getMemValue() {
-        return resultRegister;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
+import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class Load extends SingleAddressMemoryEvent implements RegWriter {
@@ -29,7 +30,9 @@ public class Load extends SingleAddressMemoryEvent implements RegWriter {
 
     @Override
     public String toString() {
-        return resultRegister + " = load(*" + address + (!mo.isEmpty() ? ", " + mo : "") + ")";
+        final MemoryOrder mo = getMetadata(MemoryOrder.class);
+        return String.format("%s = load(*%s%s)", resultRegister, address, mo != null ? ", " + mo.value() : "");
+        //return resultRegister + " = load(*" + address + (mo != null ? ", " + mo.value() : "") + ")";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -8,6 +8,8 @@ import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
+import java.util.List;
+
 public class Load extends AbstractMemoryCoreEvent implements RegWriter {
 
     protected final Register resultRegister;
@@ -35,8 +37,8 @@ public class Load extends AbstractMemoryCoreEvent implements RegWriter {
     }
 
     @Override
-    public MemoryAccess getMemoryAccess() {
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.LOAD);
+    public List<MemoryAccess> getMemoryAccesses() {
+        return List.of(new MemoryAccess(address, accessType, MemoryAccess.Mode.LOAD));
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
@@ -4,9 +4,11 @@ import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.type.Type;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
+import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public interface MemoryCoreEvent extends MemoryEvent, RegReader {
@@ -22,5 +24,23 @@ public interface MemoryCoreEvent extends MemoryEvent, RegReader {
     @Override
     default <T> T accept(EventVisitor<T> visitor) {
         return visitor.visitMemEvent(this);
+    }
+
+
+    /*
+        Convenience implementation to set the MemoryOrder metadata + add a corresponding tag.
+     */
+    default void setMemoryOrder(String newMo) {
+        final MemoryOrder mo = getMetadata(MemoryOrder.class);
+        final String oldMo = (mo == null ? null : mo.value());
+        newMo = (newMo == null || newMo.isEmpty()) ? null : newMo;
+
+        if (!Objects.equals(oldMo, newMo)) {
+            removeTags(oldMo);
+            if (newMo != null) {
+                setMetadata(new MemoryOrder(newMo));
+                addTags(newMo);
+            }
+        }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.type.Type;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
@@ -13,7 +13,7 @@ import java.util.Set;
 
 public interface MemoryCoreEvent extends MemoryEvent, RegReader {
 
-    IExpr getAddress();
+    Expression getAddress();
     Type getAccessType();
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
@@ -14,6 +14,7 @@ import java.util.Set;
 public interface MemoryCoreEvent extends MemoryEvent, RegReader {
 
     Expression getAddress();
+    void setAddress(Expression address);
     Type getAccessType();
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
@@ -1,0 +1,26 @@
+package com.dat3m.dartagnan.program.event.core;
+
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.type.Type;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.core.utils.RegReader;
+import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public interface MemoryCoreEvent extends MemoryEvent, RegReader {
+
+    IExpr getAddress();
+    Type getAccessType();
+
+    @Override
+    default Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(getAddress(), Register.UsageType.ADDR, new HashSet<>());
+    }
+
+    @Override
+    default <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitMemEvent(this);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.Expression;
-import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 public interface MemoryEvent extends Event, RegReader {
 
-
+    // TODO: Make this a List<MemoryAccess> to properly support multi-access events like MemCopy and RMW
     MemoryAccess getMemoryAccess();
 
     // TODO: Get rid of these, because only Stores have a meaningful MemValue.

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -1,8 +1,8 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -11,8 +11,8 @@ import java.util.Set;
 
 public interface MemoryEvent extends Event, RegReader {
 
-    IExpr getAddress();
-    void setAddress(IExpr address);
+
+    MemoryAccess getMemoryAccess();
 
     ExprInterface getMemValue();
     void setMemValue(ExprInterface value);
@@ -22,7 +22,7 @@ public interface MemoryEvent extends Event, RegReader {
 
     @Override
     default Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(getAddress(), Register.UsageType.ADDR, new HashSet<>());
+        return Register.collectRegisterReads(getMemoryAccess().address(), Register.UsageType.ADDR, new HashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
@@ -13,9 +12,6 @@ public interface MemoryEvent extends Event, RegReader {
 
     // TODO: Make this a List<MemoryAccess> to properly support multi-access events like MemCopy and RMW
     MemoryAccess getMemoryAccess();
-
-    // TODO: Get rid of these, because only Stores have a meaningful MemValue.
-    ExprInterface getMemValue();
 
     // TODO: Is "mo" really fundamental to all memory events?
     String getMo();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -13,9 +13,6 @@ public interface MemoryEvent extends Event, RegReader {
     // TODO: Make this a List<MemoryAccess> to properly support multi-access events like MemCopy and RMW
     MemoryAccess getMemoryAccess();
 
-    // TODO: Is "mo" really fundamental to all memory events?
-    String getMo();
-
     @Override
     default Set<Register.Read> getRegisterReads() {
         return Register.collectRegisterReads(getMemoryAccess().address(), Register.UsageType.ADDR, new HashSet<>());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -1,21 +1,25 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+
+import static com.dat3m.dartagnan.program.Register.*;
 
 public interface MemoryEvent extends Event, RegReader {
 
     // TODO: Make this a List<MemoryAccess> to properly support multi-access events like MemCopy and RMW
-    MemoryAccess getMemoryAccess();
+    List<MemoryAccess> getMemoryAccesses();
 
     @Override
-    default Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(getMemoryAccess().address(), Register.UsageType.ADDR, new HashSet<>());
+    default Set<Read> getRegisterReads() {
+        final Set<Read> regReads = new HashSet<>();
+        getMemoryAccesses().forEach(access -> collectRegisterReads(access.address(), UsageType.ADDR, regReads));
+        return regReads;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -16,11 +16,9 @@ public interface MemoryEvent extends Event, RegReader {
 
     // TODO: Get rid of these, because only Stores have a meaningful MemValue.
     ExprInterface getMemValue();
-    void setMemValue(ExprInterface value);
 
     // TODO: Is "mo" really fundamental to all memory events?
     String getMo();
-    void setMo(String mo);
 
     @Override
     default Set<Register.Read> getRegisterReads() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -14,9 +14,11 @@ public interface MemoryEvent extends Event, RegReader {
 
     MemoryAccess getMemoryAccess();
 
+    // TODO: Get rid of these, because only Stores have a meaningful MemValue.
     ExprInterface getMemValue();
     void setMemValue(ExprInterface value);
 
+    // TODO: Is "mo" really fundamental to all memory events?
     String getMo();
     void setMo(String mo);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
@@ -2,42 +2,53 @@ package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.type.Type;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.google.common.base.Preconditions;
 
 import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
 import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 
-public abstract class AbstractMemoryEvent extends AbstractEvent implements MemoryEvent {
+/*
+    WARNING: This class is an implementation detail, i.e., it does NOT provide an interface
+    and should ONLY be used to reduce common boilerplate code.
+
+    A SingleAddressMemoryEvent may perform multiple memory accesses, but all of them are on the same address
+    with the same type.
+    This includes simple loads and stores but also more complex RMW operations or abstract operations like SRCU.
+    A MemCpy accesses two different addresses and hence is unable to reuse the implementation given by this class.
+ */
+public abstract class SingleAddressMemoryEvent extends AbstractEvent implements MemoryEvent {
 
     protected IExpr address;
+    protected Type accessType;
     protected String mo;
 
     // The empty string means no memory order 
-    public AbstractMemoryEvent(IExpr address, String mo) {
+    public SingleAddressMemoryEvent(IExpr address, String mo) {
         Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;
         this.mo = mo;
+        // TODO: Add proper typing.
+        this.accessType = TypeFactory.getInstance().getArchType();
         addTags(VISIBLE, MEMORY);
         if (!mo.isEmpty()) {
             addTags(mo);
         }
     }
 
-    protected AbstractMemoryEvent(AbstractMemoryEvent other) {
+    protected SingleAddressMemoryEvent(SingleAddressMemoryEvent other) {
         super(other);
         this.address = other.address;
         this.mo = other.mo;
+        this.accessType = other.accessType;
     }
 
-    @Override
-    public IExpr getAddress() {
-        return address;
-    }
+    public IExpr getAddress() { return address; }
+    public void setAddress(IExpr address) { this.address = address; }
 
-    @Override
-    public void setAddress(IExpr address) {
-        this.address = address;
-    }
+    public Type getAccessType() { return accessType; }
+    public void setAccessType(Type type) { this.accessType = type; }
 
     @Override
     public ExprInterface getMemValue() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.type.Type;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
@@ -50,11 +49,6 @@ public abstract class SingleAddressMemoryEvent extends AbstractEvent implements 
 
     public Type getAccessType() { return accessType; }
     public void setAccessType(Type type) { this.accessType = type; }
-
-    @Override
-    public ExprInterface getMemValue() {
-        throw new RuntimeException("MemValue is not available for event " + this.getClass().getName());
-    }
 
     @Override
     public String getMo() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
@@ -11,12 +11,13 @@ import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 
 /*
     WARNING: This class is an implementation detail, i.e., it does NOT provide an interface
-    and should ONLY be used to reduce common boilerplate code.
+    and should ONLY be used to reduce boilerplate code by sharing common code.
 
     A SingleAddressMemoryEvent may perform multiple memory accesses, but all of them are on the same address
     with the same type.
-    This includes simple loads and stores but also more complex RMW operations or abstract operations like SRCU.
-    A MemCpy accesses two different addresses and hence is unable to reuse the implementation given by this class.
+    This includes simple loads and stores but also RMW events or abstract events like SRCU.
+    Complex events like MemCpy access two different addresses and hence are unable to
+    reuse the implementation given by this class.
  */
 public abstract class SingleAddressMemoryEvent extends AbstractEvent implements MemoryEvent {
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
@@ -50,7 +50,6 @@ public abstract class SingleAddressMemoryEvent extends AbstractEvent implements 
     public Type getAccessType() { return accessType; }
     public void setAccessType(Type type) { this.accessType = type; }
 
-    @Override
     public String getMo() {
         return mo;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/SingleAddressMemoryEvent.java
@@ -57,26 +57,8 @@ public abstract class SingleAddressMemoryEvent extends AbstractEvent implements 
     }
 
     @Override
-    public void setMemValue(ExprInterface value) {
-        throw new RuntimeException("SetValue is not available for event " + this.getClass().getName());
-    }
-
-    @Override
     public String getMo() {
         return mo;
-    }
-
-    @Override
-    public void setMo(String mo) {
-        Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
-        if (!this.mo.isEmpty()) {
-            removeTags(this.mo);
-        }
-        this.mo = mo;
-        // This cannot be merged with the if above, because this.mo was updated
-        if (!this.mo.isEmpty()) {
-            addTags(mo);
-        }
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -44,7 +44,6 @@ public class Store extends SingleAddressMemoryEvent {
         return value;
     }
 
-    @Override
     public void setMemValue(ExprInterface value) {
         this.value = value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -10,12 +10,12 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import java.util.Set;
 
-public class Store extends SingleAddressMemoryEvent {
+public class Store extends AbstractMemoryCoreEvent {
 
     protected ExprInterface value;
 
-    public Store(IExpr address, ExprInterface value, String mo) {
-        super(address, mo);
+    public Store(IExpr address, ExprInterface value) {
+        super(address);
         this.value = value;
         addTags(Tag.WRITE);
     }
@@ -39,7 +39,6 @@ public class Store extends SingleAddressMemoryEvent {
     public String toString() {
         final MemoryOrder mo = getMetadata(MemoryOrder.class);
         return String.format("store(*%s, %s%s)", address, value, mo != null ? ", " + mo.value() : "");
-        //return "store(*" + address + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")";
     }
 
     public ExprInterface getMemValue() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -3,12 +3,13 @@ package com.dat3m.dartagnan.program.event.core;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import java.util.Set;
 
-public class Store extends AbstractMemoryEvent {
+public class Store extends SingleAddressMemoryEvent {
 
     protected ExprInterface value;
 
@@ -26,6 +27,11 @@ public class Store extends AbstractMemoryEvent {
     @Override
     public Set<Register.Read> getRegisterReads() {
         return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
+    }
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -39,7 +39,6 @@ public class Store extends SingleAddressMemoryEvent {
         return "store(*" + address + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")";
     }
 
-    @Override
     public ExprInterface getMemValue() {
         return value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
+import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import java.util.Set;
@@ -36,7 +37,9 @@ public class Store extends SingleAddressMemoryEvent {
 
     @Override
     public String toString() {
-        return "store(*" + address + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")";
+        final MemoryOrder mo = getMetadata(MemoryOrder.class);
+        return String.format("store(*%s, %s%s)", address, value, mo != null ? ", " + mo.value() : "");
+        //return "store(*" + address + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")";
     }
 
     public ExprInterface getMemValue() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -8,6 +8,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
+import java.util.List;
 import java.util.Set;
 
 public class Store extends AbstractMemoryCoreEvent {
@@ -31,8 +32,8 @@ public class Store extends AbstractMemoryCoreEvent {
     }
 
     @Override
-    public MemoryAccess getMemoryAccess() {
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+    public List<MemoryAccess> getMemoryAccesses() {
+        return List.of(new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStore.java
@@ -15,9 +15,9 @@ public class RMWStore extends Store {
 
     protected Load loadEvent;
 
-    public RMWStore(Load loadEvent, IExpr address, ExprInterface value, String mo) {
-        super(address, value, mo);
-        Preconditions.checkArgument(loadEvent.hasTag(Tag.RMW), "The provided load event " + loadEvent + " is not tagged RMW.");
+    public RMWStore(Load loadEvent, IExpr address, ExprInterface value) {
+        super(address, value);
+        Preconditions.checkArgument(loadEvent.hasTag(Tag.RMW), "The provided load event %s is not tagged RMW.", loadEvent);
         this.loadEvent = loadEvent;
         addTags(Tag.RMW);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStoreExclusive.java
@@ -14,9 +14,9 @@ public class RMWStoreExclusive extends Store {
     private final boolean isStrong;
     private final boolean requiresMatchingAddresses;
 
-    public RMWStoreExclusive(IExpr address, ExprInterface value, String mo,
+    public RMWStoreExclusive(IExpr address, ExprInterface value,
                              boolean isStrong, boolean requiresMatchingAddresses) {
-        super(address, value, mo);
+        super(address, value);
         addTags(Tag.EXCL, Tag.RMW);
         this.isStrong = isStrong;
         this.requiresMatchingAddresses = requiresMatchingAddresses;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -43,19 +43,18 @@ public abstract class AtomicAbstract extends SingleAddressMemoryEvent implements
 
     @Override
     public ExprInterface getMemValue() {
-    	return value;
+        return value;
     }
-    
-    @Override
-    public void setMemValue(ExprInterface value){
+
+    public void setMemValue(ExprInterface value) {
         this.value = value;
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitAtomicAbstract(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitAtomicAbstract(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -41,7 +41,6 @@ public abstract class AtomicAbstract extends SingleAddressMemoryEvent implements
         return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
-    @Override
     public ExprInterface getMemValue() {
         return value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,7 +12,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class AtomicAbstract extends SingleAddressMemoryEvent implements RegWriter {
+public abstract class AtomicAbstract extends SingleAccessMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,7 +12,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class AtomicAbstract extends AbstractMemoryEvent implements RegWriter {
+public abstract class AtomicAbstract extends SingleAddressMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 
@@ -16,44 +17,55 @@ public class AtomicCmpXchg extends AtomicAbstract {
         this.isStrong = isStrong;
     }
 
-    private AtomicCmpXchg(AtomicCmpXchg other){
+    private AtomicCmpXchg(AtomicCmpXchg other) {
         super(other);
         this.expectedAddr = other.expectedAddr;
         this.isStrong = other.isStrong;
     }
 
-    public boolean isStrong() { return this.isStrong; }
-    public boolean isWeak() { return !this.isStrong; }
+    public boolean isStrong() {
+        return this.isStrong;
+    }
+
+    public boolean isWeak() {
+        return !this.isStrong;
+    }
 
     //TODO: Override getDataRegs???
 
     public IExpr getExpectedAddr() {
-    	return expectedAddr;
+        return expectedAddr;
     }
-    
+
     public void setExpectedAddr(IExpr expectedAddr) {
-    	this.expectedAddr = expectedAddr;
+        this.expectedAddr = expectedAddr;
     }
-    
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+    }
+
     @Override
     public String toString() {
         return resultRegister + " = atomic_compare_exchange" + (isStrong ? "_strong" : "_weak") +
-            "(*" + address + ", " + expectedAddr + ", " + value + ", " + mo + ")\t### C11";
+                "(*" + address + ", " + expectedAddr + ", " + value + ", " + mo + ")\t### C11";
     }
 
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public AtomicCmpXchg getCopy(){
+    public AtomicCmpXchg getCopy() {
         return new AtomicCmpXchg(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitAtomicCmpXchg(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitAtomicCmpXchg(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
@@ -31,8 +31,6 @@ public class AtomicCmpXchg extends AtomicAbstract {
         return !this.isStrong;
     }
 
-    //TODO: Override getDataRegs???
-
     public IExpr getExpectedAddr() {
         return expectedAddr;
     }
@@ -43,8 +41,7 @@ public class AtomicCmpXchg extends AtomicAbstract {
 
     @Override
     public MemoryAccess getMemoryAccess() {
-        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
@@ -32,14 +31,8 @@ public class AtomicFetchOp extends AtomicAbstract {
     }
 
     @Override
-    public ExprInterface getMemValue() {
-        return value;
-    }
-
-    @Override
     public MemoryAccess getMemoryAccess() {
-        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
-
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class AtomicFetchOp extends AtomicAbstract {
@@ -16,39 +16,45 @@ public class AtomicFetchOp extends AtomicAbstract {
         this.op = op;
     }
 
-    private AtomicFetchOp(AtomicFetchOp other){
+    private AtomicFetchOp(AtomicFetchOp other) {
         super(other);
         this.op = other.op;
     }
 
     @Override
     public String toString() {
-        return resultRegister + " = atomic_fetch_" + op.toLinuxName() + 
-            "(*" + address + ", " + value + ", " + mo + ")\t### C11";
+        return resultRegister + " = atomic_fetch_" + op.toLinuxName() +
+                "(*" + address + ", " + value + ", " + mo + ")\t### C11";
     }
 
     public IOpBin getOp() {
-    	return op;
+        return op;
     }
-    
+
     @Override
     public ExprInterface getMemValue() {
-    	return value;
+        return value;
     }
-    
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+    }
+
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public AtomicFetchOp getCopy(){
+    public AtomicFetchOp getCopy() {
         return new AtomicFetchOp(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitAtomicFetchOp(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitAtomicFetchOp(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -3,7 +3,8 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,26 +13,26 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.READ;
 
-public class AtomicLoad extends AbstractMemoryEvent implements RegWriter {
+public class AtomicLoad extends SingleAddressMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 
     public AtomicLoad(Register register, IExpr address, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "Atomic events cannot have empty memory order");
-    	Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),
-    			getClass().getName() + " can not have memory order: " + mo);
+        Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),
+                getClass().getName() + " can not have memory order: " + mo);
         this.resultRegister = register;
         addTags(READ);
     }
 
-    private AtomicLoad(AtomicLoad other){
+    private AtomicLoad(AtomicLoad other) {
         super(other);
         this.resultRegister = other.resultRegister;
     }
 
     @Override
-    public Register getResultRegister(){
+    public Register getResultRegister() {
         return resultRegister;
     }
 
@@ -41,23 +42,28 @@ public class AtomicLoad extends AbstractMemoryEvent implements RegWriter {
     }
 
     @Override
-    public ExprInterface getMemValue(){
+    public ExprInterface getMemValue() {
         return resultRegister;
     }
 
-	// Unrolling
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.LOAD);
+    }
+
+    // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public AtomicLoad getCopy(){
+    public AtomicLoad getCopy() {
         return new AtomicLoad(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitAtomicLoad(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitAtomicLoad(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
@@ -39,11 +38,6 @@ public class AtomicLoad extends SingleAddressMemoryEvent implements RegWriter {
     @Override
     public String toString() {
         return resultRegister + " = atomic_load(*" + address + ", " + mo + ")\t### C11";
-    }
-
-    @Override
-    public ExprInterface getMemValue() {
-        return resultRegister;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,7 +12,7 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.READ;
 
-public class AtomicLoad extends SingleAddressMemoryEvent implements RegWriter {
+public class AtomicLoad extends SingleAccessMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
@@ -14,7 +14,7 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
 
-public class AtomicStore extends SingleAddressMemoryEvent {
+public class AtomicStore extends SingleAccessMemoryEvent {
 
     private ExprInterface value;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -3,7 +3,8 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
@@ -13,20 +14,20 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
 
-public class AtomicStore extends AbstractMemoryEvent {
+public class AtomicStore extends SingleAddressMemoryEvent {
 
     private ExprInterface value;
 
-    public AtomicStore(IExpr address, ExprInterface value, String mo){
+    public AtomicStore(IExpr address, ExprInterface value, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "Atomic events cannot have empty memory order");
         Preconditions.checkArgument(!mo.equals(MO_ACQUIRE) && !mo.equals(MO_ACQUIRE_RELEASE),
-        		getClass().getName() + " can not have memory order: " + mo);
+                getClass().getName() + " can not have memory order: " + mo);
         this.value = value;
         addTags(WRITE);
     }
 
-    private AtomicStore(AtomicStore other){
+    private AtomicStore(AtomicStore other) {
         super(other);
         this.value = other.value;
     }
@@ -38,32 +39,37 @@ public class AtomicStore extends AbstractMemoryEvent {
 
     @Override
     public String toString() {
-        return "atomic_store(*" + address + ", " +  value + ", " + mo + ")\t### C11";
+        return "atomic_store(*" + address + ", " + value + ", " + mo + ")\t### C11";
     }
 
     @Override
     public ExprInterface getMemValue() {
-    	return value;
+        return value;
     }
-    
+
     @Override
-    public void setMemValue(ExprInterface value){
+    public void setMemValue(ExprInterface value) {
         this.value = value;
+    }
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
     }
 
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public AtomicStore getCopy(){
+    public AtomicStore getCopy() {
         return new AtomicStore(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitAtomicStore(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitAtomicStore(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -47,7 +47,6 @@ public class AtomicStore extends SingleAddressMemoryEvent {
         return value;
     }
 
-    @Override
     public void setMemValue(ExprInterface value) {
         this.value = value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -42,7 +42,6 @@ public class AtomicStore extends SingleAddressMemoryEvent {
         return "atomic_store(*" + address + ", " + value + ", " + mo + ")\t### C11";
     }
 
-    @Override
     public ExprInterface getMemValue() {
         return value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class AtomicXchg extends AtomicAbstract {
@@ -12,7 +12,7 @@ public class AtomicXchg extends AtomicAbstract {
         super(address, register, value, mo);
     }
 
-    private AtomicXchg(AtomicXchg other){
+    private AtomicXchg(AtomicXchg other) {
         super(other);
     }
 
@@ -23,22 +23,28 @@ public class AtomicXchg extends AtomicAbstract {
 
     @Override
     public ExprInterface getMemValue() {
-    	return value;
+        return value;
     }
-    
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+    }
+
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public AtomicXchg getCopy(){
+    public AtomicXchg getCopy() {
         return new AtomicXchg(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitAtomicXchg(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitAtomicXchg(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
@@ -22,14 +21,8 @@ public class AtomicXchg extends AtomicAbstract {
     }
 
     @Override
-    public ExprInterface getMemValue() {
-        return value;
-    }
-
-    @Override
     public MemoryAccess getMemoryAccess() {
-        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
@@ -8,8 +8,13 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMLoad extends Load {
 
+	private String mo;
+	public String getMo() { return mo; }
+
 	public LKMMLoad(Register register, IExpr address, String mo) {
-		super(register, address, mo);
+		super(register, address);
+		this.mo = mo;
+		tags.add(mo);
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.Expression;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMLock extends SingleAccessMemoryEvent {
@@ -16,14 +17,14 @@ public class LKMMLock extends SingleAccessMemoryEvent {
         super(other);
     }
 
-	public Expression getLock() {
-		return address;
-	}
-	
-	@Override
-	public String toString() {
-		return String.format("spin_lock(*%s)", address);
-	}
+    public Expression getLock() {
+        return address;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("spin_lock(*%s)", address);
+    }
 
     @Override
     public MemoryAccess getMemoryAccess() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMLock extends SingleAddressMemoryEvent {
@@ -28,8 +28,7 @@ public class LKMMLock extends SingleAddressMemoryEvent {
 
     @Override
     public MemoryAccess getMemoryAccess() {
-        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
     }
 
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
@@ -2,10 +2,10 @@ package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class LKMMLock extends SingleAddressMemoryEvent {
+public class LKMMLock extends SingleAccessMemoryEvent {
 
     public LKMMLock(IExpr lock) {
         // This event will be compiled to LKMMLockRead + LKMMLockWrite

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
@@ -1,43 +1,50 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class LKMMLock extends AbstractMemoryEvent {
+public class LKMMLock extends SingleAddressMemoryEvent {
 
-	public LKMMLock(IExpr lock) {
-		// This event will be compiled to LKMMLockRead + LKMMLockWrite 
-		// and each of those will be assigned a proper memory ordering
-		super(lock, "");
-	}
+    public LKMMLock(IExpr lock) {
+        // This event will be compiled to LKMMLockRead + LKMMLockWrite
+        // and each of those will be assigned a proper memory ordering
+        super(lock, "");
+    }
 
-    protected LKMMLock(LKMMLock other){
+    protected LKMMLock(LKMMLock other) {
         super(other);
     }
 
-	public IExpr getLock() {
-		return address;
-	}
-	
-	@Override
-	public String toString() {
-		return String.format("spin_lock(*%s)", address);
-	}
+    public IExpr getLock() {
+        return address;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("spin_lock(*%s)", address);
+    }
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+    }
 
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public LKMMLock getCopy(){
+    public LKMMLock getCopy() {
         return new LKMMLock(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitLKMMLock(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitLKMMLock(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockRead.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockRead.java
@@ -7,11 +7,13 @@ import com.dat3m.dartagnan.program.event.core.Load;
 import static com.dat3m.dartagnan.program.event.Tag.Linux;
 import static com.dat3m.dartagnan.program.event.Tag.RMW;
 
+// FIXME: We inherit from Load to keep this a core event.
+//  We keep this a core event just to get a better toString implementation
 public class LKMMLockRead extends Load {
 
 	public LKMMLockRead(Register register, IExpr lock) {
-		super(register, lock, Linux.MO_ACQUIRE);
-		addTags(RMW, Linux.LOCK_READ);
+		super(register, lock);
+		addTags(RMW, Linux.LOCK_READ, Linux.MO_ACQUIRE);
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockWrite.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockWrite.java
@@ -11,8 +11,8 @@ import static com.dat3m.dartagnan.program.event.Tag.RMW;
 public class LKMMLockWrite extends RMWStore {
 
 	public LKMMLockWrite(Load lockRead, IExpr lock) {
-		super(lockRead, lock, IValue.ONE, Linux.MO_ONCE);
-		addTags(RMW, Linux.LOCK_WRITE);
+		super(lockRead, lock, IValue.ONE);
+		addTags(RMW, Linux.LOCK_WRITE, Linux.MO_ONCE);
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockWrite.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockWrite.java
@@ -11,13 +11,13 @@ import static com.dat3m.dartagnan.program.event.Tag.RMW;
 
 public class LKMMLockWrite extends RMWStore {
 
-	public LKMMLockWrite(Load lockRead, Expression lock) {
-		super(lockRead, lock, ExpressionFactory.getInstance().makeOne(TypeFactory.getInstance().getArchType()), Linux.MO_ONCE);
-		addTags(RMW, Linux.LOCK_WRITE, Linux.MO_ONCE);
-	}
+    public LKMMLockWrite(Load lockRead, Expression lock) {
+        super(lockRead, lock, ExpressionFactory.getInstance().makeOne(TypeFactory.getInstance().getArchType()));
+        addTags(RMW, Linux.LOCK_WRITE, Linux.MO_ONCE);
+    }
 
-	@Override
-	public String toString() {
-		return String.format("spin_lock_W(*%s)", address);
-	}
+    @Override
+    public String toString() {
+        return String.format("spin_lock_W(*%s)", address);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
@@ -8,8 +8,13 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMStore extends Store {
 
+	private String mo;
+	public String getMo() { return mo; }
+
 	public LKMMStore(IExpr address, ExprInterface value, String mo) {
-		super(address, value, mo);
+		super(address, value);
+		this.mo = mo;
+		addTags(mo);
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMUnlock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMUnlock.java
@@ -11,8 +11,8 @@ import static com.dat3m.dartagnan.program.event.Tag.Linux.MO_RELEASE;
 public class LKMMUnlock extends Store {
 
 	public LKMMUnlock(IExpr lock) {
-		super(lock, IValue.ZERO, MO_RELEASE);
-		addTags(Tag.Linux.UNLOCK);
+		super(lock, IValue.ZERO);
+		addTags(Tag.Linux.UNLOCK, MO_RELEASE);
 	}
 
     protected LKMMUnlock(LKMMUnlock other){

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -50,8 +50,7 @@ public abstract class RMWAbstract extends SingleAddressMemoryEvent implements Re
 
     @Override
     public MemoryAccess getMemoryAccess() {
-        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
     }
 
     // Visitor

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -3,7 +3,8 @@ package com.dat3m.dartagnan.program.event.lang.linux;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -11,7 +12,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class RMWAbstract extends AbstractMemoryEvent implements RegWriter {
+public abstract class RMWAbstract extends SingleAddressMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;
@@ -23,7 +24,7 @@ public abstract class RMWAbstract extends AbstractMemoryEvent implements RegWrit
         addTags(READ, WRITE, RMW);
     }
 
-    RMWAbstract(RMWAbstract other){
+    RMWAbstract(RMWAbstract other) {
         super(other);
         this.resultRegister = other.resultRegister;
         this.value = other.value;
@@ -35,25 +36,31 @@ public abstract class RMWAbstract extends AbstractMemoryEvent implements RegWrit
     }
 
     @Override
-    public Set<Register.Read> getRegisterReads(){
+    public Set<Register.Read> getRegisterReads() {
         return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
     @Override
-    public ExprInterface getMemValue(){
+    public ExprInterface getMemValue() {
         return value;
     }
 
     @Override
-    public void setMemValue(ExprInterface value){
+    public void setMemValue(ExprInterface value) {
         this.value = value;
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+    }
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitRMWAbstract(this);
-	}
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
+
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitRMWAbstract(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -45,7 +45,6 @@ public abstract class RMWAbstract extends SingleAddressMemoryEvent implements Re
         return value;
     }
 
-    @Override
     public void setMemValue(ExprInterface value) {
         this.value = value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -53,6 +53,8 @@ public abstract class RMWAbstract extends SingleAddressMemoryEvent implements Re
         return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
     }
 
+
+
     // Visitor
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -12,7 +12,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class RMWAbstract extends SingleAddressMemoryEvent implements RegWriter {
+public abstract class RMWAbstract extends SingleAccessMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -40,7 +40,6 @@ public abstract class RMWAbstract extends SingleAddressMemoryEvent implements Re
         return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
-    @Override
     public ExprInterface getMemValue() {
         return value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
@@ -3,38 +3,44 @@ package com.dat3m.dartagnan.program.event.lang.linux;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class SrcuSync extends AbstractMemoryEvent {
+public class SrcuSync extends SingleAddressMemoryEvent {
 
-	public SrcuSync(IExpr address) {
-		super(address, Tag.Linux.SRCU_SYNC);
-	}
+    public SrcuSync(IExpr address) {
+        super(address, Tag.Linux.SRCU_SYNC);
+    }
 
-	@Override
+    @Override
     public String toString() {
         return "synchronize_srcu(" + address + ")\t### LKMM";
     }
 
     // This event is a MemEvent because it needs to contribute to the loc relation
-	// (due to let srcu-rscs = ([Srcu-lock] ; pass-cookie ; [Srcu-unlock]) & loc).
-	// However it cannot contribute to the data flow over memory, thus the memValue
-	// we assign is irrelevant. However we still need to provide an implementation
-	// to be abel to run several analysis / passes. The value below should not affect
-	// the alias analysis and the result of passes like constant propagation is 
-	// irrelevant because this event does not contribute to any data flow.
-	@Override
-	public ExprInterface getMemValue(){
-		return IValue.ZERO;
-	}
+    // (due to let srcu-rscs = ([Srcu-lock] ; pass-cookie ; [Srcu-unlock]) & loc).
+    // However it cannot contribute to the data flow over memory, thus the memValue
+    // we assign is irrelevant. However we still need to provide an implementation
+    // to be abel to run several analysis / passes. The value below should not affect
+    // the alias analysis and the result of passes like constant propagation is
+    // irrelevant because this event does not contribute to any data flow.
+    @Override
+    public ExprInterface getMemValue() {
+        return IValue.ZERO;
+    }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.OTHER);
+    }
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitSruSync(this);
-	}
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
+
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitSruSync(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
@@ -3,15 +3,19 @@ package com.dat3m.dartagnan.program.event.lang.linux;
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
+import com.dat3m.dartagnan.program.event.core.AbstractMemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
+
+import java.util.List;
 
 // This event is a MemEvent because it needs to contribute to the loc relation
 // (due to let srcu-rscs = ([Srcu-lock] ; pass-cookie ; [Srcu-unlock]) & loc).
-public class SrcuSync extends SingleAccessMemoryEvent {
+// FIXME: Add generic memory event in the core that can represent SRCU.
+public class SrcuSync extends AbstractMemoryCoreEvent {
 
     public SrcuSync(Expression address) {
-        super(address, Tag.Linux.SRCU_SYNC);
+        super(address);
+        tags.add(Tag.Linux.SRCU_SYNC);
     }
 
     @Override
@@ -20,8 +24,8 @@ public class SrcuSync extends SingleAccessMemoryEvent {
     }
 
     @Override
-    public MemoryAccess getMemoryAccess() {
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.OTHER);
+    public List<MemoryAccess> getMemoryAccesses() {
+        return List.of(new MemoryAccess(address, accessType, MemoryAccess.Mode.OTHER));
     }
 
     // Visitor
@@ -29,6 +33,6 @@ public class SrcuSync extends SingleAccessMemoryEvent {
 
     @Override
     public <T> T accept(EventVisitor<T> visitor) {
-        return visitor.visitSruSync(this);
+        return visitor.visitSrcuSync(this);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.linux;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class SrcuSync extends SingleAddressMemoryEvent {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
@@ -1,8 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
@@ -17,18 +15,6 @@ public class SrcuSync extends SingleAddressMemoryEvent {
     @Override
     public String toString() {
         return "synchronize_srcu(" + address + ")\t### LKMM";
-    }
-
-    // This event is a MemEvent because it needs to contribute to the loc relation
-    // (due to let srcu-rscs = ([Srcu-lock] ; pass-cookie ; [Srcu-unlock]) & loc).
-    // However it cannot contribute to the data flow over memory, thus the memValue
-    // we assign is irrelevant. However we still need to provide an implementation
-    // to be abel to run several analysis / passes. The value below should not affect
-    // the alias analysis and the result of passes like constant propagation is
-    // irrelevant because this event does not contribute to any data flow.
-    @Override
-    public ExprInterface getMemValue() {
-        return IValue.ZERO;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
@@ -3,10 +3,10 @@ package com.dat3m.dartagnan.program.event.lang.linux;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class SrcuSync extends SingleAddressMemoryEvent {
+public class SrcuSync extends SingleAccessMemoryEvent {
 
     public SrcuSync(IExpr address) {
         super(address, Tag.Linux.SRCU_SYNC);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
@@ -1,8 +1,7 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.Expression;
-import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.type.TypeFactory;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -11,9 +10,9 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 // (due to let srcu-rscs = ([Srcu-lock] ; pass-cookie ; [Srcu-unlock]) & loc).
 public class SrcuSync extends SingleAccessMemoryEvent {
 
-	public SrcuSync(Expression address) {
-		super(address, Tag.Linux.SRCU_SYNC);
-	}
+    public SrcuSync(Expression address) {
+        super(address, Tag.Linux.SRCU_SYNC);
+    }
 
     @Override
     public String toString() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -47,7 +47,6 @@ public abstract class LlvmAbstractRMW extends SingleAddressMemoryEvent implement
         return value;
     }
 
-    @Override
     public void setMemValue(ExprInterface value) {
         this.value = value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -52,8 +52,7 @@ public abstract class LlvmAbstractRMW extends SingleAddressMemoryEvent implement
 
     @Override
     public MemoryAccess getMemoryAccess() {
-        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
-        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
     }
 
     // Visitor

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -42,7 +42,6 @@ public abstract class LlvmAbstractRMW extends SingleAddressMemoryEvent implement
         return Register.collectRegisterReads(value, Register.UsageType.DATA, super.getRegisterReads());
     }
 
-    @Override
     public ExprInterface getMemValue() {
         return value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class LlvmAbstractRMW extends SingleAddressMemoryEvent implements RegWriter {
+public abstract class LlvmAbstractRMW extends SingleAccessMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -3,7 +3,8 @@ package com.dat3m.dartagnan.program.event.lang.llvm;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,7 +13,7 @@ import java.util.Set;
 
 import static com.dat3m.dartagnan.program.event.Tag.*;
 
-public abstract class LlvmAbstractRMW extends AbstractMemoryEvent implements RegWriter {
+public abstract class LlvmAbstractRMW extends SingleAddressMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
     protected ExprInterface value;
@@ -43,19 +44,25 @@ public abstract class LlvmAbstractRMW extends AbstractMemoryEvent implements Reg
 
     @Override
     public ExprInterface getMemValue() {
-    	return value;
+        return value;
     }
-    
+
     @Override
-    public void setMemValue(ExprInterface value){
+    public void setMemValue(ExprInterface value) {
         this.value = value;
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        // TODO: Once we can return multiple MemoryAccesses, we need to add the LOAD here as well.
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.STORE);
+    }
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitLlvmAbstract(this);
-	}
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
+
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitLlvmAbstract(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.llvm;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,7 +12,7 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.READ;
 
-public class LlvmLoad extends SingleAddressMemoryEvent implements RegWriter {
+public class LlvmLoad extends SingleAccessMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.lang.llvm;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -3,7 +3,8 @@ package com.dat3m.dartagnan.program.event.lang.llvm;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -12,26 +13,26 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.READ;
 
-public class LlvmLoad extends AbstractMemoryEvent implements RegWriter {
+public class LlvmLoad extends SingleAddressMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 
     public LlvmLoad(Register register, IExpr address, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "LLVM events cannot have empty memory order");
-    	Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),
-    			getClass().getName() + " cannot have memory order: " + mo);
+        Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),
+                getClass().getName() + " cannot have memory order: " + mo);
         this.resultRegister = register;
         addTags(READ);
     }
 
-    private LlvmLoad(LlvmLoad other){
+    private LlvmLoad(LlvmLoad other) {
         super(other);
         this.resultRegister = other.resultRegister;
     }
 
     @Override
-    public Register getResultRegister(){
+    public Register getResultRegister() {
         return resultRegister;
     }
 
@@ -41,23 +42,28 @@ public class LlvmLoad extends AbstractMemoryEvent implements RegWriter {
     }
 
     @Override
-    public ExprInterface getMemValue(){
+    public ExprInterface getMemValue() {
         return resultRegister;
     }
 
-	// Unrolling
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.LOAD);
+    }
+
+    // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public LlvmLoad getCopy(){
+    public LlvmLoad getCopy() {
         return new LlvmLoad(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitLlvmLoad(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitLlvmLoad(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
@@ -39,11 +38,6 @@ public class LlvmLoad extends SingleAddressMemoryEvent implements RegWriter {
     @Override
     public String toString() {
         return resultRegister + " = llvm_load(*" + address + ", " + mo + ")\t### LLVM";
-    }
-
-    @Override
-    public ExprInterface getMemValue() {
-        return resultRegister;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
@@ -1,10 +1,8 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
-
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LlvmRMW extends LlvmAbstractRMW {
@@ -30,11 +28,7 @@ public class LlvmRMW extends LlvmAbstractRMW {
     public IOpBin getOp() {
     	return op;
     }
-    
-    @Override
-    public ExprInterface getMemValue() {
-    	return value;
-    }
+
     
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -42,7 +42,6 @@ public class LlvmStore extends SingleAddressMemoryEvent {
         return "llvm_store(*" + address + ", " + value + ", " + mo + ")\t### LLVM";
     }
 
-    @Override
     public ExprInterface getMemValue() {
         return value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -47,7 +47,6 @@ public class LlvmStore extends SingleAddressMemoryEvent {
         return value;
     }
 
-    @Override
     public void setMemValue(ExprInterface value) {
         this.value = value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryAccess;
-import com.dat3m.dartagnan.program.event.common.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
@@ -14,7 +14,7 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_ACQUIRE_RELEASE;
 import static com.dat3m.dartagnan.program.event.Tag.WRITE;
 
-public class LlvmStore extends SingleAddressMemoryEvent {
+public class LlvmStore extends SingleAccessMemoryEvent {
 
     private ExprInterface value;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
@@ -1,9 +1,7 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
-
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LlvmXchg extends LlvmAbstractRMW {
@@ -19,11 +17,6 @@ public class LlvmXchg extends LlvmAbstractRMW {
     @Override
     public String toString() {
         return resultRegister + " = llvm_xchg(*" + address + ", " + value + ", " + mo + ")\t### LLVM";
-    }
-
-    @Override
-    public ExprInterface getMemValue() {
-    	return value;
     }
     
     // Unrolling

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Create.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Create.java
@@ -3,23 +3,23 @@ package com.dat3m.dartagnan.program.event.lang.pthread;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.Store;
+import com.dat3m.dartagnan.program.event.common.StoreBase;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;
 
-public class Create extends Store {
+public class Create extends StoreBase {
 
-	private final String routine;
-	
+    private final String routine;
+
     public Create(IExpr address, String routine) {
-    	super(address, IValue.ONE, MO_SC);
+        super(address, IValue.ONE, MO_SC);
         this.routine = routine;
         addTags(Tag.C11.PTHREAD);
     }
 
-    private Create(Create other){
-    	super(other);
+    private Create(Create other) {
+        super(other);
         this.routine = other.routine;
     }
 
@@ -27,20 +27,20 @@ public class Create extends Store {
     public String toString() {
         return "pthread_create(" + address + ", " + routine + ")";
     }
-	
+
     // Unrolling
     // -----------------------------------------------------------------------------------------------------------------
 
     @Override
-    public Create getCopy(){
+    public Create getCopy() {
         return new Create(this);
     }
 
-	// Visitor
-	// -----------------------------------------------------------------------------------------------------------------
+    // Visitor
+    // -----------------------------------------------------------------------------------------------------------------
 
-	@Override
-	public <T> T accept(EventVisitor<T> visitor) {
-		return visitor.visitCreate(this);
-	}
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitCreate(this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/End.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/End.java
@@ -3,12 +3,12 @@ package com.dat3m.dartagnan.program.event.lang.pthread;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.Store;
+import com.dat3m.dartagnan.program.event.common.StoreBase;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;
 
-public class End extends Store {
+public class End extends StoreBase {
 
     public End(IExpr address){
     	super(address, IValue.ZERO, MO_SC);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/InitLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/InitLock.java
@@ -1,12 +1,12 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
 import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.program.event.core.Store;
+import com.dat3m.dartagnan.program.event.common.StoreBase;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;
 
-public class InitLock extends Store {
+public class InitLock extends StoreBase {
 	
 	private final String name;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/InitLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/InitLock.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
 import com.dat3m.dartagnan.expression.Expression;
-import com.dat3m.dartagnan.program.event.core.Store;
+import com.dat3m.dartagnan.program.event.common.StoreBase;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
@@ -3,10 +3,10 @@ package com.dat3m.dartagnan.program.event.lang.pthread;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.Load;
+import com.dat3m.dartagnan.program.event.common.LoadBase;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
-public class Join extends Load {
+public class Join extends LoadBase {
 
     public Join(Register reg, IExpr expr) {
         // We will set the correct (C11 or LKMM) acquire tag (or barriers) when the event is compiled

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Lock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Lock.java
@@ -3,12 +3,12 @@ package com.dat3m.dartagnan.program.event.lang.pthread;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.Store;
+import com.dat3m.dartagnan.program.event.common.StoreBase;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;
 
-public class Lock extends Store {
+public class Lock extends StoreBase {
 	
 	private final String name;
 	private final Register reg;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Start.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Start.java
@@ -3,13 +3,13 @@ package com.dat3m.dartagnan.program.event.lang.pthread;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
+import com.dat3m.dartagnan.program.event.common.LoadBase;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;
 
-public class Start extends Load {
+public class Start extends LoadBase {
 
     private final Event creationEvent;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Unlock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Unlock.java
@@ -3,12 +3,12 @@ package com.dat3m.dartagnan.program.event.lang.pthread;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.event.core.Store;
+import com.dat3m.dartagnan.program.event.common.StoreBase;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;
 
-public class Unlock extends Store {
+public class Unlock extends StoreBase {
 	
 	private final String name;
 	private final Register reg;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/MemoryOrder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/MemoryOrder.java
@@ -1,0 +1,3 @@
+package com.dat3m.dartagnan.program.event.metadata;
+
+public record MemoryOrder(String value) implements Metadata {  }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/MemoryOrder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/MemoryOrder.java
@@ -1,3 +1,4 @@
 package com.dat3m.dartagnan.program.event.metadata;
 
+//TODO: Add a factory with caching, because we can share the same MemoryOrder instance between different events.
 public record MemoryOrder(String value) implements Metadata {  }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
@@ -25,7 +25,7 @@ public interface EventVisitor<T> {
 	default T visitExecutionStatus(ExecutionStatus e) { return visitEvent(e); }
 	default T visitFence(Fence e) { return visitEvent(e); }
 	default T visitIfAsJump(IfAsJump e) { return visitCondJump(e); }
-	default T visitInit(Init e) { return visitMemEvent(e); }
+	default T visitInit(Init e) { return visitStore(e); }
 	default T visitLabel(Label e) { return visitEvent(e); }
 	default T visitLoad(Load e) { return visitMemEvent(e); }
 	default T visitLocal(Local e) { return visitEvent(e); }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
@@ -37,12 +37,12 @@ public interface EventVisitor<T> {
 	default T visitCodeAnnotation(CodeAnnotation e) { return visitEvent(e); }
 
 	// Pthread Events
-	default T visitCreate(Create e) { return visitStore(e); }
-	default T visitEnd(End e) { return visitStore(e); }
-	default T visitInitLock(InitLock e) { return visitStore(e); }
-	default T visitJoin(Join e) { return visitLoad(e); }
+	default T visitCreate(Create e) { return visitMemEvent(e); }
+	default T visitEnd(End e) { return visitMemEvent(e); }
+	default T visitInitLock(InitLock e) { return visitMemEvent(e); }
+	default T visitJoin(Join e) { return visitMemEvent(e); }
 	default T visitLock(Lock e) { return visitMemEvent(e); }
-	default T visitStart(Start e) { return visitLoad(e); }
+	default T visitStart(Start e) { return visitMemEvent(e); }
 	default T visitUnlock(Unlock e) { return visitMemEvent(e); }
 
 	// RMW Events
@@ -50,7 +50,7 @@ public interface EventVisitor<T> {
 	default T visitRMWStoreExclusive(RMWStoreExclusive e) { return visitStore(e); }
 
 	// AARCH64 Events
-	default T visitStoreExclusive(StoreExclusive e) { return visitStore(e); }
+	default T visitStoreExclusive(StoreExclusive e) { return visitMemEvent(e); }
 
 	// Linux Events
 	default T visitRMWAbstract(RMWAbstract e) { return visitMemEvent(e); }
@@ -66,9 +66,9 @@ public interface EventVisitor<T> {
 	default T visitLKMMStore(LKMMStore e) { return visitStore(e); }
 
 	// Linux Lock Events
-	default T visitLKMMLock(LKMMLock e) { return visitEvent(e); }
+	default T visitLKMMLock(LKMMLock e) { return visitMemEvent(e); }
 	default T visitLKMMUnlock(LKMMUnlock e) { return visitStore(e); }
-	default T visitLKMMLockRead(LKMMLockRead e) { return visitLoad(e); }
+	default T visitLKMMLockRead(LKMMLockRead e) { return visitMemEvent(e); }
 	default T visitLKMMLockWrite(LKMMLockWrite e) { return visitStore(e); }
 
 	// Linux SRCU Events

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/visitors/EventVisitor.java
@@ -27,11 +27,12 @@ public interface EventVisitor<T> {
 	default T visitIfAsJump(IfAsJump e) { return visitCondJump(e); }
 	default T visitInit(Init e) { return visitStore(e); }
 	default T visitLabel(Label e) { return visitEvent(e); }
-	default T visitLoad(Load e) { return visitMemEvent(e); }
+	default T visitLoad(Load e) { return visitMemCoreEvent(e); }
 	default T visitLocal(Local e) { return visitEvent(e); }
 	default T visitMemEvent(MemoryEvent e) { return visitEvent(e); }
+	default T visitMemCoreEvent(MemoryCoreEvent e) { return visitMemEvent(e); }
 	default T visitSkip(Skip e) { return visitEvent(e); }
-	default T visitStore(Store e) { return visitMemEvent(e); }
+	default T visitStore(Store e) { return visitMemCoreEvent(e); }
 
 	// Annotations
 	default T visitCodeAnnotation(CodeAnnotation e) { return visitEvent(e); }
@@ -72,7 +73,7 @@ public interface EventVisitor<T> {
 	default T visitLKMMLockWrite(LKMMLockWrite e) { return visitStore(e); }
 
 	// Linux SRCU Events
-	default T visitSruSync(SrcuSync e) { return visitMemEvent(e); }
+	default T visitSrcuSync(SrcuSync e) { return visitMemCoreEvent(e); }
 
 	// TSO Events
 	default T visitXchg(Xchg e) { return visitMemEvent(e); }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LogProgramStatistics.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LogProgramStatistics.java
@@ -27,12 +27,12 @@ public class LogProgramStatistics implements ProgramProcessor {
         int fenceCount = 0;
         for (Event e : program.getEvents()) {
             totalEventCount++;
-            if (e instanceof Store) {
+            if (e instanceof Init) {
+                initCount++;
+            } else if (e instanceof Store) {
                 storeCount++;
             } else if (e instanceof Load) {
                 loadCount++;
-            } else if (e instanceof Init) {
-                initCount++;
             } else if (e instanceof Fence) {
                 fenceCount++;
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -66,7 +66,7 @@ public class ProcessingManager implements ProgramProcessor {
     @Option(name = PRINT_PROGRAM_AFTER_PROCESSING,
             description = "Prints the program after all processing.",
             secure = true)
-    private boolean printAfterProcessing = true;
+    private boolean printAfterProcessing = false;
 
 
 // ======================================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -66,7 +66,7 @@ public class ProcessingManager implements ProgramProcessor {
     @Option(name = PRINT_PROGRAM_AFTER_PROCESSING,
             description = "Prints the program after all processing.",
             secure = true)
-    private boolean printAfterProcessing = false;
+    private boolean printAfterProcessing = true;
 
 
 // ======================================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -9,7 +9,6 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
-import com.dat3m.dartagnan.program.event.lang.linux.SrcuSync;
 import com.dat3m.dartagnan.program.event.lang.std.Malloc;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -179,22 +178,15 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
         }
 
         @Override
+        public Void visitMemCoreEvent(MemoryCoreEvent e) {
+            e.setAddress(e.getAddress().visit(propagator));
+            return null;
+        }
+
+        @Override
         public Void visitStore(Store e) {
-            e.setAddress(e.getAddress().visit(propagator));
             e.setMemValue(e.getMemValue().visit(propagator));
-            return visitMemEvent(e);
-        }
-
-        @Override
-        public Void visitLoad(Load e) {
-            e.setAddress(e.getAddress().visit(propagator));
-            return null;
-        }
-
-        @Override
-        public Void visitSruSync(SrcuSync e) {
-            e.setAddress(e.getAddress().visit(propagator));
-            return null;
+            return visitMemCoreEvent(e);
         }
 
         @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -9,6 +9,7 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
+import com.dat3m.dartagnan.program.event.lang.linux.SrcuSync;
 import com.dat3m.dartagnan.program.event.lang.std.Malloc;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
@@ -177,15 +178,22 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
         }
 
         @Override
-        public Void visitMemEvent(MemoryEvent e) {
+        public Void visitStore(Store e) {
+            e.setAddress((IExpr) e.getAddress().visit(propagator));
+            e.setMemValue(e.getMemValue().visit(propagator));
+            return visitMemEvent(e);
+        }
+
+        @Override
+        public Void visitLoad(Load e) {
             e.setAddress((IExpr) e.getAddress().visit(propagator));
             return null;
         }
 
         @Override
-        public Void visitStore(Store e) {
-            e.setMemValue(e.getMemValue().visit(propagator));
-            return visitMemEvent(e);
+        public Void visitSruSync(SrcuSync e) {
+            e.setAddress((IExpr) e.getAddress().visit(propagator));
+            return null;
         }
 
         @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -477,7 +477,7 @@ class VisitorArm8 extends VisitorBase {
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
         Load load = newRMWLoadExclusiveWithMo(dummy, address, ARMv8.extractLoadMoFromLKMo(mo));
-        Store store = newRMWStoreExclusiveWithMo(address, value, ARMv8.extractStoreMoFromLKMo(mo), true);
+        Store store = newRMWStoreExclusiveWithMo(address, value, true, ARMv8.extractStoreMoFromLKMo(mo));
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? AArch64.DMB.newISHBarrier() : null;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -93,7 +93,8 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitInitLock(InitLock e) {
         return eventSequence(
-                newStoreWithMo(e.getAddress(), e.getMemValue(), ARMv8.MO_REL));
+                newStoreWithMo(e.getAddress(), e.getMemValue(), ARMv8.MO_REL)
+        );
     }
 
     @Override
@@ -108,13 +109,15 @@ class VisitorArm8 extends VisitorBase {
         return eventSequence(
                 newRMWLoadExclusiveWithMo(dummy, e.getAddress(), ARMv8.MO_ACQ),
                 newAssume(expressions.makeEQ(dummy, zero)),
-                newRMWStoreExclusive(e.getAddress(), one, true));
+                newRMWStoreExclusive(e.getAddress(), one, true)
+        );
     }
 
     @Override
     public List<Event> visitUnlock(Unlock e) {
         return eventSequence(
-                newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), ARMv8.MO_REL));
+                newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), ARMv8.MO_REL)
+        );
     }
 
     // =============================================================================================
@@ -203,11 +206,10 @@ class VisitorArm8 extends VisitorBase {
         Store store = newRMWStoreExclusiveWithMo(address, value, true, ARMv8.extractStoreMoFromCMo(mo));
 
         return eventSequence(
-                // Indentation shows the branching structure
                 load,
                 casCmpResult,
                 branchOnCasCmpResult,
-                    store,
+                store,
                 casEnd
         );
     }
@@ -260,17 +262,16 @@ class VisitorArm8 extends VisitorBase {
         }
 
         return eventSequence(
-                // Indentation shows the branching structure
                 loadExpected,
                 loadValue,
                 casCmpResult,
                 branchOnCasCmpResult,
-                    storeValue,
-                    optionalExecStatus,
-                    optionalUpdateCasCmpResult,
-                    gotoCasEnd,
+                storeValue,
+                optionalExecStatus,
+                optionalUpdateCasCmpResult,
+                gotoCasEnd,
                 casFail,
-                    storeExpected,
+                storeExpected,
                 casEnd
         );
     }
@@ -454,13 +455,12 @@ class VisitorArm8 extends VisitorBase {
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? AArch64.DMB.newISHBarrier() : null;
 
         return eventSequence(
-                // Indentation shows the branching structure
                 load,
                 branchOnCasCmpResult,
-                    store,
-                    fakeCtrlDep,
-                    label,
-                    optionalMemoryBarrierAfter,
+                store,
+                fakeCtrlDep,
+                label,
+                optionalMemoryBarrierAfter,
                 casEnd,
                 newLocal(resultRegister, dummy)
         );
@@ -601,14 +601,13 @@ class VisitorArm8 extends VisitorBase {
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? AArch64.DMB.newISHBarrier() : null;
 
         return eventSequence(
-                // Indentation shows the branching structure
                 load,
                 newLocal(dummy, expressions.makeNEQ(regValue, unless)),
                 branchOnCauCmpResult,
-                    store,
-                    fakeCtrlDep,
-                    label,
-                    optionalMemoryBarrierAfter,
+                store,
+                fakeCtrlDep,
+                label,
+                optionalMemoryBarrierAfter,
                 cauEnd,
                 newLocal(resultRegister, dummy)
         );

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -108,7 +108,7 @@ class VisitorArm8 extends VisitorBase {
         return eventSequence(
                 newRMWLoadExclusiveWithMo(dummy, e.getAddress(), ARMv8.MO_ACQ),
                 newAssume(expressions.makeEQ(dummy, zero)),
-                newRMWStoreExclusiveWithMo(e.getAddress(), one, true, ""));
+                newRMWStoreExclusive(e.getAddress(), one, true));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
@@ -105,19 +105,16 @@ class VisitorBase implements EventVisitor<List<Event>> {
     @Override
     public List<Event> visitStoreExclusive(StoreExclusive e) {
         throw error(e);
-
     }
 
     @Override
     public List<Event> visitRMWAbstract(RMWAbstract e) {
         throw error(e);
-
     }
 
     @Override
     public List<Event> visitRMWAddUnless(RMWAddUnless e) {
         throw error(e);
-
     }
 
     @Override
@@ -173,20 +170,17 @@ class VisitorBase implements EventVisitor<List<Event>> {
     @Override
     public List<Event> visitAtomicAbstract(AtomicAbstract e) {
         throw error(e);
-
     }
 
     // LLVM Events
     @Override
     public List<Event> visitLlvmAbstract(LlvmAbstractRMW e) {
         throw error(e);
-
     }
 
     @Override
     public List<Event> visitLlvmLoad(LlvmLoad e) {
         throw error(e);
-
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
@@ -65,7 +65,7 @@ class VisitorBase implements EventVisitor<List<Event>> {
 	@Override
 	public List<Event> visitInitLock(InitLock e) {
 		return eventSequence(
-                newStore(e.getAddress(), e.getMemValue(), e.getMo())
+                newStoreWithMo(e.getAddress(), e.getMemValue(), e.getMo())
         );
 	}
 
@@ -74,11 +74,11 @@ class VisitorBase implements EventVisitor<List<Event>> {
         Register resultRegister = e.getResultRegister();
 		String mo = e.getMo();
 
-		Load rmwLoad = newRMWLoad(resultRegister, e.getAddress(), mo);
+		Load rmwLoad = newRMWLoadWithMo(resultRegister, e.getAddress(), mo);
 		return eventSequence(
                 rmwLoad,
                 newJump(new Atom(resultRegister, NEQ, IValue.ZERO), (Label) e.getThread().getExit()),
-                newRMWStore(rmwLoad, e.getAddress(), IValue.ONE, mo)
+                newRMWStoreWithMo(rmwLoad, e.getAddress(), IValue.ONE, mo)
         );
     }
     
@@ -88,11 +88,11 @@ class VisitorBase implements EventVisitor<List<Event>> {
 		IExpr address = e.getAddress();
 		String mo = e.getMo();
 
-		Load rmwLoad = newRMWLoad(resultRegister, address, mo);
+		Load rmwLoad = newRMWLoadWithMo(resultRegister, address, mo);
 		return eventSequence(
                 rmwLoad,
                 newJump(new Atom(resultRegister, NEQ, IValue.ONE), (Label) e.getThread().getExit()),
-                newRMWStore(rmwLoad, address, IValue.ZERO, mo)
+                newRMWStoreWithMo(rmwLoad, address, IValue.ZERO, mo)
         );
 	}
 
@@ -162,8 +162,8 @@ class VisitorBase implements EventVisitor<List<Event>> {
 		IExpr address = e.getAddress();
 		String mo = e.getMo();
         Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
-		Load load = newRMWLoad(dummyReg, address, mo);
-        RMWStore store = newRMWStore(load, address, e.getMemValue(), mo);
+		Load load = newRMWLoadWithMo(dummyReg, address, mo);
+        RMWStore store = newRMWStoreWithMo(load, address, e.getMemValue(), mo);
 		return eventSequence(
         		load,
                 store,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
@@ -32,27 +32,27 @@ import static com.dat3m.dartagnan.program.event.EventFactory.*;
 
 class VisitorBase implements EventVisitor<List<Event>> {
 
-	protected boolean forceStart;
-	protected final TypeFactory types = TypeFactory.getInstance();
-	protected final ExpressionFactory expressions = ExpressionFactory.getInstance();
+    protected boolean forceStart;
+    protected final TypeFactory types = TypeFactory.getInstance();
+    protected final ExpressionFactory expressions = ExpressionFactory.getInstance();
 
-	protected VisitorBase(boolean forceStart) {
-		this.forceStart = forceStart;
-	}
+    protected VisitorBase(boolean forceStart) {
+        this.forceStart = forceStart;
+    }
 
-	@Override
-	public List<Event> visitEvent(Event e) {
-		return Collections.singletonList(e);
-	};
+    @Override
+    public List<Event> visitEvent(Event e) {
+        return Collections.singletonList(e);
+    }
 
-	@Override
-	public List<Event> visitCondJump(CondJump e) {
-		Preconditions.checkState(e.getSuccessor() != null, "Malformed CondJump event");
-		return visitEvent(e);
-	};
+    @Override
+    public List<Event> visitCondJump(CondJump e) {
+        Preconditions.checkState(e.getSuccessor() != null, "Malformed CondJump event");
+        return visitEvent(e);
+    }
 
-	@Override
-	public List<Event> visitStart(Start e) {
+    @Override
+    public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
         Register statusRegister = e.getThread().newRegister(resultRegister.getType());
 
@@ -60,150 +60,143 @@ class VisitorBase implements EventVisitor<List<Event>> {
                 forceStart ? newExecutionStatus(statusRegister, e.getCreationEvent()) : null,
                 forceStart ? newAssume(expressions.makeOr(resultRegister, statusRegister)) : null
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitInitLock(InitLock e) {
-		return eventSequence(
+    @Override
+    public List<Event> visitInitLock(InitLock e) {
+        return eventSequence(
                 newStoreWithMo(e.getAddress(), e.getMemValue(), e.getMo())
         );
-	}
+    }
 
-	@Override
+    @Override
     public List<Event> visitLock(Lock e) {
         Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		Expression zero = expressions.makeZero(type);
-		Expression one = expressions.makeOne(type);
-		String mo = e.getMo();
+        IntegerType type = resultRegister.getType();
+        Expression zero = expressions.makeZero(type);
+        Expression one = expressions.makeOne(type);
+        String mo = e.getMo();
 
-		Load rmwLoad = newRMWLoadWithMo(resultRegister, e.getAddress(), mo);
-		return eventSequence(
+        Load rmwLoad = newRMWLoadWithMo(resultRegister, e.getAddress(), mo);
+        return eventSequence(
                 rmwLoad,
                 newJump(expressions.makeNEQ(resultRegister, zero), (Label) e.getThread().getExit()),
                 newRMWStoreWithMo(rmwLoad, e.getAddress(), one, mo)
         );
     }
-    
-    @Override
-	public List<Event> visitUnlock(Unlock e) {
-        Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		Expression zero = expressions.makeZero(type);
-		Expression one = expressions.makeOne(type);
-		Expression address = e.getAddress();
-		String mo = e.getMo();
 
-		Load rmwLoad = newRMWLoadWithMo(resultRegister, address, mo);
-		return eventSequence(
+    @Override
+    public List<Event> visitUnlock(Unlock e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        Expression zero = expressions.makeZero(type);
+        Expression one = expressions.makeOne(type);
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+
+        Load rmwLoad = newRMWLoadWithMo(resultRegister, address, mo);
+        return eventSequence(
                 rmwLoad,
                 newJump(expressions.makeNEQ(resultRegister, one), (Label) e.getThread().getExit()),
                 newRMWStoreWithMo(rmwLoad, address, zero, mo)
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitStoreExclusive(StoreExclusive e) {
-		throw error(e);
+    @Override
+    public List<Event> visitStoreExclusive(StoreExclusive e) {
+        throw error(e);
 
-	};
+    }
 
-	@Override
-	public List<Event> visitRMWAbstract(RMWAbstract e) {
-		throw error(e);
+    @Override
+    public List<Event> visitRMWAbstract(RMWAbstract e) {
+        throw error(e);
 
-	};
+    }
 
-	@Override
-	public List<Event> visitRMWAddUnless(RMWAddUnless e) {
-		throw error(e);
+    @Override
+    public List<Event> visitRMWAddUnless(RMWAddUnless e) {
+        throw error(e);
 
-	};
+    }
 
-	@Override
-	public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
-		throw error(e);
+    @Override
+    public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
+        throw error(e);
+    }
 
-	};
+    @Override
+    public List<Event> visitRMWFetchOp(RMWFetchOp e) {
+        throw error(e);
+    }
 
-	@Override
-	public List<Event> visitRMWFetchOp(RMWFetchOp e) {
-		throw error(e);
+    @Override
+    public List<Event> visitRMWOp(RMWOp e) {
+        throw error(e);
+    }
 
-	};
+    @Override
+    public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
+        throw error(e);
+    }
 
-	@Override
-	public List<Event> visitRMWOp(RMWOp e) {
-		throw error(e);
+    @Override
+    public List<Event> visitRMWOpReturn(RMWOpReturn e) {
+        throw error(e);
+    }
 
-	};
+    @Override
+    public List<Event> visitRMWXchg(RMWXchg e) {
+        throw error(e);
+    }
 
-	@Override
-	public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
-		throw error(e);
+    @Override
+    public List<Event> visitXchg(Xchg e) {
+        throw error(e);
+    }
 
-	};
-
-	@Override
-	public List<Event> visitRMWOpReturn(RMWOpReturn e) {
-		throw error(e);
-
-	};
-
-	@Override
-	public List<Event> visitRMWXchg(RMWXchg e) {
-		throw error(e);
-
-	};
-
-	@Override
-	public List<Event> visitXchg(Xchg e) {
-		throw error(e);
-
-	}
-
-	@Override
-	public List<Event> visitRMW(RMW e) {
+    @Override
+    public List<Event> visitRMW(RMW e) {
         Register resultRegister = e.getResultRegister();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
         Register dummyReg = e.getThread().newRegister(resultRegister.getType());
-		Load load = newRMWLoadWithMo(dummyReg, address, mo);
+        Load load = newRMWLoadWithMo(dummyReg, address, mo);
         RMWStore store = newRMWStoreWithMo(load, address, e.getMemValue(), mo);
-		return eventSequence(
-				load,
+        return eventSequence(
+                load,
                 store,
                 newLocal(resultRegister, dummyReg)
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicAbstract(AtomicAbstract e) {
-		throw error(e);
+    @Override
+    public List<Event> visitAtomicAbstract(AtomicAbstract e) {
+        throw error(e);
 
-	}
+    }
 
-	// LLVM Events
-	@Override
-	public List<Event> visitLlvmAbstract(LlvmAbstractRMW e) {
-		throw error(e);
+    // LLVM Events
+    @Override
+    public List<Event> visitLlvmAbstract(LlvmAbstractRMW e) {
+        throw error(e);
 
-	}
+    }
 
-	@Override
-	public List<Event> visitLlvmLoad(LlvmLoad e) {
-		throw error(e);
+    @Override
+    public List<Event> visitLlvmLoad(LlvmLoad e) {
+        throw error(e);
 
-	}
+    }
 
-	@Override
-	public List<Event> visitLlvmStore(LlvmStore e) {
-		throw error(e);
-	}
+    @Override
+    public List<Event> visitLlvmStore(LlvmStore e) {
+        throw error(e);
+    }
 
-	private IllegalArgumentException error(Event e) {
-		return new IllegalArgumentException("Compilation for " + e.getClass().getSimpleName() +
-				" is not supported by " + getClass().getSimpleName());
-	}
+    private IllegalArgumentException error(Event e) {
+        return new IllegalArgumentException("Compilation for " + e.getClass().getSimpleName() +
+                " is not supported by " + getClass().getSimpleName());
+    }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -32,14 +32,16 @@ public class VisitorC11 extends VisitorBase {
         store.addTags(C11.PTHREAD);
 
         return tagList(eventSequence(
-                store));
+                store
+        ));
     }
 
     @Override
     public List<Event> visitEnd(End e) {
         //TODO boolean
         return tagList(eventSequence(
-                newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), Tag.C11.MO_RELEASE)));
+                newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), Tag.C11.MO_RELEASE)
+        ));
     }
 
     @Override
@@ -51,7 +53,8 @@ public class VisitorC11 extends VisitorBase {
 
         return tagList(eventSequence(
                 load,
-                newJumpUnless(expressions.makeEQ(resultRegister, zero), (Label) e.getThread().getExit())));
+                newJumpUnless(expressions.makeEQ(resultRegister, zero), (Label) e.getThread().getExit())
+        ));
     }
 
     @Override
@@ -64,14 +67,17 @@ public class VisitorC11 extends VisitorBase {
         return tagList(eventSequence(
                 load,
                 super.visitStart(e),
-                newJumpUnless(expressions.makeEQ(resultRegister, one), (Label) e.getThread().getExit())));
+                newJumpUnless(expressions.makeEQ(resultRegister, one), (Label) e.getThread().getExit())
+        ));
     }
 
+    //TODO: Is it really mandatory to copy the load here?
     @Override
     public List<Event> visitLoad(Load e) {
         return tagList(eventSequence(e.getCopy()));
     }
 
+    //TODO: Is it really mandatory to copy the store here?
     @Override
     public List<Event> visitStore(Store e) {
         return tagList(eventSequence(e.getCopy()));
@@ -102,15 +108,14 @@ public class VisitorC11 extends VisitorBase {
         Store storeValue = newRMWStoreWithMo(loadValue, address, e.getMemValue(), mo);
 
         return tagList(eventSequence(
-                // Indentation shows the branching structure
                 loadExpected,
                 loadValue,
                 casCmpResult,
                 branchOnCasCmpResult,
-                    storeValue,
-                    gotoCasEnd,
+                storeValue,
+                gotoCasEnd,
                 casFail,
-                    storeExpected,
+                storeExpected,
                 casEnd
         ));
     }
@@ -149,7 +154,8 @@ public class VisitorC11 extends VisitorBase {
     @Override
     public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
         return tagList(eventSequence(
-                newFence(e.getMo())));
+                newFence(e.getMo())
+        ));
     }
 
     @Override
@@ -173,13 +179,15 @@ public class VisitorC11 extends VisitorBase {
     @Override
     public List<Event> visitLlvmLoad(LlvmLoad e) {
         return tagList(eventSequence(
-                newLoadWithMo(e.getResultRegister(), e.getAddress(), e.getMo())));
+                newLoadWithMo(e.getResultRegister(), e.getAddress(), e.getMo())
+        ));
     }
 
     @Override
     public List<Event> visitLlvmStore(LlvmStore e) {
         return tagList(eventSequence(
-                newStoreWithMo(e.getAddress(), e.getMemValue(), e.getMo())));
+                newStoreWithMo(e.getAddress(), e.getMemValue(), e.getMo())
+        ));
     }
 
     @Override
@@ -194,7 +202,8 @@ public class VisitorC11 extends VisitorBase {
 
         return tagList(eventSequence(
                 load,
-                store));
+                store
+        ));
     }
 
     @Override
@@ -214,7 +223,8 @@ public class VisitorC11 extends VisitorBase {
         return tagList(eventSequence(
                 load,
                 localOp,
-                store));
+                store
+        ));
     }
 
     @Override
@@ -236,18 +246,19 @@ public class VisitorC11 extends VisitorBase {
         Store store = newRMWStoreExclusiveWithMo(address, value, true, mo);
 
         return tagList(eventSequence(
-                // Indentation shows the branching structure
                 load,
                 casCmpResult,
                 branchOnCasCmpResult,
-                    store,
-                casEnd));
+                store,
+                casEnd
+        ));
     }
 
     @Override
     public List<Event> visitLlvmFence(LlvmFence e) {
         return tagList(eventSequence(
-                newFence(e.getMo())));
+                newFence(e.getMo())
+        ));
     }
 
     private List<Event> tagList(List<Event> in) {
@@ -256,7 +267,7 @@ public class VisitorC11 extends VisitorBase {
     }
 
     private void tagEvent(Event e) {
-        if(e instanceof MemoryEvent) {
+        if (e instanceof MemoryEvent) {
             final MemoryOrder mo = e.getMetadata(MemoryOrder.class);
             final boolean canRace = mo == null || mo.value().equals(C11.NONATOMIC);
             e.addTags(canRace ? C11.NONATOMIC : C11.ATOMIC);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -67,14 +67,12 @@ public class VisitorC11 extends VisitorBase {
 
         @Override
         public List<Event> visitLoad(Load e) {
-                return tagList(eventSequence(
-                        newLoad(e.getResultRegister(), e.getAddress(), e.getMo())));
+                return tagList(eventSequence(e.getCopy()));
         }
 
         @Override
         public List<Event> visitStore(Store e) {
-                return tagList(eventSequence(
-                        newStore(e.getAddress(), e.getMemValue(), e.getMo())));
+                return tagList(eventSequence(e.getCopy()));
         }
 
         // =============================================================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -69,14 +69,12 @@ public class VisitorC11 extends VisitorBase {
 
     @Override
     public List<Event> visitLoad(Load e) {
-        return tagList(eventSequence(
-                newLoadWithMo(e.getResultRegister(), e.getAddress(), e.getMo())));
+        return tagList(eventSequence(e.getCopy()));
     }
 
     @Override
     public List<Event> visitStore(Store e) {
-        return tagList(eventSequence(
-                newStoreWithMo(e.getAddress(), e.getMemValue(), e.getMo())));
+        return tagList(eventSequence(e.getCopy()));
     }
 
     // =============================================================================================
@@ -234,8 +232,8 @@ public class VisitorC11 extends VisitorBase {
         Expression one = expressions.makeOne(resultRegister.getType());
         CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
 
-        Load load = newRMWLoadExclusive(oldValueRegister, address, mo);
-        Store store = newRMWStoreExclusive(address, value, true, mo);
+        Load load = newRMWLoadExclusiveWithMo(oldValueRegister, address, mo);
+        Store store = newRMWStoreExclusiveWithMo(address, value, true, mo);
 
         return tagList(eventSequence(
                 // Indentation shows the branching structure

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -13,6 +13,7 @@ import com.dat3m.dartagnan.program.event.lang.pthread.Create;
 import com.dat3m.dartagnan.program.event.lang.pthread.End;
 import com.dat3m.dartagnan.program.event.lang.pthread.Join;
 import com.dat3m.dartagnan.program.event.lang.pthread.Start;
+import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 
 import java.util.List;
 
@@ -245,8 +246,7 @@ public class VisitorC11 extends VisitorBase {
 
     @Override
     public List<Event> visitLlvmFence(LlvmFence e) {
-            return tagList(eventSequence(
-                            newFence(e.getMo())));
+            return tagList(eventSequence(newFence(e.getMo())));
     }
 
     private List<Event> tagList(List<Event> in) {
@@ -255,8 +255,9 @@ public class VisitorC11 extends VisitorBase {
     }
 
     private void tagEvent(Event e) {
-        if(e instanceof MemoryEvent memEvent) {
-            final boolean canRace = (memEvent.getMo().isEmpty() || memEvent.getMo().equals(C11.NONATOMIC));
+        if(e instanceof MemoryEvent) {
+            final MemoryOrder mo = e.getMetadata(MemoryOrder.class);
+            final boolean canRace = mo == null || mo.value().equals(C11.NONATOMIC);
             e.addTags(canRace ? C11.NONATOMIC : C11.ATOMIC);
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -25,86 +25,86 @@ import static com.dat3m.dartagnan.program.event.Tag.IMM.extractStoreMo;
 
 class VisitorIMM extends VisitorBase {
 
-	protected VisitorIMM(boolean forceStart) {
-		super(forceStart);
-	}
+    protected VisitorIMM(boolean forceStart) {
+        super(forceStart);
+    }
 
-	@Override
-	public List<Event> visitLoad(Load e) {
-		// FIXME: It is weird to compile a core-level load by transforming its tagging.
-		final MemoryOrder mo = e.getMetadata(MemoryOrder.class);
-		final boolean isNonAtomic = (mo == null || mo.value().equals(C11.NONATOMIC));
+    @Override
+    public List<Event> visitLoad(Load e) {
+        // FIXME: It is weird to compile a core-level load by transforming its tagging.
+        final MemoryOrder mo = e.getMetadata(MemoryOrder.class);
+        final boolean isNonAtomic = (mo == null || mo.value().equals(C11.NONATOMIC));
         return eventSequence(
-        		newLoadWithMo(e.getResultRegister(), e.getAddress(), isNonAtomic ? C11.MO_RELAXED : mo.value())
+                newLoadWithMo(e.getResultRegister(), e.getAddress(), isNonAtomic ? C11.MO_RELAXED : mo.value())
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitStore(Store e) {
-		// FIXME: It is weird to compile a core-level load by transforming its tagging.
-		final MemoryOrder mo = e.getMetadata(MemoryOrder.class);
-		final boolean isNonAtomic = (mo == null || mo.value().equals(C11.NONATOMIC));
+    @Override
+    public List<Event> visitStore(Store e) {
+        // FIXME: It is weird to compile a core-level load by transforming its tagging.
+        final MemoryOrder mo = e.getMetadata(MemoryOrder.class);
+        final boolean isNonAtomic = (mo == null || mo.value().equals(C11.NONATOMIC));
         return eventSequence(
-        		newStoreWithMo(e.getAddress(), e.getMemValue(), isNonAtomic ? C11.MO_RELAXED : mo.value())
+                newStoreWithMo(e.getAddress(), e.getMemValue(), isNonAtomic ? C11.MO_RELAXED : mo.value())
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitCreate(Create e) {
+    @Override
+    public List<Event> visitCreate(Create e) {
         Store store = newStoreWithMo(e.getAddress(), e.getMemValue(), C11.MO_RELEASE);
         store.addTags(C11.PTHREAD);
-        
+
         return eventSequence(
                 store
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitEnd(End e) {
+    @Override
+    public List<Event> visitEnd(End e) {
         //TODO boolean
         return eventSequence(
                 newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), C11.MO_RELEASE)
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitJoin(Join e) {
+    @Override
+    public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
         Expression zero = expressions.makeZero(resultRegister.getType());
-		Load load = newLoadWithMo(resultRegister, e.getAddress(), C11.MO_ACQUIRE);
+        Load load = newLoadWithMo(resultRegister, e.getAddress(), C11.MO_ACQUIRE);
         load.addTags(C11.PTHREAD);
 
         return eventSequence(
-				load,
+                load,
                 newJump(expressions.makeNEQ(resultRegister, zero), (Label) e.getThread().getExit())
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitStart(Start e) {
+    @Override
+    public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
         Expression one = expressions.makeOne(resultRegister.getType());
         Load load = newLoadWithMo(resultRegister, e.getAddress(), C11.MO_ACQUIRE);
         load.addTags(Tag.STARTLOAD);
 
         return eventSequence(
-				load,
-				super.visitStart(e),
-				newJump(expressions.makeNEQ(resultRegister, one), (Label) e.getThread().getExit())
+                load,
+                super.visitStart(e),
+                newJump(expressions.makeNEQ(resultRegister, one), (Label) e.getThread().getExit())
         );
-	}
+    }
 
-	// =============================================================================================
+    // =============================================================================================
     // =========================================== C11 =============================================
     // =============================================================================================
 
-	@Override
-	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
-		Register resultRegister = e.getResultRegister();
+    @Override
+    public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
+        Register resultRegister = e.getResultRegister();
         Expression address = e.getAddress();
-		String mo = e.getMo();
-		Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
-		Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
+        String mo = e.getMo();
+        Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
+        Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
         Expression expectedAddr = e.getExpectedAddr();
         IntegerType type = resultRegister.getType();
         Expression one = expressions.makeOne(type);
@@ -129,168 +129,168 @@ class VisitorIMM extends VisitorBase {
                 loadValue,
                 casCmpResult,
                 branchOnCasCmpResult,
-				optionalFenceStore,
-                    storeValue,
-                    gotoCasEnd,
+                optionalFenceStore,
+                storeValue,
+                gotoCasEnd,
                 casFail,
-                    storeExpected,
+                storeExpected,
                 casEnd
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
-		Register resultRegister = e.getResultRegister();
-		IOpBin op = e.getOp();
+    @Override
+    public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
+        Register resultRegister = e.getResultRegister();
+        IOpBin op = e.getOp();
         Expression address = e.getAddress();
-		String mo = e.getMo();
-		Fence optionalFenceBefore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
-		Fence optionalFenceAfter = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
+        String mo = e.getMo();
+        Fence optionalFenceBefore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
+        Fence optionalFenceAfter = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 
         Register dummyReg = e.getThread().newRegister(resultRegister.getType());
         Load load = newRMWLoadWithMo(resultRegister, address, extractLoadMo(mo));
 
         return eventSequence(
-				optionalFenceBefore,
+                optionalFenceBefore,
                 load,
                 newLocal(dummyReg, expressions.makeBinary(resultRegister, op, e.getMemValue())),
-				optionalFenceAfter,
+                optionalFenceAfter,
                 newRMWStoreWithMo(load, address, dummyReg, extractStoreMo(mo))
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicLoad(AtomicLoad e) {
-		String mo = e.getMo();
-		Fence optionalFence = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
+    @Override
+    public List<Event> visitAtomicLoad(AtomicLoad e) {
+        String mo = e.getMo();
+        Fence optionalFence = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
         return eventSequence(
-				optionalFence,
-				newLoadWithMo(e.getResultRegister(), e.getAddress(), extractLoadMo(mo))
+                optionalFence,
+                newLoadWithMo(e.getResultRegister(), e.getAddress(), extractLoadMo(mo))
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicStore(AtomicStore e) {
-		String mo = e.getMo();
-		Fence optionalFence = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
+    @Override
+    public List<Event> visitAtomicStore(AtomicStore e) {
+        String mo = e.getMo();
+        Fence optionalFence = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
         return eventSequence(
-				optionalFence,
-				newStoreWithMo(e.getAddress(), e.getMemValue(), extractStoreMo(mo))
+                optionalFence,
+                newStoreWithMo(e.getAddress(), e.getMemValue(), extractStoreMo(mo))
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
-		return Collections.singletonList(newFence(e.getMo()));
-	}
+    @Override
+    public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
+        return Collections.singletonList(newFence(e.getMo()));
+    }
 
-	@Override
-	public List<Event> visitAtomicXchg(AtomicXchg e) {
+    @Override
+    public List<Event> visitAtomicXchg(AtomicXchg e) {
         Expression address = e.getAddress();
-		String mo = e.getMo();
-		Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
-		Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
+        String mo = e.getMo();
+        Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
+        Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 
-		Load load = newRMWLoadWithMo(e.getResultRegister(), address, mo);
+        Load load = newRMWLoadWithMo(e.getResultRegister(), address, mo);
 
         return eventSequence(
-				optionalFenceLoad,
+                optionalFenceLoad,
                 load,
                 optionalFenceStore,
                 newRMWStoreWithMo(load, address, e.getMemValue(), extractStoreMo(mo))
         );
-	}
+    }
 
     // =============================================================================================
     // =========================================== LLVM ============================================
     // =============================================================================================
 
-	@Override
-	public List<Event> visitLlvmLoad(LlvmLoad e) {
-		return eventSequence(
-				newLoadWithMo(e.getResultRegister(), e.getAddress(), IMM.extractLoadMo(e.getMo())));
-	}
+    @Override
+    public List<Event> visitLlvmLoad(LlvmLoad e) {
+        return eventSequence(
+                newLoadWithMo(e.getResultRegister(), e.getAddress(), IMM.extractLoadMo(e.getMo())));
+    }
 
-	@Override
-	public List<Event> visitLlvmStore(LlvmStore e) {
-		return eventSequence(
-				newStoreWithMo(e.getAddress(), e.getMemValue(), IMM.extractStoreMo(e.getMo())));
-	}
+    @Override
+    public List<Event> visitLlvmStore(LlvmStore e) {
+        return eventSequence(
+                newStoreWithMo(e.getAddress(), e.getMemValue(), IMM.extractStoreMo(e.getMo())));
+    }
 
-	@Override
-	public List<Event> visitLlvmXchg(LlvmXchg e) {
-		Register resultRegister = e.getResultRegister();
+    @Override
+    public List<Event> visitLlvmXchg(LlvmXchg e) {
+        Register resultRegister = e.getResultRegister();
         Expression value = e.getMemValue();
         Expression address = e.getAddress();
-		String mo = e.getMo();
+        String mo = e.getMo();
 
-		Load load = newRMWLoadExclusiveWithMo(resultRegister, address, IMM.extractLoadMo(mo));
-		Store store = newRMWStoreExclusiveWithMo(address, value, true, IMM.extractStoreMo(mo));
-		Label label = newLabel("FakeDep");
-		Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        Load load = newRMWLoadExclusiveWithMo(resultRegister, address, IMM.extractLoadMo(mo));
+        Store store = newRMWStoreExclusiveWithMo(address, value, true, IMM.extractStoreMo(mo));
+        Label label = newLabel("FakeDep");
+        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
-		return eventSequence(
-				load,
-				fakeCtrlDep,
-				label,
-				store);
-	}
+        return eventSequence(
+                load,
+                fakeCtrlDep,
+                label,
+                store);
+    }
 
-	@Override
-	public List<Event> visitLlvmRMW(LlvmRMW e) {
-		Register resultRegister = e.getResultRegister();
-		IOpBin op = e.getOp();
+    @Override
+    public List<Event> visitLlvmRMW(LlvmRMW e) {
+        Register resultRegister = e.getResultRegister();
+        IOpBin op = e.getOp();
         Expression value = e.getMemValue();
         Expression address = e.getAddress();
-		String mo = e.getMo();
+        String mo = e.getMo();
 
         Register dummyReg = e.getThread().newRegister(resultRegister.getType());
         Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
 
-		Load load = newRMWLoadExclusiveWithMo(resultRegister, address, IMM.extractLoadMo(mo));
-		Store store = newRMWStoreExclusiveWithMo(address, dummyReg, true, IMM.extractStoreMo(mo));
-		Label label = newLabel("FakeDep");
-		Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        Load load = newRMWLoadExclusiveWithMo(resultRegister, address, IMM.extractLoadMo(mo));
+        Store store = newRMWStoreExclusiveWithMo(address, dummyReg, true, IMM.extractStoreMo(mo));
+        Label label = newLabel("FakeDep");
+        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
-		return eventSequence(
-				load,
-				fakeCtrlDep,
-				label,
-				localOp,
-				store);
-	}
+        return eventSequence(
+                load,
+                fakeCtrlDep,
+                label,
+                localOp,
+                store);
+    }
 
-	@Override
-	public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
-		Register oldValueRegister = e.getStructRegister(0);
-		Register resultRegister = e.getStructRegister(1);
+    @Override
+    public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
+        Register oldValueRegister = e.getStructRegister(0);
+        Register resultRegister = e.getStructRegister(1);
         Expression one = expressions.makeOne(resultRegister.getType());
 
         Expression value = e.getMemValue();
         Expression address = e.getAddress();
-		String mo = e.getMo();
+        String mo = e.getMo();
         Expression expectedValue = e.getExpectedValue();
 
         Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, expectedValue));
-		Label casEnd = newLabel("CAS_end");
+        Label casEnd = newLabel("CAS_end");
         CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
 
-		Load load = newRMWLoadExclusiveWithMo(oldValueRegister, address, IMM.extractLoadMo(mo));
-		Store store = newRMWStoreExclusiveWithMo(address, value, true, IMM.extractStoreMo(mo));
+        Load load = newRMWLoadExclusiveWithMo(oldValueRegister, address, IMM.extractLoadMo(mo));
+        Store store = newRMWStoreExclusiveWithMo(address, value, true, IMM.extractStoreMo(mo));
 
-		return eventSequence(
-				// Indentation shows the branching structure
-				load,
-				casCmpResult,
-				branchOnCasCmpResult,
-                    store,
-				casEnd);
-	}
+        return eventSequence(
+                // Indentation shows the branching structure
+                load,
+                casCmpResult,
+                branchOnCasCmpResult,
+                store,
+                casEnd);
+    }
 
-	@Override
-	public List<Event> visitLlvmFence(LlvmFence e) {
-		return eventSequence(
-				newFence(e.getMo()));
-	}
+    @Override
+    public List<Event> visitLlvmFence(LlvmFence e) {
+        return eventSequence(
+                newFence(e.getMo()));
+    }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -123,7 +123,6 @@ class VisitorIMM extends VisitorBase {
         Store storeValue = newRMWStoreWithMo(loadValue, address, e.getMemValue(), extractStoreMo(mo));
 
         return eventSequence(
-                // Indentation shows the branching structure
                 loadExpected,
                 optionalFenceLoad,
                 loadValue,
@@ -208,13 +207,15 @@ class VisitorIMM extends VisitorBase {
     @Override
     public List<Event> visitLlvmLoad(LlvmLoad e) {
         return eventSequence(
-                newLoadWithMo(e.getResultRegister(), e.getAddress(), IMM.extractLoadMo(e.getMo())));
+                newLoadWithMo(e.getResultRegister(), e.getAddress(), IMM.extractLoadMo(e.getMo()))
+        );
     }
 
     @Override
     public List<Event> visitLlvmStore(LlvmStore e) {
         return eventSequence(
-                newStoreWithMo(e.getAddress(), e.getMemValue(), IMM.extractStoreMo(e.getMo())));
+                newStoreWithMo(e.getAddress(), e.getMemValue(), IMM.extractStoreMo(e.getMo()))
+        );
     }
 
     @Override
@@ -233,7 +234,8 @@ class VisitorIMM extends VisitorBase {
                 load,
                 fakeCtrlDep,
                 label,
-                store);
+                store
+        );
     }
 
     @Override
@@ -257,7 +259,8 @@ class VisitorIMM extends VisitorBase {
                 fakeCtrlDep,
                 label,
                 localOp,
-                store);
+                store
+        );
     }
 
     @Override
@@ -279,18 +282,19 @@ class VisitorIMM extends VisitorBase {
         Store store = newRMWStoreExclusiveWithMo(address, value, true, IMM.extractStoreMo(mo));
 
         return eventSequence(
-                // Indentation shows the branching structure
                 load,
                 casCmpResult,
                 branchOnCasCmpResult,
                 store,
-                casEnd);
+                casEnd
+        );
     }
 
     @Override
     public List<Event> visitLlvmFence(LlvmFence e) {
         return eventSequence(
-                newFence(e.getMo()));
+                newFence(e.getMo())
+        );
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -13,6 +13,7 @@ import com.dat3m.dartagnan.program.event.lang.pthread.Create;
 import com.dat3m.dartagnan.program.event.lang.pthread.End;
 import com.dat3m.dartagnan.program.event.lang.pthread.Join;
 import com.dat3m.dartagnan.program.event.lang.pthread.Start;
+import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 
 import java.util.Collections;
 import java.util.List;
@@ -31,17 +32,21 @@ class VisitorIMM extends VisitorBase {
 
 	@Override
 	public List<Event> visitLoad(Load e) {
-		String mo = e.getMo();
+		// FIXME: It is weird to compile a core-level load by transforming its tagging.
+		final MemoryOrder mo = e.getMetadata(MemoryOrder.class);
+		final boolean isNonAtomic = (mo == null || mo.value().equals(C11.NONATOMIC));
         return eventSequence(
-        		newLoad(e.getResultRegister(), e.getAddress(), mo.isEmpty() || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
+        		newLoad(e.getResultRegister(), e.getAddress(), isNonAtomic ? C11.MO_RELAXED : mo.value())
         );
 	}
 
 	@Override
 	public List<Event> visitStore(Store e) {
-		String mo = e.getMo();
+		// FIXME: It is weird to compile a core-level load by transforming its tagging.
+		final MemoryOrder mo = e.getMetadata(MemoryOrder.class);
+		final boolean isNonAtomic = (mo == null || mo.value().equals(C11.NONATOMIC));
         return eventSequence(
-        		newStore(e.getAddress(), e.getMemValue(), mo.isEmpty() || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
+        		newStore(e.getAddress(), e.getMemValue(), isNonAtomic ? C11.MO_RELAXED : mo.value())
         );
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
@@ -23,54 +23,54 @@ import static com.dat3m.dartagnan.program.event.EventFactory.*;
 
 public class VisitorLKMM extends VisitorBase {
 
-	protected VisitorLKMM(boolean forceStart) {
-		super(forceStart);
-        }
-	
-        @Override
-        public List<Event> visitCreate(Create e) {
-            Store store = newStore(e.getAddress(), e.getMemValue(), Tag.Linux.MO_RELEASE);
-            store.addTags(C11.PTHREAD);
-
-            return eventSequence(
-                    store
-            );
-        }
-
-        @Override
-        public List<Event> visitEnd(End e) {
-            return eventSequence(
-                    newStore(e.getAddress(), IValue.ZERO, Tag.Linux.MO_RELEASE)
-            );
-        }
+    protected VisitorLKMM(boolean forceStart) {
+        super(forceStart);
+    }
 
     @Override
-	public List<Event> visitJoin(Join e) {
+    public List<Event> visitCreate(Create e) {
+        Store store = newStore(e.getAddress(), e.getMemValue(), Tag.Linux.MO_RELEASE);
+        store.addTags(C11.PTHREAD);
+
+        return eventSequence(
+                store
+        );
+    }
+
+    @Override
+    public List<Event> visitEnd(End e) {
+        return eventSequence(
+                newStore(e.getAddress(), IValue.ZERO, Tag.Linux.MO_RELEASE)
+        );
+    }
+
+    @Override
+    public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
         Load load = newLoad(resultRegister, e.getAddress(), Tag.Linux.MO_ACQUIRE);
         load.addTags(C11.PTHREAD);
-        
+
         return eventSequence(
                 load,
-        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit())
+                newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit())
         );
-	}
+    }
 
     @Override
-	public List<Event> visitStart(Start e) {
+    public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
         Load load = newLoad(resultRegister, e.getAddress(), Tag.Linux.MO_ACQUIRE);
         load.addTags(Tag.STARTLOAD);
 
         return eventSequence(
                 load,
-			    super.visitStart(e),
-        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit())
+                super.visitStart(e),
+                newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit())
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWAddUnless(RMWAddUnless e) {
+    @Override
+    public List<Event> visitRMWAddUnless(RMWAddUnless e) {
         Register resultRegister = e.getResultRegister();
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
         ExprInterface cmp = e.getCmp();
@@ -82,22 +82,22 @@ public class VisitorLKMM extends VisitorBase {
         Load rmwLoad;
         return eventSequence(
                 newJump(new BNonDet(), success),
-                    newLoad(dummy, address, Tag.Linux.MO_ONCE),
-                    newAssume(new Atom(dummy, EQ, cmp)),
-                    newGoto(end),
+                newLoad(dummy, address, Tag.Linux.MO_ONCE),
+                newAssume(new Atom(dummy, EQ, cmp)),
+                newGoto(end),
                 success, // RMW success branch
-                    Linux.newMemoryBarrier(),
-                    rmwLoad = newRMWLoad(dummy, address, Tag.Linux.MO_ONCE),
-                    newAssume(new Atom(dummy, NEQ, cmp)),
-                    newRMWStore(rmwLoad, address, new IExprBin(dummy, IOpBin.PLUS, (IExpr) value), Tag.Linux.MO_ONCE),
-                    Linux.newMemoryBarrier(),
+                Linux.newMemoryBarrier(),
+                rmwLoad = newRMWLoad(dummy, address, Tag.Linux.MO_ONCE),
+                newAssume(new Atom(dummy, NEQ, cmp)),
+                newRMWStore(rmwLoad, address, new IExprBin(dummy, IOpBin.PLUS, (IExpr) value), Tag.Linux.MO_ONCE),
+                Linux.newMemoryBarrier(),
                 end,
                 newLocal(resultRegister, new Atom(dummy, NEQ, cmp))
         );
     }
 
-	@Override
-	public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
+    @Override
+    public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
         Register resultRegister = e.getResultRegister();
         ExprInterface cmp = e.getCmp();
         ExprInterface value = e.getMemValue();
@@ -110,30 +110,30 @@ public class VisitorLKMM extends VisitorBase {
         Load casLoad;
         return eventSequence(
                 newJump(new BNonDet(), success),
-                    newLoad(dummy, address, Tag.Linux.MO_ONCE),
-                    newAssume(new Atom(dummy, NEQ, cmp)),
-                    newGoto(end),
+                newLoad(dummy, address, Tag.Linux.MO_ONCE),
+                newAssume(new Atom(dummy, NEQ, cmp)),
+                newGoto(end),
                 success, // CAS success branch
-                    mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
-                    casLoad = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo)),
-                    newAssume(new Atom(dummy, EQ, cmp)),
-                    newRMWStore(casLoad, address, value, Tag.Linux.storeMO(mo)),
-                    mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
+                mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
+                casLoad = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo)),
+                newAssume(new Atom(dummy, EQ, cmp)),
+                newRMWStore(casLoad, address, value, Tag.Linux.storeMO(mo)),
+                mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
                 end,
                 newLocal(resultRegister, dummy)
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWFetchOp(RMWFetchOp e) {
+    @Override
+    public List<Event> visitRMWFetchOp(RMWFetchOp e) {
         Register resultRegister = e.getResultRegister();
         String mo = e.getMo();
         IExpr address = e.getAddress();
         ExprInterface value = e.getMemValue();
 
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-		Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
-		Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
+        Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
+        Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
         Fence optionalMbAfter = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
 
         return eventSequence(
@@ -143,31 +143,31 @@ public class VisitorLKMM extends VisitorBase {
                 newLocal(resultRegister, dummy),
                 optionalMbAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWOp(RMWOp e) {
+    @Override
+    public List<Event> visitRMWOp(RMWOp e) {
         IExpr address = e.getAddress();
         Register resultRegister = e.getResultRegister();
-		
+
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
         Load load = newRMWLoad(dummy, address, Tag.Linux.MO_ONCE);
         load.addTags(Tag.Linux.NORETURN);
-        
+
         return eventSequence(
                 load,
                 newRMWStore(load, address, new IExprBin(dummy, e.getOp(), (IExpr) e.getMemValue()), Tag.Linux.MO_ONCE)
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
+    @Override
+    public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
         Register resultRegister = e.getResultRegister();
         IExpr address = e.getAddress();
         int precision = resultRegister.getPrecision();
-        
-		Register dummy = e.getThread().newRegister(precision);
-		Load load = newRMWLoad(dummy, address, Tag.Linux.MO_ONCE);
+
+        Register dummy = e.getThread().newRegister(precision);
+        Load load = newRMWLoad(dummy, address, Tag.Linux.MO_ONCE);
 
         return eventSequence(
                 Linux.newMemoryBarrier(),
@@ -177,17 +177,17 @@ public class VisitorLKMM extends VisitorBase {
                 newLocal(resultRegister, new Atom(dummy, EQ, new IValue(BigInteger.ZERO, precision))),
                 Linux.newMemoryBarrier()
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWOpReturn(RMWOpReturn e) {
+    @Override
+    public List<Event> visitRMWOpReturn(RMWOpReturn e) {
         Register resultRegister = e.getResultRegister();
         IExpr address = e.getAddress();
         String mo = e.getMo();
-        
-		Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-		Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
-		Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
+
+        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
+        Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
+        Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
         Fence optionalMbAfter = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
 
         return eventSequence(
@@ -198,17 +198,17 @@ public class VisitorLKMM extends VisitorBase {
                 newLocal(resultRegister, dummy),
                 optionalMbAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWXchg(RMWXchg e) {
+    @Override
+    public List<Event> visitRMWXchg(RMWXchg e) {
         Register resultRegister = e.getResultRegister();
         String mo = e.getMo();
         IExpr address = e.getAddress();
 
         Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-		Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
-		Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
+        Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
+        Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
         Fence optionalMbAfter = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
 
         return eventSequence(
@@ -218,20 +218,20 @@ public class VisitorLKMM extends VisitorBase {
                 newLocal(resultRegister, dummy),
                 optionalMbAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitLKMMLock(LKMMLock e) {
-		Register dummy = e.getThread().newRegister(GlobalSettings.getArchPrecision());
+    @Override
+    public List<Event> visitLKMMLock(LKMMLock e) {
+        Register dummy = e.getThread().newRegister(GlobalSettings.getArchPrecision());
         // In litmus tests, spin locks are guaranteed to succeed, i.e. its read part gets value 0
         Load lockRead = Linux.newLockRead(dummy, e.getLock());
-		Event middle = e.getThread().getProgram().getFormat().equals(LITMUS) ?
-				newAssume(new Atom(dummy, EQ, IValue.ZERO)) :
-				newJump(new Atom(dummy, NEQ, IValue.ZERO), (Label)e.getThread().getExit());
-		return eventSequence(
+        Event middle = e.getThread().getProgram().getFormat().equals(LITMUS) ?
+                newAssume(new Atom(dummy, EQ, IValue.ZERO)) :
+                newJump(new Atom(dummy, NEQ, IValue.ZERO), (Label) e.getThread().getExit());
+        return eventSequence(
                 lockRead,
                 middle,
                 Linux.newLockWrite(lockRead, e.getLock())
         );
-	}
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
@@ -35,13 +35,13 @@ public class VisitorLKMM extends VisitorBase {
         );
     }
 
-        @Override
-        public List<Event> visitEnd(End e) {
-            //TODO boolean
-            return eventSequence(
-                    newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), Tag.Linux.MO_RELEASE)
-            );
-        }
+    @Override
+    public List<Event> visitEnd(End e) {
+        //TODO boolean
+        return eventSequence(
+                newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), Tag.Linux.MO_RELEASE)
+        );
+    }
 
     @Override
     public List<Event> visitJoin(Join e) {
@@ -83,15 +83,15 @@ public class VisitorLKMM extends VisitorBase {
         Load rmwLoad;
         return eventSequence(
                 newJump(new BNonDet(), success),
-                    newLoadWithMo(dummy, address, Tag.Linux.MO_ONCE),
-                    newAssume(expressions.makeEQ(dummy, cmp)),
-                    newGoto(end),
+                newLoadWithMo(dummy, address, Tag.Linux.MO_ONCE),
+                newAssume(expressions.makeEQ(dummy, cmp)),
+                newGoto(end),
                 success, // RMW success branch
-                    Linux.newMemoryBarrier(),
-                    rmwLoad = newRMWLoadWithMo(dummy, address, Tag.Linux.MO_ONCE),
-                    newAssume(expressions.makeNEQ(dummy, cmp)),
-                    newRMWStoreWithMo(rmwLoad, address, expressions.makeADD(dummy, value), Tag.Linux.MO_ONCE),
-                    Linux.newMemoryBarrier(),
+                Linux.newMemoryBarrier(),
+                rmwLoad = newRMWLoadWithMo(dummy, address, Tag.Linux.MO_ONCE),
+                newAssume(expressions.makeNEQ(dummy, cmp)),
+                newRMWStoreWithMo(rmwLoad, address, expressions.makeADD(dummy, value), Tag.Linux.MO_ONCE),
+                Linux.newMemoryBarrier(),
                 end,
                 newLocal(resultRegister, expressions.makeNEQ(dummy, cmp))
         );
@@ -111,15 +111,15 @@ public class VisitorLKMM extends VisitorBase {
         Load casLoad;
         return eventSequence(
                 newJump(new BNonDet(), success),
-                    newLoadWithMo(dummy, address, Tag.Linux.MO_ONCE),
-                    newAssume(expressions.makeNEQ(dummy, cmp)),
-                    newGoto(end),
+                newLoadWithMo(dummy, address, Tag.Linux.MO_ONCE),
+                newAssume(expressions.makeNEQ(dummy, cmp)),
+                newGoto(end),
                 success, // CAS success branch
-                    mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
-                    casLoad = newRMWLoadWithMo(dummy, address, Tag.Linux.loadMO(mo)),
-                    newAssume(expressions.makeEQ(dummy, cmp)),
-                    newRMWStoreWithMo(casLoad, address, value, Tag.Linux.storeMO(mo)),
-                    mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
+                mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
+                casLoad = newRMWLoadWithMo(dummy, address, Tag.Linux.loadMO(mo)),
+                newAssume(expressions.makeEQ(dummy, cmp)),
+                newRMWStoreWithMo(casLoad, address, value, Tag.Linux.storeMO(mo)),
+                mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
                 end,
                 newLocal(resultRegister, dummy)
         );
@@ -229,7 +229,7 @@ public class VisitorLKMM extends VisitorBase {
         Load lockRead = Linux.newLockRead(dummy, e.getLock());
         Event middle = e.getThread().getProgram().getFormat().equals(LITMUS) ?
                 newAssume(expressions.makeEQ(dummy, zero)) :
-                newJump(expressions.makeNEQ(dummy, zero), (Label)e.getThread().getExit());
+                newJump(expressions.makeNEQ(dummy, zero), (Label) e.getThread().getExit());
         return eventSequence(
                 lockRead,
                 middle,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -19,51 +19,51 @@ import static com.dat3m.dartagnan.program.processing.compilation.VisitorPower.Po
 
 public class VisitorPower extends VisitorBase {
 
-	// The compilation schemes below follows the paper
-	// "Clarifying and Compiling C/C++ Concurrency: from C++11 to POWER"
-	// The paper does not define the mappings for RMW, but we derive them
-	// using the same pattern as for Load/Store
-	private final PowerScheme cToPowerScheme;
-	// Some language memory models (e.g. RC11) are non-dependency tracking and might need a
-	// strong version of no-OOTA, thus we need to strength the compilation following the papers
-	// "Repairing Sequential Consistency in C/C++11"
-	// "Outlawing Ghosts: Avoiding Out-of-Thin-Air Results"
-	private final boolean useRC11Scheme;
+    // The compilation schemes below follows the paper
+    // "Clarifying and Compiling C/C++ Concurrency: from C++11 to POWER"
+    // The paper does not define the mappings for RMW, but we derive them
+    // using the same pattern as for Load/Store
+    private final PowerScheme cToPowerScheme;
+    // Some language memory models (e.g. RC11) are non-dependency tracking and might need a
+    // strong version of no-OOTA, thus we need to strength the compilation following the papers
+    // "Repairing Sequential Consistency in C/C++11"
+    // "Outlawing Ghosts: Avoiding Out-of-Thin-Air Results"
+    private final boolean useRC11Scheme;
 
-	protected VisitorPower(boolean forceStart, boolean useRC11Scheme, PowerScheme cToPowerScheme) {
-		super(forceStart);
-		this.useRC11Scheme = useRC11Scheme;
-		this.cToPowerScheme = cToPowerScheme;
-	}
+    protected VisitorPower(boolean forceStart, boolean useRC11Scheme, PowerScheme cToPowerScheme) {
+        super(forceStart);
+        this.useRC11Scheme = useRC11Scheme;
+        this.cToPowerScheme = cToPowerScheme;
+    }
 
-	// =============================================================================================
+    // =============================================================================================
     // ========================================= PTHREAD ===========================================
     // =============================================================================================
 
     @Override
-	public List<Event> visitCreate(Create e) {
-        Store store = newStoreWithMo(e.getAddress(), e.getMemValue(), e.getMo());
+    public List<Event> visitCreate(Create e) {
+        Store store = newStore(e.getAddress(), e.getMemValue());
         store.addTags(C11.PTHREAD);
 
         return eventSequence(
                 Power.newSyncBarrier(),
                 store
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitEnd(End e) {
+    @Override
+    public List<Event> visitEnd(End e) {
         return eventSequence(
-				Power.newSyncBarrier(),
-				newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), e.getMo())
+                Power.newSyncBarrier(),
+                newStore(e.getAddress(), expressions.makeZero(types.getArchType()))
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitJoin(Join e) {
+    @Override
+    public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-		Expression zero = expressions.makeZero(resultRegister.getType());
-		Load load = newLoad(resultRegister, e.getAddress());
+        Expression zero = expressions.makeZero(resultRegister.getType());
+        Load load = newLoad(resultRegister, e.getAddress());
         load.addTags(C11.PTHREAD);
         Label label = newLabel("Jump_" + e.getGlobalId());
         CondJump fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
@@ -75,45 +75,45 @@ public class VisitorPower extends VisitorBase {
                 Power.newISyncBarrier(),
                 newJump(expressions.makeNEQ(resultRegister, zero), (Label) e.getThread().getExit())
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitStart(Start e) {
+    @Override
+    public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
-		Expression one = expressions.makeOne(resultRegister.getType());
-        Load load = newLoadWithMo(resultRegister, e.getAddress(), e.getMo());
-		load.addTags(Tag.STARTLOAD);
-		Label label = newLabel("Jump_" + e.getGlobalId());
+        Expression one = expressions.makeOne(resultRegister.getType());
+        Load load = newLoad(resultRegister, e.getAddress());
+        load.addTags(Tag.STARTLOAD);
+        Label label = newLabel("Jump_" + e.getGlobalId());
         CondJump fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
-		return eventSequence(
+        return eventSequence(
                 load,
                 fakeCtrlDep,
                 label,
                 Power.newISyncBarrier(),
-				super.visitStart(e),
+                super.visitStart(e),
                 newJump(expressions.makeNEQ(resultRegister, one), (Label) e.getThread().getExit())
         );
-	}
+    }
 
     @Override
     public List<Event> visitInitLock(InitLock e) {
         return eventSequence(
                 Power.newLwSyncBarrier(),
-                newStoreWithMo(e.getAddress(), e.getMemValue(), ""));
+                newStore(e.getAddress(), e.getMemValue()));
     }
 
     @Override
     public List<Event> visitLock(Lock e) {
         Register dummy = e.getThread().newRegister(types.getArchType());
-		Expression zero = expressions.makeZero(dummy.getType());
+        Expression zero = expressions.makeZero(dummy.getType());
         Label label = newLabel("FakeDep");
         // We implement locks as spinlocks which are guaranteed to succeed, i.e. we can
         // use assumes. The fake control dependency + isync guarantee acquire semantics.
         return eventSequence(
                 newRMWLoadExclusive(dummy, e.getAddress()),
                 newAssume(expressions.makeEQ(dummy, zero)),
-                Power.newRMWStoreConditional(e.getAddress(), expressions.makeOne(types.getArchType()), "", true),
+                Power.newRMWStoreConditional(e.getAddress(), expressions.makeOne(types.getArchType()), true),
                 // Fake dependency to guarantee acquire semantics
                 newFakeCtrlDep(dummy, label),
                 label,
@@ -126,255 +126,255 @@ public class VisitorPower extends VisitorBase {
                 Power.newLwSyncBarrier(),
                 newStore(e.getAddress(), expressions.makeZero(types.getArchType())));
     }
-    
+
     // =============================================================================================
     // =========================================== LLVM ============================================
     // =============================================================================================
 
-	@Override
-	public List<Event> visitLlvmLoad(LlvmLoad e) {
-		Register resultRegister = e.getResultRegister();
+    @Override
+    public List<Event> visitLlvmLoad(LlvmLoad e) {
+        Register resultRegister = e.getResultRegister();
 
-		Fence optionalBarrierBefore = null;
-		Load load = newLoad(resultRegister, e.getAddress());
-		Label optionalLabel = null;
-		CondJump optionalFakeCtrlDep = null;
-		Fence optionalBarrierAfter = null;
+        Fence optionalBarrierBefore = null;
+        Load load = newLoad(resultRegister, e.getAddress());
+        Label optionalLabel = null;
+        CondJump optionalFakeCtrlDep = null;
+        Fence optionalBarrierAfter = null;
 
-		switch (e.getMo()) {
-			case C11.MO_SC:
-				if (cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-					optionalLabel = newLabel("FakeDep");
-					optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
-					optionalBarrierAfter = Power.newISyncBarrier();
-				} else {
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_ACQUIRE:
-				optionalLabel = newLabel("FakeDep");
-				optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-			case C11.MO_RELAXED:
-				if (useRC11Scheme) {
-					optionalLabel = newLabel("FakeDep");
-					optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
-				}
-				break;
-		}
+        switch (e.getMo()) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                    optionalLabel = newLabel("FakeDep");
+                    optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
+                    optionalBarrierAfter = Power.newISyncBarrier();
+                } else {
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_ACQUIRE:
+                optionalLabel = newLabel("FakeDep");
+                optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+            case C11.MO_RELAXED:
+                if (useRC11Scheme) {
+                    optionalLabel = newLabel("FakeDep");
+                    optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
+                }
+                break;
+        }
 
-		return eventSequence(
-				optionalBarrierBefore,
-				load,
-				optionalFakeCtrlDep,
-				optionalLabel,
-				optionalBarrierAfter);
-	}
+        return eventSequence(
+                optionalBarrierBefore,
+                load,
+                optionalFakeCtrlDep,
+                optionalLabel,
+                optionalBarrierAfter);
+    }
 
-	@Override
-	public List<Event> visitLlvmStore(LlvmStore e) {
-		Fence optionalBarrierBefore = null;
-		Store store = newStore(e.getAddress(), e.getMemValue());
-		Fence optionalBarrierAfter = null;
+    @Override
+    public List<Event> visitLlvmStore(LlvmStore e) {
+        Fence optionalBarrierBefore = null;
+        Store store = newStore(e.getAddress(), e.getMemValue());
+        Fence optionalBarrierAfter = null;
 
-		switch (e.getMo()) {
-			case C11.MO_SC:
-				if (cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-				} else {
-					optionalBarrierBefore = Power.newLwSyncBarrier();
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				break;
-		}
+        switch (e.getMo()) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                } else {
+                    optionalBarrierBefore = Power.newLwSyncBarrier();
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                break;
+        }
 
-		return eventSequence(
-				optionalBarrierBefore,
-				store,
-				optionalBarrierAfter);
-	}
+        return eventSequence(
+                optionalBarrierBefore,
+                store,
+                optionalBarrierAfter);
+    }
 
-	@Override
-	public List<Event> visitLlvmXchg(LlvmXchg e) {
-		Register resultRegister = e.getResultRegister();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitLlvmXchg(LlvmXchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		// Power does not have mo tags, thus we use null
-		Load load = newRMWLoadExclusive(resultRegister, address);
-		Store store = Power.newRMWStoreConditional(address, e.getMemValue(), "",  true);
-		Label label = newLabel("FakeDep");
-		Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        // Power does not have mo tags, thus we use null
+        Load load = newRMWLoadExclusive(resultRegister, address);
+        Store store = Power.newRMWStoreConditional(address, e.getMemValue(), true);
+        Label label = newLabel("FakeDep");
+        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
-		Fence optionalBarrierBefore = null;
-		Fence optionalBarrierAfter = null;
+        Fence optionalBarrierBefore = null;
+        Fence optionalBarrierAfter = null;
 
-		switch (mo) {
-			case C11.MO_SC:
-				if (cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-					optionalBarrierAfter = Power.newISyncBarrier();
-				} else {
-					optionalBarrierBefore = Power.newLwSyncBarrier();
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_ACQUIRE:
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-			case C11.MO_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				break;
-			case C11.MO_ACQUIRE_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-		}
+        switch (mo) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                    optionalBarrierAfter = Power.newISyncBarrier();
+                } else {
+                    optionalBarrierBefore = Power.newLwSyncBarrier();
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_ACQUIRE:
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+            case C11.MO_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                break;
+            case C11.MO_ACQUIRE_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+        }
 
-		return eventSequence(
-				optionalBarrierBefore,
-				load,
-				fakeCtrlDep,
-				label,
-				store,
-				optionalBarrierAfter);
-	}
+        return eventSequence(
+                optionalBarrierBefore,
+                load,
+                fakeCtrlDep,
+                label,
+                store,
+                optionalBarrierAfter);
+    }
 
-	@Override
-	public List<Event> visitLlvmRMW(LlvmRMW e) {
-		Register resultRegister = e.getResultRegister();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitLlvmRMW(LlvmRMW e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
-		Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, e.getOp(), e.getMemValue()));
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+        Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, e.getOp(), e.getMemValue()));
 
-		// Power does not have mo tags, thus we use null
-		Load load = newRMWLoadExclusive(resultRegister, address);
-		Store store = Power.newRMWStoreConditional(address, dummyReg, "", true);
-		Label label = newLabel("FakeDep");
-		Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        // Power does not have mo tags, thus we use null
+        Load load = newRMWLoadExclusive(resultRegister, address);
+        Store store = Power.newRMWStoreConditional(address, dummyReg, true);
+        Label label = newLabel("FakeDep");
+        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
-		Fence optionalBarrierBefore = null;
-		// Academics papers (e.g. https://plv.mpi-sws.org/imm/paper.pdf) say an isync
-		// barrier is enough
-		// However, power compilers in godbolt.org use a lwsync.
-		// We stick to the literature to potentially find bugs in what researchers
-		// claim.
-		Fence optionalBarrierAfter = null;
+        Fence optionalBarrierBefore = null;
+        // Academics papers (e.g. https://plv.mpi-sws.org/imm/paper.pdf) say an isync
+        // barrier is enough
+        // However, power compilers in godbolt.org use a lwsync.
+        // We stick to the literature to potentially find bugs in what researchers
+        // claim.
+        Fence optionalBarrierAfter = null;
 
-		switch (mo) {
-			case C11.MO_SC:
-				if (cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-					optionalBarrierAfter = Power.newISyncBarrier();
-				} else {
-					optionalBarrierBefore = Power.newLwSyncBarrier();
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_ACQUIRE:
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-			case C11.MO_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				break;
-			case C11.MO_ACQUIRE_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-		}
+        switch (mo) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                    optionalBarrierAfter = Power.newISyncBarrier();
+                } else {
+                    optionalBarrierBefore = Power.newLwSyncBarrier();
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_ACQUIRE:
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+            case C11.MO_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                break;
+            case C11.MO_ACQUIRE_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+        }
 
-		return eventSequence(
-				optionalBarrierBefore,
-				load,
-				fakeCtrlDep,
-				label,
-				localOp,
-				store,
-				optionalBarrierAfter);
-	}
+        return eventSequence(
+                optionalBarrierBefore,
+                load,
+                fakeCtrlDep,
+                label,
+                localOp,
+                store,
+                optionalBarrierAfter);
+    }
 
-	@Override
-	public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
-		Register oldValueRegister = e.getStructRegister(0);
-		Register resultRegister = e.getStructRegister(1);
+    @Override
+    public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
+        Register oldValueRegister = e.getStructRegister(0);
+        Register resultRegister = e.getStructRegister(1);
 
-		Expression one = expressions.makeOne(resultRegister.getType());
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+        Expression one = expressions.makeOne(resultRegister.getType());
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, e.getExpectedValue()));
-		Label casEnd = newLabel("CAS_end");
-		CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, e.getExpectedValue()));
+        Label casEnd = newLabel("CAS_end");
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
 
-		Load load = newRMWLoadExclusiveWithMo(oldValueRegister, address, "");
-		Store store = Power.newRMWStoreConditional(address, e.getMemValue(), "", true);
+        Load load = newRMWLoadExclusive(oldValueRegister, address);
+        Store store = Power.newRMWStoreConditional(address, e.getMemValue(), true);
 
-		Fence optionalBarrierBefore = null;
-		Fence optionalBarrierAfter = null;
+        Fence optionalBarrierBefore = null;
+        Fence optionalBarrierAfter = null;
 
-		switch (mo) {
-			case C11.MO_SC:
-				if (cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-					optionalBarrierAfter = Power.newISyncBarrier();
-				} else {
-					optionalBarrierBefore = Power.newLwSyncBarrier();
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_ACQUIRE:
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-			case C11.MO_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				break;
-			case C11.MO_ACQUIRE_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-		}
+        switch (mo) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                    optionalBarrierAfter = Power.newISyncBarrier();
+                } else {
+                    optionalBarrierBefore = Power.newLwSyncBarrier();
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_ACQUIRE:
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+            case C11.MO_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                break;
+            case C11.MO_ACQUIRE_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+        }
 
-		return eventSequence(
-				// Indentation shows the branching structure
-				optionalBarrierBefore,
-				load,
-				casCmpResult,
-				branchOnCasCmpResult,
-				store,
-				casEnd,
-				optionalBarrierAfter);
-	}
+        return eventSequence(
+                // Indentation shows the branching structure
+                optionalBarrierBefore,
+                load,
+                casCmpResult,
+                branchOnCasCmpResult,
+                store,
+                casEnd,
+                optionalBarrierAfter);
+    }
 
-	@Override
-	public List<Event> visitLlvmFence(LlvmFence e) {
-		Fence fence = e.getMo().equals(Tag.C11.MO_SC) ? Power.newSyncBarrier() : Power.newLwSyncBarrier();
+    @Override
+    public List<Event> visitLlvmFence(LlvmFence e) {
+        Fence fence = e.getMo().equals(Tag.C11.MO_SC) ? Power.newSyncBarrier() : Power.newLwSyncBarrier();
 
-		return eventSequence(
-				fence);
-	}
+        return eventSequence(
+                fence);
+    }
 
     // =============================================================================================
     // ============================================ C11 ============================================
     // =============================================================================================
 
-	@Override
-	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
-		Register resultRegister = e.getResultRegister();
-		Expression one = expressions.makeOne(resultRegister.getType());
-		Expression address = e.getAddress();
-		Expression value = e.getMemValue();
-		String mo = e.getMo();
-		Expression expectedAddr = e.getExpectedAddr();
-		IntegerType type = resultRegister.getType();
+    @Override
+    public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression one = expressions.makeOne(resultRegister.getType());
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        String mo = e.getMo();
+        Expression expectedAddr = e.getExpectedAddr();
+        IntegerType type = resultRegister.getType();
 
-		Register regExpected = e.getThread().newRegister(type);
+        Register regExpected = e.getThread().newRegister(type);
         Register regValue = e.getThread().newRegister(type);
         Load loadExpected = newLoad(regExpected, expectedAddr);
         Store storeExpected = newStore(expectedAddr, regValue);
@@ -385,8 +385,8 @@ public class VisitorPower extends VisitorBase {
         CondJump gotoCasEnd = newGoto(casEnd);
 
         // Power does not have mo tags, thus we use the emptz string
-        Load loadValue = newRMWLoadExclusiveWithMo(regValue, address, "");
-        Store storeValue = Power.newRMWStoreConditional(address, value, "", e.isStrong());
+        Load loadValue = newRMWLoadExclusive(regValue, address);
+        Store storeValue = Power.newRMWStoreConditional(address, value, e.isStrong());
         ExecutionStatus optionalExecStatus = null;
         Local optionalUpdateCasCmpResult = null;
         if (e.isWeak()) {
@@ -397,28 +397,28 @@ public class VisitorPower extends VisitorBase {
 
         Fence optionalBarrierBefore = null;
         Fence optionalBarrierAfter = null;
-        
-        switch(mo) {
-			case C11.MO_SC:
-				if(cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-					optionalBarrierAfter = Power.newISyncBarrier();
-				} else {
-					optionalBarrierBefore = Power.newLwSyncBarrier();
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_ACQUIRE:
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-			case C11.MO_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				break;
-			case C11.MO_ACQUIRE_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-		}
+
+        switch (mo) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                    optionalBarrierAfter = Power.newISyncBarrier();
+                } else {
+                    optionalBarrierBefore = Power.newLwSyncBarrier();
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_ACQUIRE:
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+            case C11.MO_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                break;
+            case C11.MO_ACQUIRE_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+        }
 
         return eventSequence(
                 // Indentation shows the branching structure
@@ -427,31 +427,30 @@ public class VisitorPower extends VisitorBase {
                 loadValue,
                 casCmpResult,
                 branchOnCasCmpResult,
-                    storeValue,
-                    optionalExecStatus,
-                    optionalUpdateCasCmpResult,
-                    gotoCasEnd,
+                storeValue,
+                optionalExecStatus,
+                optionalUpdateCasCmpResult,
+                gotoCasEnd,
                 casFail,
-                    storeExpected,
+                storeExpected,
                 casEnd,
                 optionalBarrierAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
-		Register resultRegister = e.getResultRegister();
-		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
+        Register resultRegister = e.getResultRegister();
+        IOpBin op = e.getOp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
         Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
 
-        // Power does not have mo tags, thus we use the emptz string
-        Load load = newRMWLoadExclusiveWithMo(resultRegister, address, "");
-        Store store = Power.newRMWStoreConditional(address, dummyReg, "", true);
+        Load load = newRMWLoadExclusive(resultRegister, address);
+        Store store = Power.newRMWStoreConditional(address, dummyReg , true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
@@ -460,31 +459,31 @@ public class VisitorPower extends VisitorBase {
         // However, power compilers in godbolt.org use a lwsync.
         // We stick to the literature to potentially find bugs in what researchers claim.
         Fence optionalBarrierAfter = null;
-        
-        switch(mo) {
-			case C11.MO_SC:
-				if(cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-					optionalBarrierAfter = Power.newISyncBarrier();
-				} else {
-					optionalBarrierBefore = Power.newLwSyncBarrier();
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_ACQUIRE:
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-			case C11.MO_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				break;
-			case C11.MO_ACQUIRE_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-		}
+
+        switch (mo) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                    optionalBarrierAfter = Power.newISyncBarrier();
+                } else {
+                    optionalBarrierBefore = Power.newLwSyncBarrier();
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_ACQUIRE:
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+            case C11.MO_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                break;
+            case C11.MO_ACQUIRE_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+        }
 
         return eventSequence(
-				optionalBarrierBefore,
+                optionalBarrierBefore,
                 load,
                 fakeCtrlDep,
                 label,
@@ -492,43 +491,43 @@ public class VisitorPower extends VisitorBase {
                 store,
                 optionalBarrierAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicLoad(AtomicLoad e) {
-		Register resultRegister = e.getResultRegister();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitAtomicLoad(AtomicLoad e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Fence optionalBarrierBefore = null;
-        Load load = newLoadWithMo(resultRegister, address, mo);
+        Fence optionalBarrierBefore = null;
+        Load load = newLoad(resultRegister, address);
         Label optionalLabel = null;
         CondJump optionalFakeCtrlDep = null;
         Fence optionalBarrierAfter = null;
-        
-        switch(mo) {
-			case C11.MO_SC:
-				if(cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-					optionalLabel = newLabel("FakeDep");
-					optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
-					optionalBarrierAfter = Power.newISyncBarrier();
-				} else {
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_ACQUIRE:
-				optionalLabel = newLabel("FakeDep");
-				optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-			case C11.MO_RELAXED:
-				if(useRC11Scheme) {
-					optionalLabel = newLabel("FakeDep");
-					optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
-				}
-				break;
-		}
+
+        switch (mo) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                    optionalLabel = newLabel("FakeDep");
+                    optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
+                    optionalBarrierAfter = Power.newISyncBarrier();
+                } else {
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_ACQUIRE:
+                optionalLabel = newLabel("FakeDep");
+                optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+            case C11.MO_RELAXED:
+                if (useRC11Scheme) {
+                    optionalLabel = newLabel("FakeDep");
+                    optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
+                }
+                break;
+        }
 
         return eventSequence(
                 optionalBarrierBefore,
@@ -537,253 +536,249 @@ public class VisitorPower extends VisitorBase {
                 optionalLabel,
                 optionalBarrierAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicStore(AtomicStore e) {
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitAtomicStore(AtomicStore e) {
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
         Fence optionalBarrierBefore = null;
-        Store store = newStoreWithMo(address, value, mo);
+        Store store = newStore(address, value);
         Fence optionalBarrierAfter = null;
-        
-        switch(mo) {
-			case C11.MO_SC:
-				if(cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-				} else {
-					optionalBarrierBefore = Power.newLwSyncBarrier();
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				break;
+
+        switch (mo) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                } else {
+                    optionalBarrierBefore = Power.newLwSyncBarrier();
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                break;
         }
-        
+
         return eventSequence(
                 optionalBarrierBefore,
                 store,
                 optionalBarrierAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
+        String mo = e.getMo();
         Fence fence = mo.equals(Tag.C11.MO_SC) ? Power.newSyncBarrier() : Power.newLwSyncBarrier();
 
         return eventSequence(
                 fence
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicXchg(AtomicXchg e) {
-		Register resultRegister = e.getResultRegister();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitAtomicXchg(AtomicXchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-        // Power does not have mo tags, thus we use the emptz string
-        Load load = newRMWLoadExclusiveWithMo(resultRegister, address, "");
-        Store store = Power.newRMWStoreConditional(address, value, "", true);
+        Load load = newRMWLoadExclusive(resultRegister, address);
+        Store store = Power.newRMWStoreConditional(address, value, true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
         Fence optionalBarrierBefore = null;
         Fence optionalBarrierAfter = null;
-        
-        switch(mo) {
-			case C11.MO_SC:
-				if(cToPowerScheme.equals(LEADING_SYNC)) {
-					optionalBarrierBefore = Power.newSyncBarrier();
-					optionalBarrierAfter = Power.newISyncBarrier();
-				} else {
-					optionalBarrierBefore = Power.newLwSyncBarrier();
-					optionalBarrierAfter = Power.newSyncBarrier();
-				}
-				break;
-			case C11.MO_ACQUIRE:
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-			case C11.MO_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				break;
-			case C11.MO_ACQUIRE_RELEASE:
-				optionalBarrierBefore = Power.newLwSyncBarrier();
-				optionalBarrierAfter = Power.newISyncBarrier();
-				break;
-		}
-        
+
+        switch (mo) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                    optionalBarrierAfter = Power.newISyncBarrier();
+                } else {
+                    optionalBarrierBefore = Power.newLwSyncBarrier();
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_ACQUIRE:
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+            case C11.MO_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                break;
+            case C11.MO_ACQUIRE_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+        }
+
         return eventSequence(
-				optionalBarrierBefore,
+                optionalBarrierBefore,
                 load,
                 fakeCtrlDep,
                 label,
                 store,
                 optionalBarrierAfter
         );
-	}
+    }
 
     // =============================================================================================
     // =========================================== LKMM ============================================
     // =============================================================================================
 
-	// Following
+    // Following
 	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
-	@Override
-	public List<Event> visitLKMMLoad(LKMMLoad e) {
-		Register resultRegister = e.getResultRegister();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitLKMMLoad(LKMMLoad e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		// Power does not have mo tags, thus we use the empty string
+        // Power does not have mo tags, thus we use the empty string
         Load load = newLoad(resultRegister, address);
         Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newLwSyncBarrier() : null;
-        
+
         return eventSequence(
                 load,
                 optionalMemoryBarrier
         );
-	}
+    }
 
-	// Following
+    // Following
 	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
-	@Override
-	public List<Event> visitLKMMStore(LKMMStore e) {
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitLKMMStore(LKMMStore e) {
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-        // Power does not have mo tags, thus we use the empty string
-        Store store = newStoreWithMo(address, value, "");
+        Store store = newStore(address, value);
         Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
-        
+
         return eventSequence(
                 optionalMemoryBarrier,
                 store
         );
-	}
+    }
 
-	// Following
+    // Following
 	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
-	@Override
-	public List<Event> visitLKMMFence(LKMMFence e) {
-		Fence optionalMemoryBarrier;
-		switch(e.getName()) {
-			case Tag.Linux.MO_MB:
-			case Tag.Linux.MO_RMB:
-			case Tag.Linux.MO_WMB:
-			case Tag.Linux.BEFORE_ATOMIC:
-			case Tag.Linux.AFTER_ATOMIC:
-				optionalMemoryBarrier = Power.newSyncBarrier();
-				break;
+    @Override
+    public List<Event> visitLKMMFence(LKMMFence e) {
+        Fence optionalMemoryBarrier;
+        switch (e.getName()) {
+            case Tag.Linux.MO_MB:
+            case Tag.Linux.MO_RMB:
+            case Tag.Linux.MO_WMB:
+            case Tag.Linux.BEFORE_ATOMIC:
+            case Tag.Linux.AFTER_ATOMIC:
+                optionalMemoryBarrier = Power.newSyncBarrier();
+                break;
 			// #define smp_mb__after_spinlock()	smp_mb()
-            // 		https://elixir.bootlin.com/linux/v6.1/source/arch/powerpc/include/asm/spinlock.h#L14
+			// 		https://elixir.bootlin.com/linux/v6.1/source/arch/powerpc/include/asm/spinlock.h#L14
             case Tag.Linux.AFTER_SPINLOCK:
-				optionalMemoryBarrier = Power.newSyncBarrier();
-				break;
-            // #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
-            // 		https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
+                optionalMemoryBarrier = Power.newSyncBarrier();
+                break;
+			// #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
+			// 		https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
             // It seem to be only used for RCU related stuff in the kernel so it makes sense
             // it is defined in that header file
             case Tag.Linux.AFTER_UNLOCK_LOCK:
-				optionalMemoryBarrier = Power.newSyncBarrier();
+                optionalMemoryBarrier = Power.newSyncBarrier();
                 break;
-			default:
-				throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
-		}
+            default:
+                throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
+        }
 
-		return eventSequence(
+        return eventSequence(
                 optionalMemoryBarrier
         );
-	}
+    }
 
-	// =============================================================================================
+    // =============================================================================================
 	// 										GENERAL COMMENTS
-	// =============================================================================================
-	// Methods with no suffix (e.g. atomic_xchg), which are those having MO_MB in our case,
-	// are surrounded by a __atomic_pre_full_fence() or __atomic_post_full_fence()
+    // =============================================================================================
+    // Methods with no suffix (e.g. atomic_xchg), which are those having MO_MB in our case,
+    // are surrounded by a __atomic_pre_full_fence() or __atomic_post_full_fence()
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/fence
-	// which in turn are smp_mb__before_atomic and smp_mb__after_atomic
+    // which in turn are smp_mb__before_atomic and smp_mb__after_atomic
 	// 		https://elixir.bootlin.com/linux/v5.18/source/include/linux/atomic.h
-	// which in turn are __smp_mb()
+    // which in turn are __smp_mb()
 	// 		https://elixir.bootlin.com/linux/v5.18/source/include/asm-generic/barrier.h
-	// which in turn is just a sync
+    // which in turn is just a sync
 	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
-	//
-	// Methods with acquire or release as a suffix
+    //
+    // Methods with acquire or release as a suffix
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/acquire
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/release
-	// which result in a isync (acquire) or lwsync (release)
+    // which result in a isync (acquire) or lwsync (release)
 	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h
 	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/synch.h
-	//
-	// Most compilations have this snippet
+    //
+    // Most compilations have this snippet
 	// 1:	ldarx	%0,0,%2
 	//  	stdcx	%3,0,%2
 	// bne	1b
-	// Since we compile after unrolling, and our encoding enforces that the RMW pair is successful,
-	// we just need the final iteration of the control dependency, thus we use a newFakeCtrlDep.
-	// =============================================================================================
+    // Since we compile after unrolling, and our encoding enforces that the RMW pair is successful,
+    // we just need the final iteration of the control dependency, thus we use a newFakeCtrlDep.
+    // =============================================================================================
 
-	@Override
-	public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
-		Register resultRegister = e.getResultRegister();
-		Expression address = e.getAddress();
-		Expression value = e.getMemValue();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(e.getResultRegister().getType());
+        Register dummy = e.getThread().newRegister(e.getResultRegister().getType());
         Label casEnd = newLabel("CAS_end");
         CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(dummy, e.getCmp()), casEnd);
 
-        // Power does not have mo tags, thus we use the empty string
-        Load load = newRMWLoadExclusiveWithMo(dummy, address, "");
-        Store store = Power.newRMWStoreConditional(address, value, "", true);
+        Load load = newRMWLoadExclusive(dummy, address);
+        Store store = Power.newRMWStoreConditional(address, value, true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+                : mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newISyncBarrier() : null;
 
         return eventSequence(
                 // Indentation shows the branching structure
                 optionalMemoryBarrierBefore,
                 load,
                 branchOnCasCmpResult,
-                    store,
-                    fakeCtrlDep,
-                    label,
-                    optionalMemoryBarrierAfter,
+                store,
+                fakeCtrlDep,
+                label,
+                optionalMemoryBarrierAfter,
                 casEnd,
                 newLocal(resultRegister, dummy)
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWXchg(RMWXchg e) {
-		Register resultRegister = e.getResultRegister();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitRMWXchg(RMWXchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(resultRegister.getType());
-        // Power does not have mo tags, thus we use the empty string
-        Load load = newRMWLoadExclusiveWithMo(dummy, address, "");
-        Store store = Power.newRMWStoreConditional(address, value, "", true);
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
+        Load load = newRMWLoadExclusive(dummy, address);
+        Store store = Power.newRMWStoreConditional(address, value, true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+                : mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newISyncBarrier() : null;
 
         return eventSequence(
                 optionalMemoryBarrierBefore,
@@ -794,29 +789,29 @@ public class VisitorPower extends VisitorBase {
                 label,
                 optionalMemoryBarrierAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWOp(RMWOp e) {
-		Register resultRegister = e.getResultRegister();
-		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitRMWOp(RMWOp e) {
+        Register resultRegister = e.getResultRegister();
+        IOpBin op = e.getOp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(resultRegister.getType());
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
         // Power does not have mo tags, thus we use the empty string
         Load load = newRMWLoadExclusive(dummy, address);
-        Store store = Power.newRMWStoreConditional(address, expressions.makeBinary(dummy, op, value), "", true);
+        Store store = Power.newRMWStoreConditional(address, expressions.makeBinary(dummy, op, value), true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+                : mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newISyncBarrier() : null;
 
-        
+
         return eventSequence(
                 optionalMemoryBarrierBefore,
                 load,
@@ -825,29 +820,30 @@ public class VisitorPower extends VisitorBase {
                 label,
                 optionalMemoryBarrierAfter
         );
-	};
+    }
 
-	@Override
-	public List<Event> visitRMWOpReturn(RMWOpReturn e) {
-		Register resultRegister = e.getResultRegister();
-		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    ;
 
-		Register dummy = e.getThread().newRegister(resultRegister.getType());
-        // Power does not have mo tags, thus we use the empty string
-        Load load = newRMWLoadExclusiveWithMo(dummy, address, "");
-        Store store = Power.newRMWStoreConditional(address, dummy, "", true);
+    @Override
+    public List<Event> visitRMWOpReturn(RMWOpReturn e) {
+        Register resultRegister = e.getResultRegister();
+        IOpBin op = e.getOp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
+        Load load = newRMWLoadExclusive(dummy, address);
+        Store store = Power.newRMWStoreConditional(address, dummy, true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+                : mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newISyncBarrier() : null;
 
-        
+
         return eventSequence(
                 optionalMemoryBarrierBefore,
                 load,
@@ -858,28 +854,30 @@ public class VisitorPower extends VisitorBase {
                 label,
                 optionalMemoryBarrierAfter
         );
-	};
+    }
 
-	@Override
-	public List<Event> visitRMWFetchOp(RMWFetchOp e) {
-		Register resultRegister = e.getResultRegister();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    ;
 
-		Register dummy = e.getThread().newRegister(resultRegister.getType());
-		Load load = newRMWLoadExclusive(dummy, address);
-        Store store = Power.newRMWStoreConditional(address, expressions.makeBinary(dummy, e.getOp(), value), "", true);
+    @Override
+    public List<Event> visitRMWFetchOp(RMWFetchOp e) {
+        Register resultRegister = e.getResultRegister();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
+        Load load = newRMWLoadExclusive(dummy, address);
+        Store store = Power.newRMWStoreConditional(address, expressions.makeBinary(dummy, e.getOp(), value), true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+                : mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newISyncBarrier() : null;
 
         return eventSequence(
-				optionalMemoryBarrierBefore,
+                optionalMemoryBarrierBefore,
                 load,
                 store,
                 newLocal(resultRegister, dummy),
@@ -887,38 +885,38 @@ public class VisitorPower extends VisitorBase {
                 label,
                 optionalMemoryBarrierAfter
         );
-	}
+    }
 
-	// The implementation relies on arch_atomic_fetch_add_unless
+    // The implementation relies on arch_atomic_fetch_add_unless
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/add_unless
-	// which uses a sub at the end to return the value before the operation
+    // which uses a sub at the end to return the value before the operation
 	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h
-	// Since RMWAddUnless does not care about any returned value, we don't need the final sub
-	@Override
-	public List<Event> visitRMWAddUnless(RMWAddUnless e) {
-		Register resultRegister = e.getResultRegister();
-		Expression address = e.getAddress();
-		Expression value = e.getMemValue();
-		String mo = e.getMo();
-		IntegerType type = resultRegister.getType();
-		Expression zero = expressions.makeZero(type);
+    // Since RMWAddUnless does not care about any returned value, we don't need the final sub
+    @Override
+    public List<Event> visitRMWAddUnless(RMWAddUnless e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        String mo = e.getMo();
+        IntegerType type = resultRegister.getType();
+        Expression zero = expressions.makeZero(type);
 
         Register regValue = e.getThread().newRegister(type);
         // Power does not have mo tags, thus we use the empty string
         Load load = newRMWLoadExclusive(regValue, address);
-        Store store = Power.newRMWStoreConditional(address, expressions.makeADD(regValue, value), "", true);
+        Store store = Power.newRMWStoreConditional(address, expressions.makeADD(regValue, value), true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(regValue, label);
 
         Register dummy = e.getThread().newRegister(type);
-		Expression unless = e.getCmp();
+        Expression unless = e.getCmp();
         Label cauEnd = newLabel("CAddU_end");
         CondJump branchOnCauCmpResult = newJump(expressions.makeEQ(dummy, zero), cauEnd);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+                : mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newISyncBarrier() : null;
 
         return eventSequence(
                 // Indentation shows the branching structure
@@ -926,46 +924,47 @@ public class VisitorPower extends VisitorBase {
                 load,
                 newLocal(dummy, expressions.makeNEQ(regValue, unless)),
                 branchOnCauCmpResult,
-                    store,
-                    fakeCtrlDep,
-                    label,
-                    optionalMemoryBarrierAfter,
+                store,
+                fakeCtrlDep,
+                label,
+                optionalMemoryBarrierAfter,
                 cauEnd,
                 newLocal(resultRegister, dummy)
         );
-	};
+    }
 
-	// The implementation is arch_${atomic}_op_return(i, v) == 0;
+    ;
+
+    // The implementation is arch_${atomic}_op_return(i, v) == 0;
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/sub_and_test
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/inc_and_test
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/dec_and_test
-	@Override
-	public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		Expression zero = expressions.makeZero(type);
-		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        Expression zero = expressions.makeZero(type);
+        IOpBin op = e.getOp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(type);
+        Register dummy = e.getThread().newRegister(type);
         Register retReg = e.getThread().newRegister(type);
         Local localOp = newLocal(retReg, expressions.makeBinary(dummy, op, value));
         Local testOp = newLocal(resultRegister, expressions.makeEQ(retReg, zero));
 
-        // Power does not have mo tags, thus we use the empty string
-        Load load = newRMWLoadExclusiveWithMo(dummy, address, "");
-        Store store = Power.newRMWStoreConditional(address, retReg, "", true);
+        Load load = newRMWLoadExclusive(dummy, address);
+        Store store = Power.newRMWStoreConditional(address, retReg, true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+                : mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newISyncBarrier() : null;
 
-        
+
         return eventSequence(
                 optionalMemoryBarrierBefore,
                 load,
@@ -976,38 +975,40 @@ public class VisitorPower extends VisitorBase {
                 optionalMemoryBarrierAfter,
                 testOp
         );
-	};
+    }
 
-	@Override
-	public List<Event> visitLKMMLock(LKMMLock e) {
-		IntegerType type = types.getArchType();
-		Expression zero = expressions.makeZero(type);
-		Expression one = expressions.makeOne(type);
-		Register dummy = e.getThread().newRegister(type);
-		Label label = newLabel("FakeDep");
-    // Spinlock events are guaranteed to succeed, i.e. we can use assumes
-		return eventSequence(
-				newRMWLoadExclusive(dummy, e.getLock()),
+    ;
+
+    @Override
+    public List<Event> visitLKMMLock(LKMMLock e) {
+        IntegerType type = types.getArchType();
+        Expression zero = expressions.makeZero(type);
+        Expression one = expressions.makeOne(type);
+        Register dummy = e.getThread().newRegister(type);
+        Label label = newLabel("FakeDep");
+        // Spinlock events are guaranteed to succeed, i.e. we can use assumes
+        return eventSequence(
+                newRMWLoadExclusive(dummy, e.getLock()),
                 newAssume(expressions.makeEQ(dummy, zero)),
-                Power.newRMWStoreConditional(e.getLock(), one, "", true),
-				// Fake dependency to guarantee acquire semantics
-				newFakeCtrlDep(dummy, label),
-				label,
-				Power.newISyncBarrier()
+                Power.newRMWStoreConditional(e.getLock(), one, true),
+                // Fake dependency to guarantee acquire semantics
+                newFakeCtrlDep(dummy, label),
+                label,
+                Power.newISyncBarrier()
         );
-	}
+    }
 
-        @Override
-		public List<Event> visitLKMMUnlock(LKMMUnlock e) {
-			return eventSequence(
-					Power.newLwSyncBarrier(),
+    @Override
+    public List<Event> visitLKMMUnlock(LKMMUnlock e) {
+        return eventSequence(
+                Power.newLwSyncBarrier(),
                 newStore(e.getAddress(), expressions.makeZero(types.getArchType()))
         );
-		}
+    }
 
-	public enum PowerScheme {
+    public enum PowerScheme {
 
-		LEADING_SYNC, TRAILING_SYNC;
+        LEADING_SYNC, TRAILING_SYNC;
 
-	}
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -342,7 +342,6 @@ public class VisitorPower extends VisitorBase {
         }
 
         return eventSequence(
-                // Indentation shows the branching structure
                 optionalBarrierBefore,
                 load,
                 casCmpResult,
@@ -421,7 +420,6 @@ public class VisitorPower extends VisitorBase {
         }
 
         return eventSequence(
-                // Indentation shows the branching structure
                 optionalBarrierBefore,
                 loadExpected,
                 loadValue,
@@ -450,7 +448,7 @@ public class VisitorPower extends VisitorBase {
         Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
 
         Load load = newRMWLoadExclusive(resultRegister, address);
-        Store store = Power.newRMWStoreConditional(address, dummyReg , true);
+        Store store = Power.newRMWStoreConditional(address, dummyReg, true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
@@ -631,7 +629,7 @@ public class VisitorPower extends VisitorBase {
     // =============================================================================================
 
     // Following
-	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
+    //		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
     @Override
     public List<Event> visitLKMMLoad(LKMMLoad e) {
         Register resultRegister = e.getResultRegister();
@@ -649,7 +647,7 @@ public class VisitorPower extends VisitorBase {
     }
 
     // Following
-	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
+    //		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
     @Override
     public List<Event> visitLKMMStore(LKMMStore e) {
         Expression value = e.getMemValue();
@@ -666,7 +664,7 @@ public class VisitorPower extends VisitorBase {
     }
 
     // Following
-	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
+    //		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
     @Override
     public List<Event> visitLKMMFence(LKMMFence e) {
         Fence optionalMemoryBarrier;
@@ -678,13 +676,13 @@ public class VisitorPower extends VisitorBase {
             case Tag.Linux.AFTER_ATOMIC:
                 optionalMemoryBarrier = Power.newSyncBarrier();
                 break;
-			// #define smp_mb__after_spinlock()	smp_mb()
-			// 		https://elixir.bootlin.com/linux/v6.1/source/arch/powerpc/include/asm/spinlock.h#L14
+            // #define smp_mb__after_spinlock()	smp_mb()
+            // 		https://elixir.bootlin.com/linux/v6.1/source/arch/powerpc/include/asm/spinlock.h#L14
             case Tag.Linux.AFTER_SPINLOCK:
                 optionalMemoryBarrier = Power.newSyncBarrier();
                 break;
-			// #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
-			// 		https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
+            // #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
+            // 		https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
             // It seem to be only used for RCU related stuff in the kernel so it makes sense
             // it is defined in that header file
             case Tag.Linux.AFTER_UNLOCK_LOCK:
@@ -700,29 +698,29 @@ public class VisitorPower extends VisitorBase {
     }
 
     // =============================================================================================
-	// 										GENERAL COMMENTS
+    // 										GENERAL COMMENTS
     // =============================================================================================
     // Methods with no suffix (e.g. atomic_xchg), which are those having MO_MB in our case,
     // are surrounded by a __atomic_pre_full_fence() or __atomic_post_full_fence()
-	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/fence
+    // 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/fence
     // which in turn are smp_mb__before_atomic and smp_mb__after_atomic
-	// 		https://elixir.bootlin.com/linux/v5.18/source/include/linux/atomic.h
+    // 		https://elixir.bootlin.com/linux/v5.18/source/include/linux/atomic.h
     // which in turn are __smp_mb()
-	// 		https://elixir.bootlin.com/linux/v5.18/source/include/asm-generic/barrier.h
+    // 		https://elixir.bootlin.com/linux/v5.18/source/include/asm-generic/barrier.h
     // which in turn is just a sync
-	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
+    // 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
     //
     // Methods with acquire or release as a suffix
-	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/acquire
-	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/release
+    // 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/acquire
+    // 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/release
     // which result in a isync (acquire) or lwsync (release)
-	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h
-	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/synch.h
+    // 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h
+    // 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/synch.h
     //
     // Most compilations have this snippet
-	// 1:	ldarx	%0,0,%2
-	//  	stdcx	%3,0,%2
-	// bne	1b
+    // 1:	ldarx	%0,0,%2
+    //  	stdcx	%3,0,%2
+    // bne	1b
     // Since we compile after unrolling, and our encoding enforces that the RMW pair is successful,
     // we just need the final iteration of the control dependency, thus we use a newFakeCtrlDep.
     // =============================================================================================
@@ -749,7 +747,6 @@ public class VisitorPower extends VisitorBase {
                 : mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newISyncBarrier() : null;
 
         return eventSequence(
-                // Indentation shows the branching structure
                 optionalMemoryBarrierBefore,
                 load,
                 branchOnCasCmpResult,
@@ -888,9 +885,9 @@ public class VisitorPower extends VisitorBase {
     }
 
     // The implementation relies on arch_atomic_fetch_add_unless
-	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/add_unless
+    // 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/add_unless
     // which uses a sub at the end to return the value before the operation
-	// 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h
+    // 		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/atomic.h
     // Since RMWAddUnless does not care about any returned value, we don't need the final sub
     @Override
     public List<Event> visitRMWAddUnless(RMWAddUnless e) {
@@ -919,7 +916,6 @@ public class VisitorPower extends VisitorBase {
                 : mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newISyncBarrier() : null;
 
         return eventSequence(
-                // Indentation shows the branching structure
                 optionalMemoryBarrierBefore,
                 load,
                 newLocal(dummy, expressions.makeNEQ(regValue, unless)),
@@ -936,9 +932,9 @@ public class VisitorPower extends VisitorBase {
     ;
 
     // The implementation is arch_${atomic}_op_return(i, v) == 0;
-	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/sub_and_test
-	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/inc_and_test
-	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/dec_and_test
+    // 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/sub_and_test
+    // 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/inc_and_test
+    // 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/dec_and_test
     @Override
     public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
         Register resultRegister = e.getResultRegister();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -593,7 +593,7 @@ class VisitorRISCV extends VisitorBase {
 		Register statusReg = e.getThread().newRegister(type);
 
 		Load load = newRMWLoadExclusive(dummy, address);
-        Store store = RISCV.newRMWStoreConditional(address, expressions.makeBinary(dummy, e.getOp(), value), true,  mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "");
+        Store store = RISCV.newRMWStoreConditional(address, expressions.makeBinary(dummy, e.getOp(), value),  mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newJump(expressions.makeEQ(statusReg, expressions.makeZero(type)), label);
@@ -668,7 +668,7 @@ class VisitorRISCV extends VisitorBase {
 		Register statusReg = e.getThread().newRegister(type);
 
 		Load load = newRMWLoadExclusive(regValue, address);
-        Store store = RISCV.newRMWStoreConditional(address, expressions.makeADD(regValue, value), true, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "");
+        Store store = RISCV.newRMWStoreConditional(address, expressions.makeADD(regValue, value),  mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
 
         Label label = newLabel("FakeDep");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -19,90 +19,92 @@ import java.util.List;
 import static com.dat3m.dartagnan.program.event.EventFactory.*;
 import static com.dat3m.dartagnan.program.event.Tag.Linux.MO_ACQUIRE;
 
+//FIXME: Some compilations generate simple load/store operations with memory orderings, however,
+// it seems that RISCV does not support mo's on arbitrary memory operations (only on LL/SC and AMOs).
 class VisitorRISCV extends VisitorBase {
-	// Some language memory models (e.g. RC11) are non-dependency tracking and might need a
-	// strong version of no-OOTA, thus we need to strength the compilation. None of the usual paper
-	// "Repairing Sequential Consistency in C/C++11"
-	// "Outlawing Ghosts: Avoiding Out-of-Thin-Air Results"
-	// talk about compilation to RISCV, but since it is closer to ARMv8 than Power
-	// we use the same scheme as AMRv8
-	private final boolean useRC11Scheme;
+    // Some language memory models (e.g. RC11) are non-dependency tracking and might need a
+    // strong version of no-OOTA, thus we need to strength the compilation. None of the usual paper
+    // "Repairing Sequential Consistency in C/C++11"
+    // "Outlawing Ghosts: Avoiding Out-of-Thin-Air Results"
+    // talk about compilation to RISCV, but since it is closer to ARMv8 than Power
+    // we use the same scheme as AMRv8
+    private final boolean useRC11Scheme;
 
-	protected VisitorRISCV(boolean forceStart, boolean useRC11Scheme) {
-		super(forceStart);
-		this.useRC11Scheme = useRC11Scheme;
-	}
+    protected VisitorRISCV(boolean forceStart, boolean useRC11Scheme) {
+        super(forceStart);
+        this.useRC11Scheme = useRC11Scheme;
+    }
 
-	@Override
-	public List<Event> visitStoreExclusive(StoreExclusive e) {
+    @Override
+    public List<Event> visitStoreExclusive(StoreExclusive e) {
         RMWStoreExclusive store = RISCV.newRMWStoreConditional(e.getAddress(), e.getMemValue(), e.getMo());
 
         return eventSequence(
                 store,
                 newExecutionStatusWithDependencyTracking(e.getResultRegister(), store)
         );
-	}
+    }
 
     // =============================================================================================
     // ========================================= PTHREAD ===========================================
     // =============================================================================================
 
     @Override
-	public List<Event> visitCreate(Create e) {
+    public List<Event> visitCreate(Create e) {
         Store store = newStoreWithMo(e.getAddress(), e.getMemValue(), Tag.RISCV.MO_REL);
         store.addTags(C11.PTHREAD);
 
         return eventSequence(
                 store
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitEnd(End e) {
+    @Override
+    public List<Event> visitEnd(End e) {
         return eventSequence(
-				newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), Tag.RISCV.MO_REL));
-	}
+                newStoreWithMo(e.getAddress(), expressions.makeZero(types.getArchType()), Tag.RISCV.MO_REL));
+    }
 
-	@Override
-	public List<Event> visitJoin(Join e) {
+    @Override
+    public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-		Expression zero = expressions.makeZero(resultRegister.getType());
-		Load load = newLoadWithMo(resultRegister, e.getAddress(), Tag.RISCV.MO_ACQ);
+        Expression zero = expressions.makeZero(resultRegister.getType());
+        Load load = newLoadWithMo(resultRegister, e.getAddress(), Tag.RISCV.MO_ACQ);
         load.addTags(C11.PTHREAD);
 
         return eventSequence(
                 load,
                 newJump(expressions.makeNEQ(resultRegister, zero), (Label) e.getThread().getExit())
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitStart(Start e) {
+    @Override
+    public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
-		Expression one = expressions.makeOne(resultRegister.getType());
-		Load load = newLoadWithMo(resultRegister, e.getAddress(), Tag.RISCV.MO_ACQ);
+        Expression one = expressions.makeOne(resultRegister.getType());
+        Load load = newLoadWithMo(resultRegister, e.getAddress(), Tag.RISCV.MO_ACQ);
         load.addTags(Tag.STARTLOAD);
 
         return eventSequence(
-				load,
-				super.visitStart(e),
+                load,
+                super.visitStart(e),
                 newJump(expressions.makeNEQ(resultRegister, one), (Label) e.getThread().getExit())
         );
-	}
+    }
 
     @Override
     public List<Event> visitInitLock(InitLock e) {
         return eventSequence(
                 RISCV.newRWWFence(),
-                newStoreWithMo(e.getAddress(), e.getMemValue(), ""));
+                newStore(e.getAddress(), e.getMemValue()));
     }
 
     @Override
     public List<Event> visitLock(Lock e) {
-		IntegerType type = types.getArchType();
+        IntegerType type = types.getArchType();
         Register dummy = e.getThread().newRegister(type);
-		Expression zero = expressions.makeZero(type);
-		Expression one = expressions.makeOne(type);
+        Expression zero = expressions.makeZero(type);
+        Expression one = expressions.makeOne(type);
         // We implement locks as spinlocks which are guaranteed to succeed, i.e. we can use
         // assumes. With this we miss a ctrl dependency, but this does not matter
         // because of the fence.
@@ -120,154 +122,154 @@ class VisitorRISCV extends VisitorBase {
                 newStore(e.getAddress(), expressions.makeZero(types.getArchType())));
     }
 
-	// =============================================================================================
+    // =============================================================================================
     // =========================================== LLVM ============================================
     // =============================================================================================
 
-	@Override
-	public List<Event> visitLlvmLoad(LlvmLoad e) {
-		String mo = e.getMo();
-		Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) ? RISCV.newRWRWFence() : null;
-		Fence optionalBarrierAfter = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_ACQUIRE.equals(mo) ? RISCV.newRRWFence()
-				: null;
+    @Override
+    public List<Event> visitLlvmLoad(LlvmLoad e) {
+        String mo = e.getMo();
+        Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) ? RISCV.newRWRWFence() : null;
+        Fence optionalBarrierAfter = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_ACQUIRE.equals(mo) ? RISCV.newRRWFence()
+                : null;
 
-		return eventSequence(
-				optionalBarrierBefore,
-				newLoad(e.getResultRegister(), e.getAddress()),
-				optionalBarrierAfter);
-	}
+        return eventSequence(
+                optionalBarrierBefore,
+                newLoad(e.getResultRegister(), e.getAddress()),
+                optionalBarrierAfter);
+    }
 
-	@Override
-	public List<Event> visitLlvmStore(LlvmStore e) {
-		String mo = e.getMo();
-		Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_RELEASE.equals(mo) || useRC11Scheme
-				? RISCV.newRWWFence()
-				: null;
+    @Override
+    public List<Event> visitLlvmStore(LlvmStore e) {
+        String mo = e.getMo();
+        Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_RELEASE.equals(mo) || useRC11Scheme
+                ? RISCV.newRWWFence()
+                : null;
 
-		return eventSequence(
-				optionalBarrierBefore,
-				newStore(e.getAddress(), e.getMemValue()));
-	}
+        return eventSequence(
+                optionalBarrierBefore,
+                newStore(e.getAddress(), e.getMemValue()));
+    }
 
-	@Override
-	public List<Event> visitLlvmXchg(LlvmXchg e) {
-		Register resultRegister = e.getResultRegister();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitLlvmXchg(LlvmXchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Load load = newRMWLoadExclusiveWithMo(resultRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
-		Store store = RISCV.newRMWStoreConditional(address, value, Tag.RISCV.extractStoreMoFromCMo(mo), true);
-		Register statusReg = e.getThread().newRegister("status(" + e.getGlobalId() + ")", resultRegister.getType());
-		// We normally make the following optional.
-		// Here we make it mandatory to guarantee correct dependencies.
-		ExecutionStatus execStatus = newExecutionStatusWithDependencyTracking(statusReg, store);
-		Label label = newLabel("FakeDep");
-		Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        Load load = newRMWLoadExclusiveWithMo(resultRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
+        Store store = RISCV.newRMWStoreConditional(address, value, Tag.RISCV.extractStoreMoFromCMo(mo), true);
+        Register statusReg = e.getThread().newRegister("status(" + e.getGlobalId() + ")", resultRegister.getType());
+        // We normally make the following optional.
+        // Here we make it mandatory to guarantee correct dependencies.
+        ExecutionStatus execStatus = newExecutionStatusWithDependencyTracking(statusReg, store);
+        Label label = newLabel("FakeDep");
+        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
-		return eventSequence(
-				load,
-				fakeCtrlDep,
-				label,
-				store,
-				execStatus);
-	}
+        return eventSequence(
+                load,
+                fakeCtrlDep,
+                label,
+                store,
+                execStatus);
+    }
 
-	@Override
-	public List<Event> visitLlvmRMW(LlvmRMW e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitLlvmRMW(LlvmRMW e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        IOpBin op = e.getOp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummyReg = e.getThread().newRegister(type);
-		Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
+        Register dummyReg = e.getThread().newRegister(type);
+        Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
 
-		Load load = newRMWLoadExclusiveWithMo(resultRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
-		Store store = RISCV.newRMWStoreConditional(address, dummyReg, Tag.RISCV.extractStoreMoFromCMo(mo), true);
-		Register statusReg = e.getThread().newRegister("status(" + e.getGlobalId() + ")", type);
-		// We normally make the following optional.
-		// Here we make it mandatory to guarantee correct dependencies.
-		ExecutionStatus execStatus = newExecutionStatusWithDependencyTracking(statusReg, store);
+        Load load = newRMWLoadExclusiveWithMo(resultRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
+        Store store = RISCV.newRMWStoreConditional(address, dummyReg, Tag.RISCV.extractStoreMoFromCMo(mo), true);
+        Register statusReg = e.getThread().newRegister("status(" + e.getGlobalId() + ")", type);
+        // We normally make the following optional.
+        // Here we make it mandatory to guarantee correct dependencies.
+        ExecutionStatus execStatus = newExecutionStatusWithDependencyTracking(statusReg, store);
 
-		Label label = newLabel("FakeDep");
-		Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        Label label = newLabel("FakeDep");
+        Event fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
 
-		return eventSequence(
-				load,
-				fakeCtrlDep,
-				label,
-				localOp,
-				store,
-				execStatus);
-	}
+        return eventSequence(
+                load,
+                fakeCtrlDep,
+                label,
+                localOp,
+                store,
+                execStatus);
+    }
 
-	@Override
-	public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
-		Register oldValueRegister = e.getStructRegister(0);
-		Register resultRegister = e.getStructRegister(1);
-		Expression one = expressions.makeOne(resultRegister.getType());
+    @Override
+    public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
+        Register oldValueRegister = e.getStructRegister(0);
+        Register resultRegister = e.getStructRegister(1);
+        Expression one = expressions.makeOne(resultRegister.getType());
 
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
-		Expression expectedValue = e.getExpectedValue();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+        Expression expectedValue = e.getExpectedValue();
 
-		Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, expectedValue));
-		Label casEnd = newLabel("CAS_end");
-		CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, expectedValue));
+        Label casEnd = newLabel("CAS_end");
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
 
-		Load load = newRMWLoadExclusiveWithMo(oldValueRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
-		Store store = newRMWStoreExclusiveWithMo(address, value, true, Tag.RISCV.extractStoreMoFromCMo(mo));
+        Load load = newRMWLoadExclusiveWithMo(oldValueRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
+        Store store = newRMWStoreExclusiveWithMo(address, value, true, Tag.RISCV.extractStoreMoFromCMo(mo));
 
-		return eventSequence(
-				// Indentation shows the branching structure
-				load,
-				casCmpResult,
-				branchOnCasCmpResult,
-				store,
-				casEnd);
-	}
+        return eventSequence(
+                // Indentation shows the branching structure
+                load,
+                casCmpResult,
+                branchOnCasCmpResult,
+                store,
+                casEnd);
+    }
 
-	@Override
-	public List<Event> visitLlvmFence(LlvmFence e) {
-		Fence fence = null;
-		switch (e.getMo()) {
-			case Tag.C11.MO_ACQUIRE:
-				fence = RISCV.newRRWFence();
-				break;
-			case Tag.C11.MO_RELEASE:
-				fence = RISCV.newRWWFence();
-				break;
-			case Tag.C11.MO_ACQUIRE_RELEASE:
-				fence = RISCV.newTsoFence();
-				break;
-			case Tag.C11.MO_SC:
-				fence = RISCV.newRWRWFence();
-				break;
-		}
+    @Override
+    public List<Event> visitLlvmFence(LlvmFence e) {
+        Fence fence = null;
+        switch (e.getMo()) {
+            case Tag.C11.MO_ACQUIRE:
+                fence = RISCV.newRRWFence();
+                break;
+            case Tag.C11.MO_RELEASE:
+                fence = RISCV.newRWWFence();
+                break;
+            case Tag.C11.MO_ACQUIRE_RELEASE:
+                fence = RISCV.newTsoFence();
+                break;
+            case Tag.C11.MO_SC:
+                fence = RISCV.newRWRWFence();
+                break;
+        }
 
-		return eventSequence(
-				fence);
-	}
+        return eventSequence(
+                fence);
+    }
 
     // =============================================================================================
     // ============================================ C11 ============================================
     // =============================================================================================
 
-	@Override
-	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		Expression one = expressions.makeOne(type);
-		Expression address = e.getAddress();
-		Expression value = e.getMemValue();
-		String mo = e.getMo();
-		Expression expectedAddr = e.getExpectedAddr();
+    @Override
+    public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        Expression one = expressions.makeOne(type);
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        String mo = e.getMo();
+        Expression expectedAddr = e.getExpectedAddr();
 
-		Register regExpected = e.getThread().newRegister(type);
+        Register regExpected = e.getThread().newRegister(type);
         Register regValue = e.getThread().newRegister(type);
         Load loadExpected = newLoad(regExpected, expectedAddr);
         Store storeExpected = newStore(expectedAddr, regValue);
@@ -291,26 +293,26 @@ class VisitorRISCV extends VisitorBase {
                 loadValue,
                 casCmpResult,
                 branchOnCasCmpResult,
-                    storeValue,
-                    execStatus,
-                    updateCasCmpResult,
-                    gotoCasEnd,
+                storeValue,
+                execStatus,
+                updateCasCmpResult,
+                gotoCasEnd,
                 casFail,
-                    storeExpected,
+                storeExpected,
                 casEnd
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        IOpBin op = e.getOp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummyReg = e.getThread().newRegister(type);
+        Register dummyReg = e.getThread().newRegister(type);
         Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
 
         Load load = newRMWLoadExclusiveWithMo(resultRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
@@ -331,61 +333,61 @@ class VisitorRISCV extends VisitorBase {
                 store,
                 execStatus
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicLoad(AtomicLoad e) {
-		String mo = e.getMo();
-		Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) ? RISCV.newRWRWFence() :  null;
-		Fence optionalBarrierAfter = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_ACQUIRE.equals(mo) ? RISCV.newRRWFence() :  null;
+    @Override
+    public List<Event> visitAtomicLoad(AtomicLoad e) {
+        String mo = e.getMo();
+        Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) ? RISCV.newRWRWFence() : null;
+        Fence optionalBarrierAfter = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_ACQUIRE.equals(mo) ? RISCV.newRRWFence() : null;
 
-		return eventSequence(
-				optionalBarrierBefore,
-				newLoadWithMo(e.getResultRegister(), e.getAddress(), ""),
-				optionalBarrierAfter
-		);
-	}
+        return eventSequence(
+                optionalBarrierBefore,
+                newLoad(e.getResultRegister(), e.getAddress()),
+                optionalBarrierAfter
+        );
+    }
 
-	@Override
-	public List<Event> visitAtomicStore(AtomicStore e) {
-		String mo = e.getMo();
-		Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_RELEASE.equals(mo) || useRC11Scheme ? RISCV.newRWWFence() :  null;
+    @Override
+    public List<Event> visitAtomicStore(AtomicStore e) {
+        String mo = e.getMo();
+        Fence optionalBarrierBefore = Tag.C11.MO_SC.equals(mo) || Tag.C11.MO_RELEASE.equals(mo) || useRC11Scheme ? RISCV.newRWWFence() : null;
 
-		return eventSequence(
-				optionalBarrierBefore,
-				newStoreWithMo(e.getAddress(), e.getMemValue(), "")
-		);
-	}
+        return eventSequence(
+                optionalBarrierBefore,
+                newStore(e.getAddress(), e.getMemValue())
+        );
+    }
 
-	@Override
-	public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
-		Fence fence = null;
-		switch(e.getMo()) {
-			case Tag.C11.MO_ACQUIRE:
-				fence = RISCV.newRRWFence();
-				break;
-			case Tag.C11.MO_RELEASE:
-				fence = RISCV.newRWWFence();
-				break;
-			case Tag.C11.MO_ACQUIRE_RELEASE:
-				fence = RISCV.newTsoFence();
-				break;
-			case Tag.C11.MO_SC:
-				fence = RISCV.newRWRWFence();
-				break;
-		}
+    @Override
+    public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
+        Fence fence = null;
+        switch (e.getMo()) {
+            case Tag.C11.MO_ACQUIRE:
+                fence = RISCV.newRRWFence();
+                break;
+            case Tag.C11.MO_RELEASE:
+                fence = RISCV.newRWWFence();
+                break;
+            case Tag.C11.MO_ACQUIRE_RELEASE:
+                fence = RISCV.newTsoFence();
+                break;
+            case Tag.C11.MO_SC:
+                fence = RISCV.newRWRWFence();
+                break;
+        }
 
-		return eventSequence(
-				fence
-		);
-	}
+        return eventSequence(
+                fence
+        );
+    }
 
-	@Override
-	public List<Event> visitAtomicXchg(AtomicXchg e) {
-		Register resultRegister = e.getResultRegister();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitAtomicXchg(AtomicXchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
         Load load = newRMWLoadExclusiveWithMo(resultRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
         Store store = RISCV.newRMWStoreConditional(address, value, Tag.RISCV.extractStoreMoFromCMo(mo), true);
@@ -403,132 +405,132 @@ class VisitorRISCV extends VisitorBase {
                 store,
                 execStatus
         );
-	}
+    }
 
-	// =============================================================================================
+    // =============================================================================================
     // =========================================== LKMM ============================================
     // =============================================================================================
 
-	@Override
-	public List<Event> visitLKMMLoad(LKMMLoad e) {
+    @Override
+    public List<Event> visitLKMMLoad(LKMMLoad e) {
         String mo = e.getMo();
-		Fence optionalMemoryBarrier = mo.equals(MO_ACQUIRE) ? RISCV.newRRWFence() : null;
+        Fence optionalMemoryBarrier = mo.equals(MO_ACQUIRE) ? RISCV.newRRWFence() : null;
 
-		return eventSequence(
-				newLoad(e.getResultRegister(), e.getAddress()),
-				optionalMemoryBarrier
+        return eventSequence(
+                newLoad(e.getResultRegister(), e.getAddress()),
+                optionalMemoryBarrier
         );
 
-	}
+    }
 
-	@Override
-	public List<Event> visitLKMMStore(LKMMStore e) {
+    @Override
+    public List<Event> visitLKMMStore(LKMMStore e) {
         String mo = e.getMo();
-		Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_RELEASE) ? RISCV.newRWWFence() : null;
+        Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_RELEASE) ? RISCV.newRWWFence() : null;
 
-		return eventSequence(
-				optionalMemoryBarrier,
-				newStore(e.getAddress(), e.getMemValue())
+        return eventSequence(
+                optionalMemoryBarrier,
+                newStore(e.getAddress(), e.getMemValue())
         );
 
-	}
+    }
 
-	@Override
-	public List<Event> visitLKMMFence(LKMMFence e) {
-		Fence optionalMemoryBarrier;
-		switch(e.getName()) {
-			// smp_mb()
-			case Tag.Linux.MO_MB:
-				// https://elixir.bootlin.com/linux/v5.18/source/include/asm-generic/barrier.h
-				// https://elixir.bootlin.com/linux/v5.18/source/arch/riscv/include/asm/barrier.h
-			case Tag.Linux.BEFORE_ATOMIC:
-			case Tag.Linux.AFTER_ATOMIC:
-				optionalMemoryBarrier = RISCV.newRWRWFence();
-				break;
-			// smp_rmb()
-			case Tag.Linux.MO_RMB:
-				optionalMemoryBarrier = RISCV.newRRFence();
-				break;
-			// smp_wmb()
-			case Tag.Linux.MO_WMB:
-				optionalMemoryBarrier = RISCV.newWWFence();
-				break;
+    @Override
+    public List<Event> visitLKMMFence(LKMMFence e) {
+        Fence optionalMemoryBarrier;
+        switch (e.getName()) {
+            // smp_mb()
+            case Tag.Linux.MO_MB:
+                // https://elixir.bootlin.com/linux/v5.18/source/include/asm-generic/barrier.h
+                // https://elixir.bootlin.com/linux/v5.18/source/arch/riscv/include/asm/barrier.h
+            case Tag.Linux.BEFORE_ATOMIC:
+            case Tag.Linux.AFTER_ATOMIC:
+                optionalMemoryBarrier = RISCV.newRWRWFence();
+                break;
+            // smp_rmb()
+            case Tag.Linux.MO_RMB:
+                optionalMemoryBarrier = RISCV.newRRFence();
+                break;
+            // smp_wmb()
+            case Tag.Linux.MO_WMB:
+                optionalMemoryBarrier = RISCV.newWWFence();
+                break;
 			// ##define smp_mb__after_spinlock()	RISCV_FENCE(iorw,iorw)
-            // 		https://elixir.bootlin.com/linux/v6.1/source/arch/riscv/include/asm/barrier.h#L72
-			// RISCV_FENCE(iorw,iorw) imposes ordering both on devices and memory
+			// 		https://elixir.bootlin.com/linux/v6.1/source/arch/riscv/include/asm/barrier.h#L72
+            // RISCV_FENCE(iorw,iorw) imposes ordering both on devices and memory
 			// 		https://github.com/westerndigitalcorporation/RISC-V-Linux/blob/master/linux/arch/riscv/include/asm/barrier.h
-			// Since the memory model says nothing about devices, we use RISCV_FENCE(rw,rw) which I think
-			// gives the ordering we want wrt. memory
+            // Since the memory model says nothing about devices, we use RISCV_FENCE(rw,rw) which I think
+            // gives the ordering we want wrt. memory
             case Tag.Linux.AFTER_SPINLOCK:
-				optionalMemoryBarrier = RISCV.newRWRWFence();
-				break;
-            // #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
-            // 		https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
+                optionalMemoryBarrier = RISCV.newRWRWFence();
+                break;
+			// #define smp_mb__after_unlock_lock()	smp_mb()  /* Full ordering for lock. */
+			// 		https://elixir.bootlin.com/linux/v6.1/source/include/linux/rcupdate.h#L1008
             // It seem to be only used for RCU related stuff in the kernel so it makes sense
             // it is defined in that header file
             case Tag.Linux.AFTER_UNLOCK_LOCK:
-				optionalMemoryBarrier = RISCV.newRWRWFence();
-				break;
-			default:
-				throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
-		}
+                optionalMemoryBarrier = RISCV.newRWRWFence();
+                break;
+            default:
+                throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
+        }
 
-		return eventSequence(
+        return eventSequence(
                 optionalMemoryBarrier
         );
-	}
+    }
 
-	public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
-		Register resultRegister = e.getResultRegister();
-		Expression address = e.getAddress();
-		Expression value = e.getMemValue();
-		String mo = e.getMo();
+    public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(e.getResultRegister().getType());
-		Register statusReg = e.getThread().newRegister(e.getResultRegister().getType());
+        Register dummy = e.getThread().newRegister(e.getResultRegister().getType());
+        Register statusReg = e.getThread().newRegister(e.getResultRegister().getType());
         Label casEnd = newLabel("CAS_end");
         CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(dummy, e.getCmp()), casEnd);
-        
-        Load load = newRMWLoadExclusiveWithMo(dummy, address, "");
+
+        Load load = newRMWLoadExclusive(dummy, address); // No mo on the load?
         Store store = RISCV.newRMWStoreConditional(address, value, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newJump(expressions.makeEQ(statusReg, expressions.makeZero(types.getArchType())), label);
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_RELEASE) ? RISCV.newRWWFence() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? RISCV.newRWRWFence() : mo.equals(Tag.Linux.MO_ACQUIRE) ? RISCV.newRRWFence() : null;
-        
+
         return eventSequence(
                 // Indentation shows the branching structure
-				optionalMemoryBarrierBefore,
+                optionalMemoryBarrierBefore,
                 load,
                 branchOnCasCmpResult,
-                    store,
-                    status,
-                    fakeCtrlDep,
-                    label,
-                    optionalMemoryBarrierAfter,
+                store,
+                status,
+                fakeCtrlDep,
+                label,
+                optionalMemoryBarrierAfter,
                 casEnd,
                 newLocal(resultRegister, dummy)
         );
-	}
+    }
 
-	// Following
-	// https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:memory:porting
-	// The linux kernel uses AMO instructions which we don't yet support
-	@Override
-	public List<Event> visitRMWXchg(RMWXchg e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    // Following
+    // https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:memory:porting
+    // The linux kernel uses AMO instructions which we don't yet support
+    @Override
+    public List<Event> visitRMWXchg(RMWXchg e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(type);
-		Register statusReg = e.getThread().newRegister(type);
-		String moLoad = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.RISCV.MO_ACQ : "";
+        Register dummy = e.getThread().newRegister(type);
+        Register statusReg = e.getThread().newRegister(type);
+        String moLoad = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.RISCV.MO_ACQ : "";
         Load load = newRMWLoadExclusiveWithMo(dummy, address, moLoad);
         String moStore = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_RELEASE) ? Tag.RISCV.MO_ACQ_REL : "";
-		Store store = RISCV.newRMWStoreConditional(address, value, moStore, true);
+        Store store = RISCV.newRMWStoreConditional(address, value, moStore, true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newJump(expressions.makeEQ(statusReg, expressions.makeZero(type)), label);
@@ -543,23 +545,23 @@ class VisitorRISCV extends VisitorBase {
                 label,
                 optionalMemoryBarrierAfter
         );
-	}
+    }
 
-	// Following
-	// https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:memory:porting
-	// The linux kernel uses AMO instructions which we don't yet support
-	@Override
-	public List<Event> visitRMWOp(RMWOp e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    // Following
+    // https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:memory:porting
+    // The linux kernel uses AMO instructions which we don't yet support
+    @Override
+    public List<Event> visitRMWOp(RMWOp e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        IOpBin op = e.getOp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
         Register dummy = e.getThread().newRegister(type);
-		Register statusReg = e.getThread().newRegister(type);
-		String moLoad = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.RISCV.MO_ACQ : "";
+        Register statusReg = e.getThread().newRegister(type);
+        String moLoad = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_ACQUIRE) ? Tag.RISCV.MO_ACQ : "";
         Load load = newRMWLoadExclusiveWithMo(dummy, address, moLoad);
         String moStore = mo.equals(Tag.Linux.MO_MB) || mo.equals(Tag.Linux.MO_RELEASE) ? Tag.RISCV.MO_ACQ_REL : "";
         Store store = RISCV.newRMWStoreConditional(address, expressions.makeBinary(dummy, op, value), moStore, true);
@@ -574,26 +576,28 @@ class VisitorRISCV extends VisitorBase {
                 fakeCtrlDep,
                 label
         );
-	};
+    }
 
-	// The linux kernel uses AMO instructions which we don't yet support
-	// The scheme is not described in
-	// https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:memory:porting
-	// Since in VisitorArm8 this one is similar to visitRMWCmpXchg
-	// we also make it scheme similar to the one of visitRMWCmpXchg in this class
-	@Override
-	public List<Event> visitRMWFetchOp(RMWFetchOp e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    ;
 
-		Register dummy = e.getThread().newRegister(type);
-		Register statusReg = e.getThread().newRegister(type);
+    // The linux kernel uses AMO instructions which we don't yet support
+    // The scheme is not described in
+    // https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:memory:porting
+    // Since in VisitorArm8 this one is similar to visitRMWCmpXchg
+    // we also make it scheme similar to the one of visitRMWCmpXchg in this class
+    @Override
+    public List<Event> visitRMWFetchOp(RMWFetchOp e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Load load = newRMWLoadExclusive(dummy, address);
-        Store store = RISCV.newRMWStoreConditional(address, expressions.makeBinary(dummy, e.getOp(), value),  mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
+        Register dummy = e.getThread().newRegister(type);
+        Register statusReg = e.getThread().newRegister(type);
+
+        Load load = newRMWLoadExclusive(dummy, address);
+        Store store = RISCV.newRMWStoreConditional(address, expressions.makeBinary(dummy, e.getOp(), value), mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newJump(expressions.makeEQ(statusReg, expressions.makeZero(type)), label);
@@ -601,7 +605,7 @@ class VisitorRISCV extends VisitorBase {
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? RISCV.newRWRWFence() : mo.equals(Tag.Linux.MO_ACQUIRE) ? RISCV.newRRWFence() : null;
 
         return eventSequence(
-				optionalMemoryBarrierBefore,
+                optionalMemoryBarrierBefore,
                 load,
                 store,
                 status,
@@ -610,36 +614,36 @@ class VisitorRISCV extends VisitorBase {
                 label,
                 optionalMemoryBarrierAfter
         );
-	}
+    }
 
-	// The linux kernel uses AMO instructions which we don't yet support
-	// The scheme is not described in
-	// https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:memory:porting
-	// Since in VisitorArm8 this one is similar to visitRMWCmpXchg
-	// we also make it scheme similar to the one of visitRMWCmpXchg in this class
-	@Override
-	public List<Event> visitRMWOpReturn(RMWOpReturn e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		Expression zero = expressions.makeZero(type);
-		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    // The linux kernel uses AMO instructions which we don't yet support
+    // The scheme is not described in
+    // https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:memory:porting
+    // Since in VisitorArm8 this one is similar to visitRMWCmpXchg
+    // we also make it scheme similar to the one of visitRMWCmpXchg in this class
+    @Override
+    public List<Event> visitRMWOpReturn(RMWOpReturn e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        Expression zero = expressions.makeZero(type);
+        IOpBin op = e.getOp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(type);
-		Register statusReg = e.getThread().newRegister(type);
+        Register dummy = e.getThread().newRegister(type);
+        Register statusReg = e.getThread().newRegister(type);
 
-        Load load = newRMWLoadExclusiveWithMo(dummy, address, "");
+        Load load = newRMWLoadExclusive(dummy, address); // No mo on the load?
         Store store = RISCV.newRMWStoreConditional(address, dummy, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newJump(expressions.makeEQ(statusReg, zero), label);
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_RELEASE) ? RISCV.newRWWFence() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? RISCV.newRWRWFence() : mo.equals(Tag.Linux.MO_ACQUIRE) ? RISCV.newRRWFence() : null;
-        
+
         return eventSequence(
-				optionalMemoryBarrierBefore,
+                optionalMemoryBarrierBefore,
                 load,
                 newLocal(dummy, expressions.makeBinary(dummy, op, value)),
                 store,
@@ -649,33 +653,35 @@ class VisitorRISCV extends VisitorBase {
                 label,
                 optionalMemoryBarrierAfter
         );
-	};
+    }
 
-	// This is a simplified version that should be correct according to the instruction's semantics.
-	// The implementation from the kernel is overly complicated, but since it relies on several macros
-	// (atomic_add_unless -> atomic_fetch_add_unless -> atomic_try_cmpxchg -> atomic_cmpxchg)
-	// and not on inlined assembly, we don't really need to test that the compilation is correct
-	// (the other methods implementing the macros are been tested already).
-	@Override
-	public List<Event> visitRMWAddUnless(RMWAddUnless e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		Expression address = e.getAddress();
-		Expression value = e.getMemValue();
-		String mo = e.getMo();
+    ;
+
+    // This is a simplified version that should be correct according to the instruction's semantics.
+    // The implementation from the kernel is overly complicated, but since it relies on several macros
+    // (atomic_add_unless -> atomic_fetch_add_unless -> atomic_try_cmpxchg -> atomic_cmpxchg)
+    // and not on inlined assembly, we don't really need to test that the compilation is correct
+    // (the other methods implementing the macros are been tested already).
+    @Override
+    public List<Event> visitRMWAddUnless(RMWAddUnless e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        String mo = e.getMo();
 
         Register regValue = e.getThread().newRegister(type);
-		Register statusReg = e.getThread().newRegister(type);
+        Register statusReg = e.getThread().newRegister(type);
 
-		Load load = newRMWLoadExclusive(regValue, address);
-        Store store = RISCV.newRMWStoreConditional(address, expressions.makeADD(regValue, value),  mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
+        Load load = newRMWLoadExclusive(regValue, address);
+        Store store = RISCV.newRMWStoreConditional(address, expressions.makeADD(regValue, value), mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "", true);
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
 
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(regValue, label);
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
-		Expression unless = e.getCmp();
+        Expression unless = e.getCmp();
         Label cauEnd = newLabel("CAddU_end");
         CondJump branchOnCauCmpResult = newJump(expressions.makeEQ(dummy, expressions.makeZero(type)), cauEnd);
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? RISCV.newRWRWFence() : mo.equals(Tag.Linux.MO_ACQUIRE) ? RISCV.newRRWFence() : null;
@@ -685,42 +691,44 @@ class VisitorRISCV extends VisitorBase {
                 load,
                 newLocal(dummy, expressions.makeNEQ(regValue, unless)),
                 branchOnCauCmpResult,
-                    store,
-                    status,
-                    fakeCtrlDep,
-                    label,
-                    optionalMemoryBarrierAfter,
+                store,
+                status,
+                fakeCtrlDep,
+                label,
+                optionalMemoryBarrierAfter,
                 cauEnd,
                 newLocal(resultRegister, dummy)
         );
-	};
+    }
 
-	// The implementation is arch_${atomic}_op_return(i, v) == 0;
+    ;
+
+    // The implementation is arch_${atomic}_op_return(i, v) == 0;
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/sub_and_test
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/inc_and_test
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/dec_and_test
-	@Override
-	public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
-		Register resultRegister = e.getResultRegister();
-		IntegerType type = resultRegister.getType();
-		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
+        Register resultRegister = e.getResultRegister();
+        IntegerType type = resultRegister.getType();
+        IOpBin op = e.getOp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(type);
-		Register statusReg = e.getThread().newRegister(type);
+        Register dummy = e.getThread().newRegister(type);
+        Register statusReg = e.getThread().newRegister(type);
         Register retReg = e.getThread().newRegister(type);
         Local localOp = newLocal(retReg, expressions.makeBinary(dummy, op, value));
         Local testOp = newLocal(resultRegister, expressions.makeEQ(retReg, expressions.makeZero(type)));
 
-        Load load = newRMWLoadExclusiveWithMo(dummy, address, "");
+        Load load = newRMWLoadExclusive(dummy, address);
         Store store = newRMWStoreExclusiveWithMo(address, retReg, true, mo.equals(Tag.Linux.MO_MB) ? Tag.RISCV.MO_REL : "");
         ExecutionStatus status = newExecutionStatusWithDependencyTracking(statusReg, store);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? RISCV.newRWRWFence() : mo.equals(Tag.Linux.MO_ACQUIRE) ? RISCV.newRRWFence() : null;
-        
+
         return eventSequence(
                 load,
                 localOp,
@@ -731,30 +739,32 @@ class VisitorRISCV extends VisitorBase {
                 optionalMemoryBarrierAfter,
                 testOp
         );
-	};
+    }
 
-	@Override
-	public List<Event> visitLKMMLock(LKMMLock e) {
-		IntegerType type = types.getArchType();
-		Expression one = expressions.makeOne(type);
-		Expression zero = expressions.makeZero(type);
-		Register dummy = e.getThread().newRegister(type);
-    	// From this "unofficial" source (there is no RISCV specific implementation in the kernel)
-		// https://github.com/westerndigitalcorporation/RISC-V-Linux/blob/master/linux/arch/riscv/include/asm/spinlock.h
-		// We replace AMO instructions with LL/SC
-		return eventSequence(
-				newRMWLoadExclusive(dummy, e.getLock()),
-                newAssume(expressions.makeEQ(dummy, zero)),
-                newRMWStoreExclusive(e.getLock(), one, true),
-				RISCV.newRRWFence()
-        );
-	}
+    ;
 
     @Override
-	public List<Event> visitLKMMUnlock(LKMMUnlock e) {
-		return eventSequence(
-				RISCV.newRWWFence(),
-				newStore(e.getAddress(), expressions.makeZero(types.getArchType()))
+    public List<Event> visitLKMMLock(LKMMLock e) {
+        IntegerType type = types.getArchType();
+        Expression one = expressions.makeOne(type);
+        Expression zero = expressions.makeZero(type);
+        Register dummy = e.getThread().newRegister(type);
+        // From this "unofficial" source (there is no RISCV specific implementation in the kernel)
+        // https://github.com/westerndigitalcorporation/RISC-V-Linux/blob/master/linux/arch/riscv/include/asm/spinlock.h
+        // We replace AMO instructions with LL/SC
+        return eventSequence(
+                newRMWLoadExclusive(dummy, e.getLock()),
+                newAssume(expressions.makeEQ(dummy, zero)),
+                newRMWStoreExclusive(e.getLock(), one, true),
+                RISCV.newRRWFence()
         );
-	}
+    }
+
+    @Override
+    public List<Event> visitLKMMUnlock(LKMMUnlock e) {
+        return eventSequence(
+                RISCV.newRWWFence(),
+                newStore(e.getAddress(), expressions.makeZero(types.getArchType()))
+        );
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -32,7 +32,8 @@ class VisitorTso extends VisitorBase {
         return tagList(eventSequence(
                 load,
                 newRMWStore(load, address, resultRegister),
-                newLocal(resultRegister, dummyReg)));
+                newLocal(resultRegister, dummyReg)
+        ));
     }
 
     // =============================================================================================
@@ -46,14 +47,16 @@ class VisitorTso extends VisitorBase {
 
         return tagList(eventSequence(
                 store,
-                X86.newMemoryFence()));
+                X86.newMemoryFence()
+        ));
     }
 
     @Override
     public List<Event> visitEnd(End e) {
         return tagList(eventSequence(
                 // Nothing comes after an End event thus no need for a fence
-                newStore(e.getAddress(), expressions.makeZero(types.getArchType()))));
+                newStore(e.getAddress(), expressions.makeZero(types.getArchType()))
+        ));
     }
 
     @Override
@@ -66,7 +69,8 @@ class VisitorTso extends VisitorBase {
         return tagList(eventSequence(
                 load,
                 newJump(expressions.makeNEQ(resultRegister, zero),
-                        (Label) e.getThread().getExit())));
+                        (Label) e.getThread().getExit())
+        ));
     }
 
     @Override
@@ -80,13 +84,15 @@ class VisitorTso extends VisitorBase {
                 load,
                 super.visitStart(e),
                 newJump(expressions.makeNEQ(resultRegister, one),
-                        (Label) e.getThread().getExit())));
+                        (Label) e.getThread().getExit())
+        ));
     }
 
     public List<Event> visitInitLock(InitLock e) {
         return eventSequence(
                 newStore(e.getAddress(), e.getMemValue()),
-                X86.newMemoryFence());
+                X86.newMemoryFence()
+        );
     }
 
     @Override
@@ -99,14 +105,16 @@ class VisitorTso extends VisitorBase {
         return eventSequence(
                 load,
                 newAssume(expressions.makeEQ(dummy, expressions.makeZero(type))),
-                newRMWStore(load, e.getAddress(), expressions.makeOne(type)));
+                newRMWStore(load, e.getAddress(), expressions.makeOne(type))
+        );
     }
 
     @Override
     public List<Event> visitUnlock(Unlock e) {
         return eventSequence(
                 newStore(e.getAddress(), expressions.makeZero(types.getArchType())),
-                X86.newMemoryFence());
+                X86.newMemoryFence()
+        );
     }
 
     // =============================================================================================
@@ -116,7 +124,8 @@ class VisitorTso extends VisitorBase {
     @Override
     public List<Event> visitLlvmLoad(LlvmLoad e) {
         return eventSequence(
-                newLoad(e.getResultRegister(), e.getAddress()));
+                newLoad(e.getResultRegister(), e.getAddress())
+        );
     }
 
     @Override
@@ -125,7 +134,8 @@ class VisitorTso extends VisitorBase {
 
         return eventSequence(
                 newStore(e.getAddress(), e.getMemValue()),
-                optionalMFence);
+                optionalMFence
+        );
     }
 
     @Override
@@ -135,7 +145,8 @@ class VisitorTso extends VisitorBase {
 
         return tagList(eventSequence(
                 load,
-                newRMWStore(load, address, e.getMemValue())));
+                newRMWStore(load, address, e.getMemValue())
+        ));
     }
 
     @Override
@@ -149,7 +160,8 @@ class VisitorTso extends VisitorBase {
         return tagList(eventSequence(
                 load,
                 newLocal(dummyReg, expressions.makeBinary(resultRegister, e.getOp(), e.getMemValue())),
-                newRMWStore(load, address, dummyReg)));
+                newRMWStore(load, address, dummyReg)
+        ));
     }
 
     @Override
@@ -170,12 +182,12 @@ class VisitorTso extends VisitorBase {
         Store store = newRMWStore(load, address, value);
 
         return tagList(eventSequence(
-                // Indentation shows the branching structure
                 load,
                 casCmpResult,
                 branchOnCasCmpResult,
                 store,
-                casEnd));
+                casEnd
+        ));
     }
 
     @Override
@@ -183,7 +195,8 @@ class VisitorTso extends VisitorBase {
         Fence optionalFence = e.getMo().equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
 
         return eventSequence(
-                optionalFence);
+                optionalFence
+        );
     }
 
     // =============================================================================================
@@ -213,7 +226,6 @@ class VisitorTso extends VisitorBase {
         Store storeExpected = newStore(expectedAddr, regValue);
 
         return tagList(eventSequence(
-                // Indentation shows the branching structure
                 loadExpected,
                 loadValue,
                 casCmpResult,
@@ -222,7 +234,8 @@ class VisitorTso extends VisitorBase {
                 gotoCasEnd,
                 casFail,
                 storeExpected,
-                casEnd));
+                casEnd
+        ));
     }
 
     @Override
@@ -231,13 +244,13 @@ class VisitorTso extends VisitorBase {
         Register dummyReg = e.getThread().newRegister(resultRegister.getType());
 
         Expression address = e.getAddress();
-        String mo = e.getMo();
         Load load = newRMWLoad(resultRegister, address);
 
         return tagList(eventSequence(
                 load,
                 newLocal(dummyReg, expressions.makeBinary(resultRegister, e.getOp(), e.getMemValue())),
-                newRMWStore(load, address, dummyReg)));
+                newRMWStore(load, address, dummyReg)
+        ));
     }
 
     @Override
@@ -254,14 +267,17 @@ class VisitorTso extends VisitorBase {
 
         return eventSequence(
                 newStore(e.getAddress(), e.getMemValue()),
-                optionalMFence);
+                optionalMFence
+        );
     }
 
     @Override
     public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
         Fence optionalFence = e.getMo().equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
 
-        return eventSequence(optionalFence);
+        return eventSequence(
+                optionalFence
+        );
     }
 
     @Override
@@ -271,7 +287,8 @@ class VisitorTso extends VisitorBase {
 
         return tagList(eventSequence(
                 load,
-                newRMWStore(load, address, e.getMemValue())));
+                newRMWStore(load, address, e.getMemValue())
+        ));
     }
 
     private List<Event> tagList(List<Event> in) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -17,272 +17,272 @@ import static com.dat3m.dartagnan.program.event.EventFactory.*;
 
 class VisitorTso extends VisitorBase {
 
-        protected VisitorTso(boolean forceStart) {
-                super(forceStart);
-        }
+    protected VisitorTso(boolean forceStart) {
+        super(forceStart);
+    }
 
-        @Override
-        public List<Event> visitXchg(Xchg e) {
-                Register resultRegister = e.getResultRegister();
-                Expression address = e.getAddress();
+    @Override
+    public List<Event> visitXchg(Xchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
 
-                Register dummyReg = e.getThread().newRegister(resultRegister.getType());
-                Load load = newRMWLoad(dummyReg, address);
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+        Load load = newRMWLoad(dummyReg, address);
 
-                return tagList(eventSequence(
-                                load,
-                                newRMWStoreWithMo(load, address, resultRegister, ""),
-                                newLocal(resultRegister, dummyReg)));
-        }
+        return tagList(eventSequence(
+                load,
+                newRMWStore(load, address, resultRegister),
+                newLocal(resultRegister, dummyReg)));
+    }
 
     // =============================================================================================
     // ========================================= PTHREAD ===========================================
     // =============================================================================================
 
     @Override
-        public List<Event> visitCreate(Create e) {
-                Store store = newStoreWithMo(e.getAddress(), e.getMemValue(), "");
-                store.addTags(C11.PTHREAD);
+    public List<Event> visitCreate(Create e) {
+        Store store = newStore(e.getAddress(), e.getMemValue());
+        store.addTags(C11.PTHREAD);
 
-                return tagList(eventSequence(
-                                store,
-                                X86.newMemoryFence()));
+        return tagList(eventSequence(
+                store,
+                X86.newMemoryFence()));
+    }
+
+    @Override
+    public List<Event> visitEnd(End e) {
+        return tagList(eventSequence(
+                // Nothing comes after an End event thus no need for a fence
+                newStore(e.getAddress(), expressions.makeZero(types.getArchType()))));
+    }
+
+    @Override
+    public List<Event> visitJoin(Join e) {
+        Register resultRegister = e.getResultRegister();
+        Expression zero = expressions.makeZero(resultRegister.getType());
+        Load load = newLoad(resultRegister, e.getAddress());
+        load.addTags(C11.PTHREAD);
+
+        return tagList(eventSequence(
+                load,
+                newJump(expressions.makeNEQ(resultRegister, zero),
+                        (Label) e.getThread().getExit())));
+    }
+
+    @Override
+    public List<Event> visitStart(Start e) {
+        Register resultRegister = e.getResultRegister();
+        Expression one = expressions.makeOne(resultRegister.getType());
+        Load load = newLoad(resultRegister, e.getAddress());
+        load.addTags(Tag.STARTLOAD);
+
+        return tagList(eventSequence(
+                load,
+                super.visitStart(e),
+                newJump(expressions.makeNEQ(resultRegister, one),
+                        (Label) e.getThread().getExit())));
+    }
+
+    public List<Event> visitInitLock(InitLock e) {
+        return eventSequence(
+                newStore(e.getAddress(), e.getMemValue()),
+                X86.newMemoryFence());
+    }
+
+    @Override
+    public List<Event> visitLock(Lock e) {
+        IntegerType type = types.getArchType();
+        Register dummy = e.getThread().newRegister(type);
+        // We implement locks as spinlocks which are guaranteed to succeed, i.e. we can
+        // use assumes. Nothing else is needed to guarantee acquire semantics in TSO.
+        Load load = newRMWLoad(dummy, e.getAddress());
+        return eventSequence(
+                load,
+                newAssume(expressions.makeEQ(dummy, expressions.makeZero(type))),
+                newRMWStore(load, e.getAddress(), expressions.makeOne(type)));
+    }
+
+    @Override
+    public List<Event> visitUnlock(Unlock e) {
+        return eventSequence(
+                newStore(e.getAddress(), expressions.makeZero(types.getArchType())),
+                X86.newMemoryFence());
+    }
+
+    // =============================================================================================
+    // =========================================== LLVM ============================================
+    // =============================================================================================
+
+    @Override
+    public List<Event> visitLlvmLoad(LlvmLoad e) {
+        return eventSequence(
+                newLoad(e.getResultRegister(), e.getAddress()));
+    }
+
+    @Override
+    public List<Event> visitLlvmStore(LlvmStore e) {
+        Fence optionalMFence = e.getMo().equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
+
+        return eventSequence(
+                newStore(e.getAddress(), e.getMemValue()),
+                optionalMFence);
+    }
+
+    @Override
+    public List<Event> visitLlvmXchg(LlvmXchg e) {
+        Expression address = e.getAddress();
+        Load load = newRMWLoad(e.getResultRegister(), address);
+
+        return tagList(eventSequence(
+                load,
+                newRMWStore(load, address, e.getMemValue())));
+    }
+
+    @Override
+    public List<Event> visitLlvmRMW(LlvmRMW e) {
+        Register resultRegister = e.getResultRegister();
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+
+        Expression address = e.getAddress();
+        Load load = newRMWLoad(resultRegister, address);
+
+        return tagList(eventSequence(
+                load,
+                newLocal(dummyReg, expressions.makeBinary(resultRegister, e.getOp(), e.getMemValue())),
+                newRMWStore(load, address, dummyReg)));
+    }
+
+    @Override
+    public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
+        Register oldValueRegister = e.getStructRegister(0);
+        Register resultRegister = e.getStructRegister(1);
+        Expression one = expressions.makeOne(resultRegister.getType());
+
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
+        Expression expectedValue = e.getExpectedValue();
+
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, expectedValue));
+        Label casEnd = newLabel("CAS_end");
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
+
+        Load load = newRMWLoad(oldValueRegister, address);
+        Store store = newRMWStore(load, address, value);
+
+        return tagList(eventSequence(
+                // Indentation shows the branching structure
+                load,
+                casCmpResult,
+                branchOnCasCmpResult,
+                store,
+                casEnd));
+    }
+
+    @Override
+    public List<Event> visitLlvmFence(LlvmFence e) {
+        Fence optionalFence = e.getMo().equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
+
+        return eventSequence(
+                optionalFence);
+    }
+
+    // =============================================================================================
+    // ============================================ C11 ============================================
+    // =============================================================================================
+
+    @Override
+    public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        String mo = e.getMo();
+        Expression expectedAddr = e.getExpectedAddr();
+        IntegerType type = resultRegister.getType();
+        Expression one = expressions.makeOne(type);
+
+        Register regExpected = e.getThread().newRegister(type);
+        Load loadExpected = newLoad(regExpected, expectedAddr);
+        Register regValue = e.getThread().newRegister(type);
+        Load loadValue = newRMWLoad(regValue, address);
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(regValue, regExpected));
+        Label casFail = newLabel("CAS_fail");
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casFail);
+        Store storeValue = newRMWStore(loadValue, address, value);
+        Label casEnd = newLabel("CAS_end");
+        CondJump gotoCasEnd = newGoto(casEnd);
+        Store storeExpected = newStore(expectedAddr, regValue);
+
+        return tagList(eventSequence(
+                // Indentation shows the branching structure
+                loadExpected,
+                loadValue,
+                casCmpResult,
+                branchOnCasCmpResult,
+                storeValue,
+                gotoCasEnd,
+                casFail,
+                storeExpected,
+                casEnd));
+    }
+
+    @Override
+    public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
+        Register resultRegister = e.getResultRegister();
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+        Load load = newRMWLoad(resultRegister, address);
+
+        return tagList(eventSequence(
+                load,
+                newLocal(dummyReg, expressions.makeBinary(resultRegister, e.getOp(), e.getMemValue())),
+                newRMWStore(load, address, dummyReg)));
+    }
+
+    @Override
+    public List<Event> visitAtomicLoad(AtomicLoad e) {
+        return eventSequence(
+                newLoad(e.getResultRegister(), e.getAddress())
+        );
+    }
+
+    @Override
+    public List<Event> visitAtomicStore(AtomicStore e) {
+        String mo = e.getMo();
+        Fence optionalMFence = mo.equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
+
+        return eventSequence(
+                newStore(e.getAddress(), e.getMemValue()),
+                optionalMFence);
+    }
+
+    @Override
+    public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
+        Fence optionalFence = e.getMo().equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
+
+        return eventSequence(optionalFence);
+    }
+
+    @Override
+    public List<Event> visitAtomicXchg(AtomicXchg e) {
+        Expression address = e.getAddress();
+        Load load = newRMWLoad(e.getResultRegister(), address);
+
+        return tagList(eventSequence(
+                load,
+                newRMWStore(load, address, e.getMemValue())));
+    }
+
+    private List<Event> tagList(List<Event> in) {
+        in.forEach(this::tagEvent);
+        return in;
+    }
+
+    private void tagEvent(Event e) {
+        if (e instanceof MemoryEvent) {
+            e.addTags(Tag.TSO.ATOM);
         }
-
-        @Override
-        public List<Event> visitEnd(End e) {
-                return tagList(eventSequence(
-                                // Nothing comes after an End event thus no need for a fence
-                                newStore(e.getAddress(), expressions.makeZero(types.getArchType()))));
-        }
-
-        @Override
-        public List<Event> visitJoin(Join e) {
-                Register resultRegister = e.getResultRegister();
-                Expression zero = expressions.makeZero(resultRegister.getType());
-                Load load = newLoad(resultRegister, e.getAddress());
-                load.addTags(C11.PTHREAD);
-
-                return tagList(eventSequence(
-                                load,
-                                newJump(expressions.makeNEQ(resultRegister, zero),
-                                                (Label) e.getThread().getExit())));
-        }
-
-        @Override
-        public List<Event> visitStart(Start e) {
-                Register resultRegister = e.getResultRegister();
-                Expression one = expressions.makeOne(resultRegister.getType());
-                Load load = newLoad(resultRegister, e.getAddress());
-                load.addTags(Tag.STARTLOAD);
-
-                return tagList(eventSequence(
-                                load,
-                                super.visitStart(e),
-                                newJump(expressions.makeNEQ(resultRegister, one),
-                                                (Label) e.getThread().getExit())));
-        }
-
-        public List<Event> visitInitLock(InitLock e) {
-            return eventSequence(
-                    newStore(e.getAddress(), e.getMemValue()),
-                    X86.newMemoryFence());
-        }
-
-        @Override
-        public List<Event> visitLock(Lock e) {
-            IntegerType type = types.getArchType();
-            Register dummy = e.getThread().newRegister(type);
-            // We implement locks as spinlocks which are guaranteed to succeed, i.e. we can
-            // use assumes. Nothing else is needed to guarantee acquire semantics in TSO.
-            Load load = newRMWLoad(dummy, e.getAddress());
-            return eventSequence(
-                    load,
-                    newAssume(expressions.makeEQ(dummy, expressions.makeZero(type))),
-                    newRMWStore(load, e.getAddress(), expressions.makeOne(type)));
-        }
-
-        @Override
-        public List<Event> visitUnlock(Unlock e) {
-            return eventSequence(
-                    newStore(e.getAddress(), expressions.makeZero(types.getArchType())),
-                    X86.newMemoryFence());
-        }
-        
-        // =============================================================================================
-        // =========================================== LLVM ============================================
-        // =============================================================================================
-
-        @Override
-        public List<Event> visitLlvmLoad(LlvmLoad e) {
-                return eventSequence(
-                                newLoadWithMo(e.getResultRegister(), e.getAddress(), ""));
-        }
-
-        @Override
-        public List<Event> visitLlvmStore(LlvmStore e) {
-                Fence optionalMFence = e.getMo().equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
-
-                return eventSequence(
-                                newStoreWithMo(e.getAddress(), e.getMemValue(), ""),
-                                optionalMFence);
-        }
-
-        @Override
-        public List<Event> visitLlvmXchg(LlvmXchg e) {
-                Expression address = e.getAddress();
-                Load load = newRMWLoad(e.getResultRegister(), address);
-
-                return tagList(eventSequence(
-                                load,
-                                newRMWStore(load, address, e.getMemValue())));
-        }
-
-        @Override
-        public List<Event> visitLlvmRMW(LlvmRMW e) {
-                Register resultRegister = e.getResultRegister();
-                Register dummyReg = e.getThread().newRegister(resultRegister.getType());
-
-                Expression address = e.getAddress();
-                Load load = newRMWLoad(resultRegister, address);
-
-                return tagList(eventSequence(
-                                load,
-                                newLocal(dummyReg, expressions.makeBinary(resultRegister, e.getOp(), e.getMemValue())),
-                                newRMWStore(load, address, dummyReg)));
-        }
-
-        @Override
-        public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
-                Register oldValueRegister = e.getStructRegister(0);
-                Register resultRegister = e.getStructRegister(1);
-                Expression one = expressions.makeOne(resultRegister.getType());
-
-                Expression value = e.getMemValue();
-                Expression address = e.getAddress();
-                Expression expectedValue = e.getExpectedValue();
-
-                Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, expectedValue));
-                Label casEnd = newLabel("CAS_end");
-                CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
-
-                Load load = newRMWLoadWithMo(oldValueRegister, address, "");
-                Store store = newRMWStoreWithMo(load, address, value, "");
-
-                return tagList(eventSequence(
-                                // Indentation shows the branching structure
-                                load,
-                                casCmpResult,
-                                branchOnCasCmpResult,
-                                        store,
-                                casEnd));
-        }
-
-        @Override
-        public List<Event> visitLlvmFence(LlvmFence e) {
-                Fence optionalFence = e.getMo().equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
-
-                return eventSequence(
-                                optionalFence);
-        }
-
-        // =============================================================================================
-        // ============================================ C11 ============================================
-        // =============================================================================================
-
-        @Override
-        public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
-                Register resultRegister = e.getResultRegister();
-                Expression address = e.getAddress();
-                Expression value = e.getMemValue();
-                String mo = e.getMo();
-                Expression expectedAddr = e.getExpectedAddr();
-                IntegerType type = resultRegister.getType();
-                Expression one = expressions.makeOne(type);
-
-                Register regExpected = e.getThread().newRegister(type);
-                Load loadExpected = newLoad(regExpected, expectedAddr);
-                Register regValue = e.getThread().newRegister(type);
-                Load loadValue = newRMWLoad(regValue, address, mo);
-                Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(regValue, regExpected));
-                Label casFail = newLabel("CAS_fail");
-                CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casFail);
-                Store storeValue = newRMWStore(loadValue, address, value, mo);
-                Label casEnd = newLabel("CAS_end");
-                CondJump gotoCasEnd = newGoto(casEnd);
-                Store storeExpected = newStore(expectedAddr, regValue);
-
-                return tagList(eventSequence(
-                        // Indentation shows the branching structure
-                        loadExpected,
-                        loadValue,
-                        casCmpResult,
-                        branchOnCasCmpResult,
-                                storeValue,
-                                gotoCasEnd,
-                        casFail,
-                                storeExpected,
-                        casEnd));
-        }
-
-        @Override
-        public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
-                Register resultRegister = e.getResultRegister();
-                Register dummyReg = e.getThread().newRegister(resultRegister.getType());
-
-                Expression address = e.getAddress();
-                String mo = e.getMo();
-                Load load = newRMWLoadWithMo(resultRegister, address, mo);
-
-                return tagList(eventSequence(
-                                load,
-                                newLocal(dummyReg, expressions.makeBinary(resultRegister, e.getOp(), e.getMemValue())),
-                                newRMWStoreWithMo(load, address, dummyReg, mo)));
-        }
-
-        @Override
-        public List<Event> visitAtomicLoad(AtomicLoad e) {
-                return eventSequence(
-                                newLoadWithMo(e.getResultRegister(), e.getAddress(), e.getMo()));
-        }
-
-        @Override
-        public List<Event> visitAtomicStore(AtomicStore e) {
-                String mo = e.getMo();
-                Fence optionalMFence = mo.equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
-
-                return eventSequence(
-                        newStoreWithMo(e.getAddress(), e.getMemValue(), mo),
-                        optionalMFence);
-        }
-
-        @Override
-        public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
-                Fence optionalFence = e.getMo().equals(Tag.C11.MO_SC) ? X86.newMemoryFence() : null;
-
-                return eventSequence(optionalFence);
-        }
-
-        @Override
-        public List<Event> visitAtomicXchg(AtomicXchg e) {
-            Expression address = e.getAddress();
-            String mo = e.getMo();
-            Load load = newRMWLoadWithMo(e.getResultRegister(), address, mo);
-
-            return tagList(eventSequence(
-                    load,
-                    newRMWStoreWithMo(load, address, e.getMemValue(), mo)));
-        }
-
-        private List<Event> tagList(List<Event> in) {
-            in.forEach(this::tagEvent);
-            return in;
-        }
-
-        private void tagEvent(Event e) {
-            if (e instanceof MemoryEvent) {
-                e.addTags(Tag.TSO.ATOM);
-            }
-        }
+    }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/Refiner.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/Refiner.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.MemoryEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.AddressLiteral;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreLiteral;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.ExecLiteral;
@@ -119,16 +119,13 @@ public class Refiner {
     private BooleanFormula permuteAndConvert(CoreLiteral literal, Function<Event, Event> perm, EncodingContext encoder) {
         BooleanFormulaManager bmgr = encoder.getBooleanFormulaManager();
         BooleanFormula enc;
-        if (literal instanceof ExecLiteral) {
-            ExecLiteral lit = (ExecLiteral) literal;
+        if (literal instanceof ExecLiteral lit) {
             enc = encoder.execution(perm.apply(lit.getData()));
-        } else if (literal instanceof AddressLiteral) {
-            AddressLiteral loc = (AddressLiteral) literal;
-            MemoryEvent e1 = (MemoryEvent) perm.apply(loc.getFirst());
-            MemoryEvent e2 = (MemoryEvent) perm.apply(loc.getSecond());
+        } else if (literal instanceof AddressLiteral loc) {
+            MemoryCoreEvent e1 = (MemoryCoreEvent) perm.apply(loc.getFirst());
+            MemoryCoreEvent e2 = (MemoryCoreEvent) perm.apply(loc.getSecond());
             enc = encoder.sameAddress(e1, e2);
-        } else if (literal instanceof RelLiteral) {
-            RelLiteral lit = (RelLiteral) literal;
+        } else if (literal instanceof RelLiteral lit) {
             Relation rel = encoder.getTask().getMemoryModel().getRelation(lit.getName());
             enc = encoder.edge(rel,
                     perm.apply(lit.getData().getFirst()),

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -5,7 +5,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.MemoryEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.dat3m.dartagnan.verification.model.EventData;
@@ -71,8 +71,8 @@ public class ExecutionGraphVisualizer {
     public void generateGraphOfExecutionModel(Writer writer, String graphName, ExecutionModel model) throws IOException {
         for (EventData data : model.getEventList()) {
             if (data.isMemoryEvent()) {
-                MemoryEvent m = (MemoryEvent) data.getEvent();
-                IExpr addr = m.getMemoryAccess().address();
+                MemoryCoreEvent m = (MemoryCoreEvent) data.getEvent();
+                IExpr addr = m.getAddress();
                 if (!(addr instanceof Register)) {
                     addresses.putIfAbsent(data.getAccessedAddress(), addr);
                 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.MemoryEvent;
+import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.dat3m.dartagnan.verification.model.EventData;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
@@ -208,11 +209,11 @@ public class ExecutionGraphVisualizer {
         if (e.isMemoryEvent()) {
             Object address = addresses.get(e.getAccessedAddress());
             BigInteger value = e.getValue();
-            String mo = ((MemoryEvent) e.getEvent()).getMo();
-            mo = mo.isEmpty() ? mo : ", " + mo;
+            MemoryOrder mo = e.getEvent().getMetadata(MemoryOrder.class);
+            String moString = mo == null ? "" : ", " + mo.value();
             tag = e.isWrite() ?
-                    String.format("W(%s, %d%s)", address, value, mo) :
-                    String.format("%s = R(%s%s)", value, address, mo);
+                    String.format("W(%s, %d%s)", address, value, moString) :
+                    String.format("%s = R(%s%s)", value, address, moString);
         }
         final String callStack = makeContextString(
             synContext.getContextInfo(e.getEvent()).getContextOfType(CallContext.class), " -> \\n");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -72,7 +72,7 @@ public class ExecutionGraphVisualizer {
         for (EventData data : model.getEventList()) {
             if (data.isMemoryEvent()) {
                 MemoryCoreEvent m = (MemoryCoreEvent) data.getEvent();
-                IExpr addr = m.getAddress();
+                Expression addr = m.getAddress();
                 if (!(addr instanceof Register)) {
                     addresses.putIfAbsent(data.getAccessedAddress(), addr);
                 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -71,8 +71,9 @@ public class ExecutionGraphVisualizer {
         for (EventData data : model.getEventList()) {
             if (data.isMemoryEvent()) {
                 MemoryEvent m = (MemoryEvent) data.getEvent();
-                if (!(m.getAddress() instanceof Register)) {
-                    addresses.putIfAbsent(data.getAccessedAddress(), m.getAddress());
+                IExpr addr = m.getMemoryAccess().address();
+                if (!(addr instanceof Register)) {
+                    addresses.putIfAbsent(data.getAccessedAddress(), addr);
                 }
             }
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -9,7 +9,7 @@ import com.dat3m.dartagnan.program.analysis.BranchEquivalence;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
+import com.dat3m.dartagnan.program.event.core.MemoryEvent;
 import com.dat3m.dartagnan.program.event.metadata.OriginalId;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.dat3m.dartagnan.program.filter.Filter;
@@ -442,7 +442,7 @@ public class RefinementSolver extends ModelChecker {
         final ThreadSymmetry symm = analysisContext.requires(ThreadSymmetry.class);
         final BranchEquivalence cf = analysisContext.requires(BranchEquivalence.class);
 
-        final Set<Event> programEvents = program.getEvents(SingleAddressMemoryEvent.class).stream()
+        final Set<Event> programEvents = program.getEvents(MemoryEvent.class).stream()
                 // TODO: Can we have events with source information but without parse id?
                 .filter(e -> e.hasMetadata(SourceLocation.class) && e.hasMetadata(OriginalId.class))
                 .collect(Collectors.toSet());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -8,8 +8,8 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.BranchEquivalence;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
-import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.SingleAddressMemoryEvent;
 import com.dat3m.dartagnan.program.event.metadata.OriginalId;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.dat3m.dartagnan.program.filter.Filter;
@@ -442,7 +442,7 @@ public class RefinementSolver extends ModelChecker {
         final ThreadSymmetry symm = analysisContext.requires(ThreadSymmetry.class);
         final BranchEquivalence cf = analysisContext.requires(BranchEquivalence.class);
 
-        final Set<Event> programEvents = program.getEvents(AbstractMemoryEvent.class).stream()
+        final Set<Event> programEvents = program.getEvents(SingleAddressMemoryEvent.class).stream()
                 // TODO: Can we have events with source information but without parse id?
                 .filter(e -> e.hasMetadata(SourceLocation.class) && e.hasMetadata(OriginalId.class))
                 .collect(Collectors.toSet());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
@@ -6,7 +6,6 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.Init;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -171,12 +170,10 @@ public class WitnessBuilder {
 	}
 
 	private List<Event> getSCExecutionOrder(Model model) {
-		List<Event> execEvents = new ArrayList<>();
 		// TODO: we recently added many cline to many events and this might affect the witness generation.
 		Predicate<Event> executedCEvents = e -> Boolean.TRUE.equals(model.evaluate(context.execution(e)))
 				&& e.hasMetadata(SourceLocation.class);
-		execEvents.addAll(context.getTask().getProgram().getEvents(Init.class).stream().filter(executedCEvents).toList());
-		execEvents.addAll(context.getTask().getProgram().getEvents().stream().filter(executedCEvents).toList());
+		List<Event> execEvents = context.getTask().getProgram().getEvents().stream().filter(executedCEvents).toList();
 		Map<Integer, List<Event>> map = new HashMap<>();
         for(Event e : execEvents) {
 			// TODO improve this: these events correspond to return statements

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
@@ -5,7 +5,10 @@ import com.dat3m.dartagnan.expression.BConst;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.Init;
+import com.dat3m.dartagnan.program.event.core.Load;
+import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.lang.svcomp.EndAtomic;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
@@ -177,7 +180,7 @@ public class WitnessBuilder {
 		Map<Integer, List<Event>> map = new HashMap<>();
         for(Event e : execEvents) {
 			// TODO improve this: these events correspond to return statements
-			if(e instanceof MemoryEvent memEvent && memEvent.getMemValue() instanceof BConst bVal && bVal.isFalse()) {
+			if(e instanceof Store store && store.getMemValue() instanceof BConst bVal && bVal.isFalse()) {
 				continue;
 			}
 			BigInteger var = model.evaluate(context.clockVariable("hb", e));

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -379,7 +379,7 @@ public class AnalysisTest {
     }
 
     private Load newLoad(Register value, IExpr address) {
-        return EventFactory.newLoad(value, address, "");
+        return EventFactory.newLoad(value, address);
     }
 
     private Store newStore(IExpr address) {
@@ -387,7 +387,7 @@ public class AnalysisTest {
     }
 
     private Store newStore(IExpr address, IExpr value) {
-        return EventFactory.newStore(address, value, "");
+        return EventFactory.newStore(address, value);
     }
 
     private IValue value(long v) {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -140,10 +140,10 @@ public class AnalysisTest {
         LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
-        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
-        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
-        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
-        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryCoreEvent me0 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryCoreEvent me1 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryCoreEvent me2 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryCoreEvent me3 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);//precisely no
         assertAlias(expect[1], a, me0, me2);
@@ -184,10 +184,10 @@ public class AnalysisTest {
         LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
-        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
-        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
-        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
-        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryCoreEvent me0 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryCoreEvent me1 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryCoreEvent me2 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryCoreEvent me3 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);
         assertAlias(expect[1], a, me0, me2);
@@ -233,10 +233,10 @@ public class AnalysisTest {
         LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
-        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
-        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
-        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
-        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryCoreEvent me0 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryCoreEvent me1 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryCoreEvent me2 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryCoreEvent me3 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);
         assertAlias(expect[1], a, me0, me2);
@@ -277,10 +277,10 @@ public class AnalysisTest {
         LoopUnrolling.newInstance().run(program);
         MemoryAllocation.newInstance().run(program);
         AliasAnalysis a = analyze(program, method);
-        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
-        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
-        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
-        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryCoreEvent me0 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryCoreEvent me1 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryCoreEvent me2 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryCoreEvent me3 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);
         assertAlias(expect[1], a, me0, me2);
@@ -321,10 +321,10 @@ public class AnalysisTest {
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
-        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
-        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
-        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
-        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryCoreEvent me0 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryCoreEvent me1 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryCoreEvent me2 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryCoreEvent me3 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);//precisely no
         assertAlias(expect[1], a, me0, me2);//precisely must
@@ -365,10 +365,10 @@ public class AnalysisTest {
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
-        MemoryEvent me0 = (MemoryEvent) findMatchingEventAfterProcessing(program, e0);
-        MemoryEvent me1 = (MemoryEvent) findMatchingEventAfterProcessing(program, e1);
-        MemoryEvent me2 = (MemoryEvent) findMatchingEventAfterProcessing(program, e2);
-        MemoryEvent me3 = (MemoryEvent) findMatchingEventAfterProcessing(program, e3);
+        MemoryCoreEvent me0 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e0);
+        MemoryCoreEvent me1 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e1);
+        MemoryCoreEvent me2 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e2);
+        MemoryCoreEvent me3 = (MemoryCoreEvent) findMatchingEventAfterProcessing(program, e3);
 
         assertAlias(expect[0], a, me0, me1);//precisely no
         assertAlias(expect[1], a, me0, me2);//precisely must
@@ -408,7 +408,7 @@ public class AnalysisTest {
         return AliasAnalysis.fromConfig(program, Configuration.builder().setOption(ALIAS_METHOD, method.asStringOption()).build());
     }
 
-    private void assertAlias(Result expect, AliasAnalysis a, MemoryEvent x, MemoryEvent y) {
+    private void assertAlias(Result expect, AliasAnalysis a, MemoryCoreEvent x, MemoryCoreEvent y) {
         switch (expect) {
             case NONE:
                 assertFalse(a.mayAlias(x, y));


### PR DESCRIPTION
This PR generalizes the `MemoryEvent` interface and introduces a `MemoryCoreEvent` interface for memory events we support at the core (i.e., in analyses and encoding).
There is a new `MemoryAccess` class that describes a single memory access. A `MemoryEvent` can have multiple accesses, but all core events perform a single access.
Core events do not have a memory order anymore (only in the form of tags), but can have a `MemoryOrder` metadata attached. The metadata is used just for printing/debugging but serves no semantical purpose (\*).
The `EventFactory` now has `XYZwithMo` methods that create a core event, add a tag (based on the `mo`) and attach the `MemoryOrder` metadata.
As a result, most `CompilationVisitors` were updated to call the new methods if they provided a `mo`.
While adding these changes, I took the liberty to reformat the `CompilationVisitors` (replacing tabs by spaces etc.) and also fixed some compiler mappings that produced memory orderings even for architectures that don't have them (e.g., Power and TSO).
Lastly, there is now a `event/common` package which contains abstract classes that provide typical implementations (`StoreBase`, `LoadBase` and `SingleAccessMemoryEvent`). Most language-level events that previously inherited from core events (e.g. `Store` or `Load`) now instead inherit from these new classes instead (they are no core events after all!).
I added a new annotation `NoInterface` which we can attach to abstract classes to indicate that those are meant for sharing implementation but NOT for providing a common interface!
There are still some language-level events that inherit from the core events to provide custom printing methods, but this will be fixed in a different PR.



(\*) This is not quite true yet as we check the metadata in the SVCOMP data race detection to understand which accesses can be racing.
A better way would be to assign proper `NONATOMIC` tags beforehand, but this goes beyond this PR.



*--------------------- Outdated -----------------------*

_This PR adds the `MemoryAccess` class which describes single memory accesses.
A `MemoryEvent` is an event that performs memory accesses(\*).
The `AbstractMemoryEvent` was renamed to `SingleAddressMemoryEvent` to clearly indicate that this base class represents events accessing a single address (Load, Store, RMWs, and abstract events like SRCU).
This class is NOT intended to be an interface (i.e., our code should NEVER check if an event is a `SingleAddressMemoryEvent`), but just serves to share common implementation._

_There are some more TODOs remaining, but I haven't decided yet which of those to tackle within this PR (cause it might get to complex)._

_(\*) In the current state of the PR, `MemoryEvent` performs just a single `MemoryAccess`. I'm still wondering about whether we should have something like a `SimpleMemoryEvent` that performs exactly one memory access and if we then require that after all processing only simple memory events remain. This would be sufficient for what we do right now.
However, if we ever want to model AMOs with single events, then those events would not be "simple".
Apart from AMOs, I don't see a reason to have complex memory events after processing._