### PR TITLE
ExpressionFactory

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -303,8 +303,16 @@ public final class EncodingContext {
     }
 
     private NumeralFormula.IntegerFormula convertToIntegerFormula(Formula f) {
-        return f instanceof BitvectorFormula ?
-                formulaManager.getBitvectorFormulaManager().toIntegerFormula((BitvectorFormula) f, false) :
-                (NumeralFormula.IntegerFormula) f;
+        if (f instanceof BitvectorFormula bitvector) {
+            return formulaManager.getBitvectorFormulaManager().toIntegerFormula(bitvector, false);
+        }
+        if (f instanceof BooleanFormula guard) {
+            IntegerFormulaManager integerFormulaManager = formulaManager.getIntegerFormulaManager();
+            NumeralFormula.IntegerFormula zero = integerFormulaManager.makeNumber(0);
+            NumeralFormula.IntegerFormula one = integerFormulaManager.makeNumber(1);
+            return booleanFormulaManager.ifThenElse(guard, one, zero);
+        }
+        checkArgument(f instanceof NumeralFormula.IntegerFormula, "Unknown type of formula %s.", f);
+        return (NumeralFormula.IntegerFormula) f;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.encoding;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.Type;
@@ -113,15 +113,15 @@ public final class EncodingContext {
         return booleanFormulaManager;
     }
 
-    public Formula encodeFinalIntegerExpression(ExprInterface expression) {
+    public Formula encodeFinalIntegerExpression(Expression expression) {
         return new ExpressionEncoder(formulaManager, null).encodeAsInteger(expression);
     }
 
-    public BooleanFormula encodeBooleanExpressionAt(ExprInterface expression, Event event) {
+    public BooleanFormula encodeBooleanExpressionAt(Expression expression, Event event) {
         return new ExpressionEncoder(formulaManager, event).encodeAsBoolean(expression);
     }
 
-    public Formula encodeIntegerExpressionAt(ExprInterface expression, Event event) {
+    public Formula encodeIntegerExpressionAt(Expression expression, Event event) {
         return new ExpressionEncoder(formulaManager, event).encodeAsInteger(expression);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -58,23 +58,7 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
     }
 
     Formula encodeAsInteger(Expression expression) {
-        Formula formula = expression.visit(this);
-        if (formula instanceof BitvectorFormula || formula instanceof IntegerFormula) {
-            return formula;
-        }
-        int precision = getArchPrecision();
-        Formula one;
-        Formula zero;
-        if(precision > -1) {
-            BitvectorFormulaManager bitvectorFormulaManager = bitvectorFormulaManager();
-            one = bitvectorFormulaManager.makeBitvector(precision, 1);
-            zero = bitvectorFormulaManager.makeBitvector(precision, 0);
-        } else {
-            IntegerFormulaManager integerFormulaManager = integerFormulaManager();
-            one = integerFormulaManager.makeNumber(1);
-            zero = integerFormulaManager.makeNumber(0);
-        }
-        return booleanFormulaManager.ifThenElse((BooleanFormula) formula, one, zero);
+        return expression.visit(this);
     }
 
     static BooleanFormula encodeComparison(COpBin op, Formula lhs, Formula rhs, FormulaManager fmgr) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -334,15 +334,15 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
             }
             case CAST_SIGNED, CAST_UNSIGNED -> {
                 boolean signed = iUn.getOp().equals(IOpUn.CAST_SIGNED);
-                if (targetType instanceof IntegerType) {
-                    if (inner instanceof IntegerFormula) {
-                        return inner;
-                    }
-                    if (inner instanceof BitvectorFormula number) {
-                        return bitvectorFormulaManager().toIntegerFormula(number, signed);
-                    }
-                }
                 if (targetType instanceof IntegerType integerTargetType) {
+                    if (integerTargetType.isMathematical()) {
+                        if (inner instanceof IntegerFormula) {
+                            return inner;
+                        }
+                        if (inner instanceof BitvectorFormula number) {
+                            return bitvectorFormulaManager().toIntegerFormula(number, signed);
+                        }
+                    }
                     int bitWidth = integerTargetType.getBitWidth();
                     if (inner instanceof IntegerFormula number) {
                         return bitvectorFormulaManager().makeBitvector(bitWidth, number);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -352,7 +352,7 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
                         if (innerBitWidth < bitWidth) {
                             return bitvectorFormulaManager().extend(number, bitWidth - innerBitWidth, signed);
                         }
-                        return bitvectorFormulaManager().extract(number, bitWidth, 0);
+                        return bitvectorFormulaManager().extract(number, bitWidth - 1, 0);
                     }
                 }
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -40,7 +40,7 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
         return formulaManager.getBitvectorFormulaManager();
     }
 
-    BooleanFormula encodeAsBoolean(ExprInterface expression) {
+    BooleanFormula encodeAsBoolean(Expression expression) {
         Formula formula = expression.visit(this);
         if (formula instanceof BooleanFormula) {
             return (BooleanFormula) formula;
@@ -57,7 +57,7 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
         return integerFormulaManager.greaterThan((IntegerFormula) formula, zero);
     }
 
-    Formula encodeAsInteger(ExprInterface expression) {
+    Formula encodeAsInteger(Expression expression) {
         Formula formula = expression.visit(this);
         if (formula instanceof BitvectorFormula || formula instanceof IntegerFormula) {
             return formula;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.encoding;
 
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.COpBin;
+import com.dat3m.dartagnan.expression.op.IOpUn;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.Type;
@@ -319,141 +320,45 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
 
     @Override
     public Formula visit(IExprUn iUn) {
+        //TODO if inner is a boolean formula, we still want to encode it as boolean in case of conversions
         Formula inner = encodeAsInteger(iUn.getInner());
-        if (inner instanceof IntegerFormula) {
-            IntegerFormula i = (IntegerFormula) inner;
-            switch (iUn.getOp()) {
-                case MINUS:
-                    return integerFormulaManager().subtract(integerFormulaManager().makeNumber(0), i);
-                case BV2UINT:
-                case BV2INT:
-                    return inner;
-                // ============ INT2BV ============
-                case INT2BV1:
-                    return bitvectorFormulaManager().makeBitvector(1, i);
-                case INT2BV8:
-                    return bitvectorFormulaManager().makeBitvector(8, i);
-                case INT2BV16:
-                    return bitvectorFormulaManager().makeBitvector(16, i);
-                case INT2BV32:
-                    return bitvectorFormulaManager().makeBitvector(32, i);
-                case INT2BV64:
-                    return bitvectorFormulaManager().makeBitvector(64, i);
-                // ============ TRUNC ============
-                case TRUNC6432:
-                case TRUNC6416:
-                case TRUNC3216:
-                case TRUNC648:
-                case TRUNC328:
-                case TRUNC168:
-                case TRUNC641:
-                case TRUNC321:
-                case TRUNC161:
-                case TRUNC81:
-                // ============ ZEXT ============
-                case ZEXT18:
-                case ZEXT116:
-                case ZEXT132:
-                case ZEXT164:
-                case ZEXT816:
-                case ZEXT832:
-                case ZEXT864:
-                case ZEXT1632:
-                case ZEXT1664:
-                case ZEXT3264:
-                // ============ SEXT ============
-                case SEXT18:
-                case SEXT116:
-                case SEXT132:
-                case SEXT164:
-                case SEXT816:
-                case SEXT832:
-                case SEXT864:
-                case SEXT1632:
-                case SEXT1664:
-                case SEXT3264:
-                    return inner;
-                default:
-                    // TODO CTLZ. Right now we assume constant propagation got rid of such instructions
-                    throw new UnsupportedOperationException("Encoding of IOpUn operation " + iUn.getOp() + " not supported on integer formulas.");
+        Type targetType = iUn.getType();
+        switch (iUn.getOp()) {
+            case MINUS -> {
+                if (inner instanceof IntegerFormula number) {
+                    return integerFormulaManager().negate(number);
+                }
+                if (inner instanceof BitvectorFormula number) {
+                    return bitvectorFormulaManager().negate(number);
+                }
             }
-        } else {
-            BitvectorFormula bv = (BitvectorFormula) inner;
-            BitvectorFormulaManager bitvectorFormulaManager = bitvectorFormulaManager();
-            switch (iUn.getOp()) {
-                case MINUS:
-                    return bitvectorFormulaManager.negate(bv);
-                case BV2UINT:
-                    return getArchPrecision() < 0 ? bitvectorFormulaManager.toIntegerFormula(bv, false)
-                            : bitvectorFormulaManager.extend(bv, getArchPrecision() - bitvectorFormulaManager.getLength(bv), false);
-                case BV2INT:
-                    return getArchPrecision() < 0 ? bitvectorFormulaManager.toIntegerFormula(bv, true)
-                            : bitvectorFormulaManager.extend(bv, getArchPrecision() - bitvectorFormulaManager.getLength(bv), true);
-                // ============ INT2BV ============
-                case INT2BV1:
-                case INT2BV8:
-                case INT2BV16:
-                case INT2BV32:
-                case INT2BV64:
-                    return inner;
-                // ============ TRUNC ============
-                case TRUNC6432:
-                    return bitvectorFormulaManager.extract(bv, 31, 0);
-                case TRUNC6416:
-                case TRUNC3216:
-                    return bitvectorFormulaManager.extract(bv, 15, 0);
-                case TRUNC648:
-                case TRUNC328:
-                case TRUNC168:
-                    return bitvectorFormulaManager.extract(bv, 7, 0);
-                case TRUNC641:
-                case TRUNC321:
-                case TRUNC161:
-                case TRUNC81:
-                    return bitvectorFormulaManager.extract(bv, 1, 0);
-                // ============ ZEXT ============
-                case ZEXT18:
-                    return bitvectorFormulaManager.extend(bv, 7, false);
-                case ZEXT116:
-                    return bitvectorFormulaManager.extend(bv, 15, false);
-                case ZEXT132:
-                    return bitvectorFormulaManager.extend(bv, 31, false);
-                case ZEXT164:
-                    return bitvectorFormulaManager.extend(bv, 63, false);
-                case ZEXT816:
-                    return bitvectorFormulaManager.extend(bv, 8, false);
-                case ZEXT832:
-                    return bitvectorFormulaManager.extend(bv, 24, false);
-                case ZEXT864:
-                    return bitvectorFormulaManager.extend(bv, 56, false);
-                case ZEXT1632:
-                    return bitvectorFormulaManager.extend(bv, 16, false);
-                case ZEXT1664:
-                    return bitvectorFormulaManager.extend(bv, 48, false);
-                case ZEXT3264:
-                    return bitvectorFormulaManager.extend(bv, 32, false);
-                // ============ SEXT ============
-                case SEXT18:
-                    return bitvectorFormulaManager.extend(bv, 7, true);
-                case SEXT116:
-                    return bitvectorFormulaManager.extend(bv, 15, true);
-                case SEXT132:
-                    return bitvectorFormulaManager.extend(bv, 31, true);
-                case SEXT164:
-                    return bitvectorFormulaManager.extend(bv, 63, true);
-                case SEXT816:
-                    return bitvectorFormulaManager.extend(bv, 8, true);
-                case SEXT832:
-                    return bitvectorFormulaManager.extend(bv, 24, true);
-                case SEXT864:
-                    return bitvectorFormulaManager.extend(bv, 56, true);
-                case SEXT1632:
-                    return bitvectorFormulaManager.extend(bv, 16, true);
-                case SEXT1664:
-                    return bitvectorFormulaManager.extend(bv, 48, true);
-                case SEXT3264:
-                    return bitvectorFormulaManager.extend(bv, 32, true);
-                case CTLZ:
+            case CAST_SIGNED, CAST_UNSIGNED -> {
+                boolean signed = iUn.getOp().equals(IOpUn.CAST_SIGNED);
+                if (targetType instanceof IntegerType) {
+                    if (inner instanceof IntegerFormula) {
+                        return inner;
+                    }
+                    if (inner instanceof BitvectorFormula number) {
+                        return bitvectorFormulaManager().toIntegerFormula(number, signed);
+                    }
+                }
+                if (targetType instanceof IntegerType integerTargetType) {
+                    int bitWidth = integerTargetType.getBitWidth();
+                    if (inner instanceof IntegerFormula number) {
+                        return bitvectorFormulaManager().makeBitvector(bitWidth, number);
+                    }
+                    if (inner instanceof BitvectorFormula number) {
+                        int innerBitWidth = bitvectorFormulaManager().getLength(number);
+                        if (innerBitWidth < bitWidth) {
+                            return bitvectorFormulaManager().extend(number, bitWidth - innerBitWidth, signed);
+                        }
+                        return bitvectorFormulaManager().extract(number, bitWidth, 0);
+                    }
+                }
+            }
+            case CTLZ -> {
+                if (inner instanceof BitvectorFormula bv) {
+                    BitvectorFormulaManager bitvectorFormulaManager = bitvectorFormulaManager();
                     // enc = extract(bv, 63, 63) == 1 ? 0 : (extract(bv, 62, 62) == 1 ? 1 : extract ... extract(bv, 0, 0) ? 63 : 64)
                     int bvLength = bitvectorFormulaManager.getLength(bv);
                     BitvectorFormula bv1 = bitvectorFormulaManager.makeBitvector(1, 1);
@@ -464,10 +369,11 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
                         enc = booleanFormulaManager.ifThenElse(bitvectorFormulaManager.equal(bvbit, bv1), bvi, enc);
                     }
                     return enc;
-                default:
-                    throw new UnsupportedOperationException("Encoding of IOpUn operation " + iUn.getOp() + " not supported on bitvector formulas.");
+                }
             }
         }
+        throw new UnsupportedOperationException(
+                String.format("Encoding of (%s) %s %s not supported.", targetType, iUn.getOp(), inner));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Atom.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Atom.java
@@ -7,11 +7,11 @@ import com.google.common.collect.ImmutableSet;
 
 public class Atom extends BExpr {
 	
-	private final ExprInterface lhs;
-	private final ExprInterface rhs;
+	private final Expression lhs;
+	private final Expression rhs;
 	private final COpBin op;
 	
-	public Atom (ExprInterface lhs, COpBin op, ExprInterface rhs) {
+	public Atom (Expression lhs, COpBin op, Expression rhs) {
 		this.lhs = lhs;
 		this.rhs = rhs;
 		this.op = op;
@@ -31,11 +31,11 @@ public class Atom extends BExpr {
     	return op;
     }
     
-    public ExprInterface getLHS() {
+    public Expression getLHS() {
     	return lhs;
     }
     
-    public ExprInterface getRHS() {
+    public Expression getRHS() {
     	return rhs;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExpr.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.expression;
 import com.dat3m.dartagnan.expression.type.BooleanType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 
-public abstract class BExpr implements ExprInterface {
+public abstract class BExpr implements Expression {
 
     @Override
     public BooleanType getType() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprBin.java
@@ -7,21 +7,21 @@ import com.google.common.collect.ImmutableSet;
 
 public class BExprBin extends BExpr {
 
-    private final ExprInterface b1;
-    private final ExprInterface b2;
+    private final Expression b1;
+    private final Expression b2;
     private final BOpBin op;
 
-    public BExprBin(ExprInterface b1, BOpBin op, ExprInterface b2) {
+    public BExprBin(Expression b1, BOpBin op, Expression b2) {
         this.b1 = b1;
         this.b2 = b2;
         this.op = op;
     }
 
-    public ExprInterface getLHS() {
+    public Expression getLHS() {
     	return b1;
     }
     
-    public ExprInterface getRHS() {
+    public Expression getRHS() {
     	return b2;
     }
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/BExprUn.java
@@ -7,10 +7,10 @@ import com.google.common.collect.ImmutableSet;
 
 public class BExprUn extends BExpr {
 
-    private final ExprInterface b;
+    private final Expression b;
     private final BOpUn op;
 
-    public BExprUn(BOpUn op, ExprInterface b) {
+    public BExprUn(BOpUn op, Expression b) {
         this.b = b;
         this.op = op;
     }
@@ -19,7 +19,7 @@ public class BExprUn extends BExpr {
         return op;
     }
 
-    public ExprInterface getInner() {
+    public Expression getInner() {
         return b;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExprInterface.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExprInterface.java
@@ -16,4 +16,8 @@ public interface ExprInterface {
     <T> T visit(ExpressionVisitor<T> visitor);
 
     //default ExprInterface simplify() { return visit(ExprSimplifier.SIMPLIFIER); }
+
+    default IConst reduce() {
+        throw new UnsupportedOperationException("Reduce not supported for " + this);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Expression.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Expression.java
@@ -5,7 +5,7 @@ import com.dat3m.dartagnan.expression.type.Type;
 import com.dat3m.dartagnan.program.Register;
 import com.google.common.collect.ImmutableSet;
 
-public interface ExprInterface {
+public interface Expression {
 
     Type getType();
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
@@ -1,8 +1,7 @@
 package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.op.*;
-import com.dat3m.dartagnan.expression.type.BooleanType;
-import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.*;
 
 import java.math.BigInteger;
 
@@ -28,7 +27,7 @@ public final class ExpressionFactory {
     }
 
     public BConst makeValue(boolean value) {
-        return value ? BConst.TRUE : BConst.FALSE;
+        return value ? makeTrue() : makeFalse();
     }
 
     public BExpr makeNot(ExprInterface operand) {
@@ -68,7 +67,8 @@ public final class ExpressionFactory {
     }
 
     public IExpr makeInteger(IntegerType targetType, ExprInterface operand) {
-        if (operand.isBoolean()) {
+        Type operandType = operand.getType();
+        if (operandType instanceof BooleanType) {
             return makeConditional(operand, makeOne(targetType), makeZero(targetType));
         }
         throw new UnsupportedOperationException(String.format("makeInteger with unknown-typed operand %s.", operand));
@@ -163,6 +163,10 @@ public final class ExpressionFactory {
 
     public IExpr makeBitwiseOr(ExprInterface leftOperand, ExprInterface rightOperand) {
         return makeBinary(leftOperand, IOpBin.OR, rightOperand);
+    }
+
+    public IExpr makeXor(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, IOpBin.XOR, rightOperand);
     }
 
     public IExpr makeLeftShift(ExprInterface leftOperand, ExprInterface rightOperand) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
@@ -68,14 +68,6 @@ public final class ExpressionFactory {
         return new IValue(value, type);
     }
 
-    public IExpr makeInteger(IntegerType targetType, Expression operand) {
-        Type operandType = operand.getType();
-        if (operandType instanceof BooleanType) {
-            return makeConditional(operand, makeOne(targetType), makeZero(targetType));
-        }
-        throw new UnsupportedOperationException(String.format("makeInteger with unknown-typed operand %s.", operand));
-    }
-
     public IExpr makeConditional(Expression condition, Expression ifTrue, Expression ifFalse) {
         return new IfExpr(condition, ifTrue, ifFalse);
     }
@@ -128,6 +120,9 @@ public final class ExpressionFactory {
     }
 
     public IExpr makeIntegerCast(Expression operand, IntegerType targetType, boolean signed) {
+        if (operand.getType() instanceof BooleanType) {
+            return makeConditional(operand, makeOne(targetType), makeZero(targetType));
+        }
         return makeUnary(signed ? IOpUn.CAST_SIGNED : IOpUn.CAST_UNSIGNED, operand, targetType);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
@@ -30,23 +30,23 @@ public final class ExpressionFactory {
         return value ? makeTrue() : makeFalse();
     }
 
-    public BExpr makeNot(ExprInterface operand) {
+    public BExpr makeNot(Expression operand) {
         return makeUnary(BOpUn.NOT, operand);
     }
 
-    public BExpr makeUnary(BOpUn operator, ExprInterface operand) {
+    public BExpr makeUnary(BOpUn operator, Expression operand) {
         return new BExprUn(operator, operand);
     }
 
-    public BExpr makeAnd(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public BExpr makeAnd(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, BOpBin.AND, rightOperand);
     }
 
-    public BExpr makeOr(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public BExpr makeOr(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, BOpBin.OR, rightOperand);
     }
 
-    public BExpr makeBinary(ExprInterface leftOperand, BOpBin operator, ExprInterface rightOperand) {
+    public BExpr makeBinary(Expression leftOperand, BOpBin operator, Expression rightOperand) {
         return new BExprBin(leftOperand, operator, rightOperand);
     }
 
@@ -66,7 +66,7 @@ public final class ExpressionFactory {
         return new IValue(value, type);
     }
 
-    public IExpr makeInteger(IntegerType targetType, ExprInterface operand) {
+    public IExpr makeInteger(IntegerType targetType, Expression operand) {
         Type operandType = operand.getType();
         if (operandType instanceof BooleanType) {
             return makeConditional(operand, makeOne(targetType), makeZero(targetType));
@@ -74,11 +74,11 @@ public final class ExpressionFactory {
         throw new UnsupportedOperationException(String.format("makeInteger with unknown-typed operand %s.", operand));
     }
 
-    public IExpr makeConditional(ExprInterface condition, ExprInterface ifTrue, ExprInterface ifFalse) {
+    public IExpr makeConditional(Expression condition, Expression ifTrue, Expression ifFalse) {
         return new IfExpr(condition, ifTrue, ifFalse);
     }
 
-    public BExpr makeBoolean(ExprInterface operand) {
+    public BExpr makeBoolean(Expression operand) {
         if (operand.getType() instanceof BooleanType) {
             assert operand instanceof BExpr;
             return (BExpr) operand;
@@ -89,95 +89,95 @@ public final class ExpressionFactory {
         throw new UnsupportedOperationException(String.format("makeBoolean with unknown-typed operand %s.", operand));
     }
 
-    public BExpr makeEqual(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public BExpr makeEqual(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, COpBin.EQ, rightOperand);
     }
 
-    public BExpr makeNotEqual(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public BExpr makeNotEqual(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, COpBin.NEQ, rightOperand);
     }
 
-    public BExpr makeLess(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+    public BExpr makeLess(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? COpBin.LT : COpBin.ULT, rightOperand);
     }
 
-    public BExpr makeGreater(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+    public BExpr makeGreater(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? COpBin.GT : COpBin.UGT, rightOperand);
     }
 
-    public BExpr makeLessOrEqual(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+    public BExpr makeLessOrEqual(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? COpBin.LTE : COpBin.ULTE, rightOperand);
     }
 
-    public BExpr makeGreaterOrEqual(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+    public BExpr makeGreaterOrEqual(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? COpBin.LTE : COpBin.ULTE, rightOperand);
     }
 
-    public BExpr makeBinary(ExprInterface leftOperand, COpBin operator, ExprInterface rightOperand) {
+    public BExpr makeBinary(Expression leftOperand, COpBin operator, Expression rightOperand) {
         return new Atom(leftOperand, operator, rightOperand);
     }
 
-    public IExpr makeNegate(ExprInterface operand, IntegerType targetType) {
+    public IExpr makeNegate(Expression operand, IntegerType targetType) {
         return makeUnary(IOpUn.MINUS, operand, targetType);
     }
 
-    public IExpr makeCountLeadingZeroes(ExprInterface operand, IntegerType targetType) {
+    public IExpr makeCountLeadingZeroes(Expression operand, IntegerType targetType) {
         return makeUnary(IOpUn.CTLZ, operand, targetType);
     }
 
-    public IExpr makeIntegerCast(ExprInterface operand, IntegerType targetType, boolean signed) {
+    public IExpr makeIntegerCast(Expression operand, IntegerType targetType, boolean signed) {
         return makeUnary(signed ? IOpUn.CAST_SIGNED : IOpUn.CAST_UNSIGNED, operand, targetType);
     }
 
-    public IExpr makeUnary(IOpUn operator, ExprInterface operand, IntegerType targetType) {
+    public IExpr makeUnary(IOpUn operator, Expression operand, IntegerType targetType) {
         return new IExprUn(operator, (IExpr) operand, targetType);
     }
 
-    public IExpr makePlus(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public IExpr makePlus(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.PLUS, rightOperand);
     }
 
-    public IExpr makeMinus(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public IExpr makeMinus(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.MINUS, rightOperand);
     }
 
-    public IExpr makeMultiply(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public IExpr makeMultiply(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.MULT, rightOperand);
     }
 
-    public IExpr makeDivision(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+    public IExpr makeDivision(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? IOpBin.DIV : IOpBin.UDIV, rightOperand);
     }
 
-    public IExpr makeModulo(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public IExpr makeModulo(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.MOD, rightOperand);
     }
 
-    public IExpr makeRemainder(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+    public IExpr makeRemainder(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? IOpBin.SREM : IOpBin.UREM, rightOperand);
     }
 
-    public IExpr makeBitwiseAnd(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public IExpr makeBitwiseAnd(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.AND, rightOperand);
     }
 
-    public IExpr makeBitwiseOr(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public IExpr makeBitwiseOr(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.OR, rightOperand);
     }
 
-    public IExpr makeXor(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public IExpr makeXor(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.XOR, rightOperand);
     }
 
-    public IExpr makeLeftShift(ExprInterface leftOperand, ExprInterface rightOperand) {
+    public IExpr makeLeftShift(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.L_SHIFT, rightOperand);
     }
 
-    public IExpr makeRightShift(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+    public IExpr makeRightShift(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? IOpBin.AR_SHIFT : IOpBin.R_SHIFT, rightOperand);
     }
 
-    public IExpr makeBinary(ExprInterface leftOperand, IOpBin operator, ExprInterface rightOperand) {
+    public IExpr makeBinary(Expression leftOperand, IOpBin operator, Expression rightOperand) {
         return new IExprBin((IExpr) leftOperand, operator, (IExpr) rightOperand);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
@@ -86,32 +86,32 @@ public final class ExpressionFactory {
             return (BExpr) operand;
         }
         if (operand.getType() instanceof IntegerType integerType) {
-            return makeNotEqual(operand, makeZero(integerType));
+            return makeNEQ(operand, makeZero(integerType));
         }
         throw new UnsupportedOperationException(String.format("makeBoolean with unknown-typed operand %s.", operand));
     }
 
-    public BExpr makeEqual(Expression leftOperand, Expression rightOperand) {
+    public BExpr makeEQ(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, COpBin.EQ, rightOperand);
     }
 
-    public BExpr makeNotEqual(Expression leftOperand, Expression rightOperand) {
+    public BExpr makeNEQ(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, COpBin.NEQ, rightOperand);
     }
 
-    public BExpr makeLess(Expression leftOperand, Expression rightOperand, boolean signed) {
+    public BExpr makeLT(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? COpBin.LT : COpBin.ULT, rightOperand);
     }
 
-    public BExpr makeGreater(Expression leftOperand, Expression rightOperand, boolean signed) {
+    public BExpr makeGT(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? COpBin.GT : COpBin.UGT, rightOperand);
     }
 
-    public BExpr makeLessOrEqual(Expression leftOperand, Expression rightOperand, boolean signed) {
+    public BExpr makeLTE(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? COpBin.LTE : COpBin.ULTE, rightOperand);
     }
 
-    public BExpr makeGreaterOrEqual(Expression leftOperand, Expression rightOperand, boolean signed) {
+    public BExpr makeGTE(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? COpBin.GTE : COpBin.UGTE, rightOperand);
     }
 
@@ -119,11 +119,11 @@ public final class ExpressionFactory {
         return new Atom(leftOperand, operator, rightOperand);
     }
 
-    public IExpr makeNegate(Expression operand, IntegerType targetType) {
+    public IExpr makeNEG(Expression operand, IntegerType targetType) {
         return makeUnary(IOpUn.MINUS, operand, targetType);
     }
 
-    public IExpr makeCountLeadingZeroes(Expression operand, IntegerType targetType) {
+    public IExpr makeCTLZ(Expression operand, IntegerType targetType) {
         return makeUnary(IOpUn.CTLZ, operand, targetType);
     }
 
@@ -136,47 +136,47 @@ public final class ExpressionFactory {
         return new IExprUn(operator, (IExpr) operand, targetType);
     }
 
-    public IExpr makePlus(Expression leftOperand, Expression rightOperand) {
+    public IExpr makeADD(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.PLUS, rightOperand);
     }
 
-    public IExpr makeMinus(Expression leftOperand, Expression rightOperand) {
+    public IExpr makeSUB(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.MINUS, rightOperand);
     }
 
-    public IExpr makeMultiply(Expression leftOperand, Expression rightOperand) {
+    public IExpr makeMUL(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.MULT, rightOperand);
     }
 
-    public IExpr makeDivision(Expression leftOperand, Expression rightOperand, boolean signed) {
+    public IExpr makeDIV(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? IOpBin.DIV : IOpBin.UDIV, rightOperand);
     }
 
-    public IExpr makeModulo(Expression leftOperand, Expression rightOperand) {
+    public IExpr makeMOD(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.MOD, rightOperand);
     }
 
-    public IExpr makeRemainder(Expression leftOperand, Expression rightOperand, boolean signed) {
+    public IExpr makeREM(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? IOpBin.SREM : IOpBin.UREM, rightOperand);
     }
 
-    public IExpr makeBitwiseAnd(Expression leftOperand, Expression rightOperand) {
+    public IExpr makeAND(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.AND, rightOperand);
     }
 
-    public IExpr makeBitwiseOr(Expression leftOperand, Expression rightOperand) {
+    public IExpr makeOR(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.OR, rightOperand);
     }
 
-    public IExpr makeXor(Expression leftOperand, Expression rightOperand) {
+    public IExpr makeXOR(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.XOR, rightOperand);
     }
 
-    public IExpr makeLeftShift(Expression leftOperand, Expression rightOperand) {
+    public IExpr makeLSH(Expression leftOperand, Expression rightOperand) {
         return makeBinary(leftOperand, IOpBin.L_SHIFT, rightOperand);
     }
 
-    public IExpr makeRightShift(Expression leftOperand, Expression rightOperand, boolean signed) {
+    public IExpr makeRSH(Expression leftOperand, Expression rightOperand, boolean signed) {
         return makeBinary(leftOperand, signed ? IOpBin.AR_SHIFT : IOpBin.R_SHIFT, rightOperand);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
@@ -1,0 +1,179 @@
+package com.dat3m.dartagnan.expression;
+
+import com.dat3m.dartagnan.expression.op.*;
+import com.dat3m.dartagnan.expression.type.BooleanType;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+
+import java.math.BigInteger;
+
+public final class ExpressionFactory {
+
+    private static final ExpressionFactory instance = new ExpressionFactory();
+
+    private ExpressionFactory() {}
+
+    public static ExpressionFactory getInstance() {
+        return instance;
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Boolean
+
+    public BConst makeTrue() {
+        return BConst.TRUE;
+    }
+
+    public BConst makeFalse() {
+        return BConst.FALSE;
+    }
+
+    public BConst makeValue(boolean value) {
+        return value ? BConst.TRUE : BConst.FALSE;
+    }
+
+    public BExpr makeNot(ExprInterface operand) {
+        return makeUnary(BOpUn.NOT, operand);
+    }
+
+    public BExpr makeUnary(BOpUn operator, ExprInterface operand) {
+        return new BExprUn(operator, operand);
+    }
+
+    public BExpr makeAnd(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, BOpBin.AND, rightOperand);
+    }
+
+    public BExpr makeOr(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, BOpBin.OR, rightOperand);
+    }
+
+    public BExpr makeBinary(ExprInterface leftOperand, BOpBin operator, ExprInterface rightOperand) {
+        return new BExprBin(leftOperand, operator, rightOperand);
+    }
+
+    public IValue makeZero(IntegerType type) {
+        return makeValue(BigInteger.ZERO, type);
+    }
+
+    public IValue makeOne(IntegerType type) {
+        return makeValue(BigInteger.ONE, type);
+    }
+
+    public IValue parseValue(String text, IntegerType type) {
+        return makeValue(new BigInteger(text), type);
+    }
+
+    public IValue makeValue(BigInteger value, IntegerType type) {
+        return new IValue(value, type);
+    }
+
+    public IExpr makeInteger(IntegerType targetType, ExprInterface operand) {
+        if (operand.isBoolean()) {
+            return makeConditional(operand, makeOne(targetType), makeZero(targetType));
+        }
+        throw new UnsupportedOperationException(String.format("makeInteger with unknown-typed operand %s.", operand));
+    }
+
+    public IExpr makeConditional(ExprInterface condition, ExprInterface ifTrue, ExprInterface ifFalse) {
+        return new IfExpr(condition, ifTrue, ifFalse);
+    }
+
+    public BExpr makeBoolean(ExprInterface operand) {
+        if (operand.getType() instanceof BooleanType) {
+            assert operand instanceof BExpr;
+            return (BExpr) operand;
+        }
+        if (operand.getType() instanceof IntegerType integerType) {
+            return makeNotEqual(operand, makeZero(integerType));
+        }
+        throw new UnsupportedOperationException(String.format("makeBoolean with unknown-typed operand %s.", operand));
+    }
+
+    public BExpr makeEqual(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, COpBin.EQ, rightOperand);
+    }
+
+    public BExpr makeNotEqual(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, COpBin.NEQ, rightOperand);
+    }
+
+    public BExpr makeLess(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+        return makeBinary(leftOperand, signed ? COpBin.LT : COpBin.ULT, rightOperand);
+    }
+
+    public BExpr makeGreater(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+        return makeBinary(leftOperand, signed ? COpBin.GT : COpBin.UGT, rightOperand);
+    }
+
+    public BExpr makeLessOrEqual(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+        return makeBinary(leftOperand, signed ? COpBin.LTE : COpBin.ULTE, rightOperand);
+    }
+
+    public BExpr makeGreaterOrEqual(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+        return makeBinary(leftOperand, signed ? COpBin.LTE : COpBin.ULTE, rightOperand);
+    }
+
+    public BExpr makeBinary(ExprInterface leftOperand, COpBin operator, ExprInterface rightOperand) {
+        return new Atom(leftOperand, operator, rightOperand);
+    }
+
+    public IExpr makeNegate(ExprInterface operand, IntegerType targetType) {
+        return makeUnary(IOpUn.MINUS, operand, targetType);
+    }
+
+    public IExpr makeCountLeadingZeroes(ExprInterface operand, IntegerType targetType) {
+        return makeUnary(IOpUn.CTLZ, operand, targetType);
+    }
+
+    public IExpr makeIntegerCast(ExprInterface operand, IntegerType targetType, boolean signed) {
+        return makeUnary(signed ? IOpUn.CAST_SIGNED : IOpUn.CAST_UNSIGNED, operand, targetType);
+    }
+
+    public IExpr makeUnary(IOpUn operator, ExprInterface operand, IntegerType targetType) {
+        return new IExprUn(operator, (IExpr) operand, targetType);
+    }
+
+    public IExpr makePlus(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, IOpBin.PLUS, rightOperand);
+    }
+
+    public IExpr makeMinus(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, IOpBin.MINUS, rightOperand);
+    }
+
+    public IExpr makeMultiply(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, IOpBin.MULT, rightOperand);
+    }
+
+    public IExpr makeDivision(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+        return makeBinary(leftOperand, signed ? IOpBin.DIV : IOpBin.UDIV, rightOperand);
+    }
+
+    public IExpr makeModulo(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, IOpBin.MOD, rightOperand);
+    }
+
+    public IExpr makeRemainder(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+        return makeBinary(leftOperand, signed ? IOpBin.SREM : IOpBin.UREM, rightOperand);
+    }
+
+    public IExpr makeBitwiseAnd(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, IOpBin.AND, rightOperand);
+    }
+
+    public IExpr makeBitwiseOr(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, IOpBin.OR, rightOperand);
+    }
+
+    public IExpr makeLeftShift(ExprInterface leftOperand, ExprInterface rightOperand) {
+        return makeBinary(leftOperand, IOpBin.L_SHIFT, rightOperand);
+    }
+
+    public IExpr makeRightShift(ExprInterface leftOperand, ExprInterface rightOperand, boolean signed) {
+        return makeBinary(leftOperand, signed ? IOpBin.AR_SHIFT : IOpBin.R_SHIFT, rightOperand);
+    }
+
+    public IExpr makeBinary(ExprInterface leftOperand, IOpBin operator, ExprInterface rightOperand) {
+        return new IExprBin((IExpr) leftOperand, operator, (IExpr) rightOperand);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
@@ -5,6 +5,8 @@ import com.dat3m.dartagnan.expression.type.*;
 
 import java.math.BigInteger;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public final class ExpressionFactory {
 
     private static final ExpressionFactory instance = new ExpressionFactory();
@@ -110,7 +112,7 @@ public final class ExpressionFactory {
     }
 
     public BExpr makeGreaterOrEqual(Expression leftOperand, Expression rightOperand, boolean signed) {
-        return makeBinary(leftOperand, signed ? COpBin.LTE : COpBin.ULTE, rightOperand);
+        return makeBinary(leftOperand, signed ? COpBin.GTE : COpBin.UGTE, rightOperand);
     }
 
     public BExpr makeBinary(Expression leftOperand, COpBin operator, Expression rightOperand) {
@@ -130,6 +132,7 @@ public final class ExpressionFactory {
     }
 
     public IExpr makeUnary(IOpUn operator, Expression operand, IntegerType targetType) {
+        checkArgument(operand instanceof IExpr, String.format("Non-integer operand for %s %s.", operator, operand));
         return new IExprUn(operator, (IExpr) operand, targetType);
     }
 
@@ -178,6 +181,8 @@ public final class ExpressionFactory {
     }
 
     public IExpr makeBinary(Expression leftOperand, IOpBin operator, Expression rightOperand) {
+        checkArgument(leftOperand instanceof IExpr && rightOperand instanceof IExpr,
+                String.format("Non-integer operands for %s %s %s.", leftOperand, operator, rightOperand));
         return new IExprBin((IExpr) leftOperand, operator, (IExpr) rightOperand);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.type.IntegerType;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public abstract class IExpr implements ExprInterface {
+public abstract class IExpr implements Expression {
 
 	private final IntegerType type;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
@@ -15,12 +15,7 @@ public abstract class IExpr implements ExprInterface {
 	public IExpr getBase() {
 		throw new UnsupportedOperationException("getBase() not supported for " + this);
 	}
-	
-	@Deprecated
-	public int getPrecision() {
-		return type.isMathematical() ? -1 : type.getBitWidth();
-	}
-	
+
 	public boolean isBV() {
 		return !getType().isMathematical();
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExpr.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.type.IntegerType;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public abstract class IExpr implements Reducible {
+public abstract class IExpr implements ExprInterface {
 
 	private final IntegerType type;
 
@@ -21,11 +21,6 @@ public abstract class IExpr implements Reducible {
 		return type.isMathematical() ? -1 : type.getBitWidth();
 	}
 	
-	@Override
-	public IConst reduce() {
-		throw new UnsupportedOperationException("Reduce not supported for " + this);
-	}
-
 	public boolean isBV() {
 		return !getType().isMathematical();
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
@@ -37,7 +37,7 @@ public class IExprBin extends IExpr {
 	public IConst reduce() {
     	BigInteger v1 = lhs.reduce().getValue();
     	BigInteger v2 = rhs.reduce().getValue();
-		return new IValue(op.combine(v1, v2), lhs.getPrecision());
+		return new IValue(op.combine(v1, v2), lhs.getType());
 	}
 	
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
@@ -3,37 +3,22 @@ package com.dat3m.dartagnan.expression;
 import com.dat3m.dartagnan.expression.op.IOpUn;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
 import com.dat3m.dartagnan.expression.type.IntegerType;
-import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
 import com.google.common.collect.ImmutableSet;
 
 import java.math.BigInteger;
 
+import static com.google.common.base.Verify.verify;
+
 public class IExprUn extends IExpr {
 
-    private static final TypeFactory types = TypeFactory.getInstance();
     private final IExpr b;
     private final IOpUn op;
 
-    public IExprUn(IOpUn op, IExpr b) {
-        super(inferType(op, b));
+    public IExprUn(IOpUn op, IExpr b, IntegerType t) {
+        super(t);
         this.b = b;
         this.op = op;
-    }
-
-    private static IntegerType inferType(IOpUn op, IExpr b) {
-        return switch (op) {
-            // Formerly, CTLZ threw an exception when asked for precision.
-            case MINUS, CTLZ -> b.getType();
-            case BV2UINT, BV2INT -> types.getArchType();
-            case INT2BV1, TRUNC321, TRUNC641, TRUNC161, TRUNC81 -> types.getIntegerType(1);
-            case INT2BV8, TRUNC648, TRUNC328, TRUNC168, ZEXT18, SEXT18 -> types.getIntegerType(8);
-            case INT2BV16, TRUNC6416, TRUNC3216, ZEXT116, ZEXT816, SEXT116, SEXT816 -> types.getIntegerType(16);
-            case INT2BV32, TRUNC6432, ZEXT132, ZEXT832, ZEXT1632, SEXT132, SEXT832, SEXT1632 ->
-                    types.getIntegerType(32);
-            case INT2BV64, ZEXT164, ZEXT864, ZEXT1664, ZEXT3264, SEXT164, SEXT864, SEXT1664, SEXT3264 ->
-                    types.getIntegerType(64);
-        };
     }
 
     public IOpUn getOp() {
@@ -56,33 +41,52 @@ public class IExprUn extends IExpr {
 
     @Override
     public IConst reduce() {
+        IntegerType innerType = b.getType();
         IConst inner = b.reduce();
+        verify(inner.getType().equals(innerType),
+                "Reduced to wrong type %s instead of %s.", inner.getType(), innerType);
+        BigInteger value = inner.getValue();
+        IntegerType targetType = getType();
         switch (op) {
-            case MINUS:
-            return new IValue(inner.getValue().negate(), b.getPrecision());
-            case BV2UINT: case BV2INT:
-            case INT2BV1: case INT2BV8: case INT2BV16: case INT2BV32: case INT2BV64: 
-            case TRUNC6432: case TRUNC6416: case TRUNC648: case TRUNC641: case TRUNC3216: case TRUNC328: case TRUNC321: case TRUNC168: case TRUNC161: case TRUNC81:
-            case ZEXT18: case ZEXT116: case ZEXT132: case ZEXT164: case ZEXT816: case ZEXT832: case ZEXT864: case ZEXT1632: case ZEXT1664: case ZEXT3264: 
-            case SEXT18: case SEXT116: case SEXT132: case SEXT164: case SEXT816: case SEXT832: case SEXT864: case SEXT1632: case SEXT1664: case SEXT3264:
-                return inner;
-            case CTLZ:
-                int leading;
-                int precision = inner.getPrecision();
-                switch (precision) {
-                    case 32:
-                        leading = Integer.numberOfLeadingZeros(inner.getValueAsInt());
-                        break;
-                    case 64:
-                        leading = Long.numberOfLeadingZeros(inner.getValueAsInt());
-                        break;
-                    default:
-                        throw new UnsupportedOperationException(
-                                "Reduce not supported for " + this + " with precision " + precision);
+            case CAST_SIGNED, CAST_UNSIGNED -> {
+                boolean signed = op.equals(IOpUn.CAST_SIGNED);
+                boolean truncate = !targetType.isMathematical() &&
+                        (innerType.isMathematical() || targetType.getBitWidth() < innerType.getBitWidth());
+                if (truncate) {
+                    BigInteger v = value;
+                    for (int i = targetType.getBitWidth(); i < value.bitLength(); i++) {
+                        v = v.clearBit(i);
+                    }
+                    return new IValue(v, targetType);
                 }
-                return new IValue(BigInteger.valueOf(leading), precision);
-            default:
-                throw new UnsupportedOperationException("Reduce not supported for " + this);
+                if (!innerType.isMathematical()) {
+                    int bitWidth = innerType.getBitWidth();
+                    verify(BigInteger.TWO.pow(bitWidth - 1).negate().compareTo(value) <= 0);
+                    verify(BigInteger.TWO.pow(bitWidth).compareTo(value) > 0);
+                    return new IValue(signed ?
+                            value.testBit(bitWidth - 1) ? value.subtract(BigInteger.TWO.pow(bitWidth)) : value :
+                            value.signum() >= 0 ? value : BigInteger.TWO.pow(bitWidth).add(value),
+                            targetType);
+                }
+                return new IValue(value, targetType);
+            }
+            case MINUS -> {
+                return new IValue(value.negate(), targetType);
+            }
+            case CTLZ -> {
+                if (innerType.isMathematical()) {
+                    throw new UnsupportedOperationException(
+                            String.format("Counting leading zeroes in mathematical integer %s.", inner));
+                }
+                if (value.signum() == -1) {
+                    return new IValue(BigInteger.ZERO, targetType);
+                }
+                int bitWidth = innerType.getBitWidth();
+                int length = value.bitLength();
+                verify(length <= bitWidth, "Value %s returned by %s not in range of type %s.", value);
+                return new IValue(BigInteger.valueOf(bitWidth - length), targetType);
+            }
+            default -> throw new UnsupportedOperationException("Reduce not supported for " + this);
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprUn.java
@@ -60,13 +60,9 @@ public class IExprUn extends IExpr {
                     return new IValue(v, targetType);
                 }
                 if (!innerType.isMathematical()) {
-                    int bitWidth = innerType.getBitWidth();
-                    verify(BigInteger.TWO.pow(bitWidth - 1).negate().compareTo(value) <= 0);
-                    verify(BigInteger.TWO.pow(bitWidth).compareTo(value) > 0);
-                    return new IValue(signed ?
-                            value.testBit(bitWidth - 1) ? value.subtract(BigInteger.TWO.pow(bitWidth)) : value :
-                            value.signum() >= 0 ? value : BigInteger.TWO.pow(bitWidth).add(value),
-                            targetType);
+                    verify(innerType.canContain(value), "");
+                    BigInteger result = innerType.applySign(value, signed);
+                    return new IValue(result, targetType);
                 }
                 return new IValue(value, targetType);
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
@@ -13,14 +13,6 @@ public final class IValue extends IConst {
 
     private static final TypeFactory types = TypeFactory.getInstance();
 
-    // TODO(TH): not sure where this are used, but why do you set the precision to 0?
-    // TH: This was a temporary try for integer logic only
-    // However, it is impossible to define general constants, we need a function that produces
-    // a constant for each precision degree
-    // HP: agree. I assume you wanted this to improve code readability, but having one constant per precision won't help.
-    public static IConst ZERO = new IValue(BigInteger.ZERO, types.getArchType());
-    public static IConst ONE = new IValue(BigInteger.ONE, types.getArchType());
-
     private final BigInteger value;
 
     @Deprecated

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IValue.java
@@ -15,11 +15,6 @@ public final class IValue extends IConst {
 
     private final BigInteger value;
 
-    @Deprecated
-    public IValue(BigInteger v, int p) {
-        this(v, p == -1 ? types.getIntegerType() : types.getIntegerType(p));
-    }
-
     public IValue(BigInteger value, IntegerType type) {
         super(type);
         this.value = value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
@@ -1,23 +1,34 @@
 package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
+import com.dat3m.dartagnan.expression.type.BooleanType;
+import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class IfExpr extends IExpr {
 
-	private final BExpr guard;
-	private final IExpr tbranch;
-	private final IExpr fbranch;
+	private final ExprInterface guard;
+	private final ExprInterface tbranch;
+	private final ExprInterface fbranch;
 	
-	public IfExpr(BExpr guard, IExpr tbranch, IExpr fbranch) {
-		super(tbranch.getType());
-    	Preconditions.checkArgument(tbranch.getType().equals(fbranch.getType()),
-    			"The types of %s and %s do not match.", tbranch, fbranch);
+	public IfExpr(ExprInterface guard, ExprInterface tbranch, ExprInterface fbranch) {
+		super(checkIntegerType(tbranch));
+		checkArgument(guard.getType() instanceof BooleanType, "IfThenElse with non-boolean guard %s.", guard);
+        checkArgument(tbranch.getType().equals(fbranch.getType()),
+                "IfThenElse with mismatching branches %s and %s.", tbranch, fbranch);
 		this.guard =  guard;
 		this.tbranch = tbranch;
 		this.fbranch = fbranch;
+	}
+
+	private static IntegerType checkIntegerType(ExprInterface tbranch) {
+		if (tbranch.getType() instanceof IntegerType integerType) {
+			return integerType;
+		}
+		throw new IllegalArgumentException(String.format("IfThenElse with non-integer branch %s.", tbranch));
 	}
 
 	@Override
@@ -30,15 +41,15 @@ public class IfExpr extends IExpr {
         return "(if " + guard + " then " + tbranch + " else " + fbranch + ")";
     }
 
-	public BExpr getGuard() {
+	public ExprInterface getGuard() {
 		return guard;
 	}
 
-	public IExpr getTrueBranch() {
+	public ExprInterface getTrueBranch() {
 		return tbranch;
 	}
 
-	public IExpr getFalseBranch() {
+	public ExprInterface getFalseBranch() {
 		return fbranch;
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IfExpr.java
@@ -10,11 +10,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class IfExpr extends IExpr {
 
-	private final ExprInterface guard;
-	private final ExprInterface tbranch;
-	private final ExprInterface fbranch;
+	private final Expression guard;
+	private final Expression tbranch;
+	private final Expression fbranch;
 	
-	public IfExpr(ExprInterface guard, ExprInterface tbranch, ExprInterface fbranch) {
+	public IfExpr(Expression guard, Expression tbranch, Expression fbranch) {
 		super(checkIntegerType(tbranch));
 		checkArgument(guard.getType() instanceof BooleanType, "IfThenElse with non-boolean guard %s.", guard);
         checkArgument(tbranch.getType().equals(fbranch.getType()),
@@ -24,7 +24,7 @@ public class IfExpr extends IExpr {
 		this.fbranch = fbranch;
 	}
 
-	private static IntegerType checkIntegerType(ExprInterface tbranch) {
+	private static IntegerType checkIntegerType(Expression tbranch) {
 		if (tbranch.getType() instanceof IntegerType integerType) {
 			return integerType;
 		}
@@ -41,15 +41,15 @@ public class IfExpr extends IExpr {
         return "(if " + guard + " then " + tbranch + " else " + fbranch + ")";
     }
 
-	public ExprInterface getGuard() {
+	public Expression getGuard() {
 		return guard;
 	}
 
-	public ExprInterface getTrueBranch() {
+	public Expression getTrueBranch() {
 		return tbranch;
 	}
 
-	public ExprInterface getFalseBranch() {
+	public Expression getFalseBranch() {
 		return fbranch;
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Reducible.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Reducible.java
@@ -1,7 +1,0 @@
-package com.dat3m.dartagnan.expression;
-
-public interface Reducible extends ExprInterface {
-
-	IConst reduce();
-	
-}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/op/IOpUn.java
@@ -1,23 +1,18 @@
 package com.dat3m.dartagnan.expression.op;
 
 public enum IOpUn {
-    MINUS,
-    BV2UINT, BV2INT,
-    INT2BV1, INT2BV8, INT2BV16, INT2BV32, INT2BV64,
-    TRUNC6432, TRUNC6416, TRUNC648, TRUNC641, TRUNC3216, TRUNC328, TRUNC321, TRUNC168, TRUNC161, TRUNC81,
-    ZEXT18, ZEXT116, ZEXT132, ZEXT164, ZEXT816, ZEXT832, ZEXT864, ZEXT1632, ZEXT1664, ZEXT3264,
-    SEXT18, SEXT116, SEXT132, SEXT164, SEXT816, SEXT832, SEXT864, SEXT1632, SEXT1664, SEXT3264,
-    CTLZ;
+    CAST_SIGNED,
+    CAST_UNSIGNED,
+    CTLZ,
+    MINUS;
 
     @Override
     public String toString() {
-        switch (this) {
-            case MINUS:
-                return "-";
-            case CTLZ:
-                return "ctlz ";
-            default:
-                return "";
-        }
+        return switch (this) {
+            case CAST_SIGNED -> "cast signed ";
+            case CAST_UNSIGNED -> "cast unsigned ";
+            case CTLZ -> "ctlz ";
+            case MINUS -> "-";
+        };
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
@@ -231,7 +231,7 @@ public class ExprSimplifier extends ExprTransformer {
             return cond;
         } else if (t instanceof IConst tConstant && tConstant.isInteger() && tConstant.getValueAsInt() == 0
                 && f instanceof IConst fConstant && fConstant.isInteger() && fConstant.getValueAsInt() == 1) {
-            return expressions.makeUnary(BOpUn.NOT, cond);
+            return expressions.makeNot(cond);
         }
 
         return expressions.makeConditional(cond, t, f);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
@@ -15,9 +15,9 @@ import static com.dat3m.dartagnan.expression.op.IOpBin.R_SHIFT;
 public class ExprSimplifier extends ExprTransformer {
 
     @Override
-    public ExprInterface visit(Atom atom) {
-        ExprInterface lhs = atom.getLHS().visit(this);
-        ExprInterface rhs = atom.getRHS().visit(this);
+    public Expression visit(Atom atom) {
+        Expression lhs = atom.getLHS().visit(this);
+        Expression rhs = atom.getRHS().visit(this);
         if (lhs.equals(rhs)) {
             switch(atom.getOp()) {
                 case EQ:
@@ -100,7 +100,7 @@ public class ExprSimplifier extends ExprTransformer {
     @Override
     public BExpr visit(BExprUn bUn) {
         // Due to constant propagation we are not guaranteed to get BExprs
-        ExprInterface innerExpr = bUn.getInner().visit(this);
+        Expression innerExpr = bUn.getInner().visit(this);
         if(!(innerExpr instanceof BExpr)) {
             return bUn;
         }
@@ -213,10 +213,10 @@ public class ExprSimplifier extends ExprTransformer {
     }
 
     @Override
-    public ExprInterface visit(IfExpr ifExpr) {
-        ExprInterface cond = ifExpr.getGuard().visit(this);
-        ExprInterface t = ifExpr.getTrueBranch().visit(this);
-        ExprInterface f = ifExpr.getFalseBranch().visit(this);
+    public Expression visit(IfExpr ifExpr) {
+        Expression cond = ifExpr.getGuard().visit(this);
+        Expression t = ifExpr.getTrueBranch().visit(this);
+        Expression f = ifExpr.getFalseBranch().visit(this);
 
         if (cond instanceof BConst constantGuard) {
             return constantGuard.getValue() ? t : f;
@@ -243,12 +243,12 @@ public class ExprSimplifier extends ExprTransformer {
     }
 
     @Override
-    public ExprInterface visit(Register reg) {
+    public Expression visit(Register reg) {
         return reg;
     }
 
     @Override
-    public ExprInterface visit(MemoryObject address) {
+    public Expression visit(MemoryObject address) {
         return address;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
@@ -19,20 +19,20 @@ public class ExprSimplifier extends ExprTransformer {
         ExprInterface lhs = atom.getLHS().visit(this);
         ExprInterface rhs = atom.getRHS().visit(this);
         if (lhs.equals(rhs)) {
-        	switch(atom.getOp()) {
-        		case EQ:
-        		case LTE:
-        		case ULTE:
-        		case GTE:
-        		case UGTE:
-        			return BConst.TRUE;
-        		case NEQ:
-        		case LT:
-        		case ULT:
-        		case GT:
-        		case UGT:
-        			return BConst.FALSE;
-        	}
+            switch(atom.getOp()) {
+                case EQ:
+                case LTE:
+                case ULTE:
+                case GTE:
+                case UGTE:
+                    return BConst.TRUE;
+                case NEQ:
+                case LT:
+                case ULT:
+                case GT:
+                case UGT:
+                    return BConst.FALSE;
+            }
         }
         if (lhs instanceof IConst && rhs instanceof  IConst) {
             IConst lc = (IConst) lhs;
@@ -68,10 +68,10 @@ public class ExprSimplifier extends ExprTransformer {
 
     @Override
     public BExpr visit(BExprBin bBin) {
-    	// Due to constant propagation we are not guaranteed to get BExprs
-    	if(!(bBin.getLHS().visit(this) instanceof BExpr && bBin.getRHS().visit(this) instanceof BExpr)) {
-    		return bBin;
-    	}
+        // Due to constant propagation we are not guaranteed to get BExprs
+        if(!(bBin.getLHS().visit(this) instanceof BExpr && bBin.getRHS().visit(this) instanceof BExpr)) {
+            return bBin;
+        }
         BExpr lhs = (BExpr) bBin.getLHS().visit(this);
         BExpr rhs = (BExpr) bBin.getRHS().visit(this);
         switch (bBin.getOp()) {
@@ -99,11 +99,11 @@ public class ExprSimplifier extends ExprTransformer {
 
     @Override
     public BExpr visit(BExprUn bUn) {
-    	// Due to constant propagation we are not guaranteed to get BExprs
+        // Due to constant propagation we are not guaranteed to get BExprs
         ExprInterface innerExpr = bUn.getInner().visit(this);
-    	if(!(innerExpr instanceof BExpr)) {
-    		return bUn;
-    	}
+        if(!(innerExpr instanceof BExpr)) {
+            return bUn;
+        }
         BExpr inner = (BExpr) innerExpr;
         if (inner instanceof BConst) {
             return inner.isTrue() ? BConst.FALSE : BConst.TRUE;
@@ -136,26 +136,26 @@ public class ExprSimplifier extends ExprTransformer {
         IExpr rhs = (IExpr)iBin.getRHS().visit(this);
         IOpBin op = iBin.getOp();
         if (lhs.equals(rhs)) {
-        	switch(op) {
-        		case AND:
-        		case OR:
-        			return lhs;
-        		case XOR:
-        			return IValue.ZERO;
-        	}
+            switch(op) {
+                case AND:
+                case OR:
+                    return lhs;
+                case XOR:
+                    return IValue.ZERO;
+            }
         }
         if (! (lhs instanceof IConst || rhs instanceof IConst)) {
             return new IExprBin(lhs, iBin.getOp(), rhs);
         } else if (lhs instanceof IConst && rhs instanceof IConst) {
-    		// If we reduce MemoryObject as a normal IConst, we loose the fact that it is a Memory Object
-    		// We cannot call reduce for R_SHIFT (lack of implementation)
-    		if(!(lhs instanceof MemoryObject) && iBin.getOp() != R_SHIFT) {
-    			return new IExprBin(lhs, iBin.getOp(), rhs).reduce();
-    		}
-    		// Rule to reduce &mem + 0
-    		if(lhs instanceof MemoryObject && rhs.equals(IValue.ZERO)) {
-    			return lhs;
-    		}
+            // If we reduce MemoryObject as a normal IConst, we loose the fact that it is a Memory Object
+            // We cannot call reduce for R_SHIFT (lack of implementation)
+            if(!(lhs instanceof MemoryObject) && iBin.getOp() != R_SHIFT) {
+                return new IExprBin(lhs, iBin.getOp(), rhs).reduce();
+            }
+            // Rule to reduce &mem + 0
+            if(lhs instanceof MemoryObject && rhs.equals(IValue.ZERO)) {
+                return lhs;
+            }
         }
 
         if (lhs instanceof IConst) {
@@ -178,19 +178,19 @@ public class ExprSimplifier extends ExprTransformer {
                 return val.compareTo(BigInteger.ZERO) == 0 ? IValue.ZERO : val.equals(BigInteger.ONE) ? lhs : new IExprBin(lhs, op, rhs);
             case PLUS:
             case MINUS:
-            	if(val.compareTo(BigInteger.ZERO) == 0) {
-            		return lhs;
-            	}
-            	// Rule for associativity (rhs is IConst) since we cannot reduce MemoryObjects
-            	// Either op can be +/-, but this does not affect correctness
-            	// e.g. (&mem + x) - y -> &mem + reduced(x - y)
-            	if(lhs instanceof IExprBin && ((IExprBin)lhs).getRHS() instanceof IConst  && ((IExprBin)lhs).getOp() != R_SHIFT) {
-        			IExprBin lhsBin = (IExprBin)lhs;
-            		IExpr newLHS = lhsBin.getLHS();
-					IExpr newRHS = new IExprBin(lhsBin.getRHS(), lhsBin.getOp(), rhs).reduce();
-					return new IExprBin(newLHS, op, newRHS);
-            	}
-            	return new IExprBin(lhs, op, rhs);
+                if(val.compareTo(BigInteger.ZERO) == 0) {
+                    return lhs;
+                }
+                // Rule for associativity (rhs is IConst) since we cannot reduce MemoryObjects
+                // Either op can be +/-, but this does not affect correctness
+                // e.g. (&mem + x) - y -> &mem + reduced(x - y)
+                if(lhs instanceof IExprBin && ((IExprBin)lhs).getRHS() instanceof IConst  && ((IExprBin)lhs).getOp() != R_SHIFT) {
+                    IExprBin lhsBin = (IExprBin)lhs;
+                    IExpr newLHS = lhsBin.getLHS();
+                    IExpr newRHS = new IExprBin(lhsBin.getRHS(), lhsBin.getOp(), rhs).reduce();
+                    return new IExprBin(newLHS, op, newRHS);
+                }
+                return new IExprBin(lhs, op, rhs);
             default:
                 return new IExprBin(lhs, op, rhs);
         }
@@ -198,7 +198,7 @@ public class ExprSimplifier extends ExprTransformer {
 
     @Override
     public IExpr visit(IExprUn iUn) {
-        return new IExprUn(iUn.getOp(), iUn.getInner());
+        return new IExprUn(iUn.getOp(), iUn.getInner(), iUn.getType());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprTransformer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprTransformer.java
@@ -44,7 +44,7 @@ public abstract class ExprTransformer implements ExpressionVisitor<ExprInterface
 
     @Override
     public IExpr visit(IExprUn iUn) {
-        return new IExprUn(iUn.getOp(), (IExpr) iUn.getInner().visit(this));
+        return new IExprUn(iUn.getOp(), (IExpr) iUn.getInner().visit(this), iUn.getType());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprTransformer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprTransformer.java
@@ -1,15 +1,19 @@
 package com.dat3m.dartagnan.expression.processing;
 
 import com.dat3m.dartagnan.expression.*;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.memory.Location;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 
 public abstract class ExprTransformer implements ExpressionVisitor<ExprInterface> {
 
+    protected final TypeFactory types = TypeFactory.getInstance();
+    protected final ExpressionFactory expressions = ExpressionFactory.getInstance();
+
     @Override
     public ExprInterface visit(Atom atom) {
-        return new Atom(atom.getLHS().visit(this), atom.getOp(), atom.getRHS().visit(this));
+        return expressions.makeBinary(atom.getLHS().visit(this), atom.getOp(), atom.getRHS().visit(this));
     }
 
     @Override
@@ -19,12 +23,12 @@ public abstract class ExprTransformer implements ExpressionVisitor<ExprInterface
 
     @Override
     public BExpr visit(BExprBin bBin) {
-        return new BExprBin(bBin.getLHS().visit(this), bBin.getOp(), bBin.getRHS().visit(this));
+        return expressions.makeBinary(bBin.getLHS().visit(this), bBin.getOp(), bBin.getRHS().visit(this));
     }
 
     @Override
     public BExpr visit(BExprUn bUn) {
-        return new BExprUn(bUn.getOp(), bUn.getInner().visit(this));
+        return expressions.makeUnary(bUn.getOp(), bUn.getInner().visit(this));
     }
 
     @Override
@@ -39,17 +43,20 @@ public abstract class ExprTransformer implements ExpressionVisitor<ExprInterface
 
     @Override
     public IExpr visit(IExprBin iBin) {
-        return new IExprBin((IExpr) iBin.getLHS().visit(this), iBin.getOp(), (IExpr) iBin.getRHS().visit(this));
+        return expressions.makeBinary(iBin.getLHS().visit(this), iBin.getOp(), iBin.getRHS().visit(this));
     }
 
     @Override
     public IExpr visit(IExprUn iUn) {
-        return new IExprUn(iUn.getOp(), (IExpr) iUn.getInner().visit(this), iUn.getType());
+        return expressions.makeUnary(iUn.getOp(), iUn.getInner().visit(this), iUn.getType());
     }
 
     @Override
     public ExprInterface visit(IfExpr ifExpr) {
-        return new IfExpr((BExpr)ifExpr.getGuard().visit(this), (IExpr)ifExpr.getTrueBranch().visit(this), (IExpr)ifExpr.getFalseBranch().visit(this));
+        return expressions.makeConditional(
+                ifExpr.getGuard().visit(this),
+                ifExpr.getTrueBranch().visit(this),
+                ifExpr.getFalseBranch().visit(this));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprTransformer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprTransformer.java
@@ -6,13 +6,13 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.memory.Location;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 
-public abstract class ExprTransformer implements ExpressionVisitor<ExprInterface> {
+public abstract class ExprTransformer implements ExpressionVisitor<Expression> {
 
     protected final TypeFactory types = TypeFactory.getInstance();
     protected final ExpressionFactory expressions = ExpressionFactory.getInstance();
 
     @Override
-    public ExprInterface visit(Atom atom) {
+    public Expression visit(Atom atom) {
         return expressions.makeBinary(atom.getLHS().visit(this), atom.getOp(), atom.getRHS().visit(this));
     }
 
@@ -52,7 +52,7 @@ public abstract class ExprTransformer implements ExpressionVisitor<ExprInterface
     }
 
     @Override
-    public ExprInterface visit(IfExpr ifExpr) {
+    public Expression visit(IfExpr ifExpr) {
         return expressions.makeConditional(
                 ifExpr.getGuard().visit(this),
                 ifExpr.getTrueBranch().visit(this),
@@ -65,17 +65,17 @@ public abstract class ExprTransformer implements ExpressionVisitor<ExprInterface
     }
 
     @Override
-    public ExprInterface visit(Register reg) {
+    public Expression visit(Register reg) {
         return reg;
     }
 
     @Override
-    public ExprInterface visit(MemoryObject address) {
+    public Expression visit(MemoryObject address) {
         return address;
     }
 
     @Override
-    public ExprInterface visit(Location location) {
+    public Expression visit(Location location) {
         return location;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/IntegerType.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/IntegerType.java
@@ -1,5 +1,7 @@
 package com.dat3m.dartagnan.expression.type;
 
+import java.math.BigInteger;
+
 import static com.google.common.base.Preconditions.checkState;
 
 public final class IntegerType implements Type {
@@ -19,6 +21,29 @@ public final class IntegerType implements Type {
     public int getBitWidth() {
         checkState(bitWidth > 0, "Invalid integer bound %s", bitWidth);
         return bitWidth;
+    }
+
+    public boolean canContain(BigInteger value) {
+        // Both signed and unsigned versions are allowed.
+        // The value range is the union of [ 0, 2^bitWidth ) and [ -2^(bitWidth-1), 2^(bitWidth-1) ).
+        if (isMathematical()) {
+            return true;
+        } else if (value.signum() >= 0) {
+            // check for upper bound for unsigned value
+            final BigInteger upperBoundExclusive = BigInteger.TWO.pow(bitWidth);
+            return value.compareTo(upperBoundExclusive) < 0; // value < 2^(bitWidth)
+        } else {
+            // check for lower bound for signed values
+            final BigInteger lowerBoundInclusive = BigInteger.TWO.pow(bitWidth - 1).negate();
+            return value.compareTo(lowerBoundInclusive) >= 0; // value >= -2^(bitWidth - 1) (1 bit is used for the sign)
+        }
+    }
+
+    public BigInteger applySign(BigInteger value, boolean signed) {
+        if (signed) {
+            return value.testBit(bitWidth - 1) ? value.subtract(BigInteger.TWO.pow(bitWidth)) : value;
+        }
+        return value.signum() >= 0 ? value : BigInteger.TWO.pow(bitWidth).add(value);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmFunctions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmFunctions.java
@@ -1,10 +1,6 @@
 package com.dat3m.dartagnan.parsers.program.boogie;
 
-import com.dat3m.dartagnan.expression.BExprUn;
-import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IConst;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IExprBin;
+import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.op.BOpUn;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.exception.ParsingException;
@@ -33,7 +29,7 @@ public class LlvmFunctions {
 			"$and.",
 			"$nand.");
 	
-	public static Object llvmFunction(String name, List<Object> callParams) {
+	public static Object llvmFunction(String name, List<Object> callParams, ExpressionFactory factory) {
 		IOpBin op = null; 
 		if(name.startsWith("$add.")) {
 			op = PLUS;
@@ -65,7 +61,7 @@ public class LlvmFunctions {
 				if (c.getValueAsInt() == 0) {
 					return callParams.get(0);
 				} else if (c.getValueAsInt() == 1) {
-					return new BExprUn(BOpUn.NOT, (ExprInterface) callParams.get(0));
+					return factory.makeUnary(BOpUn.NOT, (ExprInterface) callParams.get(0));
 				}
 			}
 			op = XOR;
@@ -77,6 +73,6 @@ public class LlvmFunctions {
 		if(op == null) {
 			throw new ParsingException("Function " + name + " has no implementation");
 		}
-		return new IExprBin((IExpr)callParams.get(0), op, (IExpr)callParams.get(1));
+		return factory.makeBinary((IExpr)callParams.get(0), op, (IExpr)callParams.get(1));
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmFunctions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmFunctions.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.parsers.program.boogie;
 
 import com.dat3m.dartagnan.expression.*;
-import com.dat3m.dartagnan.expression.op.BOpUn;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.exception.ParsingException;
 
@@ -61,7 +60,7 @@ public class LlvmFunctions {
 				if (c.getValueAsInt() == 0) {
 					return callParams.get(0);
 				} else if (c.getValueAsInt() == 1) {
-					return factory.makeUnary(BOpUn.NOT, (Expression) callParams.get(0));
+					return factory.makeNot((Expression) callParams.get(0));
 				}
 			}
 			op = XOR;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmFunctions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmFunctions.java
@@ -61,7 +61,7 @@ public class LlvmFunctions {
 				if (c.getValueAsInt() == 0) {
 					return callParams.get(0);
 				} else if (c.getValueAsInt() == 1) {
-					return factory.makeUnary(BOpUn.NOT, (ExprInterface) callParams.get(0));
+					return factory.makeUnary(BOpUn.NOT, (Expression) callParams.get(0));
 				}
 			}
 			op = XOR;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmPredicates.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmPredicates.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.parsers.program.boogie;
 
-import com.dat3m.dartagnan.expression.Atom;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.exception.ParsingException;
@@ -58,7 +58,7 @@ public class LlvmPredicates {
 			"$ne.bv8.bool", "$ne.bv16.bool", "$ne.bv32.bool", "$ne.bv64.bool"
 			);
 	
-	public static Object llvmPredicate(String name, List<Object> callParams) {
+	public static Object llvmPredicate(String name, List<Object> callParams, ExpressionFactory factory) {
 		COpBin op = null;
 		if(name.startsWith("$sle.")) {
 			op = LTE;
@@ -84,6 +84,6 @@ public class LlvmPredicates {
 		if(op == null) {
 			throw new ParsingException("Function " + name + " has no implementation");
 		}
-		return new Atom((ExprInterface)callParams.get(0), op, (ExprInterface)callParams.get(1));
+		return factory.makeBinary((ExprInterface)callParams.get(0), op, (ExprInterface)callParams.get(1));
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmPredicates.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmPredicates.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.parsers.program.boogie;
 
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.exception.ParsingException;
 
@@ -84,6 +84,6 @@ public class LlvmPredicates {
 		if(op == null) {
 			throw new ParsingException("Function " + name + " has no implementation");
 		}
-		return factory.makeBinary((ExprInterface)callParams.get(0), op, (ExprInterface)callParams.get(1));
+		return factory.makeBinary((Expression)callParams.get(0), op, (Expression)callParams.get(1));
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
@@ -73,12 +73,11 @@ public class LlvmUnary {
             case TRUNCATE, SIGNED_EXTEND, UNSIGNED_EXTEND -> {
                 boolean signed = !prefix.equals(UNSIGNED_EXTEND);
                 String[] suffixParts = suffix.split("\\.");
-                assert suffixParts.length == 2 && suffixParts[0].startsWith("bv") && suffixParts[1].startsWith("bv");
-                int expectedBitWidth = Integer.parseInt(suffixParts[0].substring(2));
-                checkArgument(!integerType.isMathematical() && integerType.getBitWidth() == expectedBitWidth,
-                        "Type mismatch between %s and bv%s.", integerType, expectedBitWidth);
-                int bitWidth = Integer.parseInt(suffixParts[1].substring(2));
-                IntegerType targetType = types.getIntegerType(bitWidth);
+                assert suffixParts.length == 2;
+                IntegerType innerType = Types.parseIntegerType(suffixParts[0], types);
+                checkArgument(integerType.equals(innerType),
+                        "Type mismatch between %s and %s.", integerType, innerType);
+                IntegerType targetType = Types.parseIntegerType(suffixParts[1], types);
                 return expressions.makeIntegerCast(inner, targetType, signed);
             }
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
@@ -22,7 +22,7 @@ public class LlvmUnary {
     private static final String TRUNCATE = "$trunc.";
     private static final String SIGNED_EXTEND = "$sext.";
     private static final String UNSIGNED_EXTEND = "$zext.";
-    public static List<String> LLVMUNARY = Arrays.asList(
+    public static final List<String> LLVMUNARY = Arrays.asList(
             NOT,
             BITVECTOR_TO_SIGNED_INTEGER,
             BITVECTOR_TO_UNSIGNED_INTEGER,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
@@ -61,7 +61,7 @@ public class LlvmUnary {
             case BITVECTOR_TO_SIGNED_INTEGER, BITVECTOR_TO_UNSIGNED_INTEGER -> {
                 checkArgument(!integerType.isMathematical(), "Expected bv, got int.");
                 boolean signed = prefix.equals(BITVECTOR_TO_SIGNED_INTEGER);
-                return expressions.makeIntegerCast(inner, types.getIntegerType(), signed);
+                return expressions.makeIntegerCast(inner, types.getArchType(), signed);
             }
             case SIGNED_INTEGER_TO_BITVECTOR, UNSIGNED_INTEGER_TO_BITVECTOR -> {
                 checkArgument(integerType.isMathematical(), "Expected int, got %s.", integerType);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
@@ -1,141 +1,88 @@
 package com.dat3m.dartagnan.parsers.program.boogie;
 
 import com.dat3m.dartagnan.exception.ParsingException;
-import com.dat3m.dartagnan.expression.BExprUn;
-import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IExprUn;
+import com.dat3m.dartagnan.expression.*;
+import com.dat3m.dartagnan.expression.op.BOpUn;
 import com.dat3m.dartagnan.expression.op.IOpUn;
+import com.dat3m.dartagnan.expression.type.*;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static com.dat3m.dartagnan.expression.op.BOpUn.NOT;
-import static com.dat3m.dartagnan.expression.op.IOpUn.*;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class LlvmUnary {
 
-	public static List<String> LLVMUNARY = Arrays.asList(
-			"$not.",
+    // List of supported prefixes.
+    private static final String NOT = "$not.";
+    private static final String BITVECTOR_TO_SIGNED_INTEGER = "$bv2int.";
+    private static final String BITVECTOR_TO_UNSIGNED_INTEGER = "$bv2uint.";
+    private static final String SIGNED_INTEGER_TO_BITVECTOR = "$int2bv.";
+    private static final String UNSIGNED_INTEGER_TO_BITVECTOR = "$uint2bv.";
+    private static final String TRUNCATE = "$trunc.";
+    private static final String SIGNED_EXTEND = "$sext.";
+    private static final String UNSIGNED_EXTEND = "$zext.";
+    public static List<String> LLVMUNARY = Arrays.asList(
+            NOT,
+            BITVECTOR_TO_SIGNED_INTEGER,
+            BITVECTOR_TO_UNSIGNED_INTEGER,
+            SIGNED_INTEGER_TO_BITVECTOR,
+            UNSIGNED_INTEGER_TO_BITVECTOR,
+            TRUNCATE,
+            SIGNED_EXTEND,
+            UNSIGNED_EXTEND
+    );
 
-			"$bv2uint.", "$bv2int.",
+    public static Object llvmUnary(String name, List<Object> callParams) {
+        try {
+            for (String prefix : LLVMUNARY) {
+                if (name.startsWith(prefix)) {
+                    String suffix = name.substring(prefix.length());
+                    return llvmUnary(prefix, suffix, callParams);
+                }
+            }
+        } catch (IllegalArgumentException x) {
+            throw new ParsingException(String.format("Function %s is not implemented: %s", name, x.getMessage()));
+        }
+        throw new ParsingException(String.format("Function %s is not implemented.", name));
+    }
 
-			"$uint2bv.1", "$uint2bv.8", "$uint2bv.16", "$uint2bv.32", "$uint2bv.64",
-			"$int2bv.1", "$int2bv.8", "$int2bv.16", "$int2bv.32", "$int2bv.64",
-			
-			"$trunc.bv64.bv32", "$trunc.bv64.bv16", "$trunc.bv64.bv8", "$trunc.bv64.bv1",
-			"$trunc.bv32.bv16", "$trunc.bv32.bv8", "$trunc.bv32.bv1",
-			"$trunc.bv16.bv8", "$trunc.bv16.bv1",
-			"$trunc.bv8.bv1",
-			
-			"$zext.bv1.bv8", "$zext.bv1.bv16", "$zext.bv1.bv32","$zext.bv1.bv64", 
-			"$zext.bv8.bv16", "$zext.bv8.bv32", "$zext.bv8.bv64",
-			"$zext.bv16.bv32", "$zext.bv16.bv64",
-			"$zext.bv32.bv64",
-			
-			"$sext.bv1.bv8", "$sext.bv1.bv16", "$sext.bv1.bv32","$sext.bv1.bv64", 
-			"$sext.bv8.bv16", "$sext.bv8.bv32", "$sext.bv8.bv64",
-			"$sext.bv16.bv32", "$sext.bv16.bv64",
-			"$sext.bv32.bv64"
-			);
-	
-	public static Object llvmUnary(String name, List<Object> callParams) {
-		if(name.startsWith("$not.")) {
-			return new BExprUn(NOT, (ExprInterface)callParams.get(0));
-		}
-
-		IOpUn op = null;
-		if(name.startsWith("$bv2uint.")) {
-			op = BV2UINT;
-		} else if(name.startsWith("$bv2int.")) {
-			op = BV2INT;
-		} else if (name.contains("int2bv")) {
-			// ============ INT2BV ============
-			if (name.equals("$uint2bv.1") || name.equals("$int2bv.1")) {
-				op = INT2BV1;
-			} else if (name.equals("$uint2bv.8") || name.equals("$int2bv.8")) {
-				op = INT2BV8;
-			} else if (name.equals("$uint2bv.16") || name.equals("$int2bv.16")) {
-				op = INT2BV16;
-			} else if (name.equals("$uint2bv.32") || name.equals("$int2bv.32")) {
-				op = INT2BV32;
-			} else if (name.equals("$uint2bv.64") || name.equals("$int2bv.64")) {
-				op = INT2BV64;
-			}
-		} else if (name.startsWith("$trunc.")) {
-			// ============ TRUNC ============
-			if (name.equals("$trunc.bv64.bv32")) {
-				op = TRUNC6432;
-			} else if (name.equals("$trunc.bv64.bv16")) {
-				op = TRUNC6416;
-			} else if (name.equals("$trunc.bv64.bv8")) {
-				op = TRUNC648;
-			} else if (name.equals("$trunc.bv64.bv1")) {
-				op = TRUNC641;
-			} else if (name.equals("$trunc.bv32.bv16")) {
-				op = TRUNC3216;
-			} else if (name.equals("$trunc.bv32.bv8")) {
-				op = TRUNC328;
-			} else if (name.equals("$trunc.bv32.bv1")) {
-				op = TRUNC321;
-			} else if (name.equals("$trunc.bv16.bv8")) {
-				op = TRUNC168;
-			} else if (name.equals("$trunc.bv16.bv1")) {
-				op = TRUNC161;
-			} else if (name.equals("$trunc.bv8.bv1")) {
-				op = TRUNC81;
-			}
-		} else if (name.startsWith("$zext")) {
-			// ============ ZEXT ============
-			if (name.equals("$zext.bv1.bv8")) {
-				op = ZEXT18;
-			} else if (name.equals("$zext.bv1.bv16")) {
-				op = ZEXT116;
-			} else if (name.equals("$zext.bv1.bv32")) {
-				op = ZEXT132;
-			} else if (name.equals("$zext.bv1.bv64")) {
-				op = ZEXT164;
-			} else if (name.equals("$zext.bv8.bv16")) {
-				op = ZEXT816;
-			} else if (name.equals("$zext.bv8.bv32")) {
-				op = ZEXT832;
-			} else if (name.equals("$zext.bv8.bv64")) {
-				op = ZEXT864;
-			} else if (name.equals("$zext.bv16.bv32")) {
-				op = ZEXT1632;
-			} else if (name.equals("$zext.bv16.bv64")) {
-				op = ZEXT1664;
-			} else if (name.equals("$zext.bv32.bv64")) {
-				op = ZEXT3264;
-			}
-		} else if (name.startsWith("$sext")) {
-			// ============ SEXT ============
-			if (name.equals("$sext.bv1.bv8")) {
-				op = SEXT18;
-			} else if (name.equals("$sext.bv1.bv16")) {
-				op = SEXT116;
-			} else if (name.equals("$sext.bv1.bv32")) {
-				op = SEXT132;
-			} else if (name.equals("$sext.bv1.bv64")) {
-				op = SEXT164;
-			} else if (name.equals("$sext.bv8.bv16")) {
-				op = SEXT816;
-			} else if (name.equals("$sext.bv8.bv32")) {
-				op = SEXT832;
-			} else if (name.equals("$sext.bv8.bv64")) {
-				op = SEXT864;
-			} else if (name.equals("$sext.bv16.bv32")) {
-				op = SEXT1632;
-			} else if (name.equals("$sext.bv16.bv64")) {
-				op = SEXT1664;
-			} else if (name.equals("$sext.bv32.bv64")) {
-				op = SEXT3264;
-			}
-		}
-
-		if(op == null) {
-			throw new ParsingException("Function " + name + " has no implementation");
-		}
-		return new IExprUn(op, (IExpr)callParams.get(0));
-	}
+    private static Object llvmUnary(String prefix, String suffix, List<Object> callParams) {
+        TypeFactory types = TypeFactory.getInstance();
+        IExpr inner = (IExpr) callParams.get(0);
+        IntegerType integerType = inner.getType();
+        switch (prefix) {
+            case NOT -> {
+                //TODO type-cast
+                return new BExprUn(BOpUn.NOT, inner);
+            }
+            case BITVECTOR_TO_SIGNED_INTEGER, BITVECTOR_TO_UNSIGNED_INTEGER -> {
+                checkArgument(!integerType.isMathematical(), "Expected bv, got int.");
+                boolean signed = prefix.equals(BITVECTOR_TO_SIGNED_INTEGER);
+                IOpUn operator = signed ? IOpUn.CAST_SIGNED : IOpUn.CAST_UNSIGNED;
+                return new IExprUn(operator, inner, types.getIntegerType());
+            }
+            case SIGNED_INTEGER_TO_BITVECTOR, UNSIGNED_INTEGER_TO_BITVECTOR -> {
+                checkArgument(integerType.isMathematical(), "Expected int, got %s.", integerType);
+                boolean signed = prefix.equals(SIGNED_INTEGER_TO_BITVECTOR);
+                IOpUn operator = signed ? IOpUn.CAST_SIGNED : IOpUn.CAST_UNSIGNED;
+                int bitWidth = Integer.parseInt(suffix);
+                IntegerType targetType = types.getIntegerType(bitWidth);
+                return new IExprUn(operator, inner, targetType);
+            }
+            case TRUNCATE, SIGNED_EXTEND, UNSIGNED_EXTEND -> {
+                boolean signed = !prefix.equals(UNSIGNED_EXTEND);
+                IOpUn operator = signed ? IOpUn.CAST_SIGNED : IOpUn.CAST_UNSIGNED;
+                String[] suffixParts = suffix.split("\\.");
+                assert suffixParts.length == 2 && suffixParts[0].startsWith("bv") && suffixParts[1].startsWith("bv");
+                int expectedBitWidth = Integer.parseInt(suffixParts[0].substring(2));
+                checkArgument(!integerType.isMathematical() && integerType.getBitWidth() == expectedBitWidth,
+                        "Type mismatch between %s and bv%s.", integerType, expectedBitWidth);
+                int bitWidth = Integer.parseInt(suffixParts[1].substring(2));
+                IntegerType targetType = types.getIntegerType(bitWidth);
+                return new IExprUn(operator, inner, targetType);
+            }
+        }
+        throw new AssertionError();
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/LlvmUnary.java
@@ -1,8 +1,8 @@
 package com.dat3m.dartagnan.parsers.program.boogie;
 
 import com.dat3m.dartagnan.exception.ParsingException;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 
@@ -49,7 +49,7 @@ public class LlvmUnary {
 
     private static Object llvmUnary(String prefix, String suffix, List<Object> callParams, ExpressionFactory expressions) {
         TypeFactory types = TypeFactory.getInstance();
-        ExprInterface inner = (ExprInterface) callParams.get(0);
+        Expression inner = (Expression) callParams.get(0);
         if (!(inner.getType() instanceof IntegerType integerType)) {
             throw new ParsingException(String.format("%s is not an integer expression.", inner));
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/SmackPredicates.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/SmackPredicates.java
@@ -108,9 +108,9 @@ public class SmackPredicates {
 		IValue maxValue = expressions.parseValue(max, var.getType());
 		return expressions.makeConditional(
 				expressions.makeAnd(
-						expressions.makeGreaterOrEqual(var, expressions.parseValue(min, var.getType()), true),
-						expressions.makeLessOrEqual(var, maxValue, true)),
+						expressions.makeGTE(var, expressions.parseValue(min, var.getType()), true),
+						expressions.makeLTE(var, maxValue, true)),
 				var,
-				expressions.makeModulo(var, maxValue));
+				expressions.makeMOD(var, maxValue));
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/SmackPredicates.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/SmackPredicates.java
@@ -5,7 +5,6 @@ import static com.dat3m.dartagnan.expression.op.COpBin.LTE;
 import static com.dat3m.dartagnan.expression.op.COpBin.GTE;
 import static com.dat3m.dartagnan.expression.op.IOpBin.MOD;
 
-import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 
@@ -21,7 +20,7 @@ public class SmackPredicates {
 			"$tos.i56", "$tos.i64", "$tos.i80", "$tos.i88", "$tos.i96", "$tos.i128", "$tos.i160", "$tos.i256"
 			);
 	
-	public static Object smackPredicate(String name, List<Object> callParams) {
+	public static Object smackPredicate(String name, List<Object> callParams, ExpressionFactory factory) {
 		String min = "0";
 		String max = "1";
 		IExpr var = (IExpr)callParams.get(0);
@@ -109,11 +108,13 @@ public class SmackPredicates {
 				throw new ParsingException("Function " + name + " has no implementation");
 			}
 		}
-		IValue maxValue = new IValue(new BigInteger(max),var.getPrecision());
-		Atom c1 = new Atom(var,GTE,new IValue(new BigInteger(min),var.getPrecision()));
-		Atom c2 = new Atom(var,LTE,maxValue);
-		BExprBin guard = new BExprBin(c1, AND, c2);
-		IExpr fbranch = new IExprBin(var,MOD,maxValue);
-		return new IfExpr(guard, var, fbranch);
+		IValue maxValue = factory.parseValue(max, var.getType());
+		return factory.makeConditional(
+				factory.makeBinary(
+						factory.makeBinary(var, GTE, factory.parseValue(min, var.getType())),
+						AND,
+						factory.makeBinary(var, LTE, maxValue)),
+				var,
+				factory.makeBinary(var, MOD, maxValue));
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/SmackPredicates.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/SmackPredicates.java
@@ -1,15 +1,12 @@
 package com.dat3m.dartagnan.parsers.program.boogie;
 
-import static com.dat3m.dartagnan.expression.op.BOpBin.AND;
-import static com.dat3m.dartagnan.expression.op.COpBin.LTE;
-import static com.dat3m.dartagnan.expression.op.COpBin.GTE;
-import static com.dat3m.dartagnan.expression.op.IOpBin.MOD;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.exception.ParsingException;
 
 import java.util.Arrays;
 import java.util.List;
-
-import com.dat3m.dartagnan.expression.*;
-import com.dat3m.dartagnan.exception.ParsingException;
 
 public class SmackPredicates {
 
@@ -20,7 +17,7 @@ public class SmackPredicates {
 			"$tos.i56", "$tos.i64", "$tos.i80", "$tos.i88", "$tos.i96", "$tos.i128", "$tos.i160", "$tos.i256"
 			);
 	
-	public static Object smackPredicate(String name, List<Object> callParams, ExpressionFactory factory) {
+	public static Object smackPredicate(String name, List<Object> callParams, ExpressionFactory expressions) {
 		String min = "0";
 		String max = "1";
 		IExpr var = (IExpr)callParams.get(0);
@@ -108,13 +105,12 @@ public class SmackPredicates {
 				throw new ParsingException("Function " + name + " has no implementation");
 			}
 		}
-		IValue maxValue = factory.parseValue(max, var.getType());
-		return factory.makeConditional(
-				factory.makeBinary(
-						factory.makeBinary(var, GTE, factory.parseValue(min, var.getType())),
-						AND,
-						factory.makeBinary(var, LTE, maxValue)),
+		IValue maxValue = expressions.parseValue(max, var.getType());
+		return expressions.makeConditional(
+				expressions.makeAnd(
+						expressions.makeGreaterOrEqual(var, expressions.parseValue(min, var.getType()), true),
+						expressions.makeLessOrEqual(var, maxValue, true)),
 				var,
-				factory.makeBinary(var, MOD, maxValue));
+				expressions.makeModulo(var, maxValue));
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/Types.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/boogie/Types.java
@@ -1,0 +1,16 @@
+package com.dat3m.dartagnan.parsers.program.boogie;
+
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
+
+public class Types {
+
+    private Types() {}
+
+    public static IntegerType parseIntegerType(String name, TypeFactory types) {
+        if (name.contains("bv")) {
+            return types.getIntegerType(Integer.parseInt(name.split("bv")[1]));
+        }
+        return types.getArchType();
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -108,20 +108,10 @@ public class ProgramBuilder {
         getOrNewObject(locName).setInitialValue(0,iValue);
     }
 
-    @Deprecated
-    public void initRegEqLocPtr(int regThread, String regName, String locName, int precision){
-        initRegEqLocPtr(regThread, regName, locName, types.getIntegerType(precision));
-    }
-
     public void initRegEqLocPtr(int regThread, String regName, String locName, IntegerType type) {
         MemoryObject object = getOrNewObject(locName);
         Register reg = getOrNewRegister(regThread, regName, type);
         addChild(regThread, EventFactory.newLocal(reg, object));
-    }
-
-    @Deprecated
-    public void initRegEqLocVal(int regThread, String regName, String locName, int precision){
-        initRegEqLocVal(regThread, regName, locName, types.getIntegerType(precision));
     }
 
     public void initRegEqLocVal(int regThread, String regName, String locName, IntegerType type) {
@@ -146,10 +136,6 @@ public class ProgramBuilder {
         return constant;
     }
 
-    public Event getLastEvent(int thread){
-        return threads.get(thread).getExit();
-    }
-
     public MemoryObject getObject(String name) {
         return locations.get(name);
     }
@@ -172,12 +158,6 @@ public class ProgramBuilder {
             return threads.get(thread).getRegister(name);
         }
         return null;
-    }
-
-    @Deprecated
-    public Register getOrCreateRegister(int threadId, String name, int precision) {
-        IntegerType type = precision < 0 ? types.getIntegerType() : types.getIntegerType(precision);
-        return getOrNewRegister(threadId, name, type);
     }
 
     public Register getOrNewRegister(int threadId, String name) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -108,19 +108,29 @@ public class ProgramBuilder {
         getOrNewObject(locName).setInitialValue(0,iValue);
     }
 
+    @Deprecated
     public void initRegEqLocPtr(int regThread, String regName, String locName, int precision){
+        initRegEqLocPtr(regThread, regName, locName, types.getIntegerType(precision));
+    }
+
+    public void initRegEqLocPtr(int regThread, String regName, String locName, IntegerType type) {
         MemoryObject object = getOrNewObject(locName);
-        Register reg = getOrCreateRegister(regThread, regName, precision);
+        Register reg = getOrNewRegister(regThread, regName, type);
         addChild(regThread, EventFactory.newLocal(reg, object));
     }
 
+    @Deprecated
     public void initRegEqLocVal(int regThread, String regName, String locName, int precision){
-        Register reg = getOrCreateRegister(regThread, regName, precision);
+        initRegEqLocVal(regThread, regName, locName, types.getIntegerType(precision));
+    }
+
+    public void initRegEqLocVal(int regThread, String regName, String locName, IntegerType type) {
+        Register reg = getOrNewRegister(regThread, regName, type);
         addChild(regThread,EventFactory.newLocal(reg,getInitialValue(locName)));
     }
 
     public void initRegEqConst(int regThread, String regName, IConst iValue){
-        addChild(regThread, EventFactory.newLocal(getOrCreateRegister(regThread, regName, iValue.getPrecision()), iValue));
+        addChild(regThread, EventFactory.newLocal(getOrNewRegister(regThread, regName, iValue.getType()), iValue));
     }
 
     private IConst getInitialValue(String name) {
@@ -168,6 +178,10 @@ public class ProgramBuilder {
     public Register getOrCreateRegister(int threadId, String name, int precision) {
         IntegerType type = precision < 0 ? types.getIntegerType() : types.getIntegerType(precision);
         return getOrNewRegister(threadId, name, type);
+    }
+
+    public Register getOrNewRegister(int threadId, String name) {
+        return getOrNewRegister(threadId, name, types.getArchType());
     }
 
     public Register getOrNewRegister(int threadId, String name, IntegerType type) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.parsers.program.visitors;
 
 import com.dat3m.dartagnan.exception.ParsingException;
 import com.dat3m.dartagnan.expression.*;
-import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.LitmusAArch64BaseVisitor;
@@ -260,7 +259,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         IExpr expr = ctx.immediate() == null
                 ? programBuilder.getOrErrorRegister(mainThread, ctx.expressionConversion().register32().id)
                 : expressions.parseValue(ctx.immediate().constant().getText(), archType);
-        programBuilder.addChild(mainThread, EventFactory.newLocal(result, expressions.makeBinary(register, IOpBin.PLUS, expr)));
+        programBuilder.addChild(mainThread, EventFactory.newLocal(result, expressions.makePlus(register, expr)));
         return result;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -196,7 +196,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         if(cmp == null){
             throw new ParsingException("Invalid syntax near " + ctx.getText());
         }
-        ExprInterface expr = expressions.makeBinary(cmp.left, ctx.branchCondition().op, cmp.right);
+        Expression expr = expressions.makeBinary(cmp.left, ctx.branchCondition().op, cmp.right);
         return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label));
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -259,7 +259,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         IExpr expr = ctx.immediate() == null
                 ? programBuilder.getOrErrorRegister(mainThread, ctx.expressionConversion().register32().id)
                 : expressions.parseValue(ctx.immediate().constant().getText(), archType);
-        programBuilder.addChild(mainThread, EventFactory.newLocal(result, expressions.makePlus(register, expr)));
+        programBuilder.addChild(mainThread, EventFactory.newLocal(result, expressions.makeADD(register, expr)));
         return result;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAssertions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAssertions.java
@@ -1,9 +1,9 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
-import java.math.BigInteger;
-
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.LitmusAssertionsBaseVisitor;
 import com.dat3m.dartagnan.parsers.LitmusAssertionsParser;
 import com.dat3m.dartagnan.exception.ParsingException;
@@ -13,12 +13,13 @@ import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.memory.Location;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
-import static com.dat3m.dartagnan.GlobalSettings.getArchPrecision;
 import static com.google.common.base.Preconditions.checkState;
 
 public class VisitorLitmusAssertions extends LitmusAssertionsBaseVisitor<AbstractAssert> {
 
     private final ProgramBuilder programBuilder;
+    private final ExpressionFactory expressions = ExpressionFactory.getInstance();
+    private final IntegerType archType = TypeFactory.getInstance().getArchType();
 
     public VisitorLitmusAssertions(ProgramBuilder programBuilder){
         this.programBuilder = programBuilder;
@@ -73,7 +74,7 @@ public class VisitorLitmusAssertions extends LitmusAssertionsBaseVisitor<Abstrac
 
     private ExprInterface acceptAssertionValue(LitmusAssertionsParser.AssertionValueContext ctx, boolean right) {
         if(ctx.constant() != null) {
-            return new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision());
+            return expressions.parseValue(ctx.constant().getText(), archType);
         }
         String name = ctx.varName().getText();
         if(ctx.threadId() != null) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAssertions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAssertions.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
@@ -67,12 +67,12 @@ public class VisitorLitmusAssertions extends LitmusAssertionsBaseVisitor<Abstrac
 
     @Override
     public AbstractAssert visitAssertionBasic(LitmusAssertionsParser.AssertionBasicContext ctx){
-        ExprInterface expr1 = acceptAssertionValue(ctx.assertionValue(0),false);
-        ExprInterface expr2 = acceptAssertionValue(ctx.assertionValue(1),true);
+        Expression expr1 = acceptAssertionValue(ctx.assertionValue(0),false);
+        Expression expr2 = acceptAssertionValue(ctx.assertionValue(1),true);
         return new AssertBasic(expr1, ctx.assertionCompare().op, expr2);
     }
 
-    private ExprInterface acceptAssertionValue(LitmusAssertionsParser.AssertionValueContext ctx, boolean right) {
+    private Expression acceptAssertionValue(LitmusAssertionsParser.AssertionValueContext ctx, boolean right) {
         if(ctx.constant() != null) {
             return expressions.parseValue(ctx.constant().getText(), archType);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -1,8 +1,8 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
 import com.dat3m.dartagnan.exception.ParsingException;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IValue;
@@ -200,7 +200,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
 
     @Override
     public Object visitIfExpression(LitmusCParser.IfExpressionContext ctx) {
-    	ExprInterface expr = (ExprInterface) ctx.re().accept(this);
+    	Expression expr = (Expression) ctx.re().accept(this);
 
     	ifId++;
         Label elseL = programBuilder.getOrCreateLabel("else_" + ifId);
@@ -230,7 +230,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     @Override
     public IExpr visitReAtomicOpReturn(LitmusCParser.ReAtomicOpReturnContext ctx){
         Register register = getReturnRegister(true);
-        ExprInterface value = returnExpressionOrOne(ctx.value);
+        Expression value = returnExpressionOrOne(ctx.value);
         Event event = EventFactory.Linux.newRMWOpReturn(getAddress(ctx.address), register, value, ctx.op, ctx.mo);
         programBuilder.addChild(currentThread, event);
         return register;
@@ -270,7 +270,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public IExpr visitReAtomicAddUnless(LitmusCParser.ReAtomicAddUnlessContext ctx){
         Register register = getReturnRegister(true);
         IExpr value = (IExpr)ctx.value.accept(this);
-        ExprInterface cmp = (ExprInterface)ctx.cmp.accept(this);
+        Expression cmp = (Expression)ctx.cmp.accept(this);
         programBuilder.addChild(currentThread, EventFactory.Linux.newRMWAddUnless(getAddress(ctx.address), register, cmp, value));
         return register;
     }
@@ -305,7 +305,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     @Override
     public IExpr visitReCmpXchg(LitmusCParser.ReCmpXchgContext ctx){
         Register register = getReturnRegister(true);
-        ExprInterface cmp = (ExprInterface)ctx.cmp.accept(this);
+        Expression cmp = (Expression)ctx.cmp.accept(this);
         IExpr value = (IExpr)ctx.value.accept(this);
         Event event = EventFactory.Linux.newRMWCompareExchange(getAddress(ctx.address), register, cmp, value, ctx.mo);
         programBuilder.addChild(currentThread, event);
@@ -347,17 +347,17 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     // Return expressions (register for return value is optional)
 
     @Override
-    public ExprInterface visitReOpCompare(LitmusCParser.ReOpCompareContext ctx){
+    public Expression visitReOpCompare(LitmusCParser.ReOpCompareContext ctx){
         //TODO boolean register
         Register register = getReturnRegister(false);
-        ExprInterface v1 = (ExprInterface)ctx.re(0).accept(this);
-        ExprInterface v2 = (ExprInterface)ctx.re(1).accept(this);
-        ExprInterface result = expressions.makeBinary(v1, ctx.opCompare().op, v2);
+        Expression v1 = (Expression)ctx.re(0).accept(this);
+        Expression v2 = (Expression)ctx.re(1).accept(this);
+        Expression result = expressions.makeBinary(v1, ctx.opCompare().op, v2);
         return assignToReturnRegister(register, result);
     }
 
     @Override
-    public ExprInterface visitReOpArith(LitmusCParser.ReOpArithContext ctx){
+    public Expression visitReOpArith(LitmusCParser.ReOpArithContext ctx){
         Register register = getReturnRegister(false);
         IExpr v1 = (IExpr)ctx.re(0).accept(this);
         IExpr v2 = (IExpr)ctx.re(1).accept(this);
@@ -366,41 +366,41 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     }
 
     @Override
-    public ExprInterface visitReOpBool(LitmusCParser.ReOpBoolContext ctx){
+    public Expression visitReOpBool(LitmusCParser.ReOpBoolContext ctx){
         Register register = getReturnRegister(false);
-        ExprInterface v1 = (ExprInterface)ctx.re(0).accept(this);
-        ExprInterface v2 = (ExprInterface)ctx.re(1).accept(this);
-        ExprInterface result = expressions.makeBinary(v1, ctx.opBool().op, v2);
+        Expression v1 = (Expression)ctx.re(0).accept(this);
+        Expression v2 = (Expression)ctx.re(1).accept(this);
+        Expression result = expressions.makeBinary(v1, ctx.opBool().op, v2);
         return assignToReturnRegister(register, result);
     }
 
     @Override
-    public ExprInterface visitReOpBoolNot(LitmusCParser.ReOpBoolNotContext ctx){
+    public Expression visitReOpBoolNot(LitmusCParser.ReOpBoolNotContext ctx){
         Register register = getReturnRegister(false);
-        ExprInterface v = (ExprInterface)ctx.re().accept(this);
-        ExprInterface result = expressions.makeNot(v);
+        Expression v = (Expression)ctx.re().accept(this);
+        Expression result = expressions.makeNot(v);
         return assignToReturnRegister(register, result);
     }
 
     @Override
-    public ExprInterface visitReBoolConst(LitmusCParser.ReBoolConstContext ctx){
+    public Expression visitReBoolConst(LitmusCParser.ReBoolConstContext ctx){
         return expressions.makeValue(ctx.boolConst().value);
     }
 
     @Override
-    public ExprInterface visitReParenthesis(LitmusCParser.ReParenthesisContext ctx){
-        return (ExprInterface)ctx.re().accept(this);
+    public Expression visitReParenthesis(LitmusCParser.ReParenthesisContext ctx){
+        return (Expression)ctx.re().accept(this);
     }
 
     @Override
-    public ExprInterface visitReCast(LitmusCParser.ReCastContext ctx){
+    public Expression visitReCast(LitmusCParser.ReCastContext ctx){
         Register register = getReturnRegister(false);
-        ExprInterface result = (ExprInterface)ctx.re().accept(this);
+        Expression result = (Expression)ctx.re().accept(this);
         return assignToReturnRegister(register, result);
     }
 
     @Override
-    public ExprInterface visitReVarName(LitmusCParser.ReVarNameContext ctx){
+    public Expression visitReVarName(LitmusCParser.ReVarNameContext ctx){
         Register register = getReturnRegister(false);
         IExpr variable = visitVarName(ctx.varName());
         if (variable instanceof Register result) {
@@ -410,7 +410,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     }
 
     @Override
-    public ExprInterface visitReConst(LitmusCParser.ReConstContext ctx){
+    public Expression visitReConst(LitmusCParser.ReConstContext ctx){
         Register register = getReturnRegister(false);
         IValue result = expressions.parseValue(ctx.getText(), archType);
         return assignToReturnRegister(register, result);
@@ -430,7 +430,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
 
     @Override
     public Object visitNreStore(LitmusCParser.NreStoreContext ctx){
-        ExprInterface value = (ExprInterface)ctx.value.accept(this);
+        Expression value = (Expression)ctx.value.accept(this);
         if(ctx.mo.equals(Tag.Linux.MO_MB)){
             Event event = EventFactory.Linux.newLKMMStore(getAddress(ctx.address), value, Tag.Linux.MO_ONCE);
             programBuilder.addChild(currentThread, event);
@@ -442,21 +442,21 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
 
     @Override
     public Object visitNreWriteOnce(LitmusCParser.NreWriteOnceContext ctx){
-        ExprInterface value = (ExprInterface)ctx.value.accept(this);
+        Expression value = (Expression)ctx.value.accept(this);
         Event event = EventFactory.Linux.newLKMMStore(getAddress(ctx.address), value, ctx.mo);
         return programBuilder.addChild(currentThread, event);
     }
 
 	@Override
 	public Object visitNreC11Store(LitmusCParser.NreC11StoreContext ctx) {
-        ExprInterface value = (ExprInterface)ctx.value.accept(this);
+        Expression value = (Expression)ctx.value.accept(this);
         Event event = EventFactory.Atomic.newStore(getAddress(ctx.address), value, ctx.c11Mo().mo);
         return programBuilder.addChild(currentThread, event);
 	}
 
     @Override
     public Object visitNreAssignment(LitmusCParser.NreAssignmentContext ctx){
-        ExprInterface variable = (ExprInterface)ctx.varName().accept(this);
+        Expression variable = (Expression)ctx.varName().accept(this);
         if(ctx.Ast() == null){
             if(variable instanceof Register){
                 returnRegister = (Register)variable;
@@ -466,7 +466,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
             throw new ParsingException("Invalid syntax near " + ctx.getText());
         }
 
-        ExprInterface value = (ExprInterface)ctx.re().accept(this);
+        Expression value = (Expression)ctx.re().accept(this);
         if(variable instanceof MemoryObject || variable instanceof Register){
             Event event = EventFactory.newStore(variable, value, C11.NONATOMIC);
             return programBuilder.addChild(currentThread, event);
@@ -538,7 +538,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     }
 
     private IExpr getAddress(LitmusCParser.ReContext ctx){
-        ExprInterface address = (ExprInterface)ctx.accept(this);
+        Expression address = (Expression)ctx.accept(this);
         if(address instanceof IExpr){
            return (IExpr)address;
         }
@@ -558,7 +558,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         return register;
     }
 
-    private ExprInterface assignToReturnRegister(Register register, ExprInterface value){
+    private Expression assignToReturnRegister(Register register, Expression value){
         if(register != null){
             programBuilder.addChild(currentThread, EventFactory.newLocal(register, value));
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.type.IntegerType;
@@ -118,7 +118,7 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
 	@Override
 	public Object visitLocal(LitmusLISAParser.LocalContext ctx) {
         Register reg = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
-		ExprInterface e = (ExprInterface) ctx.expression().accept(this);
+		Expression e = (Expression) ctx.expression().accept(this);
         programBuilder.addChild(mainThread, EventFactory.newLocal(reg, e));
 		return null;
 	}
@@ -162,8 +162,8 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
 	public Object visitJump(LitmusLISAParser.JumpContext ctx) {
         Label label = programBuilder.getOrCreateLabel(ctx.labelName().getText());
         Register reg = (Register) ctx.register().accept(this);
-		ExprInterface one = expressions.makeOne(reg.getType());
-        ExprInterface cond = expressions.makeEqual(reg, one);
+		Expression one = expressions.makeOne(reg.getType());
+        Expression cond = expressions.makeEqual(reg, one);
 		programBuilder.addChild(mainThread, EventFactory.newJump(cond, label));
 		return null;
 	}
@@ -222,15 +222,15 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
 
 	@Override
 	public Object visitEq(LitmusLISAParser.EqContext ctx) {
-		ExprInterface e1 = (ExprInterface) ctx.expression(0).accept(this);
-		ExprInterface e2 = (ExprInterface) ctx.expression(1).accept(this);
+		Expression e1 = (Expression) ctx.expression(0).accept(this);
+		Expression e2 = (Expression) ctx.expression(1).accept(this);
 		return expressions.makeEqual(e1, e2);
 	}
 
 	@Override
 	public Object visitNeq(LitmusLISAParser.NeqContext ctx) {
-		ExprInterface e1 = (ExprInterface) ctx.expression(0).accept(this);
-		ExprInterface e2 = (ExprInterface) ctx.expression(1).accept(this);
+		Expression e1 = (Expression) ctx.expression(0).accept(this);
+		Expression e2 = (Expression) ctx.expression(1).accept(this);
 		return expressions.makeNotEqual(e1, e2);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusLISA.java
@@ -163,7 +163,7 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
         Label label = programBuilder.getOrCreateLabel(ctx.labelName().getText());
         Register reg = (Register) ctx.register().accept(this);
 		Expression one = expressions.makeOne(reg.getType());
-        Expression cond = expressions.makeEqual(reg, one);
+        Expression cond = expressions.makeEQ(reg, one);
 		programBuilder.addChild(mainThread, EventFactory.newJump(cond, label));
 		return null;
 	}
@@ -189,49 +189,49 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
 	public Object visitAdd(LitmusLISAParser.AddContext ctx) {
 		IExpr e1 = (IExpr) ctx.expression(0).accept(this);
 		IExpr e2 = (IExpr) ctx.expression(1).accept(this);
-		return expressions.makePlus(e1, e2);
+		return expressions.makeADD(e1, e2);
 	}
 
 	@Override
 	public Object visitSub(LitmusLISAParser.SubContext ctx) {
 		IExpr e1 = (IExpr) ctx.expression(0).accept(this);
 		IExpr e2 = (IExpr) ctx.expression(1).accept(this);
-		return expressions.makeMinus(e1, e2);
+		return expressions.makeSUB(e1, e2);
 	}
 
 	@Override
 	public Object visitXor(LitmusLISAParser.XorContext ctx) {
 		IExpr e1 = (IExpr) ctx.expression(0).accept(this);
 		IExpr e2 = (IExpr) ctx.expression(1).accept(this);
-		return expressions.makeXor(e1, e2);
+		return expressions.makeXOR(e1, e2);
 	}
 
 	@Override
 	public Object visitOr(LitmusLISAParser.OrContext ctx) {
 		IExpr e1 = (IExpr) ctx.expression(0).accept(this);
 		IExpr e2 = (IExpr) ctx.expression(1).accept(this);
-		return expressions.makeBitwiseOr(e1, e2);
+		return expressions.makeOR(e1, e2);
 	}
 
 	@Override
 	public Object visitAnd(LitmusLISAParser.AndContext ctx) {
 		IExpr e1 = (IExpr) ctx.expression(0).accept(this);
 		IExpr e2 = (IExpr) ctx.expression(1).accept(this);
-		return expressions.makeBitwiseAnd(e1, e2);
+		return expressions.makeAND(e1, e2);
 	}
 
 	@Override
 	public Object visitEq(LitmusLISAParser.EqContext ctx) {
 		Expression e1 = (Expression) ctx.expression(0).accept(this);
 		Expression e2 = (Expression) ctx.expression(1).accept(this);
-		return expressions.makeEqual(e1, e2);
+		return expressions.makeEQ(e1, e2);
 	}
 
 	@Override
 	public Object visitNeq(LitmusLISAParser.NeqContext ctx) {
 		Expression e1 = (Expression) ctx.expression(0).accept(this);
 		Expression e2 = (Expression) ctx.expression(1).accept(this);
-		return expressions.makeNotEqual(e1, e2);
+		return expressions.makeNEQ(e1, e2);
 	}
 
 	@Override
@@ -243,7 +243,7 @@ public class VisitorLitmusLISA extends LitmusLISABaseVisitor<Object> {
 	public Object visitArrayAccess(LitmusLISAParser.ArrayAccessContext ctx) {
 		MemoryObject base = (MemoryObject) ctx.location().accept(this);
 		IExpr offset = (IExpr) ctx.value().accept(this);
-		return expressions.makePlus(base, offset);
+		return expressions.makeADD(base, offset);
 	}
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -4,7 +4,6 @@ import com.dat3m.dartagnan.exception.ParsingException;
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.IValue;
-import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.LitmusPPCBaseVisitor;
@@ -172,7 +171,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.PLUS, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makePlus(r2, constant)));
     }
 
     @Override
@@ -180,7 +179,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.XOR, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeXor(r2, r3)));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -1,8 +1,8 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
 import com.dat3m.dartagnan.exception.ParsingException;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
@@ -25,10 +25,10 @@ import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.*;
 public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
 
     private static class CmpInstruction {
-        private final ExprInterface left;
-        private final ExprInterface right;
+        private final Expression left;
+        private final Expression right;
 
-        public CmpInstruction(Register left, ExprInterface comparand) {
+        public CmpInstruction(Register left, Expression comparand) {
             this.left = left;
             this.right = comparand;
         }
@@ -198,7 +198,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         if(cmp == null){
             throw new ParsingException("Invalid syntax near " + ctx.getText());
         }
-        ExprInterface expr = expressions.makeBinary(cmp.left, ctx.cond().op, cmp.right);
+        Expression expr = expressions.makeBinary(cmp.left, ctx.cond().op, cmp.right);
         return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label));
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -171,7 +171,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makePlus(r2, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeADD(r2, constant)));
     }
 
     @Override
@@ -179,7 +179,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeXor(r2, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeXOR(r2, r3)));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -1,11 +1,12 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
 import com.dat3m.dartagnan.exception.ParsingException;
-import com.dat3m.dartagnan.expression.Atom;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IExprBin;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.LitmusPPCBaseVisitor;
 import com.dat3m.dartagnan.parsers.LitmusPPCParser;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
@@ -16,20 +17,18 @@ import com.dat3m.dartagnan.program.event.core.Label;
 import com.google.common.collect.ImmutableSet;
 import org.antlr.v4.runtime.misc.Interval;
 
-import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.dat3m.dartagnan.GlobalSettings.getArchPrecision;
 import static com.dat3m.dartagnan.wmm.relation.RelationNameRepository.*;
 
 public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
 
     private static class CmpInstruction {
-        private final IExpr left;
-        private final IExpr right;
+        private final ExprInterface left;
+        private final ExprInterface right;
 
-        public CmpInstruction(Register left, IExpr comparand) {
+        public CmpInstruction(Register left, ExprInterface comparand) {
             this.left = left;
             this.right = comparand;
         }
@@ -37,7 +36,10 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
 
     private final static ImmutableSet<String> fences = ImmutableSet.of(SYNC, LWSYNC, ISYNC);
 
+    private final TypeFactory types = TypeFactory.getInstance();
+    private final ExpressionFactory expressions = ExpressionFactory.getInstance();
     private final ProgramBuilder programBuilder;
+    private final IntegerType archType = types.getArchType();
     private final Map<Integer, CmpInstruction> lastCmpInstructionPerThread = new HashMap<>();
     private int mainThread;
     private int threadCount = 0;
@@ -75,19 +77,21 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
 
     @Override
     public Object visitVariableDeclaratorLocation(LitmusPPCParser.VariableDeclaratorLocationContext ctx) {
-        programBuilder.initLocEqConst(ctx.location().getText(), new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision()));
+        IValue value = expressions.parseValue(ctx.constant().getText(), archType);
+        programBuilder.initLocEqConst(ctx.location().getText(), value);
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegister(LitmusPPCParser.VariableDeclaratorRegisterContext ctx) {
-        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision()));
+        IValue value = expressions.parseValue(ctx.constant().getText(), archType);
+        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), value);
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegisterLocation(LitmusPPCParser.VariableDeclaratorRegisterLocationContext ctx) {
-        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), getArchPrecision());
+        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType);
         return null;
     }
 
@@ -125,14 +129,14 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
 
     @Override
     public Object visitLi(LitmusPPCParser.LiContext ctx) {
-        Register register = programBuilder.getOrCreateRegister(mainThread, ctx.register().getText(), getArchPrecision());
-        IValue constant = new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision());
+        Register register = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
+        IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
         return programBuilder.addChild(mainThread, EventFactory.newLocal(register, constant));
     }
 
     @Override
     public Object visitLwz(LitmusPPCParser.LwzContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         return programBuilder.addChild(mainThread, EventFactory.newLoad(r1, ra, "_rx"));
     }
@@ -158,25 +162,25 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
 
     @Override
     public Object visitMr(LitmusPPCParser.MrContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, r2));
     }
 
     @Override
     public Object visitAddi(LitmusPPCParser.AddiContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        IValue constant = new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.PLUS, constant)));
+        IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.PLUS, constant)));
     }
 
     @Override
     public Object visitXor(LitmusPPCParser.XorContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.XOR, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.XOR, r3)));
     }
 
     @Override
@@ -194,7 +198,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         if(cmp == null){
             throw new ParsingException("Invalid syntax near " + ctx.getText());
         }
-        Atom expr = new Atom(cmp.left, ctx.cond().op, cmp.right);
+        ExprInterface expr = expressions.makeBinary(cmp.left, ctx.cond().op, cmp.right);
         return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label));
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -1,8 +1,8 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
 import com.dat3m.dartagnan.exception.ParsingException;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
@@ -223,7 +223,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Label label = programBuilder.getOrCreateLabel(ctx.Label().getText());
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
-        ExprInterface expr = expressions.makeBinary(r1, ctx.cond().op, r2);
+        Expression expr = expressions.makeBinary(r1, ctx.cond().op, r2);
         return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label));
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -1,10 +1,12 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
 import com.dat3m.dartagnan.exception.ParsingException;
-import com.dat3m.dartagnan.expression.Atom;
-import com.dat3m.dartagnan.expression.IExprBin;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.LitmusRISCVBaseVisitor;
 import com.dat3m.dartagnan.parsers.LitmusRISCVParser;
 import com.dat3m.dartagnan.parsers.program.utils.AssertionHelper;
@@ -15,13 +17,12 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Label;
 import org.antlr.v4.runtime.misc.Interval;
 
-import java.math.BigInteger;
-
-import static com.dat3m.dartagnan.GlobalSettings.getArchPrecision;
-
 public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
 
+    private final TypeFactory types = TypeFactory.getInstance();
+    private final ExpressionFactory expressions = ExpressionFactory.getInstance();
     private final ProgramBuilder programBuilder;
+    private final IntegerType archType = types.getArchType();
     private int mainThread;
     private int threadCount = 0;
 
@@ -58,19 +59,21 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
 
     @Override
     public Object visitVariableDeclaratorLocation(LitmusRISCVParser.VariableDeclaratorLocationContext ctx) {
-        programBuilder.initLocEqConst(ctx.location().getText(), new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision()));
+        IValue value = expressions.parseValue(ctx.constant().getText(), archType);
+        programBuilder.initLocEqConst(ctx.location().getText(), value);
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegister(LitmusRISCVParser.VariableDeclaratorRegisterContext ctx) {
-        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision()));
+        IValue value = expressions.parseValue(ctx.constant().getText(), archType);
+        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), value);
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegisterLocation(LitmusRISCVParser.VariableDeclaratorRegisterLocationContext ctx) {
-        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), getArchPrecision());
+        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType);
         return null;
     }
 
@@ -105,85 +108,85 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         }
         return null;
     }
-    
+
 	@Override
 	public Object visitLi(LitmusRISCVParser.LiContext ctx) {
-        Register register = programBuilder.getOrCreateRegister(mainThread, ctx.register().getText(), getArchPrecision());
-        IValue constant = new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision());
+        Register register = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
+        IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
         return programBuilder.addChild(mainThread, EventFactory.newLocal(register, constant));
 	}
-	
+
 	@Override
 	public Object visitXor(LitmusRISCVParser.XorContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.XOR, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.XOR, r3)));
 
 	}
-	
+
 	@Override
 	public Object visitAnd(LitmusRISCVParser.AndContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.AND, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.AND, r3)));
 
 	}
-	
+
 	@Override
 	public Object visitOr(LitmusRISCVParser.OrContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.OR, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.OR, r3)));
 
 	}
-	
+
 	@Override
 	public Object visitAdd(LitmusRISCVParser.AddContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.PLUS, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.PLUS, r3)));
 
 	}
-	
+
 	@Override
 	public Object visitXori(LitmusRISCVParser.XoriContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        IValue constant = new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.XOR, constant)));
+        IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.XOR, constant)));
 	}
-	
+
 	@Override
 	public Object visitAndi(LitmusRISCVParser.AndiContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        IValue constant = new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.AND, constant)));
+        IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.AND, constant)));
 	}
-	
+
 	@Override
 	public Object visitOri(LitmusRISCVParser.OriContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
-        Register r2 = programBuilder.getOrCreateRegister(mainThread, ctx.register(1).getText(), getArchPrecision());
-        IValue constant = new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.OR, constant)));
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
+        Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
+        IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.OR, constant)));
 	}
 
 	@Override
 	public Object visitAddi(LitmusRISCVParser.AddiContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
-        Register r2 = programBuilder.getOrCreateRegister(mainThread, ctx.register(1).getText(), getArchPrecision());
-        IValue constant = new IValue(new BigInteger(ctx.constant().getText()), getArchPrecision());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, new IExprBin(r2, IOpBin.PLUS, constant)));
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
+        Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
+        IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.PLUS, constant)));
 	}
 
 	@Override
 	public Object visitLw(LitmusRISCVParser.LwContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         return programBuilder.addChild(mainThread, EventFactory.newLoad(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
 	}
@@ -194,18 +197,18 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         return programBuilder.addChild(mainThread, EventFactory.newStore(ra, r1, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
 	}
-	
+
 	@Override
 	public Object visitLr(LitmusRISCVParser.LrContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         return programBuilder.addChild(mainThread, EventFactory.newRMWLoadExclusive(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
 	}
 
 	@Override
 	public Object visitSc(LitmusRISCVParser.ScContext ctx) {
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
-        Register r2 = programBuilder.getOrCreateRegister(mainThread, ctx.register(1).getText(), getArchPrecision());
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
+        Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
         return programBuilder.addChild(mainThread, EventFactory.Common.newExclusiveStore(r1, ra, r2, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
 	}
@@ -214,29 +217,29 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
 	public Object visitLabel(LitmusRISCVParser.LabelContext ctx) {
 		return programBuilder.addChild(mainThread, programBuilder.getOrCreateLabel(ctx.Label().getText()));
 	}
-	
+
 	@Override
 	public Object visitBranchCond(LitmusRISCVParser.BranchCondContext ctx) {
         Label label = programBuilder.getOrCreateLabel(ctx.Label().getText());
-        Register r1 = programBuilder.getOrCreateRegister(mainThread, ctx.register(0).getText(), getArchPrecision());
-        Register r2 = programBuilder.getOrCreateRegister(mainThread, ctx.register(1).getText(), getArchPrecision());
-        Atom expr = new Atom(r1, ctx.cond().op, r2);
+        Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
+        Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
+        ExprInterface expr = expressions.makeBinary(r1, ctx.cond().op, r2);
         return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label));
 	}
-	
+
 	@Override
 	public Object visitFence(LitmusRISCVParser.FenceContext ctx) {
 		return programBuilder.addChild(mainThread, EventFactory.newFence("Fence." + ctx.fenceMode().mode));
 	}
-	
+
 	@Override
 	public Object visitAmoadd(LitmusRISCVParser.AmoaddContext ctx) {
 		throw new ParsingException("No support for amoadd instructions");	}
-	
+
 	@Override
 	public Object visitAmoor(LitmusRISCVParser.AmoorContext ctx) {
 		throw new ParsingException("No support for amoor instructions");	}
-	
+
 	@Override
 	public Object visitAmoswap(LitmusRISCVParser.AmoswapContext ctx) {
 		throw new ParsingException("No support for amoswap instructions");
@@ -245,7 +248,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
 	// =======================================
 	// ================ Utils ================
 	// =======================================
-	
+
 	private String getMo(LitmusRISCVParser.MoRISCVContext mo1, LitmusRISCVParser.MoRISCVContext mo2) {
 		String moR = mo1 != null ? mo1.mo : "";
 		String moW = mo2 != null ? mo2.mo : "";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -4,7 +4,6 @@ import com.dat3m.dartagnan.exception.ParsingException;
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.IValue;
-import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.LitmusRISCVBaseVisitor;
@@ -121,7 +120,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.XOR, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeXor(r2, r3)));
 
 	}
 
@@ -130,7 +129,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.AND, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBitwiseAnd(r2, r3)));
 
 	}
 
@@ -139,7 +138,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.OR, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBitwiseOr(r2, r3)));
 
 	}
 
@@ -148,7 +147,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.PLUS, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makePlus(r2, r3)));
 
 	}
 
@@ -157,7 +156,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.XOR, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeXor(r2, constant)));
 	}
 
 	@Override
@@ -165,7 +164,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.AND, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBitwiseAnd(r2, constant)));
 	}
 
 	@Override
@@ -173,7 +172,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.OR, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBitwiseOr(r2, constant)));
 	}
 
 	@Override
@@ -181,7 +180,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBinary(r2, IOpBin.PLUS, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makePlus(r2, constant)));
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -120,7 +120,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeXor(r2, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeXOR(r2, r3)));
 
 	}
 
@@ -129,7 +129,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBitwiseAnd(r2, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeAND(r2, r3)));
 
 	}
 
@@ -138,7 +138,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBitwiseOr(r2, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeOR(r2, r3)));
 
 	}
 
@@ -147,7 +147,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makePlus(r2, r3)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeADD(r2, r3)));
 
 	}
 
@@ -156,7 +156,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeXor(r2, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeXOR(r2, constant)));
 	}
 
 	@Override
@@ -164,7 +164,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBitwiseAnd(r2, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeAND(r2, constant)));
 	}
 
 	@Override
@@ -172,7 +172,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeBitwiseOr(r2, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeOR(r2, constant)));
 	}
 
 	@Override
@@ -180,7 +180,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         IValue constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makePlus(r2, constant)));
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeADD(r2, constant)));
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LkmmProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LkmmProcedures.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.parsers.program.visitors.boogie;
 
-import com.dat3m.dartagnan.GlobalSettings;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.op.IOpBin;
@@ -31,7 +30,7 @@ public class LkmmProcedures {
 		String name = ctx.call_params().Define() == null ? ctx.call_params().Ident(0).getText() : ctx.call_params().Ident(1).getText();
 		List<BoogieParser.ExprContext> params = ctx.call_params().exprs().expr();
 
-		Register reg = visitor.programBuilder.getOrCreateRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText(), GlobalSettings.getArchPrecision());
+		Register reg = visitor.programBuilder.getOrNewRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText());
 		
 		Object p0 = params.get(0).accept(visitor);
 		Object p1 = params.size() > 1 ? params.get(1).accept(visitor) : null;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.parsers.program.visitors.boogie;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
@@ -46,15 +46,15 @@ public class LlvmProcedures {
         String regName = visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText();
         Register reg = visitor.programBuilder.getOrNewRegister(visitor.threadCount, regName);
 
-        ExprInterface p0 = (ExprInterface) params.get(0).accept(visitor);
-        ExprInterface p1 = params.size() > 1 ? (ExprInterface) params.get(1).accept(visitor) : null;
-        ExprInterface p2 = params.size() > 2 ? (ExprInterface) params.get(2).accept(visitor) : null;
-        ExprInterface p3 = params.size() > 3 ? (ExprInterface) params.get(3).accept(visitor) : null;
+        Expression p0 = (Expression) params.get(0).accept(visitor);
+        Expression p1 = params.size() > 1 ? (Expression) params.get(1).accept(visitor) : null;
+        Expression p2 = params.size() > 2 ? (Expression) params.get(2).accept(visitor) : null;
+        Expression p3 = params.size() > 3 ? (Expression) params.get(3).accept(visitor) : null;
 
         String mo;
 
         // For intrinsics
-        ExprInterface cond;
+        Expression cond;
 
         switch (name) {
             case "__llvm_atomic32_load":

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
@@ -154,9 +154,8 @@ public class LlvmProcedures {
             case "llvm.ctlz.i32":
             case "llvm.ctlz.i64":
                 i1 = (IExpr) p0;
-                i2 = (IExpr) p1;
                 visitor.programBuilder
-                        .addChild(visitor.threadCount, EventFactory.newLocal(reg, new IExprUn(IOpUn.CTLZ, i1)))
+                        .addChild(visitor.threadCount, EventFactory.newLocal(reg, new IExprUn(IOpUn.CTLZ, i1, i1.getType())))
                         .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
                 return;
             default:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/LlvmProcedures.java
@@ -126,7 +126,7 @@ public class LlvmProcedures {
             case "llvm.smax.i64":
             case "llvm.umax.i32":
             case "llvm.umax.i64":
-                cond = visitor.expressions.makeGreater(p0, p1, name.contains("smax"));
+                cond = visitor.expressions.makeGT(p0, p1, name.contains("smax"));
                 visitor.programBuilder
                         .addChild(visitor.threadCount, EventFactory.newLocal(reg, visitor.expressions.makeConditional(cond, p0, p1)))
                         .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
@@ -135,7 +135,7 @@ public class LlvmProcedures {
             case "llvm.smin.i64":
             case "llvm.umin.i32":
             case "llvm.umin.i64":
-                cond = visitor.expressions.makeLess(p0, p1, name.contains("smin"));
+                cond = visitor.expressions.makeLT(p0, p1, name.contains("smin"));
                 visitor.programBuilder
                         .addChild(visitor.threadCount, EventFactory.newLocal(reg, visitor.expressions.makeConditional(cond, p0, p1)))
                         .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
@@ -143,7 +143,7 @@ public class LlvmProcedures {
             case "llvm.ctlz.i32":
             case "llvm.ctlz.i64":
                 visitor.programBuilder
-                        .addChild(visitor.threadCount, EventFactory.newLocal(reg, visitor.expressions.makeCountLeadingZeroes(p0, (IntegerType) p0.getType())))
+                        .addChild(visitor.threadCount, EventFactory.newLocal(reg, visitor.expressions.makeCTLZ(p0, (IntegerType) p0.getType())))
                         .setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
                 return;
             default:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/PthreadsProcedures.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.parsers.program.visitors.boogie;
 
 import com.dat3m.dartagnan.exception.ParsingException;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.parsers.BoogieParser.Call_cmdContext;
 import com.dat3m.dartagnan.parsers.BoogieParser.ExprContext;
@@ -69,7 +69,7 @@ public class PthreadsProcedures {
 		visitor.currentThread++;
 
 		visitor.threadCallingValues.put(visitor.currentThread, new ArrayList<>());
-		ExprInterface callingValue = (ExprInterface)ctx.call_params().exprs().expr().get(3).accept(visitor);
+		Expression callingValue = (Expression)ctx.call_params().exprs().expr().get(3).accept(visitor);
 		visitor.threadCallingValues.get(visitor.currentThread).add(callingValue);
 
 		IExpr pointer = (IExpr)ctx.call_params().exprs().expr(0).accept(visitor);
@@ -84,7 +84,7 @@ public class PthreadsProcedures {
 		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.Pthread.newCreate(pointer, threadName))
 				.setCFileInformation(visitor.currentLine, visitor.sourceCodeFile);
 		Register reg = visitor.programBuilder.getOrNewRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + ctx.call_params().Ident(0).getText());
-		ExprInterface zero = visitor.expressions.makeZero(reg.getType());
+		Expression zero = visitor.expressions.makeZero(reg.getType());
 		visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(reg, zero));
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/StdProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/StdProcedures.java
@@ -11,8 +11,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.dat3m.dartagnan.GlobalSettings.getArchPrecision;
-
 public class StdProcedures {
 
     public static List<String> STDPROCEDURES = Arrays.asList(
@@ -50,7 +48,7 @@ public class StdProcedures {
         if (name.equals("get_my_tid")) {
             String registerName = ctx.call_params().Ident(0).getText();
             Register register = visitor.programBuilder.getRegister(visitor.threadCount, visitor.currentScope.getID() + ":" + registerName);
-            IValue tid = new IValue(BigInteger.valueOf(visitor.threadCount), getArchPrecision());
+            IValue tid = visitor.expressions.makeValue(BigInteger.valueOf(visitor.threadCount), register.getType());
             visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newLocal(register, tid));
             return;
         }
@@ -124,7 +122,7 @@ public class StdProcedures {
     }
 
     private static void __assert_fail(VisitorBoogie visitor) {
-        visitor.addAssertion(IValue.ZERO);
+        visitor.addAssertion(visitor.expressions.makeZero(visitor.types.getArchType()));
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/SvcompProcedures.java
@@ -84,7 +84,7 @@ public class SvcompProcedures {
 	}
 
 	private static void __VERIFIER_assume(VisitorBoogie visitor, Call_cmdContext ctx) {
-    	ExprInterface expr = (ExprInterface)ctx.call_params().exprs().accept(visitor);
+    	Expression expr = (Expression)ctx.call_params().exprs().accept(visitor);
        	visitor.programBuilder.addChild(visitor.threadCount, EventFactory.newAssume(expr));
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -567,7 +567,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 	@Override
 	public Object visitMinus_expr(Minus_exprContext ctx) {
 		IExpr v = (IExpr)ctx.unary_expr().accept(this);
-		return new IExprUn(IOpUn.MINUS, v);
+		return new IExprUn(IOpUn.MINUS, v, v.getType());
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/boogie/VisitorBoogie.java
@@ -569,7 +569,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 	@Override
 	public Object visitMinus_expr(Minus_exprContext ctx) {
 		IExpr v = (IExpr)ctx.unary_expr().accept(this);
-		return expressions.makeNegate(v, v.getType());
+		return expressions.makeNEG(v, v.getType());
 	}
 
 	@Override
@@ -607,16 +607,16 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 		for(int i = 0; i < ctx.bv_term().size()-1; i++) {
 			v2 = (Expression)ctx.bv_term(i+1).accept(this);
 			v1 = switch (ctx.rel_op(i).op) {
-				case EQ -> expressions.makeEqual(v1, v2);
-				case NEQ -> expressions.makeNotEqual(v1, v2);
-				case GTE -> expressions.makeGreaterOrEqual(v1, v2, true);
-				case LTE -> expressions.makeLessOrEqual(v1, v2, true);
-				case GT -> expressions.makeGreater(v1, v2, true);
-				case LT -> expressions.makeLess(v1, v2, true);
-				case UGTE -> expressions.makeGreaterOrEqual(v1, v2, false);
-				case ULTE -> expressions.makeLessOrEqual(v1, v2, false);
-				case UGT -> expressions.makeGreater(v1, v2, false);
-				case ULT -> expressions.makeLess(v1, v2, false);
+				case EQ -> expressions.makeEQ(v1, v2);
+				case NEQ -> expressions.makeNEQ(v1, v2);
+				case GTE -> expressions.makeGTE(v1, v2, true);
+				case LTE -> expressions.makeLTE(v1, v2, true);
+				case GT -> expressions.makeGT(v1, v2, true);
+				case LT -> expressions.makeLT(v1, v2, true);
+				case UGTE -> expressions.makeGTE(v1, v2, false);
+				case ULTE -> expressions.makeLTE(v1, v2, false);
+				case UGT -> expressions.makeGT(v1, v2, false);
+				case ULT -> expressions.makeLT(v1, v2, false);
 			};
 		}
 		return v1;
@@ -628,7 +628,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 		Expression v2;
 		for(int i = 0; i < ctx.factor().size()-1; i++) {
 			v2 = (Expression)ctx.factor(i+1).accept(this);
-			v1 = expressions.makePlus(v1, v2);
+			v1 = expressions.makeADD(v1, v2);
 		}
 		return v1;
 	}
@@ -639,7 +639,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 		Expression v2 ;
 		for(int i = 0; i < ctx.power().size()-1; i++) {
 			v2 = (Expression)ctx.power(i+1).accept(this);
-			v1 = expressions.makeMultiply(v1, v2);
+			v1 = expressions.makeMUL(v1, v2);
 		}
 		return v1;
 	}
@@ -804,7 +804,7 @@ public class VisitorBoogie extends BoogieBaseVisitor<Object> {
 				.setCFileInformation(currentLine, sourceCodeFile)
 				.addTags(Tag.ASSERTION);
 		Label end = programBuilder.getOrCreateLabel("END_OF_T" + threadCount);
-		CondJump jump = EventFactory.newJump(expressions.makeNotEqual(ass, one), end);
+		CondJump jump = EventFactory.newJump(expressions.makeNEQ(ass, one), end);
 		jump.addTags(Tag.EARLYTERMINATION);
 		programBuilder.addChild(threadCount, jump);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Register.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
 import com.dat3m.dartagnan.expression.type.IntegerType;
@@ -79,7 +79,7 @@ public class Register extends IExpr {
 
     // ============================== Static utility =============================
 
-    public static Set<Read> collectRegisterReads(ExprInterface expr, Register.UsageType usageType, Set<Read> collector) {
+    public static Set<Read> collectRegisterReads(Expression expr, Register.UsageType usageType, Set<Read> collector) {
         expr.getRegs().stream().map(r -> new Register.Read(r, usageType)).forEach(collector::add);
         return collector;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.program;
 
 import com.dat3m.dartagnan.exception.MalformedProgramException;
 import com.dat3m.dartagnan.expression.type.IntegerType;
-import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.google.common.base.Preconditions;
 
@@ -14,7 +13,6 @@ import java.util.stream.Collectors;
 
 public class Thread {
 
-    private static final TypeFactory types = TypeFactory.getInstance();
     private String name;
     private final int id;
     private final Event entry;
@@ -82,19 +80,8 @@ public class Thread {
         return registers.get(name);
     }
 
-    @Deprecated
-    public Register newRegister(int precision) {
-        return newRegister(precision < 0 ? types.getIntegerType() : types.getIntegerType(precision));
-    }
-
     public Register newRegister(IntegerType type) {
         return newRegister("DUMMY_REG_" + dummyCount++, type);
-    }
-
-    @Deprecated
-    public Register newRegister(String name, int precision) {
-        IntegerType type = precision < 0 ? types.getIntegerType() : types.getIntegerType(precision);
-        return newRegister(name, type);
     }
 
     public Register newRegister(String name, IntegerType type) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.analysis.alias;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IExprBin;
@@ -103,7 +103,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
     }
 
     private void processLocs(MemoryEvent e) {
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
         // Collect for each v events of form: p = *v, *v = q
         if (address instanceof Register) {
             addEvent((Register) address, e);
@@ -133,7 +133,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
         }
         //event is a store operation
         Verify.verify(e.hasTag(Tag.WRITE), "memory event that is neither tagged \"W\" nor a register writer");
-        ExprInterface value = e.getMemValue();
+        Expression value = e.getMemValue();
         if (value instanceof Register) {
             addEdge(value, location);
             return;
@@ -149,7 +149,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
 
     private void processRegs(Local e) {
         Register register = e.getResultRegister();
-        ExprInterface expr = e.getExpr();
+        Expression expr = e.getExpr();
         if (expr instanceof Register) {
             // r1 = r2 -> add edge r2 --> r1
             addEdge(expr, register);
@@ -180,7 +180,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
                             }
                         } else if (e instanceof Store) {
                             // *variable = register
-                            ExprInterface value = e.getMemValue();
+                            Expression value = e.getMemValue();
                             if (value instanceof Register) {
                                 Register register = (Register) value;
                                 // Add edge from register to location
@@ -203,7 +203,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
     }
 
     private void processResults(Local e) {
-        ExprInterface exp = e.getExpr();
+        Expression exp = e.getExpr();
         Register reg = e.getResultRegister();
         if (exp instanceof MemoryObject) {
             addTarget(reg, new Location((MemoryObject) exp, 0));
@@ -242,7 +242,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
     }
 
     private void processResults(MemoryEvent e) {
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
         Set<Location> addresses;
         if (address instanceof Register) {
             Set<Location> target = targets.get(address);
@@ -271,7 +271,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
         /**
          * Tries to match an expression as a constant address.
          */
-        Constant(ExprInterface x) {
+        Constant(Expression x) {
             if (x instanceof IConst) {
                 location = x instanceof MemoryObject ? new Location((MemoryObject) x, 0) : null;
                 failed = false;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AndersenAliasAnalysis.java
@@ -103,7 +103,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
     }
 
     private void processLocs(MemoryEvent e) {
-        IExpr address = e.getAddress();
+        ExprInterface address = e.getAddress();
         // Collect for each v events of form: p = *v, *v = q
         if (address instanceof Register) {
             addEvent((Register) address, e);
@@ -242,7 +242,7 @@ public class AndersenAliasAnalysis implements AliasAnalysis {
     }
 
     private void processResults(MemoryEvent e) {
-        IExpr address = e.getAddress();
+        ExprInterface address = e.getAddress();
         Set<Location> addresses;
         if (address instanceof Register) {
             Set<Location> target = targets.get(address);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/FieldSensitiveAndersen.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/FieldSensitiveAndersen.java
@@ -276,7 +276,7 @@ public class FieldSensitiveAndersen implements AliasAnalysis {
         final HashSet<Register> register = new HashSet<>();
         Result result;
 
-        Collector(ExprInterface x) {
+        Collector(Expression x) {
             result = x.visit(this);
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -93,7 +93,7 @@ public class EventFactory {
 
     public static Init newInit(MemoryObject base, int offset) {
         IValue offsetExpression = expressions.makeValue(BigInteger.valueOf(offset), base.getType());
-        return new Init(base, offset, expressions.makePlus(base, offsetExpression));
+        return new Init(base, offset, expressions.makeADD(base, offsetExpression));
     }
 
     // ------------------------------------------ Local events ------------------------------------------
@@ -146,7 +146,7 @@ public class EventFactory {
     }
 
     public static CondJump newFakeCtrlDep(Register reg, Label target) {
-        CondJump jump = newJump(expressions.makeEqual(reg, reg), target);
+        CondJump jump = newJump(expressions.makeEQ(reg, reg), target);
         jump.addTags(Tag.NOOPT);
         return jump;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.event;
 
 import com.dat3m.dartagnan.expression.BConst;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.op.IOpBin;
@@ -73,11 +73,11 @@ public class EventFactory {
 
     // ------------------------------------------ Memory events ------------------------------------------
 
-    public static Load newLoad(Register register, ExprInterface address, String mo) {
+    public static Load newLoad(Register register, Expression address, String mo) {
         return new Load(register, address, mo);
     }
 
-    public static Store newStore(ExprInterface address, ExprInterface value, String mo) {
+    public static Store newStore(Expression address, Expression value, String mo) {
         return new Store(address, value, mo);
     }
 
@@ -114,7 +114,7 @@ public class EventFactory {
         return new StringAnnotation(annotation);
     }
 
-    public static Local newLocal(Register register, ExprInterface expr) {
+    public static Local newLocal(Register register, Expression expr) {
         return new Local(register, expr);
     }
 
@@ -122,22 +122,22 @@ public class EventFactory {
         return new Label(name);
     }
 
-    public static CondJump newJump(ExprInterface cond, Label target) {
+    public static CondJump newJump(Expression cond, Label target) {
         return new CondJump(cond, target);
     }
 
-    public static CondJump newJumpUnless(ExprInterface cond, Label target) {
+    public static CondJump newJumpUnless(Expression cond, Label target) {
         if (cond instanceof BConst constant && constant.isFalse()) {
             return newGoto(target);
         }
         return new CondJump(expressions.makeNot(cond), target);
     }
 
-    public static IfAsJump newIfJump(ExprInterface expr, Label label, Label end) {
+    public static IfAsJump newIfJump(Expression expr, Label label, Label end) {
         return new IfAsJump(expr, label, end);
     }
 
-    public static IfAsJump newIfJumpUnless(ExprInterface expr, Label label, Label end) {
+    public static IfAsJump newIfJumpUnless(Expression expr, Label label, Label end) {
         return newIfJump(expressions.makeNot(expr), label, end);
     }
 
@@ -151,33 +151,33 @@ public class EventFactory {
         return jump;
     }
 
-    public static Assume newAssume(ExprInterface expr) {
+    public static Assume newAssume(Expression expr) {
         return new Assume(expr);
     }
 
     // ------------------------------------------ RMW events ------------------------------------------
 
-    public static Load newRMWLoad(Register reg, ExprInterface address, String mo) {
+    public static Load newRMWLoad(Register reg, Expression address, String mo) {
         Load load = newLoad(reg, address, mo);
         load.addTags(Tag.RMW);
         return load;
     }
 
-    public static RMWStore newRMWStore(Load loadEvent, ExprInterface address, ExprInterface value, String mo) {
+    public static RMWStore newRMWStore(Load loadEvent, Expression address, Expression value, String mo) {
         return new RMWStore(loadEvent, address, value, mo);
     }
 
-    public static Load newRMWLoadExclusive(Register reg, ExprInterface address, String mo) {
+    public static Load newRMWLoadExclusive(Register reg, Expression address, String mo) {
         Load load = new Load(reg, address, mo);
         load.addTags(Tag.RMW, Tag.EXCL);
         return load;
     }
 
-    public static RMWStoreExclusive newRMWStoreExclusive(ExprInterface address, ExprInterface value, String mo, boolean isStrong) {
+    public static RMWStoreExclusive newRMWStoreExclusive(Expression address, Expression value, String mo, boolean isStrong) {
         return new RMWStoreExclusive(address, value, mo, isStrong, false);
     }
 
-    public static RMWStoreExclusive newRMWStoreExclusive(ExprInterface address, ExprInterface value, String mo) {
+    public static RMWStoreExclusive newRMWStoreExclusive(Expression address, Expression value, String mo) {
         return newRMWStoreExclusive(address, value, mo, false);
     }
 
@@ -200,7 +200,7 @@ public class EventFactory {
         private Common() {
         }
 
-        public static StoreExclusive newExclusiveStore(Register register, ExprInterface address, ExprInterface value, String mo) {
+        public static StoreExclusive newExclusiveStore(Register register, Expression address, Expression value, String mo) {
             return new StoreExclusive(register, address, value, mo);
         }
     }
@@ -213,31 +213,31 @@ public class EventFactory {
         private Pthread() {
         }
 
-        public static Create newCreate(ExprInterface address, String routine) {
+        public static Create newCreate(Expression address, String routine) {
             return new Create(address, routine);
         }
 
-        public static End newEnd(ExprInterface address) {
+        public static End newEnd(Expression address) {
             return new End(address);
         }
 
-        public static InitLock newInitLock(String name, ExprInterface address, ExprInterface value) {
+        public static InitLock newInitLock(String name, Expression address, Expression value) {
             return new InitLock(name, address, value);
         }
 
-        public static Join newJoin(Register reg, ExprInterface expr) {
+        public static Join newJoin(Register reg, Expression expr) {
             return new Join(reg, expr);
         }
 
-        public static Lock newLock(String name, ExprInterface address, Register reg) {
+        public static Lock newLock(String name, Expression address, Register reg) {
             return new Lock(name, address, reg);
         }
 
-        public static Start newStart(Register reg, ExprInterface address, Event creationEvent) {
+        public static Start newStart(Register reg, Expression address, Event creationEvent) {
             return new Start(reg, address, creationEvent);
         }
 
-        public static Unlock newUnlock(String name, ExprInterface address, Register reg) {
+        public static Unlock newUnlock(String name, Expression address, Register reg) {
             return new Unlock(name, address, reg);
         }
     }
@@ -250,31 +250,31 @@ public class EventFactory {
         private Atomic() {
         }
 
-        public static AtomicCmpXchg newCompareExchange(Register register, ExprInterface address, ExprInterface expectedAddr, ExprInterface desiredValue, String mo, boolean isStrong) {
+        public static AtomicCmpXchg newCompareExchange(Register register, Expression address, Expression expectedAddr, Expression desiredValue, String mo, boolean isStrong) {
             return new AtomicCmpXchg(register, address, expectedAddr, desiredValue, mo, isStrong);
         }
 
-        public static AtomicCmpXchg newCompareExchange(Register register, ExprInterface address, ExprInterface expectedAddr, ExprInterface desiredValue, String mo) {
+        public static AtomicCmpXchg newCompareExchange(Register register, Expression address, Expression expectedAddr, Expression desiredValue, String mo) {
             return newCompareExchange(register, address, expectedAddr, desiredValue, mo, false);
         }
 
-        public static AtomicFetchOp newFetchOp(Register register, ExprInterface address, ExprInterface value, IOpBin op, String mo) {
+        public static AtomicFetchOp newFetchOp(Register register, Expression address, Expression value, IOpBin op, String mo) {
             return new AtomicFetchOp(register, address, value, op, mo);
         }
 
-        public static AtomicFetchOp newFADD(Register register, ExprInterface address, ExprInterface value, String mo) {
+        public static AtomicFetchOp newFADD(Register register, Expression address, Expression value, String mo) {
             return newFetchOp(register, address, value, IOpBin.PLUS, mo);
         }
 
-        public static AtomicFetchOp newIncrement(Register register, ExprInterface address, String mo) {
+        public static AtomicFetchOp newIncrement(Register register, Expression address, String mo) {
             return newFetchOp(register, address, expressions.makeOne(register.getType()), IOpBin.PLUS, mo);
         }
 
-        public static AtomicLoad newLoad(Register register, ExprInterface address, String mo) {
+        public static AtomicLoad newLoad(Register register, Expression address, String mo) {
             return new AtomicLoad(register, address, mo);
         }
 
-        public static AtomicStore newStore(ExprInterface address, ExprInterface value, String mo) {
+        public static AtomicStore newStore(Expression address, Expression value, String mo) {
             return new AtomicStore(address, value, mo);
         }
 
@@ -282,7 +282,7 @@ public class EventFactory {
             return new AtomicThreadFence(mo);
         }
 
-        public static AtomicXchg newExchange(Register register, ExprInterface address, ExprInterface value, String mo) {
+        public static AtomicXchg newExchange(Register register, Expression address, Expression value, String mo) {
             return new AtomicXchg(register, address, value, mo);
         }
     }
@@ -294,27 +294,27 @@ public class EventFactory {
         private Llvm() {
         }
 
-        public static LlvmLoad newLoad(Register register, ExprInterface address, String mo) {
+        public static LlvmLoad newLoad(Register register, Expression address, String mo) {
             return new LlvmLoad(register, address, mo);
         }
 
-        public static LlvmStore newStore(ExprInterface address, ExprInterface value, String mo) {
+        public static LlvmStore newStore(Expression address, Expression value, String mo) {
             return new LlvmStore(address, value, mo);
         }
 
-        public static LlvmXchg newExchange(Register register, ExprInterface address, ExprInterface value, String mo) {
+        public static LlvmXchg newExchange(Register register, Expression address, Expression value, String mo) {
             return new LlvmXchg(register, address, value, mo);
         }
 
-        public static LlvmCmpXchg newCompareExchange(Register oldValueRegister, Register cmpRegister, ExprInterface address, ExprInterface expectedAddr, ExprInterface desiredValue, String mo, boolean isStrong) {
+        public static LlvmCmpXchg newCompareExchange(Register oldValueRegister, Register cmpRegister, Expression address, Expression expectedAddr, Expression desiredValue, String mo, boolean isStrong) {
             return new LlvmCmpXchg(oldValueRegister, cmpRegister, address, expectedAddr, desiredValue, mo, isStrong);
         }
 
-        public static LlvmCmpXchg newCompareExchange(Register oldValueRegister, Register cmpRegister, ExprInterface address, ExprInterface expectedAddr, ExprInterface desiredValue, String mo) {
+        public static LlvmCmpXchg newCompareExchange(Register oldValueRegister, Register cmpRegister, Expression address, Expression expectedAddr, Expression desiredValue, String mo) {
             return newCompareExchange(oldValueRegister, cmpRegister, address, expectedAddr, desiredValue, mo, false);
         }
 
-        public static LlvmRMW newRMW(Register register, ExprInterface address, ExprInterface value, IOpBin op, String mo) {
+        public static LlvmRMW newRMW(Register register, Expression address, Expression value, IOpBin op, String mo) {
             return new LlvmRMW(register, address, value, op, mo);
         }
 
@@ -331,7 +331,7 @@ public class EventFactory {
     public static class Std {
         private Std() { }
 
-        public static Malloc newMalloc(Register resultReg, ExprInterface sizeExpr) {
+        public static Malloc newMalloc(Register resultReg, Expression sizeExpr) {
             return new Malloc(resultReg, sizeExpr);
         }
     }
@@ -429,39 +429,39 @@ public class EventFactory {
         private Linux() {
         }
 
-        public static LKMMLoad newLKMMLoad(Register reg, ExprInterface address, String mo) {
+        public static LKMMLoad newLKMMLoad(Register reg, Expression address, String mo) {
             return new LKMMLoad(reg, address, mo);
         }
 
-        public static LKMMStore newLKMMStore(ExprInterface address, ExprInterface value, String mo) {
+        public static LKMMStore newLKMMStore(Expression address, Expression value, String mo) {
             return new LKMMStore(address, value, mo);
         }
 
-        public static RMWAddUnless newRMWAddUnless(ExprInterface address, Register register, ExprInterface cmp, ExprInterface value) {
+        public static RMWAddUnless newRMWAddUnless(Expression address, Register register, Expression cmp, Expression value) {
             return new RMWAddUnless(address, register, cmp, value);
         }
 
-        public static RMWCmpXchg newRMWCompareExchange(ExprInterface address, Register register, ExprInterface cmp, ExprInterface value, String mo) {
+        public static RMWCmpXchg newRMWCompareExchange(Expression address, Register register, Expression cmp, Expression value, String mo) {
             return new RMWCmpXchg(address, register, cmp, value, mo);
         }
 
-        public static RMWFetchOp newRMWFetchOp(ExprInterface address, Register register, ExprInterface value, IOpBin op, String mo) {
+        public static RMWFetchOp newRMWFetchOp(Expression address, Register register, Expression value, IOpBin op, String mo) {
             return new RMWFetchOp(address, register, value, op, mo);
         }
 
-        public static RMWOp newRMWOp(ExprInterface address, Register register, ExprInterface value, IOpBin op) {
+        public static RMWOp newRMWOp(Expression address, Register register, Expression value, IOpBin op) {
             return new RMWOp(address, register, value, op);
         }
 
-        public static RMWOpAndTest newRMWOpAndTest(ExprInterface address, Register register, ExprInterface value, IOpBin op) {
+        public static RMWOpAndTest newRMWOpAndTest(Expression address, Register register, Expression value, IOpBin op) {
             return new RMWOpAndTest(address, register, value, op);
         }
 
-        public static RMWOpReturn newRMWOpReturn(ExprInterface address, Register register, ExprInterface value, IOpBin op, String mo) {
+        public static RMWOpReturn newRMWOpReturn(Expression address, Register register, Expression value, IOpBin op, String mo) {
             return new RMWOpReturn(address, register, value, op, mo);
         }
 
-        public static RMWXchg newRMWExchange(ExprInterface address, Register register, ExprInterface value, String mo) {
+        public static RMWXchg newRMWExchange(Expression address, Register register, Expression value, String mo) {
             return new RMWXchg(address, register, value, mo);
         }
 
@@ -473,23 +473,23 @@ public class EventFactory {
             return new LKMMFence(name);
         }
 
-        public static LKMMLockRead newLockRead(Register register, ExprInterface address) {
+        public static LKMMLockRead newLockRead(Register register, Expression address) {
             return new LKMMLockRead(register, address);
         }
 
-        public static LKMMLockWrite newLockWrite(Load lockRead, ExprInterface address) {
+        public static LKMMLockWrite newLockWrite(Load lockRead, Expression address) {
             return new LKMMLockWrite(lockRead, address);
         }
 
-        public static LKMMLock newLock(ExprInterface address) {
+        public static LKMMLock newLock(Expression address) {
             return new LKMMLock(address);
         }
 
-        public static LKMMUnlock newUnlock(ExprInterface address) {
+        public static LKMMUnlock newUnlock(Expression address) {
             return new LKMMUnlock(address);
         }
 
-        public static SrcuSync newSrcuSync(ExprInterface address) {
+        public static SrcuSync newSrcuSync(Expression address) {
             return new SrcuSync(address);
         }
 
@@ -520,13 +520,13 @@ public class EventFactory {
         private RISCV() {
         }
 
-        public static RMWStoreExclusive newRMWStoreConditional(ExprInterface address, ExprInterface value, String mo, boolean isStrong) {
+        public static RMWStoreExclusive newRMWStoreConditional(Expression address, Expression value, String mo, boolean isStrong) {
             RMWStoreExclusive store = new RMWStoreExclusive(address, value, mo, isStrong, true);
             store.addTags(Tag.RISCV.STCOND);
             return store;
         }
 
-        public static RMWStoreExclusive newRMWStoreConditional(ExprInterface address, ExprInterface value, String mo) {
+        public static RMWStoreExclusive newRMWStoreConditional(Expression address, Expression value, String mo) {
             return RISCV.newRMWStoreConditional(address, value, mo, false);
         }
 
@@ -579,7 +579,7 @@ public class EventFactory {
         private LISA() {
         }
 
-        public static RMW newRMW(ExprInterface address, Register register, ExprInterface value, String mo) {
+        public static RMW newRMW(Expression address, Register register, Expression value, String mo) {
             return new RMW(address, register, value, mo);
         }
     }
@@ -592,7 +592,7 @@ public class EventFactory {
         private Power() {
         }
 
-        public static RMWStoreExclusive newRMWStoreConditional(ExprInterface address, ExprInterface value, String mo, boolean isStrong) {
+        public static RMWStoreExclusive newRMWStoreConditional(Expression address, Expression value, String mo, boolean isStrong) {
             return new RMWStoreExclusive(address, value, mo, isStrong, true);
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/StoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/StoreExclusive.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.arch;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Store;
@@ -15,7 +15,7 @@ public class StoreExclusive extends Store implements RegWriter {
 
     private final Register register;
 
-    public StoreExclusive(Register register, ExprInterface address, ExprInterface value, String mo) {
+    public StoreExclusive(Register register, Expression address, Expression value, String mo) {
         super(address, value, mo);
         this.register = register;
         addTags(Tag.EXCL);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/StoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/StoreExclusive.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.arch;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Store;
@@ -16,7 +15,7 @@ public class StoreExclusive extends Store implements RegWriter {
 
     private final Register register;
 
-    public StoreExclusive(Register register, IExpr address, ExprInterface value, String mo) {
+    public StoreExclusive(Register register, ExprInterface address, ExprInterface value, String mo) {
         super(address, value, mo);
         this.register = register;
         addTags(Tag.EXCL);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.arch.lisa;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -14,10 +14,10 @@ import static com.dat3m.dartagnan.program.event.Tag.*;
 public class RMW extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
-    private final ExprInterface value;
+    private final Expression value;
     
 
-    public RMW(ExprInterface address, Register register, ExprInterface value, String mo) {
+    public RMW(Expression address, Register register, Expression value, String mo) {
         super(address, mo);
 		this.resultRegister = register;
         this.value = value;
@@ -35,7 +35,7 @@ public class RMW extends AbstractMemoryEvent implements RegWriter {
         return resultRegister + " := rmw[" + mo + "](" + value + ", " + address + ")";
     }
 
-    public ExprInterface getMemValue(){
+    public Expression getMemValue(){
         return value;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/lisa/RMW.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.arch.lisa;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -15,10 +14,10 @@ import static com.dat3m.dartagnan.program.event.Tag.*;
 public class RMW extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
-    private final IExpr value;
+    private final ExprInterface value;
     
 
-    public RMW(IExpr address, Register register, IExpr value, String mo) {
+    public RMW(ExprInterface address, Register register, ExprInterface value, String mo) {
         super(address, mo);
 		this.resultRegister = register;
         this.value = value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/Xchg.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.arch.tso;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -42,7 +42,7 @@ public class Xchg extends AbstractMemoryEvent implements RegWriter {
     }
 
     @Override
-    public ExprInterface getMemValue(){
+    public Expression getMemValue(){
         return resultRegister;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryEvent.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.google.common.base.Preconditions;
 
 import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
@@ -9,11 +8,11 @@ import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 
 public abstract class AbstractMemoryEvent extends AbstractEvent implements MemoryEvent {
 
-    protected IExpr address;
+    protected ExprInterface address;
     protected String mo;
 
     // The empty string means no memory order 
-    public AbstractMemoryEvent(IExpr address, String mo) {
+    public AbstractMemoryEvent(ExprInterface address, String mo) {
         Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;
         this.mo = mo;
@@ -30,12 +29,12 @@ public abstract class AbstractMemoryEvent extends AbstractEvent implements Memor
     }
 
     @Override
-    public IExpr getAddress() {
+    public ExprInterface getAddress() {
         return address;
     }
 
     @Override
-    public void setAddress(IExpr address) {
+    public void setAddress(ExprInterface address) {
         this.address = address;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/AbstractMemoryEvent.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.google.common.base.Preconditions;
 
 import static com.dat3m.dartagnan.program.event.Tag.MEMORY;
@@ -8,11 +8,11 @@ import static com.dat3m.dartagnan.program.event.Tag.VISIBLE;
 
 public abstract class AbstractMemoryEvent extends AbstractEvent implements MemoryEvent {
 
-    protected ExprInterface address;
+    protected Expression address;
     protected String mo;
 
     // The empty string means no memory order 
-    public AbstractMemoryEvent(ExprInterface address, String mo) {
+    public AbstractMemoryEvent(Expression address, String mo) {
         Preconditions.checkNotNull(mo, "The memory ordering cannot be null");
         this.address = address;
         this.mo = mo;
@@ -29,22 +29,22 @@ public abstract class AbstractMemoryEvent extends AbstractEvent implements Memor
     }
 
     @Override
-    public ExprInterface getAddress() {
+    public Expression getAddress() {
         return address;
     }
 
     @Override
-    public void setAddress(ExprInterface address) {
+    public void setAddress(Expression address) {
         this.address = address;
     }
 
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
         throw new RuntimeException("MemValue is not available for event " + this.getClass().getName());
     }
 
     @Override
-    public void setMemValue(ExprInterface value) {
+    public void setMemValue(Expression value) {
         throw new RuntimeException("SetValue is not available for event " + this.getClass().getName());
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -13,9 +13,9 @@ import java.util.Set;
 
 public class Assume extends AbstractEvent implements RegReader {
 
-	protected final ExprInterface expr;
+	protected final Expression expr;
 
-	public Assume(ExprInterface expr) {
+	public Assume(Expression expr) {
 		super();
 		this.expr = expr;
 	}
@@ -26,7 +26,7 @@ public class Assume extends AbstractEvent implements RegReader {
 	}
 
 
-	public ExprInterface getExpr(){
+	public Expression getExpr(){
 		return expr;
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.BConst;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.type.BooleanType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
@@ -17,9 +17,9 @@ import java.util.Set;
 public class CondJump extends AbstractEvent implements RegReader {
 
     private Label label;
-    private ExprInterface guard;
+    private Expression guard;
 
-    public CondJump(ExprInterface guard, Label label) {
+    public CondJump(Expression guard, Label label) {
     	Preconditions.checkNotNull(label, "CondJump event requires non null label event");
     	Preconditions.checkNotNull(guard, "CondJump event requires non null expression");
         Preconditions.checkArgument(guard.getType() instanceof BooleanType,
@@ -49,10 +49,10 @@ public class CondJump extends AbstractEvent implements RegReader {
         return label;
     }
 
-    public ExprInterface getGuard() {
+    public Expression getGuard() {
         return guard;
     }
-    public void setGuard(ExprInterface guard) {
+    public void setGuard(Expression guard) {
         this.guard = guard;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
@@ -1,6 +1,8 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.BExpr;
+import com.dat3m.dartagnan.expression.BConst;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.type.BooleanType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -15,11 +17,13 @@ import java.util.Set;
 public class CondJump extends AbstractEvent implements RegReader {
 
     private Label label;
-    private BExpr guard;
+    private ExprInterface guard;
 
-    public CondJump(BExpr guard, Label label){
+    public CondJump(ExprInterface guard, Label label) {
     	Preconditions.checkNotNull(label, "CondJump event requires non null label event");
     	Preconditions.checkNotNull(guard, "CondJump event requires non null expression");
+        Preconditions.checkArgument(guard.getType() instanceof BooleanType,
+                "CondJump event with non-boolean guard %s.", guard);
         this.label = label;
         this.label.getJumpSet().add(this);
         this.thread = label.getThread();
@@ -34,18 +38,21 @@ public class CondJump extends AbstractEvent implements RegReader {
     }
     
     public boolean isGoto() {
-    	return guard.isTrue();
+    	return guard instanceof BConst constant && constant.getValue();
     }
-    public boolean isDead() {return guard.isFalse(); }
+
+    public boolean isDead() {
+        return guard instanceof BConst constant && !constant.getValue();
+    }
     
     public Label getLabel(){
         return label;
     }
 
-    public BExpr getGuard(){
+    public ExprInterface getGuard() {
         return guard;
     }
-    public void setGuard(BExpr guard){
+    public void setGuard(ExprInterface guard) {
         this.guard = guard;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/ExecutionStatus.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/ExecutionStatus.java
@@ -62,7 +62,7 @@ public class ExecutionStatus extends AbstractEvent implements RegWriter {
             } else {
                 BitvectorFormulaManager bitvectorFormulaManager = formulaManager.getBitvectorFormulaManager();
                 int bitWidth = integerType.getBitWidth();
-                one = bitvectorFormulaManager.makeBitvector(1, bitWidth);
+                one = bitvectorFormulaManager.makeBitvector(bitWidth, 1);
             }
             return booleanFormulaManager.and(super.encodeExec(context),
                     booleanFormulaManager.implication(eventExecuted,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/IfAsJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/IfAsJump.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.BExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
@@ -11,7 +11,7 @@ public class IfAsJump extends CondJump {
 
 	private final Label end;
 	
-	public IfAsJump(BExpr expr, Label label, Label end) {
+	public IfAsJump(ExprInterface expr, Label label, Label end) {
 		super(expr, label);
 		this.end = end;
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/IfAsJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/IfAsJump.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.google.common.base.Preconditions;
 
@@ -11,7 +11,7 @@ public class IfAsJump extends CondJump {
 
 	private final Label end;
 	
-	public IfAsJump(ExprInterface expr, Label label, Label end) {
+	public IfAsJump(Expression expr, Label label, Label end) {
 		super(expr, label);
 		this.end = end;
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -16,7 +16,7 @@ public class Init extends AbstractMemoryEvent {
 	private final MemoryObject base;
 	private final int offset;
 	
-	public Init(MemoryObject b, int o, ExprInterface address) {
+	public Init(MemoryObject b, int o, Expression address) {
 		super(address, "");
 		base = b;
 		offset = o;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -1,5 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -15,8 +16,8 @@ public class Init extends AbstractMemoryEvent {
 	private final MemoryObject base;
 	private final int offset;
 	
-	public Init(MemoryObject b, int o) {
-		super(b.add(o), "");
+	public Init(MemoryObject b, int o, ExprInterface address) {
+		super(address, "");
 		base = b;
 		offset = o;
 		addTags(Tag.WRITE, Tag.INIT);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -11,7 +10,7 @@ public class Load extends AbstractMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
 
-    public Load(Register register, IExpr address, String mo) {
+    public Load(Register register, ExprInterface address, String mo) {
         super(address, mo);
         this.resultRegister = register;
         addTags(Tag.READ);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -10,7 +10,7 @@ public class Load extends AbstractMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
 
-    public Load(Register register, ExprInterface address, String mo) {
+    public Load(Register register, Expression address, String mo) {
         super(address, mo);
         this.resultRegister = register;
         addTags(Tag.READ);
@@ -32,7 +32,7 @@ public class Load extends AbstractMemoryEvent implements RegWriter {
     }
 
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
         return resultRegister;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
@@ -15,9 +15,9 @@ import java.util.Set;
 public class Local extends AbstractEvent implements RegWriter, RegReader {
 
     protected final Register register;
-    protected ExprInterface expr;
+    protected Expression expr;
 
-    public Local(Register register, ExprInterface expr) {
+    public Local(Register register, Expression expr) {
         this.register = register;
         this.expr = expr;
     }
@@ -28,11 +28,11 @@ public class Local extends AbstractEvent implements RegWriter, RegReader {
         this.expr = other.expr;
     }
 
-    public ExprInterface getExpr() {
+    public Expression getExpr() {
         return expr;
     }
 
-    public void setExpr(ExprInterface expr) {
+    public void setExpr(Expression expr) {
         this.expr = expr;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -11,8 +10,8 @@ import java.util.Set;
 
 public interface MemoryEvent extends Event, RegReader {
 
-    IExpr getAddress();
-    void setAddress(IExpr address);
+    ExprInterface getAddress();
+    void setAddress(ExprInterface address);
 
     ExprInterface getMemValue();
     void setMemValue(ExprInterface value);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryEvent.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -10,11 +10,11 @@ import java.util.Set;
 
 public interface MemoryEvent extends Event, RegReader {
 
-    ExprInterface getAddress();
-    void setAddress(ExprInterface address);
+    Expression getAddress();
+    void setAddress(Expression address);
 
-    ExprInterface getMemValue();
-    void setMemValue(ExprInterface value);
+    Expression getMemValue();
+    void setMemValue(Expression value);
 
     String getMo();
     void setMo(String mo);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -12,7 +11,7 @@ public class Store extends AbstractMemoryEvent {
 
     protected ExprInterface value;
 
-    public Store(IExpr address, ExprInterface value, String mo) {
+    public Store(ExprInterface address, ExprInterface value, String mo) {
         super(address, mo);
         this.value = value;
         addTags(Tag.WRITE);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -9,9 +9,9 @@ import java.util.Set;
 
 public class Store extends AbstractMemoryEvent {
 
-    protected ExprInterface value;
+    protected Expression value;
 
-    public Store(ExprInterface address, ExprInterface value, String mo) {
+    public Store(Expression address, Expression value, String mo) {
         super(address, mo);
         this.value = value;
         addTags(Tag.WRITE);
@@ -33,12 +33,12 @@ public class Store extends AbstractMemoryEvent {
     }
 
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
         return value;
     }
 
     @Override
-    public void setMemValue(ExprInterface value) {
+    public void setMemValue(Expression value) {
         this.value = value;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStore.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.core.rmw;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Load;
@@ -15,7 +14,7 @@ public class RMWStore extends Store {
 
     protected Load loadEvent;
 
-    public RMWStore(Load loadEvent, IExpr address, ExprInterface value, String mo) {
+    public RMWStore(Load loadEvent, ExprInterface address, ExprInterface value, String mo) {
         super(address, value, mo);
         Preconditions.checkArgument(loadEvent.hasTag(Tag.RMW), "The provided load event " + loadEvent + " is not tagged RMW.");
         this.loadEvent = loadEvent;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStore.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.core.rmw;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Load;
@@ -14,7 +14,7 @@ public class RMWStore extends Store {
 
     protected Load loadEvent;
 
-    public RMWStore(Load loadEvent, ExprInterface address, ExprInterface value, String mo) {
+    public RMWStore(Load loadEvent, Expression address, Expression value, String mo) {
         super(address, value, mo);
         Preconditions.checkArgument(loadEvent.hasTag(Tag.RMW), "The provided load event " + loadEvent + " is not tagged RMW.");
         this.loadEvent = loadEvent;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStoreExclusive.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.event.core.rmw;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Store;
@@ -13,7 +13,7 @@ public class RMWStoreExclusive extends Store {
     private final boolean isStrong;
     private final boolean requiresMatchingAddresses;
 
-    public RMWStoreExclusive(ExprInterface address, ExprInterface value, String mo,
+    public RMWStoreExclusive(Expression address, Expression value, String mo,
                              boolean isStrong, boolean requiresMatchingAddresses) {
         super(address, value, mo);
         addTags(Tag.EXCL, Tag.RMW);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/rmw/RMWStoreExclusive.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.program.event.core.rmw;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Store;
@@ -14,7 +13,7 @@ public class RMWStoreExclusive extends Store {
     private final boolean isStrong;
     private final boolean requiresMatchingAddresses;
 
-    public RMWStoreExclusive(IExpr address, ExprInterface value, String mo,
+    public RMWStoreExclusive(ExprInterface address, ExprInterface value, String mo,
                              boolean isStrong, boolean requiresMatchingAddresses) {
         super(address, value, mo);
         addTags(Tag.EXCL, Tag.RMW);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -17,7 +16,7 @@ public abstract class AtomicAbstract extends AbstractMemoryEvent implements RegW
     protected final Register resultRegister;
     protected ExprInterface value;
 
-    AtomicAbstract(IExpr address, Register register, IExpr value, String mo) {
+    AtomicAbstract(ExprInterface address, Register register, ExprInterface value, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "Atomic events cannot have empty memory order");
         this.resultRegister = register;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicAbstract.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -14,9 +14,9 @@ import static com.dat3m.dartagnan.program.event.Tag.*;
 public abstract class AtomicAbstract extends AbstractMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
-    protected ExprInterface value;
+    protected Expression value;
 
-    AtomicAbstract(ExprInterface address, Register register, ExprInterface value, String mo) {
+    AtomicAbstract(Expression address, Register register, Expression value, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "Atomic events cannot have empty memory order");
         this.resultRegister = register;
@@ -41,12 +41,12 @@ public abstract class AtomicAbstract extends AbstractMemoryEvent implements RegW
     }
 
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
     	return value;
     }
     
     @Override
-    public void setMemValue(ExprInterface value){
+    public void setMemValue(Expression value){
         this.value = value;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -8,10 +8,10 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class AtomicCmpXchg extends AtomicAbstract {
 
-    private ExprInterface expectedAddr;
+    private Expression expectedAddr;
     private boolean isStrong;
 
-    public AtomicCmpXchg(Register register, ExprInterface address, ExprInterface expectedAddr, ExprInterface value, String mo, boolean isStrong) {
+    public AtomicCmpXchg(Register register, Expression address, Expression expectedAddr, Expression value, String mo, boolean isStrong) {
         super(address, register, value, mo);
         this.expectedAddr = expectedAddr;
         this.isStrong = isStrong;
@@ -28,11 +28,11 @@ public class AtomicCmpXchg extends AtomicAbstract {
 
     //TODO: Override getDataRegs???
 
-    public ExprInterface getExpectedAddr() {
+    public Expression getExpectedAddr() {
     	return expectedAddr;
     }
     
-    public void setExpectedAddr(ExprInterface expectedAddr) {
+    public void setExpectedAddr(Expression expectedAddr) {
         this.expectedAddr = expectedAddr;
     }
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
@@ -1,16 +1,17 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 
+
 public class AtomicCmpXchg extends AtomicAbstract {
 
-    private IExpr expectedAddr;
+    private ExprInterface expectedAddr;
     private boolean isStrong;
 
-    public AtomicCmpXchg(Register register, IExpr address, IExpr expectedAddr, IExpr value, String mo, boolean isStrong) {
+    public AtomicCmpXchg(Register register, ExprInterface address, ExprInterface expectedAddr, ExprInterface value, String mo, boolean isStrong) {
         super(address, register, value, mo);
         this.expectedAddr = expectedAddr;
         this.isStrong = isStrong;
@@ -27,12 +28,12 @@ public class AtomicCmpXchg extends AtomicAbstract {
 
     //TODO: Override getDataRegs???
 
-    public IExpr getExpectedAddr() {
+    public ExprInterface getExpectedAddr() {
     	return expectedAddr;
     }
     
-    public void setExpectedAddr(IExpr expectedAddr) {
-    	this.expectedAddr = expectedAddr;
+    public void setExpectedAddr(ExprInterface expectedAddr) {
+        this.expectedAddr = expectedAddr;
     }
     
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 
@@ -11,7 +10,7 @@ public class AtomicFetchOp extends AtomicAbstract {
 
     private final IOpBin op;
 
-    public AtomicFetchOp(Register register, IExpr address, IExpr value, IOpBin op, String mo) {
+    public AtomicFetchOp(Register register, ExprInterface address, ExprInterface value, IOpBin op, String mo) {
         super(address, register, value, mo);
         this.op = op;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 
@@ -10,7 +10,7 @@ public class AtomicFetchOp extends AtomicAbstract {
 
     private final IOpBin op;
 
-    public AtomicFetchOp(Register register, ExprInterface address, ExprInterface value, IOpBin op, String mo) {
+    public AtomicFetchOp(Register register, Expression address, Expression value, IOpBin op, String mo) {
         super(address, register, value, mo);
         this.op = op;
     }
@@ -31,7 +31,7 @@ public class AtomicFetchOp extends AtomicAbstract {
     }
     
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
     	return value;
     }
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -15,7 +15,7 @@ public class AtomicLoad extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 
-    public AtomicLoad(Register register, ExprInterface address, String mo) {
+    public AtomicLoad(Register register, Expression address, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "Atomic events cannot have empty memory order");
     	Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),
@@ -40,7 +40,7 @@ public class AtomicLoad extends AbstractMemoryEvent implements RegWriter {
     }
 
     @Override
-    public ExprInterface getMemValue(){
+    public Expression getMemValue(){
         return resultRegister;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -16,7 +15,7 @@ public class AtomicLoad extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 
-    public AtomicLoad(Register register, IExpr address, String mo) {
+    public AtomicLoad(Register register, ExprInterface address, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "Atomic events cannot have empty memory order");
     	Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -14,9 +14,9 @@ import static com.dat3m.dartagnan.program.event.Tag.WRITE;
 
 public class AtomicStore extends AbstractMemoryEvent {
 
-    private ExprInterface value;
+    private Expression value;
 
-    public AtomicStore(ExprInterface address, ExprInterface value, String mo){
+    public AtomicStore(Expression address, Expression value, String mo){
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "Atomic events cannot have empty memory order");
         Preconditions.checkArgument(!mo.equals(MO_ACQUIRE) && !mo.equals(MO_ACQUIRE_RELEASE),
@@ -41,12 +41,12 @@ public class AtomicStore extends AbstractMemoryEvent {
     }
 
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
     	return value;
     }
     
     @Override
-    public void setMemValue(ExprInterface value){
+    public void setMemValue(Expression value){
         this.value = value;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -17,7 +16,7 @@ public class AtomicStore extends AbstractMemoryEvent {
 
     private ExprInterface value;
 
-    public AtomicStore(IExpr address, ExprInterface value, String mo){
+    public AtomicStore(ExprInterface address, ExprInterface value, String mo){
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "Atomic events cannot have empty memory order");
         Preconditions.checkArgument(!mo.equals(MO_ACQUIRE) && !mo.equals(MO_ACQUIRE_RELEASE),

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
@@ -1,14 +1,13 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class AtomicXchg extends AtomicAbstract {
 
-    public AtomicXchg(Register register, IExpr address, IExpr value, String mo) {
+    public AtomicXchg(Register register, ExprInterface address, ExprInterface value, String mo) {
         super(address, register, value, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
@@ -1,13 +1,13 @@
 package com.dat3m.dartagnan.program.event.lang.catomic;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class AtomicXchg extends AtomicAbstract {
 
-    public AtomicXchg(Register register, ExprInterface address, ExprInterface value, String mo) {
+    public AtomicXchg(Register register, Expression address, Expression value, String mo) {
         super(address, register, value, mo);
     }
 
@@ -21,7 +21,7 @@ public class AtomicXchg extends AtomicAbstract {
     }
 
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
     	return value;
     }
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Load;
@@ -8,7 +8,7 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMLoad extends Load {
 
-	public LKMMLoad(Register register, IExpr address, String mo) {
+	public LKMMLoad(Register register, ExprInterface address, String mo) {
 		super(register, address, mo);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Load;
@@ -8,7 +8,7 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMLoad extends Load {
 
-	public LKMMLoad(Register register, ExprInterface address, String mo) {
+	public LKMMLoad(Register register, Expression address, String mo) {
 		super(register, address, mo);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
@@ -1,12 +1,12 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMLock extends AbstractMemoryEvent {
 
-	public LKMMLock(IExpr lock) {
+	public LKMMLock(ExprInterface lock) {
 		// This event will be compiled to LKMMLockRead + LKMMLockWrite 
 		// and each of those will be assigned a proper memory ordering
 		super(lock, "");
@@ -16,7 +16,7 @@ public class LKMMLock extends AbstractMemoryEvent {
         super(other);
     }
 
-	public IExpr getLock() {
+	public ExprInterface getLock() {
 		return address;
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
@@ -1,12 +1,12 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMLock extends AbstractMemoryEvent {
 
-	public LKMMLock(ExprInterface lock) {
+	public LKMMLock(Expression lock) {
 		// This event will be compiled to LKMMLockRead + LKMMLockWrite 
 		// and each of those will be assigned a proper memory ordering
 		super(lock, "");
@@ -16,7 +16,7 @@ public class LKMMLock extends AbstractMemoryEvent {
         super(other);
     }
 
-	public ExprInterface getLock() {
+	public Expression getLock() {
 		return address;
 	}
 	

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockRead.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockRead.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.Load;
 
@@ -9,7 +9,7 @@ import static com.dat3m.dartagnan.program.event.Tag.RMW;
 
 public class LKMMLockRead extends Load {
 
-	public LKMMLockRead(Register register, ExprInterface lock) {
+	public LKMMLockRead(Register register, Expression lock) {
 		super(register, lock, Linux.MO_ACQUIRE);
 		addTags(RMW, Linux.LOCK_READ);
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockRead.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockRead.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.Load;
 
@@ -9,7 +9,7 @@ import static com.dat3m.dartagnan.program.event.Tag.RMW;
 
 public class LKMMLockRead extends Load {
 
-	public LKMMLockRead(Register register, IExpr lock) {
+	public LKMMLockRead(Register register, ExprInterface lock) {
 		super(register, lock, Linux.MO_ACQUIRE);
 		addTags(RMW, Linux.LOCK_READ);
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockWrite.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockWrite.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.core.rmw.RMWStore;
 
@@ -10,8 +11,8 @@ import static com.dat3m.dartagnan.program.event.Tag.RMW;
 
 public class LKMMLockWrite extends RMWStore {
 
-	public LKMMLockWrite(Load lockRead, IExpr lock) {
-		super(lockRead, lock, IValue.ONE, Linux.MO_ONCE);
+	public LKMMLockWrite(Load lockRead, ExprInterface lock) {
+		super(lockRead, lock, ExpressionFactory.getInstance().makeOne(TypeFactory.getInstance().getArchType()), Linux.MO_ONCE);
 		addTags(RMW, Linux.LOCK_WRITE);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockWrite.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLockWrite.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.core.Load;
@@ -11,7 +11,7 @@ import static com.dat3m.dartagnan.program.event.Tag.RMW;
 
 public class LKMMLockWrite extends RMWStore {
 
-	public LKMMLockWrite(Load lockRead, ExprInterface lock) {
+	public LKMMLockWrite(Load lockRead, Expression lock) {
 		super(lockRead, lock, ExpressionFactory.getInstance().makeOne(TypeFactory.getInstance().getArchType()), Linux.MO_ONCE);
 		addTags(RMW, Linux.LOCK_WRITE);
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
@@ -1,13 +1,13 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMStore extends Store {
 
-	public LKMMStore(ExprInterface address, ExprInterface value, String mo) {
+	public LKMMStore(Expression address, Expression value, String mo) {
 		super(address, value, mo);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
@@ -1,14 +1,13 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LKMMStore extends Store {
 
-	public LKMMStore(IExpr address, ExprInterface value, String mo) {
+	public LKMMStore(ExprInterface address, ExprInterface value, String mo) {
 		super(address, value, mo);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMUnlock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMUnlock.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -10,8 +11,8 @@ import static com.dat3m.dartagnan.program.event.Tag.Linux.MO_RELEASE;
 
 public class LKMMUnlock extends Store {
 
-	public LKMMUnlock(IExpr lock) {
-		super(lock, IValue.ZERO, MO_RELEASE);
+	public LKMMUnlock(ExprInterface lock) {
+		super(lock, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType()), MO_RELEASE);
 		addTags(Tag.Linux.UNLOCK);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMUnlock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMUnlock.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -11,7 +11,7 @@ import static com.dat3m.dartagnan.program.event.Tag.Linux.MO_RELEASE;
 
 public class LKMMUnlock extends Store {
 
-	public LKMMUnlock(ExprInterface lock) {
+	public LKMMUnlock(Expression lock) {
 		super(lock, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType()), MO_RELEASE);
 		addTags(Tag.Linux.UNLOCK);
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -16,7 +15,7 @@ public abstract class RMWAbstract extends AbstractMemoryEvent implements RegWrit
     protected final Register resultRegister;
     protected ExprInterface value;
 
-    RMWAbstract(IExpr address, Register register, ExprInterface value, String mo) {
+    RMWAbstract(ExprInterface address, Register register, ExprInterface value, String mo) {
         super(address, mo);
         this.resultRegister = register;
         this.value = value;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAbstract.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -13,9 +13,9 @@ import static com.dat3m.dartagnan.program.event.Tag.*;
 public abstract class RMWAbstract extends AbstractMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
-    protected ExprInterface value;
+    protected Expression value;
 
-    RMWAbstract(ExprInterface address, Register register, ExprInterface value, String mo) {
+    RMWAbstract(Expression address, Register register, Expression value, String mo) {
         super(address, mo);
         this.resultRegister = register;
         this.value = value;
@@ -39,12 +39,12 @@ public abstract class RMWAbstract extends AbstractMemoryEvent implements RegWrit
     }
 
     @Override
-    public ExprInterface getMemValue(){
+    public Expression getMemValue(){
         return value;
     }
 
     @Override
-    public void setMemValue(ExprInterface value){
+    public void setMemValue(Expression value){
         this.value = value;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAddUnless.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAddUnless.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -12,7 +11,7 @@ public class RMWAddUnless extends RMWAbstract {
 
     private final ExprInterface cmp;
 
-    public RMWAddUnless(IExpr address, Register register, ExprInterface cmp, IExpr value) {
+    public RMWAddUnless(ExprInterface address, Register register, ExprInterface cmp, ExprInterface value) {
         super(address, register, value, Tag.Linux.MO_MB);
         this.cmp = cmp;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAddUnless.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWAddUnless.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -9,9 +9,9 @@ import java.util.Set;
 
 public class RMWAddUnless extends RMWAbstract {
 
-    private final ExprInterface cmp;
+    private final Expression cmp;
 
-    public RMWAddUnless(ExprInterface address, Register register, ExprInterface cmp, ExprInterface value) {
+    public RMWAddUnless(Expression address, Register register, Expression cmp, Expression value) {
         super(address, register, value, Tag.Linux.MO_MB);
         this.cmp = cmp;
     }
@@ -26,7 +26,7 @@ public class RMWAddUnless extends RMWAbstract {
         return resultRegister + " := atomic_add_unless" + "(" + address + ", " + value + ", " + cmp + ")\t### LKMM";
     }
 
-    public ExprInterface getCmp() {
+    public Expression getCmp() {
     	return cmp;
     }
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWCmpXchg.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -12,7 +11,7 @@ public class RMWCmpXchg extends RMWAbstract {
 
     private final ExprInterface cmp;
 
-    public RMWCmpXchg(IExpr address, Register register, ExprInterface cmp, IExpr value, String mo) {
+    public RMWCmpXchg(ExprInterface address, Register register, ExprInterface cmp, ExprInterface value, String mo) {
         super(address, register, value, mo);
         this.cmp = cmp;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWCmpXchg.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -9,9 +9,9 @@ import java.util.Set;
 
 public class RMWCmpXchg extends RMWAbstract {
 
-    private final ExprInterface cmp;
+    private final Expression cmp;
 
-    public RMWCmpXchg(ExprInterface address, Register register, ExprInterface cmp, ExprInterface value, String mo) {
+    public RMWCmpXchg(Expression address, Register register, Expression cmp, Expression value, String mo) {
         super(address, register, value, mo);
         this.cmp = cmp;
     }
@@ -26,7 +26,7 @@ public class RMWCmpXchg extends RMWAbstract {
         return resultRegister + " := atomic_cmpxchg" + Tag.Linux.toText(mo) + "(" + address + ", " + cmp + ", " + value + ")\t### LKMM";
     }
 
-    public ExprInterface getCmp() {
+    public Expression getCmp() {
     	return cmp;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWFetchOp.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -10,7 +10,7 @@ public class RMWFetchOp extends RMWAbstract {
 
     private final IOpBin op;
 
-    public RMWFetchOp(ExprInterface address, Register register, ExprInterface value, IOpBin op, String mo) {
+    public RMWFetchOp(Expression address, Register register, Expression value, IOpBin op, String mo) {
         super(address, register, value, mo);
         this.op = op;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWFetchOp.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -10,7 +10,7 @@ public class RMWFetchOp extends RMWAbstract {
 
     private final IOpBin op;
 
-    public RMWFetchOp(IExpr address, Register register, IExpr value, IOpBin op, String mo) {
+    public RMWFetchOp(ExprInterface address, Register register, ExprInterface value, IOpBin op, String mo) {
         super(address, register, value, mo);
         this.op = op;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOp.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -10,7 +10,7 @@ public class RMWOp extends RMWAbstract {
 
     private final IOpBin op;
 
-    public RMWOp(ExprInterface address, Register register, ExprInterface value, IOpBin op) {
+    public RMWOp(Expression address, Register register, Expression value, IOpBin op) {
         super(address, register, value, Tag.Linux.MO_ONCE);
         this.op = op;
         addTags(Tag.Linux.NORETURN);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOp.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -10,7 +10,7 @@ public class RMWOp extends RMWAbstract {
 
     private final IOpBin op;
 
-    public RMWOp(IExpr address, Register register, IExpr value, IOpBin op) {
+    public RMWOp(ExprInterface address, Register register, ExprInterface value, IOpBin op) {
         super(address, register, value, Tag.Linux.MO_ONCE);
         this.op = op;
         addTags(Tag.Linux.NORETURN);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOpAndTest.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOpAndTest.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -10,7 +10,7 @@ public class RMWOpAndTest extends RMWAbstract {
 
     private final IOpBin op;
 
-    public RMWOpAndTest(ExprInterface address, Register register, ExprInterface value, IOpBin op) {
+    public RMWOpAndTest(Expression address, Register register, Expression value, IOpBin op) {
         super(address, register, value, Tag.Linux.MO_MB);
         this.op = op;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOpAndTest.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOpAndTest.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.*;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -10,7 +10,7 @@ public class RMWOpAndTest extends RMWAbstract {
 
     private final IOpBin op;
 
-    public RMWOpAndTest(IExpr address, Register register, IExpr value, IOpBin op) {
+    public RMWOpAndTest(ExprInterface address, Register register, ExprInterface value, IOpBin op) {
         super(address, register, value, Tag.Linux.MO_MB);
         this.op = op;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOpReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOpReturn.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -10,7 +10,7 @@ public class RMWOpReturn extends RMWAbstract {
 
     private final IOpBin op;
 
-    public RMWOpReturn(ExprInterface address, Register register, ExprInterface value, IOpBin op, String mo) {
+    public RMWOpReturn(Expression address, Register register, Expression value, IOpBin op, String mo) {
         super(address, register, value, mo);
         this.op = op;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOpReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWOpReturn.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -10,7 +10,7 @@ public class RMWOpReturn extends RMWAbstract {
 
     private final IOpBin op;
 
-    public RMWOpReturn(IExpr address, Register register, IExpr value, IOpBin op, String mo) {
+    public RMWOpReturn(ExprInterface address, Register register, ExprInterface value, IOpBin op, String mo) {
         super(address, register, value, mo);
         this.op = op;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWXchg.java
@@ -1,13 +1,13 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class RMWXchg extends RMWAbstract {
 
-    public RMWXchg(IExpr address, Register register, IExpr value, String mo) {
+    public RMWXchg(ExprInterface address, Register register, ExprInterface value, String mo) {
         super(address, register, value, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/RMWXchg.java
@@ -1,13 +1,13 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class RMWXchg extends RMWAbstract {
 
-    public RMWXchg(ExprInterface address, Register register, ExprInterface value, String mo) {
+    public RMWXchg(Expression address, Register register, Expression value, String mo) {
         super(address, register, value, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -9,7 +9,7 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class SrcuSync extends AbstractMemoryEvent {
 
-	public SrcuSync(ExprInterface address) {
+	public SrcuSync(Expression address) {
 		super(address, Tag.Linux.SRCU_SYNC);
 	}
 
@@ -26,7 +26,7 @@ public class SrcuSync extends AbstractMemoryEvent {
 	// the alias analysis and the result of passes like constant propagation is 
 	// irrelevant because this event does not contribute to any data flow.
 	@Override
-	public ExprInterface getMemValue(){
+	public Expression getMemValue(){
 		return ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType());
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/SrcuSync.java
@@ -1,15 +1,15 @@
 package com.dat3m.dartagnan.program.event.lang.linux;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class SrcuSync extends AbstractMemoryEvent {
 
-	public SrcuSync(IExpr address) {
+	public SrcuSync(ExprInterface address) {
 		super(address, Tag.Linux.SRCU_SYNC);
 	}
 
@@ -27,7 +27,7 @@ public class SrcuSync extends AbstractMemoryEvent {
 	// irrelevant because this event does not contribute to any data flow.
 	@Override
 	public ExprInterface getMemValue(){
-		return IValue.ZERO;
+		return ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType());
 	}
 
 	// Visitor

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -17,7 +16,7 @@ public abstract class LlvmAbstractRMW extends AbstractMemoryEvent implements Reg
     protected final Register resultRegister;
     protected ExprInterface value;
 
-    LlvmAbstractRMW(IExpr address, Register register, IExpr value, String mo) {
+    LlvmAbstractRMW(ExprInterface address, Register register, ExprInterface value, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "LLVM events cannot have empty memory order");
         this.resultRegister = register;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmAbstractRMW.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -14,9 +14,9 @@ import static com.dat3m.dartagnan.program.event.Tag.*;
 public abstract class LlvmAbstractRMW extends AbstractMemoryEvent implements RegWriter {
 
     protected final Register resultRegister;
-    protected ExprInterface value;
+    protected Expression value;
 
-    LlvmAbstractRMW(ExprInterface address, Register register, ExprInterface value, String mo) {
+    LlvmAbstractRMW(Expression address, Register register, Expression value, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "LLVM events cannot have empty memory order");
         this.resultRegister = register;
@@ -41,12 +41,12 @@ public abstract class LlvmAbstractRMW extends AbstractMemoryEvent implements Reg
     }
 
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
     	return value;
     }
     
     @Override
-    public void setMemValue(ExprInterface value){
+    public void setMemValue(Expression value){
         this.value = value;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -8,13 +8,13 @@ import java.util.Set;
 
 public class LlvmCmpXchg extends LlvmAbstractRMW {
 
-    private ExprInterface expectedValue;
+    private Expression expectedValue;
     private Register oldValueRegister;
     private Register cmpRegister;
     private boolean isStrong;
 
-    public LlvmCmpXchg(Register oldValueRegister, Register cmpRegister, ExprInterface address,
-                       ExprInterface expectedValue, ExprInterface value, String mo, boolean isStrong) {
+    public LlvmCmpXchg(Register oldValueRegister, Register cmpRegister, Expression address,
+                       Expression expectedValue, Expression value, String mo, boolean isStrong) {
         super(address, null, value, mo);
         this.expectedValue = expectedValue;
         this.oldValueRegister = oldValueRegister;
@@ -52,7 +52,7 @@ public class LlvmCmpXchg extends LlvmAbstractRMW {
         }
     }
 
-    public ExprInterface getExpectedValue() {
+    public Expression getExpectedValue() {
     	return expectedValue;
     }
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -9,13 +8,13 @@ import java.util.Set;
 
 public class LlvmCmpXchg extends LlvmAbstractRMW {
 
-    private IExpr expectedValue;
+    private ExprInterface expectedValue;
     private Register oldValueRegister;
     private Register cmpRegister;
     private boolean isStrong;
 
-    public LlvmCmpXchg(Register oldValueRegister, Register cmpRegister, IExpr address, IExpr expectedValue, IExpr value,
-                       String mo, boolean isStrong) {
+    public LlvmCmpXchg(Register oldValueRegister, Register cmpRegister, ExprInterface address,
+                       ExprInterface expectedValue, ExprInterface value, String mo, boolean isStrong) {
         super(address, null, value, mo);
         this.expectedValue = expectedValue;
         this.oldValueRegister = oldValueRegister;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -15,7 +15,7 @@ public class LlvmLoad extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 
-    public LlvmLoad(Register register, ExprInterface address, String mo) {
+    public LlvmLoad(Register register, Expression address, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "LLVM events cannot have empty memory order");
     	Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),
@@ -40,7 +40,7 @@ public class LlvmLoad extends AbstractMemoryEvent implements RegWriter {
     }
 
     @Override
-    public ExprInterface getMemValue(){
+    public Expression getMemValue(){
         return resultRegister;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
@@ -16,7 +15,7 @@ public class LlvmLoad extends AbstractMemoryEvent implements RegWriter {
 
     private final Register resultRegister;
 
-    public LlvmLoad(Register register, IExpr address, String mo) {
+    public LlvmLoad(Register register, ExprInterface address, String mo) {
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "LLVM events cannot have empty memory order");
     	Preconditions.checkArgument(!mo.equals(MO_RELEASE) && !mo.equals(MO_ACQUIRE_RELEASE),

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 
@@ -10,7 +10,7 @@ public class LlvmRMW extends LlvmAbstractRMW {
 
     private final IOpBin op;
 
-    public LlvmRMW(Register register, ExprInterface address, ExprInterface value, IOpBin op, String mo) {
+    public LlvmRMW(Register register, Expression address, Expression value, IOpBin op, String mo) {
         super(address, register, value, mo);
         this.op = op;
     }
@@ -31,7 +31,7 @@ public class LlvmRMW extends LlvmAbstractRMW {
     }
     
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
     	return value;
     }
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.program.Register;
 
@@ -11,7 +10,7 @@ public class LlvmRMW extends LlvmAbstractRMW {
 
     private final IOpBin op;
 
-    public LlvmRMW(Register register, IExpr address, IExpr value, IOpBin op, String mo) {
+    public LlvmRMW(Register register, ExprInterface address, ExprInterface value, IOpBin op, String mo) {
         super(address, register, value, mo);
         this.op = op;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -17,7 +16,7 @@ public class LlvmStore extends AbstractMemoryEvent {
 
     private ExprInterface value;
 
-    public LlvmStore(IExpr address, ExprInterface value, String mo){
+    public LlvmStore(ExprInterface address, ExprInterface value, String mo){
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "LLVM events cannot have empty memory order");
         Preconditions.checkArgument(!mo.equals(MO_ACQUIRE) && !mo.equals(MO_ACQUIRE_RELEASE),

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.AbstractMemoryEvent;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -14,9 +14,9 @@ import static com.dat3m.dartagnan.program.event.Tag.WRITE;
 
 public class LlvmStore extends AbstractMemoryEvent {
 
-    private ExprInterface value;
+    private Expression value;
 
-    public LlvmStore(ExprInterface address, ExprInterface value, String mo){
+    public LlvmStore(Expression address, Expression value, String mo){
         super(address, mo);
         Preconditions.checkArgument(!mo.isEmpty(), "LLVM events cannot have empty memory order");
         Preconditions.checkArgument(!mo.equals(MO_ACQUIRE) && !mo.equals(MO_ACQUIRE_RELEASE),
@@ -41,12 +41,12 @@ public class LlvmStore extends AbstractMemoryEvent {
     }
 
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
     	return value;
     }
     
     @Override
-    public void setMemValue(ExprInterface value){
+    public void setMemValue(Expression value){
         this.value = value;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
@@ -1,14 +1,13 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
 import com.dat3m.dartagnan.expression.ExprInterface;
-import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.program.Register;
 
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LlvmXchg extends LlvmAbstractRMW {
 
-    public LlvmXchg(Register register, IExpr address, IExpr value, String mo) {
+    public LlvmXchg(Register register, ExprInterface address, ExprInterface value, String mo) {
         super(address, register, value, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
@@ -1,13 +1,13 @@
 package com.dat3m.dartagnan.program.event.lang.llvm;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class LlvmXchg extends LlvmAbstractRMW {
 
-    public LlvmXchg(Register register, ExprInterface address, ExprInterface value, String mo) {
+    public LlvmXchg(Register register, Expression address, Expression value, String mo) {
         super(address, register, value, mo);
     }
 
@@ -21,7 +21,7 @@ public class LlvmXchg extends LlvmAbstractRMW {
     }
 
     @Override
-    public ExprInterface getMemValue() {
+    public Expression getMemValue() {
     	return value;
     }
     

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Create.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Create.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -12,8 +13,8 @@ public class Create extends Store {
 
 	private final String routine;
 	
-    public Create(IExpr address, String routine) {
-    	super(address, IValue.ONE, MO_SC);
+    public Create(ExprInterface address, String routine) {
+        super(address, ExpressionFactory.getInstance().makeOne(TypeFactory.getInstance().getArchType()), MO_SC);
         this.routine = routine;
         addTags(Tag.C11.PTHREAD);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Create.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Create.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -13,7 +13,7 @@ public class Create extends Store {
 
 	private final String routine;
 	
-    public Create(ExprInterface address, String routine) {
+    public Create(Expression address, String routine) {
         super(address, ExpressionFactory.getInstance().makeOne(TypeFactory.getInstance().getArchType()), MO_SC);
         this.routine = routine;
         addTags(Tag.C11.PTHREAD);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/End.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/End.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -11,7 +11,7 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;
 
 public class End extends Store {
 
-    public End(ExprInterface address){
+    public End(Expression address){
     	super(address, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType()), MO_SC);
     	addTags(Tag.C11.PTHREAD);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/End.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/End.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -10,8 +11,8 @@ import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;
 
 public class End extends Store {
 
-    public End(IExpr address){
-    	super(address, IValue.ZERO, MO_SC);
+    public End(ExprInterface address){
+    	super(address, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType()), MO_SC);
     	addTags(Tag.C11.PTHREAD);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/InitLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/InitLock.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -10,7 +10,7 @@ public class InitLock extends Store {
 	
 	private final String name;
 
-	public InitLock(String name, ExprInterface address, ExprInterface value) {
+	public InitLock(String name, Expression address, Expression value) {
 		super(address, value, MO_SC);
 		this.name = name;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/InitLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/InitLock.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
@@ -10,7 +10,7 @@ public class InitLock extends Store {
 	
 	private final String name;
 
-	public InitLock(String name, IExpr address, IExpr value){
+	public InitLock(String name, ExprInterface address, ExprInterface value) {
 		super(address, value, MO_SC);
 		this.name = name;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Load;
@@ -8,7 +8,7 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class Join extends Load {
 
-    public Join(Register reg, ExprInterface expr) {
+    public Join(Register reg, Expression expr) {
         // We will set the correct (C11 or LKMM) acquire tag (or barriers) when the event is compiled
     	super(reg, expr, "");
         addTags(Tag.C11.PTHREAD);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Join.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Load;
@@ -8,7 +8,7 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 
 public class Join extends Load {
 
-    public Join(Register reg, IExpr expr) {
+    public Join(Register reg, ExprInterface expr) {
         // We will set the correct (C11 or LKMM) acquire tag (or barriers) when the event is compiled
     	super(reg, expr, "");
         addTags(Tag.C11.PTHREAD);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Lock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Lock.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
@@ -14,7 +14,7 @@ public class Lock extends Store {
 	private final String name;
 	private final Register reg;
 
-	public Lock(String name, ExprInterface address, Register reg){
+	public Lock(String name, Expression address, Register reg){
 		super(address, ExpressionFactory.getInstance().makeOne(TypeFactory.getInstance().getArchType()), MO_SC);
 		this.name = name;
         this.reg = reg;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Lock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Lock.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -9,12 +10,12 @@ import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import static com.dat3m.dartagnan.program.event.Tag.C11.MO_SC;
 
 public class Lock extends Store {
-	
+
 	private final String name;
 	private final Register reg;
 
-	public Lock(String name, IExpr address, Register reg){
-		super(address, IValue.ONE, MO_SC);
+	public Lock(String name, ExprInterface address, Register reg){
+		super(address, ExpressionFactory.getInstance().makeOne(TypeFactory.getInstance().getArchType()), MO_SC);
 		this.name = name;
         this.reg = reg;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Start.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Start.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
@@ -13,7 +13,7 @@ public class Start extends Load {
 
     private final Event creationEvent;
 
-	public Start(Register reg, ExprInterface address, Event creationEvent){
+	public Start(Register reg, Expression address, Event creationEvent){
 		super(reg, address, MO_SC);
         this.creationEvent = creationEvent;
         addTags(Tag.C11.PTHREAD);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Start.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Start.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Event;
@@ -13,7 +13,7 @@ public class Start extends Load {
 
     private final Event creationEvent;
 
-	public Start(Register reg, IExpr address, Event creationEvent){
+	public Start(Register reg, ExprInterface address, Event creationEvent){
 		super(reg, address, MO_SC);
         this.creationEvent = creationEvent;
         addTags(Tag.C11.PTHREAD);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Unlock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Unlock.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
@@ -14,7 +14,7 @@ public class Unlock extends Store {
 	private final String name;
 	private final Register reg;
 
-	public Unlock(String name, ExprInterface address, Register reg) {
+	public Unlock(String name, Expression address, Register reg) {
 		super(address, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType()), MO_SC);
 		this.name = name;
         this.reg = reg;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Unlock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/pthread/Unlock.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.event.lang.pthread;
 
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
@@ -13,8 +14,8 @@ public class Unlock extends Store {
 	private final String name;
 	private final Register reg;
 
-	public Unlock(String name, IExpr address, Register reg){
-		super(address, IValue.ZERO, MO_SC);
+	public Unlock(String name, ExprInterface address, Register reg) {
+		super(address, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType()), MO_SC);
 		this.name = name;
         this.reg = reg;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/std/Malloc.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/std/Malloc.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.event.lang.std;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.AbstractEvent;
@@ -13,6 +14,8 @@ import org.sosy_lab.java_smt.api.BooleanFormula;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /*
     NOTE: Although this event is no core event, it does not get compiled in the compilation pass.
     Instead, it will get replaced by a dedicated memory allocation pass.
@@ -22,9 +25,10 @@ import java.util.Set;
 public class Malloc extends AbstractEvent implements RegWriter, RegReader {
 
     protected final Register register;
-    protected IExpr sizeExpr;
+    protected ExprInterface sizeExpr;
 
-    public Malloc(Register register, IExpr sizeExpr) {
+    public Malloc(Register register, ExprInterface sizeExpr) {
+        checkArgument(sizeExpr.getType() instanceof IntegerType, "Malloc with non-integer size %s.", sizeExpr);
         this.register = register;
         this.sizeExpr = sizeExpr;
         addTags(Tag.Std.MALLOC);
@@ -36,8 +40,8 @@ public class Malloc extends AbstractEvent implements RegWriter, RegReader {
         this.sizeExpr = other.sizeExpr;
     }
 
-    public IExpr getSizeExpr() { return sizeExpr; }
-    public void setSizeExpr(IExpr sizeExpr) { this.sizeExpr = sizeExpr; }
+    public ExprInterface getSizeExpr() { return sizeExpr; }
+    public void setSizeExpr(ExprInterface sizeExpr) { this.sizeExpr = sizeExpr; }
 
     @Override
     public Register getResultRegister() { return register; }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/std/Malloc.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/std/Malloc.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.event.lang.std;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -25,9 +25,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class Malloc extends AbstractEvent implements RegWriter, RegReader {
 
     protected final Register register;
-    protected ExprInterface sizeExpr;
+    protected Expression sizeExpr;
 
-    public Malloc(Register register, ExprInterface sizeExpr) {
+    public Malloc(Register register, Expression sizeExpr) {
         checkArgument(sizeExpr.getType() instanceof IntegerType, "Malloc with non-integer size %s.", sizeExpr);
         this.register = register;
         this.sizeExpr = sizeExpr;
@@ -40,8 +40,8 @@ public class Malloc extends AbstractEvent implements RegWriter, RegReader {
         this.sizeExpr = other.sizeExpr;
     }
 
-    public ExprInterface getSizeExpr() { return sizeExpr; }
-    public void setSizeExpr(ExprInterface sizeExpr) { this.sizeExpr = sizeExpr; }
+    public Expression getSizeExpr() { return sizeExpr; }
+    public void setSizeExpr(Expression sizeExpr) { this.sizeExpr = sizeExpr; }
 
     @Override
     public Register getResultRegister() { return register; }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
@@ -1,9 +1,7 @@
 package com.dat3m.dartagnan.program.memory;
 
+import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.IConst;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IExprBin;
-import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 
@@ -11,7 +9,6 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Set;
 
-import static com.dat3m.dartagnan.expression.op.IOpBin.PLUS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -42,7 +39,7 @@ public class MemoryObject extends IConst {
 
         if (isStaticallyAllocated) {
             // Static allocations are default-initialized
-            initialValues.put(0, IValue.ZERO);
+            initialValues.put(0, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType()));
         }
     }
 
@@ -74,7 +71,7 @@ public class MemoryObject extends IConst {
      */
     public IConst getInitialValue(int offset) {
         checkArgument(offset >= 0 && offset < size, "array index out of bounds");
-        return initialValues.getOrDefault(offset, IValue.ZERO);
+        return initialValues.getOrDefault(offset, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType()));
     }
 
     /**
@@ -103,17 +100,6 @@ public class MemoryObject extends IConst {
             size = offset + 1;
         }
         initialValues.put(offset, value);
-    }
-
-    /**
-     * Expresses the address of a field of this array.
-     *
-     * @param offset Non-negative number of fields before the target field.
-     * @return Points to the target.
-     */
-    public IExpr add(int offset) {
-        checkArgument(0 <= offset && offset < size, "array index out of bounds");
-        return offset == 0 ? this : new IExprBin(this, PLUS, new IValue(BigInteger.valueOf(offset), getPrecision()));
     }
 
     public boolean isAtomic() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -138,7 +138,7 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
 
         ExpressionFactory expressionFactory = ExpressionFactory.getInstance();
         final Expression atLeastOneSideEffect = trackingRegs.stream()
-                .map(reg -> expressionFactory.makeEqual(reg, expressionFactory.makeZero(reg.getType())))
+                .map(reg -> expressionFactory.makeEQ(reg, expressionFactory.makeZero(reg.getType())))
                 .reduce(expressionFactory.makeFalse(), expressionFactory::makeOr);
         final CondJump assumeSideEffect = EventFactory.newJumpUnless(atLeastOneSideEffect, (Label) thread.getExit());
         assumeSideEffect.addTags(Tag.SPINLOOP, Tag.EARLYTERMINATION, Tag.NOOPT);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicPureLoopCutting.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.processing;
 
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Program;
@@ -137,7 +137,7 @@ public class DynamicPureLoopCutting implements ProgramProcessor {
         }
 
         ExpressionFactory expressionFactory = ExpressionFactory.getInstance();
-        final ExprInterface atLeastOneSideEffect = trackingRegs.stream()
+        final Expression atLeastOneSideEffect = trackingRegs.stream()
                 .map(reg -> expressionFactory.makeEqual(reg, expressionFactory.makeZero(reg.getType())))
                 .reduce(expressionFactory.makeFalse(), expressionFactory::makeOr);
         final CondJump assumeSideEffect = EventFactory.newJumpUnless(atLeastOneSideEffect, (Label) thread.getExit());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadCondJumps.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadCondJumps.java
@@ -114,17 +114,14 @@ public class RemoveDeadCondJumps implements ProgramProcessor {
    }
     
     private boolean mutuallyExclusiveIfs(CondJump jump, Event e) {
-        if (!(e instanceof CondJump)) {
+        if (!(e instanceof CondJump other)) {
             return false;
         }
-        final CondJump other = (CondJump) e;
-        if (jump.getGuard() instanceof BExprUn && ((BExprUn)jump.getGuard()).getInner().equals(other.getGuard())
-                || other.getGuard() instanceof BExprUn && ((BExprUn) other.getGuard()).getInner().equals(jump.getGuard())) {
+        if (jump.getGuard() instanceof BExprUn jumpGuard && jumpGuard.getInner().equals(other.getGuard())
+                || other.getGuard() instanceof BExprUn otherGuard && otherGuard.getInner().equals(jump.getGuard())) {
             return true;
         }
-        if (jump.getGuard() instanceof Atom && other.getGuard() instanceof Atom) {
-            final Atom a1 = (Atom) jump.getGuard();
-            final Atom a2 = (Atom) other.getGuard();
+        if (jump.getGuard() instanceof Atom a1 && other.getGuard() instanceof Atom a2) {
             return a1.getOp().inverted() == a2.getOp() && a1.getLHS().equals(a2.getLHS()) && a1.getRHS().equals(a2.getRHS());
         }
         return false;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Simplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Simplifier.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.processing;
 
 import com.dat3m.dartagnan.expression.BConst;
-import com.dat3m.dartagnan.expression.BExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -72,7 +72,7 @@ public class Simplifier implements ProgramProcessor {
     private boolean simplifyJump(CondJump jump) {
         final Label jumpTarget = jump.getLabel();
         final Event successor = jump.getSuccessor();
-        final BExpr guard = jump.getGuard();
+        final ExprInterface guard = jump.getGuard();
         if(jumpTarget.equals(successor) && guard instanceof BConst) {
             jump.delete();
             return true;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Simplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Simplifier.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.processing;
 
 import com.dat3m.dartagnan.expression.BConst;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -72,7 +72,7 @@ public class Simplifier implements ProgramProcessor {
     private boolean simplifyJump(CondJump jump) {
         final Label jumpTarget = jump.getLabel();
         final Event successor = jump.getSuccessor();
-        final ExprInterface guard = jump.getGuard();
+        final Expression guard = jump.getGuard();
         if(jumpTarget.equals(successor) && guard instanceof BConst) {
             jump.delete();
             return true;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -166,7 +166,7 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
 
         @Override
         public Void visitCondJump(CondJump e) {
-            e.setGuard((BExpr) e.getGuard().visit(propagator));
+            e.setGuard(e.getGuard().visit(propagator));
             return null;
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing;
 
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.processing.ExprTransformer;
+import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
@@ -225,15 +226,13 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
         public Expression visit(Atom atom) {
             Expression lhs = atom.getLHS().visit(this);
             Expression rhs = atom.getRHS().visit(this);
-            if (lhs instanceof BConst) {
-                lhs = expressions.makeValue(
-                        ((BConst) lhs).isTrue() ? BigInteger.ONE : BigInteger.ZERO,
-                        rhs instanceof IExpr ? ((IExpr) rhs).getType() : types.getIntegerType(1));
+            if (lhs instanceof BConst constant) {
+                IntegerType type = rhs instanceof IExpr ? ((IExpr) rhs).getType() : types.getIntegerType(1);
+                lhs = constant.isTrue() ? expressions.makeOne(type) : expressions.makeZero(type);
             }
-            if (rhs instanceof BConst) {
-                rhs = expressions.makeValue(
-                        ((BConst) rhs).isTrue() ? BigInteger.ONE : BigInteger.ZERO,
-                        lhs instanceof IExpr ? ((IExpr) lhs).getType() : types.getIntegerType(1));
+            if (rhs instanceof BConst constant) {
+                IntegerType type = lhs instanceof IExpr ? ((IExpr) lhs).getType() : types.getIntegerType(1);
+                rhs = constant.isTrue() ? expressions.makeOne(type) : expressions.makeZero(type);
             }
             if (lhs instanceof IValue left && rhs instanceof IValue right) {
                 return expressions.makeValue(atom.getOp().combine(left.getValue(), right.getValue()));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -279,11 +279,11 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
         public IExpr visit(IExprUn iUn) {
             IExpr inner = (IExpr) iUn.getInner().visit(this);
             if (inner instanceof IValue && iUn.getOp() == IOpUn.MINUS) {
-                return new IValue(((IValue) inner).getValue().negate(), inner.getPrecision());
+                return new IValue(((IValue) inner).getValue().negate(), iUn.getType());
             } else if (inner instanceof IValue && iUn.getOp() == IOpUn.CTLZ) {
-                return new IExprUn(iUn.getOp(), inner).reduce();
+                return new IExprUn(iUn.getOp(), inner, iUn.getType()).reduce();
             } else {
-                return new IExprUn(iUn.getOp(), inner);
+                return new IExprUn(iUn.getOp(), inner, iUn.getType());
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.processing;
 
 import com.dat3m.dartagnan.expression.*;
-import com.dat3m.dartagnan.expression.op.IOpUn;
 import com.dat3m.dartagnan.expression.processing.ExprTransformer;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
@@ -278,13 +277,10 @@ public class SparseConditionalConstantPropagation implements ProgramProcessor {
         @Override
         public IExpr visit(IExprUn iUn) {
             IExpr inner = (IExpr) iUn.getInner().visit(this);
-            if (inner instanceof IValue && iUn.getOp() == IOpUn.MINUS) {
-                return expressions.makeValue(((IValue) inner).getValue().negate(), iUn.getType());
-            } else if (inner instanceof IValue && iUn.getOp() == IOpUn.CTLZ) {
+            if (inner instanceof IValue) {
                 return expressions.makeUnary(iUn.getOp(), inner, iUn.getType()).reduce();
-            } else {
-                return expressions.makeUnary(iUn.getOp(), inner, iUn.getType());
             }
+            return expressions.makeUnary(iUn.getOp(), inner, iUn.getType());
         }
 
         @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -624,7 +624,7 @@ class VisitorArm8 extends VisitorBase {
     public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
         Register resultRegister = e.getResultRegister();
         IntegerType type = resultRegister.getType();
-        Expression one = expressions.makeOne(type);
+        Expression zero = expressions.makeZero(type);
         IOpBin op = e.getOp();
         Expression value = e.getMemValue();
         Expression address = e.getAddress();
@@ -633,7 +633,7 @@ class VisitorArm8 extends VisitorBase {
         Register dummy = e.getThread().newRegister(type);
         Register retReg = e.getThread().newRegister(type);
         Local localOp = newLocal(retReg, expressions.makeBinary(dummy, op, value));
-        Local testOp = newLocal(resultRegister, expressions.makeEqual(retReg, one));
+        Local testOp = newLocal(resultRegister, expressions.makeEqual(retReg, zero));
 
         Load load = newRMWLoadExclusive(dummy, address, ARMv8.extractLoadMoFromLKMo(mo));
         Store store = newRMWStoreExclusive(address, retReg, ARMv8.extractStoreMoFromLKMo(mo), true);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
@@ -57,7 +57,7 @@ class VisitorArm8 extends VisitorBase {
 
     @Override
     public List<Event> visitEnd(End e) {
-        ExprInterface zero = expressions.makeZero(types.getArchType());
+        Expression zero = expressions.makeZero(types.getArchType());
         return eventSequence(
                 newStore(e.getAddress(), zero, Tag.ARMv8.MO_REL)
         );
@@ -66,7 +66,7 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface zero = expressions.makeZero(resultRegister.getType());
+        Expression zero = expressions.makeZero(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), Tag.ARMv8.MO_ACQ);
         load.addTags(C11.PTHREAD);
 
@@ -79,7 +79,7 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface one = expressions.makeOne(resultRegister.getType());
+        Expression one = expressions.makeOne(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), Tag.ARMv8.MO_ACQ);
         load.addTags(Tag.STARTLOAD);
 
@@ -99,8 +99,8 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitLock(Lock e) {
         IntegerType type = types.getArchType();
-        ExprInterface zero = expressions.makeZero(type);
-        ExprInterface one = expressions.makeOne(type);
+        Expression zero = expressions.makeZero(type);
+        Expression one = expressions.makeOne(type);
         Register dummy = e.getThread().newRegister(type);
         // We implement locks as spinlocks which are guaranteed to succeed, i.e. we can use
         // assumes. With this we miss a ctrl dependency, but this does not matter
@@ -142,8 +142,8 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitLlvmXchg(LlvmXchg e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Load load = newRMWLoadExclusive(resultRegister, address, ARMv8.extractLoadMoFromCMo(mo));
@@ -163,8 +163,8 @@ class VisitorArm8 extends VisitorBase {
     public List<Event> visitLlvmRMW(LlvmRMW e) {
         Register resultRegister = e.getResultRegister();
         IOpBin op = e.getOp();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Register dummyReg = e.getThread().newRegister(resultRegister.getType());
@@ -188,12 +188,12 @@ class VisitorArm8 extends VisitorBase {
     public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
         Register oldValueRegister = e.getStructRegister(0);
         Register resultRegister = e.getStructRegister(1);
-        ExprInterface one = expressions.makeOne(resultRegister.getType());
+        Expression one = expressions.makeOne(resultRegister.getType());
 
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
-        ExprInterface expectedValue = e.getExpectedValue();
+        Expression expectedValue = e.getExpectedValue();
 
         Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
         Label casEnd = newLabel("CAS_end");
@@ -233,12 +233,12 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface address = e.getAddress();
-        ExprInterface value = e.getMemValue();
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
         String mo = e.getMo();
-        ExprInterface expectedAddr = e.getExpectedAddr();
+        Expression expectedAddr = e.getExpectedAddr();
         IntegerType type = resultRegister.getType();
-        ExprInterface one = expressions.makeOne(type);
+        Expression one = expressions.makeOne(type);
         Register regExpected = e.getThread().newRegister(type);
         Register regValue = e.getThread().newRegister(type);
         Load loadExpected = newLoad(regExpected, expectedAddr, "");
@@ -279,8 +279,8 @@ class VisitorArm8 extends VisitorBase {
     public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
         Register resultRegister = e.getResultRegister();
         IOpBin op = e.getOp();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Register dummyReg = e.getThread().newRegister(resultRegister.getType());
@@ -328,8 +328,8 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitAtomicXchg(AtomicXchg e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Load load = newRMWLoadExclusive(resultRegister, address, ARMv8.extractLoadMoFromCMo(mo));
@@ -354,7 +354,7 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitLKMMLoad(LKMMLoad e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Load load = newLoad(resultRegister, address, ARMv8.extractLoadMoFromLKMo(mo));
@@ -368,8 +368,8 @@ class VisitorArm8 extends VisitorBase {
     //		https://elixir.bootlin.com/linux/v5.18/source/arch/arm64/include/asm/barrier.h#L116
     @Override
     public List<Event> visitLKMMStore(LKMMStore e) {
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Store store = newStore(address, value, mo.equals(Tag.Linux.MO_RELEASE) ? Tag.ARMv8.MO_REL : "");
@@ -437,8 +437,8 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface address = e.getAddress();
-        ExprInterface value = e.getMemValue();
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
         String mo = e.getMo();
 
         Register dummy = e.getThread().newRegister(e.getResultRegister().getType());
@@ -471,8 +471,8 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitRMWXchg(RMWXchg e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
@@ -498,8 +498,8 @@ class VisitorArm8 extends VisitorBase {
     public List<Event> visitRMWOp(RMWOp e) {
         Register resultRegister = e.getResultRegister();
         IOpBin op = e.getOp();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
         Load load = newRMWLoadExclusive(dummy, address, "");
@@ -523,8 +523,8 @@ class VisitorArm8 extends VisitorBase {
     public List<Event> visitRMWOpReturn(RMWOpReturn e) {
         Register resultRegister = e.getResultRegister();
         IOpBin op = e.getOp();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
@@ -552,8 +552,8 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitRMWFetchOp(RMWFetchOp e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
@@ -581,11 +581,11 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitRMWAddUnless(RMWAddUnless e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface address = e.getAddress();
-        ExprInterface value = e.getMemValue();
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
         String mo = e.getMo();
         IntegerType type = resultRegister.getType();
-        ExprInterface zero = expressions.makeZero(type);
+        Expression zero = expressions.makeZero(type);
 
         Register regValue = e.getThread().newRegister(type);
         Load load = newRMWLoadExclusive(regValue, address, ARMv8.extractLoadMoFromLKMo(mo));
@@ -595,7 +595,7 @@ class VisitorArm8 extends VisitorBase {
         Event fakeCtrlDep = newFakeCtrlDep(regValue, label);
 
         Register dummy = e.getThread().newRegister(type);
-        ExprInterface unless = e.getCmp();
+        Expression unless = e.getCmp();
         Label cauEnd = newLabel("CAddU_end");
         CondJump branchOnCauCmpResult = newJump(expressions.makeEqual(dummy, zero), cauEnd);
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? AArch64.DMB.newISHBarrier() : null;
@@ -624,10 +624,10 @@ class VisitorArm8 extends VisitorBase {
     public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
         Register resultRegister = e.getResultRegister();
         IntegerType type = resultRegister.getType();
-        ExprInterface one = expressions.makeOne(type);
+        Expression one = expressions.makeOne(type);
         IOpBin op = e.getOp();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Register dummy = e.getThread().newRegister(type);
@@ -658,8 +658,8 @@ class VisitorArm8 extends VisitorBase {
     @Override
     public List<Event> visitLKMMLock(LKMMLock e) {
         IntegerType type = types.getArchType();
-        ExprInterface zero = expressions.makeZero(type);
-        ExprInterface one = expressions.makeOne(type);
+        Expression zero = expressions.makeZero(type);
+        Expression one = expressions.makeOne(type);
         Register dummy = e.getThread().newRegister(type);
         // Spinlock events are guaranteed to succeed, i.e. we can use assumes
         // With this we miss a ctrl dependency, but this does not matter
@@ -673,7 +673,7 @@ class VisitorArm8 extends VisitorBase {
 
     @Override
     public List<Event> visitLKMMUnlock(LKMMUnlock e) {
-        ExprInterface zero = expressions.makeZero(types.getArchType());
+        Expression zero = expressions.makeZero(types.getArchType());
         return eventSequence(
                 newStore(e.getAddress(), zero, ARMv8.MO_REL)
         );

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
@@ -73,8 +73,8 @@ class VisitorBase implements EventVisitor<List<Event>> {
     public List<Event> visitLock(Lock e) {
         Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
-		ExprInterface zero = expressions.makeZero(type);
-		ExprInterface one = expressions.makeOne(type);
+		Expression zero = expressions.makeZero(type);
+		Expression one = expressions.makeOne(type);
 		String mo = e.getMo();
 
 		Load rmwLoad = newRMWLoad(resultRegister, e.getAddress(), mo);
@@ -89,9 +89,9 @@ class VisitorBase implements EventVisitor<List<Event>> {
 	public List<Event> visitUnlock(Unlock e) {
         Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
-		ExprInterface zero = expressions.makeZero(type);
-		ExprInterface one = expressions.makeOne(type);
-		ExprInterface address = e.getAddress();
+		Expression zero = expressions.makeZero(type);
+		Expression one = expressions.makeOne(type);
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Load rmwLoad = newRMWLoad(resultRegister, address, mo);
@@ -165,7 +165,7 @@ class VisitorBase implements EventVisitor<List<Event>> {
 	@Override
 	public List<Event> visitRMW(RMW e) {
         Register resultRegister = e.getResultRegister();
-		ExprInterface address = e.getAddress();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
         Register dummyReg = e.getThread().newRegister(resultRegister.getType());
 		Load load = newRMWLoad(dummyReg, address, mo);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
@@ -1,10 +1,9 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.Atom;
-import com.dat3m.dartagnan.expression.BExprBin;
-import com.dat3m.dartagnan.expression.IExpr;
-import com.dat3m.dartagnan.expression.IValue;
-import com.dat3m.dartagnan.expression.op.BOpBin;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.arch.StoreExclusive;
 import com.dat3m.dartagnan.program.event.arch.lisa.RMW;
@@ -29,17 +28,18 @@ import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
 
-import static com.dat3m.dartagnan.expression.op.COpBin.NEQ;
 import static com.dat3m.dartagnan.program.event.EventFactory.*;
 
 class VisitorBase implements EventVisitor<List<Event>> {
 
 	protected boolean forceStart;
+	protected final TypeFactory types = TypeFactory.getInstance();
+	protected final ExpressionFactory expressions = ExpressionFactory.getInstance();
 
 	protected VisitorBase(boolean forceStart) {
 		this.forceStart = forceStart;
 	}
-	
+
 	@Override
 	public List<Event> visitEvent(Event e) {
 		return Collections.singletonList(e);
@@ -47,21 +47,21 @@ class VisitorBase implements EventVisitor<List<Event>> {
 
 	@Override
 	public List<Event> visitCondJump(CondJump e) {
-    	Preconditions.checkState(e.getSuccessor() != null, "Malformed CondJump event");
+		Preconditions.checkState(e.getSuccessor() != null, "Malformed CondJump event");
 		return visitEvent(e);
 	};
 
 	@Override
 	public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
-        Register statusRegister = e.getThread().newRegister(resultRegister.getPrecision());
+        Register statusRegister = e.getThread().newRegister(resultRegister.getType());
 
         return eventSequence(
                 forceStart ? newExecutionStatus(statusRegister, e.getCreationEvent()) : null,
-                forceStart ? newAssume(new BExprBin(resultRegister, BOpBin.OR, statusRegister)) : null
+                forceStart ? newAssume(expressions.makeOr(resultRegister, statusRegister)) : null
         );
 	}
-	
+
 	@Override
 	public List<Event> visitInitLock(InitLock e) {
 		return eventSequence(
@@ -72,27 +72,33 @@ class VisitorBase implements EventVisitor<List<Event>> {
 	@Override
     public List<Event> visitLock(Lock e) {
         Register resultRegister = e.getResultRegister();
+		IntegerType type = resultRegister.getType();
+		ExprInterface zero = expressions.makeZero(type);
+		ExprInterface one = expressions.makeOne(type);
 		String mo = e.getMo();
 
 		Load rmwLoad = newRMWLoad(resultRegister, e.getAddress(), mo);
 		return eventSequence(
                 rmwLoad,
-                newJump(new Atom(resultRegister, NEQ, IValue.ZERO), (Label) e.getThread().getExit()),
-                newRMWStore(rmwLoad, e.getAddress(), IValue.ONE, mo)
+                newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit()),
+                newRMWStore(rmwLoad, e.getAddress(), one, mo)
         );
     }
     
     @Override
 	public List<Event> visitUnlock(Unlock e) {
         Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		IntegerType type = resultRegister.getType();
+		ExprInterface zero = expressions.makeZero(type);
+		ExprInterface one = expressions.makeOne(type);
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
 		Load rmwLoad = newRMWLoad(resultRegister, address, mo);
 		return eventSequence(
                 rmwLoad,
-                newJump(new Atom(resultRegister, NEQ, IValue.ONE), (Label) e.getThread().getExit()),
-                newRMWStore(rmwLoad, address, IValue.ZERO, mo)
+                newJump(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit()),
+                newRMWStore(rmwLoad, address, zero, mo)
         );
 	}
 
@@ -159,18 +165,18 @@ class VisitorBase implements EventVisitor<List<Event>> {
 	@Override
 	public List<Event> visitRMW(RMW e) {
         Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
-        Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
 		Load load = newRMWLoad(dummyReg, address, mo);
         RMWStore store = newRMWStore(load, address, e.getMemValue(), mo);
 		return eventSequence(
-        		load,
+				load,
                 store,
                 newLocal(resultRegister, dummyReg)
         );
 	}
-	
+
 	@Override
 	public List<Event> visitAtomicAbstract(AtomicAbstract e) {
 		throw error(e);
@@ -196,8 +202,8 @@ class VisitorBase implements EventVisitor<List<Event>> {
 	}
 
 	private IllegalArgumentException error(Event e) {
-		return new IllegalArgumentException("Compilation for " + e.getClass().getSimpleName() + 
+		return new IllegalArgumentException("Compilation for " + e.getClass().getSimpleName() +
 				" is not supported by " + getClass().getSimpleName());
 	}
-	
+
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
@@ -80,7 +80,7 @@ class VisitorBase implements EventVisitor<List<Event>> {
 		Load rmwLoad = newRMWLoad(resultRegister, e.getAddress(), mo);
 		return eventSequence(
                 rmwLoad,
-                newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit()),
+                newJump(expressions.makeNEQ(resultRegister, zero), (Label) e.getThread().getExit()),
                 newRMWStore(rmwLoad, e.getAddress(), one, mo)
         );
     }
@@ -97,7 +97,7 @@ class VisitorBase implements EventVisitor<List<Event>> {
 		Load rmwLoad = newRMWLoad(resultRegister, address, mo);
 		return eventSequence(
                 rmwLoad,
-                newJump(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit()),
+                newJump(expressions.makeNEQ(resultRegister, one), (Label) e.getThread().getExit()),
                 newRMWStore(rmwLoad, address, zero, mo)
         );
 	}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.*;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.Tag.C11;
@@ -16,86 +17,87 @@ import com.dat3m.dartagnan.program.event.lang.pthread.Start;
 
 import java.util.List;
 
-import static com.dat3m.dartagnan.expression.op.COpBin.EQ;
-import static com.dat3m.dartagnan.expression.op.COpBin.NEQ;
 import static com.dat3m.dartagnan.program.event.EventFactory.*;
 
 public class VisitorC11 extends VisitorBase {
 
-        protected VisitorC11(boolean forceStart) {
-                super(forceStart);
-        }
+    protected VisitorC11(boolean forceStart) {
+        super(forceStart);
+    }
 
-        @Override
-        public List<Event> visitCreate(Create e) {
-                Store store = newStore(e.getAddress(), e.getMemValue(), Tag.C11.MO_RELEASE);
-                store.addTags(C11.PTHREAD);
+    @Override
+    public List<Event> visitCreate(Create e) {
+        Store store = newStore(e.getAddress(), e.getMemValue(), Tag.C11.MO_RELEASE);
+        store.addTags(C11.PTHREAD);
 
-                return tagList(eventSequence(
-                                store));
-        }
+        return tagList(eventSequence(
+                store));
+    }
 
-        @Override
-        public List<Event> visitEnd(End e) {
-                return tagList(eventSequence(
-                        newStore(e.getAddress(), IValue.ZERO, Tag.C11.MO_RELEASE)));
-        }
+    @Override
+    public List<Event> visitEnd(End e) {
+        //TODO boolean
+        return tagList(eventSequence(
+                newStore(e.getAddress(), expressions.makeZero(types.getArchType()), Tag.C11.MO_RELEASE)));
+    }
 
-        @Override
-        public List<Event> visitJoin(Join e) {
-                Register resultRegister = e.getResultRegister();
-                Load load = newLoad(resultRegister, e.getAddress(), Tag.C11.MO_ACQUIRE);
-                load.addTags(C11.PTHREAD);
+    @Override
+    public List<Event> visitJoin(Join e) {
+        Register resultRegister = e.getResultRegister();
+        ExprInterface zero = expressions.makeZero(resultRegister.getType());
+        Load load = newLoad(resultRegister, e.getAddress(), Tag.C11.MO_ACQUIRE);
+        load.addTags(C11.PTHREAD);
 
-                return tagList(eventSequence(
-                                load,
-                                newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit())));
-        }
+        return tagList(eventSequence(
+                load,
+                newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit())));
+    }
 
-        @Override
-        public List<Event> visitStart(Start e) {
-                Register resultRegister = e.getResultRegister();
-                Load load = newLoad(resultRegister, e.getAddress(), Tag.C11.MO_ACQUIRE);
-                load.addTags(Tag.STARTLOAD);
+    @Override
+    public List<Event> visitStart(Start e) {
+        Register resultRegister = e.getResultRegister();
+        ExprInterface one = expressions.makeOne(resultRegister.getType());
+        Load load = newLoad(resultRegister, e.getAddress(), Tag.C11.MO_ACQUIRE);
+        load.addTags(Tag.STARTLOAD);
 
-                return tagList(eventSequence(
-                                load,
-                                super.visitStart(e),
-                                newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit())));
-        }
+        return tagList(eventSequence(
+                load,
+                super.visitStart(e),
+                newJump(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit())));
+    }
 
-        @Override
-        public List<Event> visitLoad(Load e) {
-                return tagList(eventSequence(
-                        newLoad(e.getResultRegister(), e.getAddress(), e.getMo())));
-        }
+    @Override
+    public List<Event> visitLoad(Load e) {
+        return tagList(eventSequence(
+                newLoad(e.getResultRegister(), e.getAddress(), e.getMo())));
+    }
 
-        @Override
-        public List<Event> visitStore(Store e) {
-                return tagList(eventSequence(
-                        newStore(e.getAddress(), e.getMemValue(), e.getMo())));
-        }
+    @Override
+    public List<Event> visitStore(Store e) {
+        return tagList(eventSequence(
+                newStore(e.getAddress(), e.getMemValue(), e.getMo())));
+    }
 
-        // =============================================================================================
-        // =========================================== C11 =============================================
-        // =============================================================================================
+    // =============================================================================================
+    // =========================================== C11 =============================================
+    // =============================================================================================
 
-        @Override
-	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
-		Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
-		String mo = e.getMo();
-		IExpr expectedAddr = e.getExpectedAddr();
-		int precision = resultRegister.getPrecision();
+    @Override
+    public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
+        Register resultRegister = e.getResultRegister();
+        ExprInterface address = e.getAddress();
+        String mo = e.getMo();
+        ExprInterface expectedAddr = e.getExpectedAddr();
+        IntegerType type = resultRegister.getType();
 
-		Register regExpected = e.getThread().newRegister(precision);
-        Register regValue = e.getThread().newRegister(precision);
+        Register regExpected = e.getThread().newRegister(type);
+        Register regValue = e.getThread().newRegister(type);
         Load loadExpected = newLoad(regExpected, expectedAddr, "");
         Store storeExpected = newStore(expectedAddr, regValue, "");
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");
-        Local casCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, regExpected));
-        CondJump branchOnCasCmpResult = newJump(new Atom(resultRegister, NEQ, IValue.ONE), casFail);
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(regValue, regExpected));
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, expressions.makeOne(type)), casFail);
         CondJump gotoCasEnd = newGoto(casEnd);
         Load loadValue = newRMWLoad(regValue, address, mo);
         Store storeValue = newRMWStore(loadValue, address, e.getMemValue(), mo);
@@ -106,65 +108,64 @@ public class VisitorC11 extends VisitorBase {
                 loadValue,
                 casCmpResult,
                 branchOnCasCmpResult,
-                    storeValue,
-                    gotoCasEnd,
+                storeValue,
+                gotoCasEnd,
                 casFail,
-                    storeExpected,
+                storeExpected,
                 casEnd
         ));
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
-		Register resultRegister = e.getResultRegister();
-		IOpBin op = e.getOp();
-		IExpr address = e.getAddress();
-		String mo = e.getMo();
-		
-        Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
+    @Override
+    public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
+        Register resultRegister = e.getResultRegister();
+        IOpBin op = e.getOp();
+        ExprInterface address = e.getAddress();
+        String mo = e.getMo();
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
         Load load = newRMWLoad(resultRegister, address, mo);
         RMWStore store = newRMWStore(load, address, dummyReg, mo);
-        
-		return tagList(eventSequence(
+
+        return tagList(eventSequence(
                 load,
-                newLocal(dummyReg, new IExprBin(resultRegister, op, (IExpr) e.getMemValue())),
+                newLocal(dummyReg, expressions.makeBinary(resultRegister, op, e.getMemValue())),
                 store
         ));
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicLoad(AtomicLoad e) {
-		return tagList(eventSequence(
-        		newLoad(e.getResultRegister(), e.getAddress(), e.getMo())
+    @Override
+    public List<Event> visitAtomicLoad(AtomicLoad e) {
+        return tagList(eventSequence(
+                newLoad(e.getResultRegister(), e.getAddress(), e.getMo())
         ));
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicStore(AtomicStore e) {
-		return tagList(eventSequence(
-        		newStore(e.getAddress(), e.getMemValue(), e.getMo())
+    @Override
+    public List<Event> visitAtomicStore(AtomicStore e) {
+        return tagList(eventSequence(
+                newStore(e.getAddress(), e.getMemValue(), e.getMo())
         ));
-	}
+    }
 
-	@Override
-	public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
-                return tagList(eventSequence(
-                        newFence(e.getMo())));
-	}
+    @Override
+    public List<Event> visitAtomicThreadFence(AtomicThreadFence e) {
+        return tagList(eventSequence(
+                newFence(e.getMo())));
+    }
 
-	@Override
-	public List<Event> visitAtomicXchg(AtomicXchg e) {
-		IExpr address = e.getAddress();
-		String mo = e.getMo();
+    @Override
+    public List<Event> visitAtomicXchg(AtomicXchg e) {
+        ExprInterface address = e.getAddress();
+        String mo = e.getMo();
 
         Load load = newRMWLoad(e.getResultRegister(), address, mo);
         RMWStore store = newRMWStore(load, address, e.getMemValue(), mo);
-        
-		return tagList(eventSequence(
+
+        return tagList(eventSequence(
                 load,
                 store
         ));
-	}
+    }
 
     // =============================================================================================
     // =========================================== LLVM ============================================
@@ -172,81 +173,82 @@ public class VisitorC11 extends VisitorBase {
 
     @Override
     public List<Event> visitLlvmLoad(LlvmLoad e) {
-            return tagList(eventSequence(
+        return tagList(eventSequence(
                 newLoad(e.getResultRegister(), e.getAddress(), e.getMo())));
     }
 
     @Override
     public List<Event> visitLlvmStore(LlvmStore e) {
-           return tagList(eventSequence(
+        return tagList(eventSequence(
                 newStore(e.getAddress(), e.getMemValue(), e.getMo())));
     }
 
     @Override
     public List<Event> visitLlvmXchg(LlvmXchg e) {
-            Register resultRegister = e.getResultRegister();
-            ExprInterface value = e.getMemValue();
-            IExpr address = e.getAddress();
-            String mo = e.getMo();
+        Register resultRegister = e.getResultRegister();
+        ExprInterface value = e.getMemValue();
+        ExprInterface address = e.getAddress();
+        String mo = e.getMo();
 
-            Load load = newRMWLoadExclusive(resultRegister, address, mo);
-            Store store = newRMWStoreExclusive(address, value, mo, true);
+        Load load = newRMWLoadExclusive(resultRegister, address, mo);
+        Store store = newRMWStoreExclusive(address, value, mo, true);
 
-            return tagList(eventSequence(
-                            load,
-                            store));
+        return tagList(eventSequence(
+                load,
+                store));
     }
 
     @Override
     public List<Event> visitLlvmRMW(LlvmRMW e) {
-            Register resultRegister = e.getResultRegister();
-            IOpBin op = e.getOp();
-            IExpr value = (IExpr) e.getMemValue();
-            IExpr address = e.getAddress();
-            String mo = e.getMo();
+        Register resultRegister = e.getResultRegister();
+        IOpBin op = e.getOp();
+        ExprInterface value = e.getMemValue();
+        ExprInterface address = e.getAddress();
+        String mo = e.getMo();
 
-            Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
-            Local localOp = newLocal(dummyReg, new IExprBin(resultRegister, op, value));
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+        Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
 
-            Load load = newRMWLoadExclusive(resultRegister, address, mo);
-            Store store = newRMWStoreExclusive(address, dummyReg, mo, true);
+        Load load = newRMWLoadExclusive(resultRegister, address, mo);
+        Store store = newRMWStoreExclusive(address, dummyReg, mo, true);
 
-            return tagList(eventSequence(
-                            load,
-                            localOp,
-                            store));
+        return tagList(eventSequence(
+                load,
+                localOp,
+                store));
     }
 
     @Override
     public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
-            Register oldValueRegister = e.getStructRegister(0);
-            Register resultRegister = e.getStructRegister(1);
+        Register oldValueRegister = e.getStructRegister(0);
+        Register resultRegister = e.getStructRegister(1);
 
-            ExprInterface value = e.getMemValue();
-            IExpr address = e.getAddress();
-            String mo = e.getMo();
-            ExprInterface expectedValue = e.getExpectedValue();
+        ExprInterface value = e.getMemValue();
+        ExprInterface address = e.getAddress();
+        String mo = e.getMo();
+        ExprInterface expectedValue = e.getExpectedValue();
 
-            Local casCmpResult = newLocal(resultRegister, new Atom(oldValueRegister, EQ, expectedValue));
-            Label casEnd = newLabel("CAS_end");
-            CondJump branchOnCasCmpResult = newJump(new Atom(resultRegister, NEQ, IValue.ONE), casEnd);
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
+        Label casEnd = newLabel("CAS_end");
+        ExprInterface one = expressions.makeOne(resultRegister.getType());
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casEnd);
 
-            Load load = newRMWLoadExclusive(oldValueRegister, address, mo);
-            Store store = newRMWStoreExclusive(address, value, mo, true);
+        Load load = newRMWLoadExclusive(oldValueRegister, address, mo);
+        Store store = newRMWStoreExclusive(address, value, mo, true);
 
-            return tagList(eventSequence(
-                            // Indentation shows the branching structure
-                            load,
-                            casCmpResult,
-                            branchOnCasCmpResult,
-                                store,
-                            casEnd));
+        return tagList(eventSequence(
+                // Indentation shows the branching structure
+                load,
+                casCmpResult,
+                branchOnCasCmpResult,
+                store,
+                casEnd));
     }
 
     @Override
     public List<Event> visitLlvmFence(LlvmFence e) {
-            return tagList(eventSequence(
-                            newFence(e.getMo())));
+        return tagList(eventSequence(
+                newFence(e.getMo())));
     }
 
     private List<Event> tagList(List<Event> in) {
@@ -255,7 +257,7 @@ public class VisitorC11 extends VisitorBase {
     }
 
     private void tagEvent(Event e) {
-        if(e instanceof MemoryEvent memEvent) {
+        if (e instanceof MemoryEvent memEvent) {
             final boolean canRace = (memEvent.getMo().isEmpty() || memEvent.getMo().equals(C11.NONATOMIC));
             e.addTags(canRace ? C11.NONATOMIC : C11.ATOMIC);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -50,7 +50,7 @@ public class VisitorC11 extends VisitorBase {
 
         return tagList(eventSequence(
                 load,
-                newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit())));
+                newJumpUnless(expressions.makeEqual(resultRegister, zero), (Label) e.getThread().getExit())));
     }
 
     @Override
@@ -63,7 +63,7 @@ public class VisitorC11 extends VisitorBase {
         return tagList(eventSequence(
                 load,
                 super.visitStart(e),
-                newJump(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit())));
+                newJumpUnless(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit())));
     }
 
     @Override
@@ -108,10 +108,10 @@ public class VisitorC11 extends VisitorBase {
                 loadValue,
                 casCmpResult,
                 branchOnCasCmpResult,
-                storeValue,
-                gotoCasEnd,
+                    storeValue,
+                    gotoCasEnd,
                 casFail,
-                storeExpected,
+                    storeExpected,
                 casEnd
         ));
     }
@@ -241,7 +241,7 @@ public class VisitorC11 extends VisitorBase {
                 load,
                 casCmpResult,
                 branchOnCasCmpResult,
-                store,
+                    store,
                 casEnd));
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -63,7 +63,7 @@ public class VisitorC11 extends VisitorBase {
         return tagList(eventSequence(
                 load,
                 super.visitStart(e),
-                newJumpUnless(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit())));
+                newJumpUnless(expressions.makeEqual(resultRegister, one), (Label) e.getThread().getExit())));
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
@@ -44,7 +44,7 @@ public class VisitorC11 extends VisitorBase {
     @Override
     public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface zero = expressions.makeZero(resultRegister.getType());
+        Expression zero = expressions.makeZero(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), Tag.C11.MO_ACQUIRE);
         load.addTags(C11.PTHREAD);
 
@@ -56,7 +56,7 @@ public class VisitorC11 extends VisitorBase {
     @Override
     public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface one = expressions.makeOne(resultRegister.getType());
+        Expression one = expressions.makeOne(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), Tag.C11.MO_ACQUIRE);
         load.addTags(Tag.STARTLOAD);
 
@@ -85,9 +85,9 @@ public class VisitorC11 extends VisitorBase {
     @Override
     public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
         String mo = e.getMo();
-        ExprInterface expectedAddr = e.getExpectedAddr();
+        Expression expectedAddr = e.getExpectedAddr();
         IntegerType type = resultRegister.getType();
 
         Register regExpected = e.getThread().newRegister(type);
@@ -120,7 +120,7 @@ public class VisitorC11 extends VisitorBase {
     public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
         Register resultRegister = e.getResultRegister();
         IOpBin op = e.getOp();
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
         String mo = e.getMo();
         Register dummyReg = e.getThread().newRegister(resultRegister.getType());
         Load load = newRMWLoad(resultRegister, address, mo);
@@ -155,7 +155,7 @@ public class VisitorC11 extends VisitorBase {
 
     @Override
     public List<Event> visitAtomicXchg(AtomicXchg e) {
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Load load = newRMWLoad(e.getResultRegister(), address, mo);
@@ -186,8 +186,8 @@ public class VisitorC11 extends VisitorBase {
     @Override
     public List<Event> visitLlvmXchg(LlvmXchg e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Load load = newRMWLoadExclusive(resultRegister, address, mo);
@@ -202,8 +202,8 @@ public class VisitorC11 extends VisitorBase {
     public List<Event> visitLlvmRMW(LlvmRMW e) {
         Register resultRegister = e.getResultRegister();
         IOpBin op = e.getOp();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Register dummyReg = e.getThread().newRegister(resultRegister.getType());
@@ -223,14 +223,14 @@ public class VisitorC11 extends VisitorBase {
         Register oldValueRegister = e.getStructRegister(0);
         Register resultRegister = e.getStructRegister(1);
 
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
-        ExprInterface expectedValue = e.getExpectedValue();
+        Expression expectedValue = e.getExpectedValue();
 
         Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
         Label casEnd = newLabel("CAS_end");
-        ExprInterface one = expressions.makeOne(resultRegister.getType());
+        Expression one = expressions.makeOne(resultRegister.getType());
         CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casEnd);
 
         Load load = newRMWLoadExclusive(oldValueRegister, address, mo);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -50,7 +50,7 @@ public class VisitorC11 extends VisitorBase {
 
         return tagList(eventSequence(
                 load,
-                newJumpUnless(expressions.makeEqual(resultRegister, zero), (Label) e.getThread().getExit())));
+                newJumpUnless(expressions.makeEQ(resultRegister, zero), (Label) e.getThread().getExit())));
     }
 
     @Override
@@ -63,7 +63,7 @@ public class VisitorC11 extends VisitorBase {
         return tagList(eventSequence(
                 load,
                 super.visitStart(e),
-                newJumpUnless(expressions.makeEqual(resultRegister, one), (Label) e.getThread().getExit())));
+                newJumpUnless(expressions.makeEQ(resultRegister, one), (Label) e.getThread().getExit())));
     }
 
     @Override
@@ -96,8 +96,8 @@ public class VisitorC11 extends VisitorBase {
         Store storeExpected = newStore(expectedAddr, regValue, "");
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");
-        Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(regValue, regExpected));
-        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, expressions.makeOne(type)), casFail);
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(regValue, regExpected));
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, expressions.makeOne(type)), casFail);
         CondJump gotoCasEnd = newGoto(casEnd);
         Load loadValue = newRMWLoad(regValue, address, mo);
         Store storeValue = newRMWStore(loadValue, address, e.getMemValue(), mo);
@@ -228,10 +228,10 @@ public class VisitorC11 extends VisitorBase {
         String mo = e.getMo();
         Expression expectedValue = e.getExpectedValue();
 
-        Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, expectedValue));
         Label casEnd = newLabel("CAS_end");
         Expression one = expressions.makeOne(resultRegister.getType());
-        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casEnd);
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
 
         Load load = newRMWLoadExclusive(oldValueRegister, address, mo);
         Store store = newRMWStoreExclusive(address, value, mo, true);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -71,7 +71,7 @@ class VisitorIMM extends VisitorBase {
 
         return eventSequence(
 				load,
-                newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit())
+                newJump(expressions.makeNEQ(resultRegister, zero), (Label) e.getThread().getExit())
         );
 	}
 
@@ -85,7 +85,7 @@ class VisitorIMM extends VisitorBase {
         return eventSequence(
 				load,
 				super.visitStart(e),
-				newJump(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit())
+				newJump(expressions.makeNEQ(resultRegister, one), (Label) e.getThread().getExit())
         );
 	}
 
@@ -111,8 +111,8 @@ class VisitorIMM extends VisitorBase {
         Store storeExpected = newStore(expectedAddr, regValue, "");
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");
-        Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(regValue, regExpected));
-        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casFail);
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(regValue, regExpected));
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casFail);
         CondJump gotoCasEnd = newGoto(casEnd);
         Load loadValue = newRMWLoad(regValue, address, extractLoadMo(mo));
         Store storeValue = newRMWStore(loadValue, address, e.getMemValue(), extractStoreMo(mo));
@@ -266,9 +266,9 @@ class VisitorIMM extends VisitorBase {
 		String mo = e.getMo();
         Expression expectedValue = e.getExpectedValue();
 
-        Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, expectedValue));
 		Label casEnd = newLabel("CAS_end");
-        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casEnd);
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
 
 		Load load = newRMWLoadExclusive(oldValueRegister, address, IMM.extractLoadMo(mo));
 		Store store = newRMWStoreExclusive(address, value, IMM.extractStoreMo(mo), true);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
@@ -65,7 +65,7 @@ class VisitorIMM extends VisitorBase {
 	@Override
 	public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-		ExprInterface zero = expressions.makeZero(resultRegister.getType());
+		Expression zero = expressions.makeZero(resultRegister.getType());
 		Load load = newLoad(resultRegister, e.getAddress(), C11.MO_ACQUIRE);
         load.addTags(C11.PTHREAD);
         
@@ -78,7 +78,7 @@ class VisitorIMM extends VisitorBase {
 	@Override
 	public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
-		ExprInterface one = expressions.makeOne(resultRegister.getType());
+		Expression one = expressions.makeOne(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), C11.MO_ACQUIRE);
         load.addTags(Tag.STARTLOAD);
 
@@ -96,13 +96,13 @@ class VisitorIMM extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface address = e.getAddress();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 		Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 		Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
-		ExprInterface expectedAddr = e.getExpectedAddr();
+		Expression expectedAddr = e.getExpectedAddr();
 		IntegerType type = resultRegister.getType();
-		ExprInterface one = expressions.makeOne(type);
+		Expression one = expressions.makeOne(type);
 
 		Register regExpected = e.getThread().newRegister(type);
         Register regValue = e.getThread().newRegister(type);
@@ -137,7 +137,7 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		ExprInterface address = e.getAddress();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 		Fence optionalFenceBefore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 		Fence optionalFenceAfter = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
@@ -181,7 +181,7 @@ class VisitorIMM extends VisitorBase {
 
 	@Override
 	public List<Event> visitAtomicXchg(AtomicXchg e) {
-		ExprInterface address = e.getAddress();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 		Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 		Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
@@ -215,8 +215,8 @@ class VisitorIMM extends VisitorBase {
 	@Override
 	public List<Event> visitLlvmXchg(LlvmXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Load load = newRMWLoadExclusive(resultRegister, address, IMM.extractLoadMo(mo));
@@ -235,8 +235,8 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitLlvmRMW(LlvmRMW e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
@@ -259,12 +259,12 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
 		Register oldValueRegister = e.getStructRegister(0);
 		Register resultRegister = e.getStructRegister(1);
-		ExprInterface one = expressions.makeOne(resultRegister.getType());
+		Expression one = expressions.makeOne(resultRegister.getType());
 
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
-		ExprInterface expectedValue = e.getExpectedValue();
+		Expression expectedValue = e.getExpectedValue();
 
 		Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
 		Label casEnd = newLabel("CAS_end");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -56,29 +56,29 @@ class VisitorIMM extends VisitorBase {
 
 	@Override
 	public List<Event> visitEnd(End e) {
-		//TODO boolean
+        //TODO boolean
         return eventSequence(
-				newStore(e.getAddress(), expressions.makeZero(types.getArchType()), C11.MO_RELEASE)
+                newStore(e.getAddress(), expressions.makeZero(types.getArchType()), C11.MO_RELEASE)
         );
 	}
 
 	@Override
 	public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-		Expression zero = expressions.makeZero(resultRegister.getType());
+        Expression zero = expressions.makeZero(resultRegister.getType());
 		Load load = newLoad(resultRegister, e.getAddress(), C11.MO_ACQUIRE);
         load.addTags(C11.PTHREAD);
-        
+
         return eventSequence(
 				load,
-				newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit())
+                newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit())
         );
 	}
 
 	@Override
 	public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
-		Expression one = expressions.makeOne(resultRegister.getType());
+        Expression one = expressions.makeOne(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), C11.MO_ACQUIRE);
         load.addTags(Tag.STARTLOAD);
 
@@ -96,15 +96,15 @@ class VisitorIMM extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
 		Register resultRegister = e.getResultRegister();
-		Expression address = e.getAddress();
+        Expression address = e.getAddress();
 		String mo = e.getMo();
 		Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 		Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
-		Expression expectedAddr = e.getExpectedAddr();
-		IntegerType type = resultRegister.getType();
-		Expression one = expressions.makeOne(type);
+        Expression expectedAddr = e.getExpectedAddr();
+        IntegerType type = resultRegister.getType();
+        Expression one = expressions.makeOne(type);
 
-		Register regExpected = e.getThread().newRegister(type);
+        Register regExpected = e.getThread().newRegister(type);
         Register regValue = e.getThread().newRegister(type);
         Load loadExpected = newLoad(regExpected, expectedAddr, "");
         loadExpected.addTags(Tag.IMM.CASDEPORIGIN);
@@ -137,12 +137,12 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		Expression address = e.getAddress();
+        Expression address = e.getAddress();
 		String mo = e.getMo();
 		Fence optionalFenceBefore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 		Fence optionalFenceAfter = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 
-		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
         Load load = newRMWLoad(resultRegister, address, extractLoadMo(mo));
 
         return eventSequence(
@@ -181,13 +181,13 @@ class VisitorIMM extends VisitorBase {
 
 	@Override
 	public List<Event> visitAtomicXchg(AtomicXchg e) {
-		Expression address = e.getAddress();
+        Expression address = e.getAddress();
 		String mo = e.getMo();
 		Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 		Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 
 		Load load = newRMWLoad(e.getResultRegister(), address, mo);
-        
+
         return eventSequence(
 				optionalFenceLoad,
                 load,
@@ -215,8 +215,8 @@ class VisitorIMM extends VisitorBase {
 	@Override
 	public List<Event> visitLlvmXchg(LlvmXchg e) {
 		Register resultRegister = e.getResultRegister();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Load load = newRMWLoadExclusive(resultRegister, address, IMM.extractLoadMo(mo));
@@ -235,12 +235,12 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitLlvmRMW(LlvmRMW e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
 		String mo = e.getMo();
 
-		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
-		Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
+        Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+        Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
 
 		Load load = newRMWLoadExclusive(resultRegister, address, IMM.extractLoadMo(mo));
 		Store store = newRMWStoreExclusive(address, dummyReg, IMM.extractStoreMo(mo), true);
@@ -259,16 +259,16 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
 		Register oldValueRegister = e.getStructRegister(0);
 		Register resultRegister = e.getStructRegister(1);
-		Expression one = expressions.makeOne(resultRegister.getType());
+        Expression one = expressions.makeOne(resultRegister.getType());
 
-		Expression value = e.getMemValue();
-		Expression address = e.getAddress();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
 		String mo = e.getMo();
-		Expression expectedValue = e.getExpectedValue();
+        Expression expectedValue = e.getExpectedValue();
 
-		Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
 		Label casEnd = newLabel("CAS_end");
-		CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casEnd);
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casEnd);
 
 		Load load = newRMWLoadExclusive(oldValueRegister, address, IMM.extractLoadMo(mo));
 		Store store = newRMWStoreExclusive(address, value, IMM.extractStoreMo(mo), true);
@@ -278,7 +278,7 @@ class VisitorIMM extends VisitorBase {
 				load,
 				casCmpResult,
 				branchOnCasCmpResult,
-				store,
+                    store,
 				casEnd);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -1,7 +1,8 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.*;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.Tag.C11;
@@ -17,8 +18,6 @@ import com.dat3m.dartagnan.program.event.lang.pthread.Start;
 import java.util.Collections;
 import java.util.List;
 
-import static com.dat3m.dartagnan.expression.op.COpBin.EQ;
-import static com.dat3m.dartagnan.expression.op.COpBin.NEQ;
 import static com.dat3m.dartagnan.program.event.EventFactory.*;
 import static com.dat3m.dartagnan.program.event.Tag.IMM.extractLoadMo;
 import static com.dat3m.dartagnan.program.event.Tag.IMM.extractStoreMo;
@@ -33,7 +32,7 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitLoad(Load e) {
 		String mo = e.getMo();
         return eventSequence(
-        		newLoad(e.getResultRegister(), e.getAddress(), mo.isEmpty() || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
+				newLoad(e.getResultRegister(), e.getAddress(), mo.isEmpty() || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
         );
 	}
 
@@ -41,10 +40,10 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitStore(Store e) {
 		String mo = e.getMo();
         return eventSequence(
-        		newStore(e.getAddress(), e.getMemValue(), mo.isEmpty() || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
+				newStore(e.getAddress(), e.getMemValue(), mo.isEmpty() || mo.equals(C11.NONATOMIC) ? C11.MO_RELAXED : mo)
         );
 	}
-	
+
 	@Override
 	public List<Event> visitCreate(Create e) {
         Store store = newStore(e.getAddress(), e.getMemValue(), C11.MO_RELEASE);
@@ -57,33 +56,36 @@ class VisitorIMM extends VisitorBase {
 
 	@Override
 	public List<Event> visitEnd(End e) {
+		//TODO boolean
         return eventSequence(
-        		newStore(e.getAddress(), IValue.ZERO, C11.MO_RELEASE)
+				newStore(e.getAddress(), expressions.makeZero(types.getArchType()), C11.MO_RELEASE)
         );
 	}
 
 	@Override
 	public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
+		ExprInterface zero = expressions.makeZero(resultRegister.getType());
 		Load load = newLoad(resultRegister, e.getAddress(), C11.MO_ACQUIRE);
         load.addTags(C11.PTHREAD);
         
         return eventSequence(
-        		load,
-        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit())
+				load,
+				newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit())
         );
 	}
 
 	@Override
 	public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
+		ExprInterface one = expressions.makeOne(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), C11.MO_ACQUIRE);
         load.addTags(Tag.STARTLOAD);
 
         return eventSequence(
-        		load,
+				load,
 				super.visitStart(e),
-        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit())
+				newJump(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit())
         );
 	}
 
@@ -94,22 +96,23 @@ class VisitorIMM extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
 		Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 		Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 		Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
-		IExpr expectedAddr = e.getExpectedAddr();
-		int precision = resultRegister.getPrecision();
+		ExprInterface expectedAddr = e.getExpectedAddr();
+		IntegerType type = resultRegister.getType();
+		ExprInterface one = expressions.makeOne(type);
 
-		Register regExpected = e.getThread().newRegister(precision);
-        Register regValue = e.getThread().newRegister(precision);
+		Register regExpected = e.getThread().newRegister(type);
+        Register regValue = e.getThread().newRegister(type);
         Load loadExpected = newLoad(regExpected, expectedAddr, "");
         loadExpected.addTags(Tag.IMM.CASDEPORIGIN);
         Store storeExpected = newStore(expectedAddr, regValue, "");
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");
-        Local casCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, regExpected));
-        CondJump branchOnCasCmpResult = newJump(new Atom(resultRegister, NEQ, IValue.ONE), casFail);
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(regValue, regExpected));
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casFail);
         CondJump gotoCasEnd = newGoto(casEnd);
         Load loadValue = newRMWLoad(regValue, address, extractLoadMo(mo));
         Store storeValue = newRMWStore(loadValue, address, e.getMemValue(), extractStoreMo(mo));
@@ -121,7 +124,7 @@ class VisitorIMM extends VisitorBase {
                 loadValue,
                 casCmpResult,
                 branchOnCasCmpResult,
-                	optionalFenceStore,
+				optionalFenceStore,
                     storeValue,
                     gotoCasEnd,
                 casFail,
@@ -134,19 +137,19 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 		Fence optionalFenceBefore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 		Fence optionalFenceAfter = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
-		
-        Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
+
+		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
         Load load = newRMWLoad(resultRegister, address, extractLoadMo(mo));
 
         return eventSequence(
-        		optionalFenceBefore,
+				optionalFenceBefore,
                 load,
-                newLocal(dummyReg, new IExprBin(resultRegister, op, (IExpr) e.getMemValue())),
-        		optionalFenceAfter,
+                newLocal(dummyReg, expressions.makeBinary(resultRegister, op, e.getMemValue())),
+				optionalFenceAfter,
                 newRMWStore(load, address, dummyReg, extractStoreMo(mo))
         );
 	}
@@ -156,8 +159,8 @@ class VisitorIMM extends VisitorBase {
 		String mo = e.getMo();
 		Fence optionalFence = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
         return eventSequence(
-        		optionalFence,
-        		newLoad(e.getResultRegister(), e.getAddress(), extractLoadMo(mo))
+				optionalFence,
+				newLoad(e.getResultRegister(), e.getAddress(), extractLoadMo(mo))
         );
 	}
 
@@ -166,8 +169,8 @@ class VisitorIMM extends VisitorBase {
 		String mo = e.getMo();
 		Fence optionalFence = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
         return eventSequence(
-        		optionalFence,
-        		newStore(e.getAddress(), e.getMemValue(), extractStoreMo(mo))
+				optionalFence,
+				newStore(e.getAddress(), e.getMemValue(), extractStoreMo(mo))
         );
 	}
 
@@ -178,15 +181,15 @@ class VisitorIMM extends VisitorBase {
 
 	@Override
 	public List<Event> visitAtomicXchg(AtomicXchg e) {
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 		Fence optionalFenceLoad = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
 		Fence optionalFenceStore = mo.equals(Tag.C11.MO_SC) ? newFence(Tag.C11.MO_SC) : null;
-		
-        Load load = newRMWLoad(e.getResultRegister(), address, mo);
+
+		Load load = newRMWLoad(e.getResultRegister(), address, mo);
         
         return eventSequence(
-        		optionalFenceLoad,
+				optionalFenceLoad,
                 load,
                 optionalFenceStore,
                 newRMWStore(load, address, e.getMemValue(), extractStoreMo(mo))
@@ -213,7 +216,7 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitLlvmXchg(LlvmXchg e) {
 		Register resultRegister = e.getResultRegister();
 		ExprInterface value = e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
 		Load load = newRMWLoadExclusive(resultRegister, address, IMM.extractLoadMo(mo));
@@ -232,12 +235,12 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitLlvmRMW(LlvmRMW e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		IExpr value = (IExpr) e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface value = e.getMemValue();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
-		Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
-		Local localOp = newLocal(dummyReg, new IExprBin(resultRegister, op, value));
+		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+		Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
 
 		Load load = newRMWLoadExclusive(resultRegister, address, IMM.extractLoadMo(mo));
 		Store store = newRMWStoreExclusive(address, dummyReg, IMM.extractStoreMo(mo), true);
@@ -256,15 +259,16 @@ class VisitorIMM extends VisitorBase {
 	public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
 		Register oldValueRegister = e.getStructRegister(0);
 		Register resultRegister = e.getStructRegister(1);
+		ExprInterface one = expressions.makeOne(resultRegister.getType());
 
 		ExprInterface value = e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 		ExprInterface expectedValue = e.getExpectedValue();
 
-		Local casCmpResult = newLocal(resultRegister, new Atom(oldValueRegister, EQ, expectedValue));
+		Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
 		Label casEnd = newLabel("CAS_end");
-		CondJump branchOnCasCmpResult = newJump(new Atom(resultRegister, NEQ, IValue.ONE), casEnd);
+		CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casEnd);
 
 		Load load = newRMWLoadExclusive(oldValueRegister, address, IMM.extractLoadMo(mo));
 		Store store = newRMWStoreExclusive(address, value, IMM.extractStoreMo(mo), true);
@@ -274,7 +278,7 @@ class VisitorIMM extends VisitorBase {
 				load,
 				casCmpResult,
 				branchOnCasCmpResult,
-					store,
+				store,
 				casEnd);
 	}
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
 import com.dat3m.dartagnan.expression.BNonDet;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
@@ -74,9 +74,9 @@ public class VisitorLKMM extends VisitorBase {
     public List<Event> visitRMWAddUnless(RMWAddUnless e) {
         Register resultRegister = e.getResultRegister();
         Register dummy = e.getThread().newRegister(resultRegister.getType());
-        ExprInterface cmp = e.getCmp();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression cmp = e.getCmp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
 
         Label success = newLabel("RMW_success");
         Label end = newLabel("RMW_end");
@@ -100,9 +100,9 @@ public class VisitorLKMM extends VisitorBase {
     @Override
     public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface cmp = e.getCmp();
-        ExprInterface value = e.getMemValue();
-        ExprInterface address = e.getAddress();
+        Expression cmp = e.getCmp();
+        Expression value = e.getMemValue();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Label success = newLabel("CAS_success");
@@ -129,8 +129,8 @@ public class VisitorLKMM extends VisitorBase {
     public List<Event> visitRMWFetchOp(RMWFetchOp e) {
         Register resultRegister = e.getResultRegister();
         String mo = e.getMo();
-        ExprInterface address = e.getAddress();
-        ExprInterface value = e.getMemValue();
+        Expression address = e.getAddress();
+        Expression value = e.getMemValue();
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
         Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
@@ -148,7 +148,7 @@ public class VisitorLKMM extends VisitorBase {
 
     @Override
     public List<Event> visitRMWOp(RMWOp e) {
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
         Register resultRegister = e.getResultRegister();
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
@@ -164,7 +164,7 @@ public class VisitorLKMM extends VisitorBase {
     @Override
     public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
         IntegerType type = resultRegister.getType();
 
         Register dummy = e.getThread().newRegister(type);
@@ -183,7 +183,7 @@ public class VisitorLKMM extends VisitorBase {
     @Override
     public List<Event> visitRMWOpReturn(RMWOpReturn e) {
         Register resultRegister = e.getResultRegister();
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
         String mo = e.getMo();
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
@@ -205,7 +205,7 @@ public class VisitorLKMM extends VisitorBase {
     public List<Event> visitRMWXchg(RMWXchg e) {
         Register resultRegister = e.getResultRegister();
         String mo = e.getMo();
-        ExprInterface address = e.getAddress();
+        Expression address = e.getAddress();
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
         Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
@@ -224,7 +224,7 @@ public class VisitorLKMM extends VisitorBase {
     @Override
     public List<Event> visitLKMMLock(LKMMLock e) {
         Register dummy = e.getThread().newRegister(types.getArchType());
-        ExprInterface zero = expressions.makeZero(dummy.getType());
+        Expression zero = expressions.makeZero(dummy.getType());
         // In litmus tests, spin locks are guaranteed to succeed, i.e. its read part gets value 0
         Load lockRead = Linux.newLockRead(dummy, e.getLock());
         Event middle = e.getThread().getProgram().getFormat().equals(LITMUS) ?

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
@@ -1,8 +1,9 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.GlobalSettings;
-import com.dat3m.dartagnan.expression.*;
-import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.expression.BNonDet;
+import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.Tag.C11;
@@ -13,21 +14,18 @@ import com.dat3m.dartagnan.program.event.lang.pthread.End;
 import com.dat3m.dartagnan.program.event.lang.pthread.Join;
 import com.dat3m.dartagnan.program.event.lang.pthread.Start;
 
-import java.math.BigInteger;
 import java.util.List;
 
-import static com.dat3m.dartagnan.expression.op.COpBin.EQ;
-import static com.dat3m.dartagnan.expression.op.COpBin.NEQ;
 import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
 import static com.dat3m.dartagnan.program.event.EventFactory.*;
 
 public class VisitorLKMM extends VisitorBase {
 
-	protected VisitorLKMM(boolean forceStart) {
-		super(forceStart);
+    protected VisitorLKMM(boolean forceStart) {
+        super(forceStart);
         }
-	
-        @Override
+
+    @Override
         public List<Event> visitCreate(Create e) {
             Store store = newStore(e.getAddress(), e.getMemValue(), Tag.Linux.MO_RELEASE);
             store.addTags(C11.PTHREAD);
@@ -39,43 +37,46 @@ public class VisitorLKMM extends VisitorBase {
 
         @Override
         public List<Event> visitEnd(End e) {
+            //TODO boolean
             return eventSequence(
-                    newStore(e.getAddress(), IValue.ZERO, Tag.Linux.MO_RELEASE)
+                    newStore(e.getAddress(), expressions.makeZero(types.getArchType()), Tag.Linux.MO_RELEASE)
             );
         }
 
     @Override
-	public List<Event> visitJoin(Join e) {
+    public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
+        IValue zero = expressions.makeZero(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), Tag.Linux.MO_ACQUIRE);
         load.addTags(C11.PTHREAD);
         
         return eventSequence(
                 load,
-        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit())
+                newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit())
         );
-	}
+    }
 
     @Override
-	public List<Event> visitStart(Start e) {
+    public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
+        IValue one = expressions.makeOne(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), Tag.Linux.MO_ACQUIRE);
         load.addTags(Tag.STARTLOAD);
 
         return eventSequence(
                 load,
-			    super.visitStart(e),
-        		newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit())
+                super.visitStart(e),
+                newJump(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit())
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWAddUnless(RMWAddUnless e) {
+    @Override
+    public List<Event> visitRMWAddUnless(RMWAddUnless e) {
         Register resultRegister = e.getResultRegister();
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
         ExprInterface cmp = e.getCmp();
         ExprInterface value = e.getMemValue();
-        IExpr address = e.getAddress();
+        ExprInterface address = e.getAddress();
 
         Label success = newLabel("RMW_success");
         Label end = newLabel("RMW_end");
@@ -83,132 +84,132 @@ public class VisitorLKMM extends VisitorBase {
         return eventSequence(
                 newJump(new BNonDet(), success),
                     newLoad(dummy, address, Tag.Linux.MO_ONCE),
-                    newAssume(new Atom(dummy, EQ, cmp)),
+                    newAssume(expressions.makeEqual(dummy, cmp)),
                     newGoto(end),
                 success, // RMW success branch
                     Linux.newMemoryBarrier(),
                     rmwLoad = newRMWLoad(dummy, address, Tag.Linux.MO_ONCE),
-                    newAssume(new Atom(dummy, NEQ, cmp)),
-                    newRMWStore(rmwLoad, address, new IExprBin(dummy, IOpBin.PLUS, (IExpr) value), Tag.Linux.MO_ONCE),
+                    newAssume(expressions.makeNotEqual(dummy, cmp)),
+                    newRMWStore(rmwLoad, address, expressions.makePlus(dummy, value), Tag.Linux.MO_ONCE),
                     Linux.newMemoryBarrier(),
                 end,
-                newLocal(resultRegister, new Atom(dummy, NEQ, cmp))
+                newLocal(resultRegister, expressions.makeNotEqual(dummy, cmp))
         );
     }
 
-	@Override
-	public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
+    @Override
+    public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
         Register resultRegister = e.getResultRegister();
         ExprInterface cmp = e.getCmp();
         ExprInterface value = e.getMemValue();
-        IExpr address = e.getAddress();
+        ExprInterface address = e.getAddress();
         String mo = e.getMo();
 
         Label success = newLabel("CAS_success");
         Label end = newLabel("CAS_end");
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
         Load casLoad;
         return eventSequence(
                 newJump(new BNonDet(), success),
                     newLoad(dummy, address, Tag.Linux.MO_ONCE),
-                    newAssume(new Atom(dummy, NEQ, cmp)),
+                    newAssume(expressions.makeNotEqual(dummy, cmp)),
                     newGoto(end),
                 success, // CAS success branch
                     mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
                     casLoad = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo)),
-                    newAssume(new Atom(dummy, EQ, cmp)),
+                    newAssume(expressions.makeEqual(dummy, cmp)),
                     newRMWStore(casLoad, address, value, Tag.Linux.storeMO(mo)),
                     mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null,
                 end,
                 newLocal(resultRegister, dummy)
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWFetchOp(RMWFetchOp e) {
+    @Override
+    public List<Event> visitRMWFetchOp(RMWFetchOp e) {
         Register resultRegister = e.getResultRegister();
         String mo = e.getMo();
-        IExpr address = e.getAddress();
+        ExprInterface address = e.getAddress();
         ExprInterface value = e.getMemValue();
 
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-		Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
-		Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
+        Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
+        Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
         Fence optionalMbAfter = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
 
         return eventSequence(
                 optionalMbBefore,
                 load,
-                newRMWStore(load, address, new IExprBin(dummy, e.getOp(), (IExpr) value), Tag.Linux.storeMO(mo)),
+                newRMWStore(load, address, expressions.makeBinary(dummy, e.getOp(), value), Tag.Linux.storeMO(mo)),
                 newLocal(resultRegister, dummy),
                 optionalMbAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWOp(RMWOp e) {
-        IExpr address = e.getAddress();
+    @Override
+    public List<Event> visitRMWOp(RMWOp e) {
+        ExprInterface address = e.getAddress();
         Register resultRegister = e.getResultRegister();
-		
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
+
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
         Load load = newRMWLoad(dummy, address, Tag.Linux.MO_ONCE);
         load.addTags(Tag.Linux.NORETURN);
         
         return eventSequence(
                 load,
-                newRMWStore(load, address, new IExprBin(dummy, e.getOp(), (IExpr) e.getMemValue()), Tag.Linux.MO_ONCE)
+                newRMWStore(load, address, expressions.makeBinary(dummy, e.getOp(), e.getMemValue()), Tag.Linux.MO_ONCE)
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
+    @Override
+    public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
         Register resultRegister = e.getResultRegister();
-        IExpr address = e.getAddress();
-        int precision = resultRegister.getPrecision();
-        
-		Register dummy = e.getThread().newRegister(precision);
-		Load load = newRMWLoad(dummy, address, Tag.Linux.MO_ONCE);
+        ExprInterface address = e.getAddress();
+        IntegerType type = resultRegister.getType();
+
+        Register dummy = e.getThread().newRegister(type);
+        Load load = newRMWLoad(dummy, address, Tag.Linux.MO_ONCE);
 
         return eventSequence(
                 Linux.newMemoryBarrier(),
                 load,
-                newLocal(dummy, new IExprBin(dummy, e.getOp(), (IExpr) e.getMemValue())),
+                newLocal(dummy, expressions.makeBinary(dummy, e.getOp(), e.getMemValue())),
                 newRMWStore(load, address, dummy, Tag.Linux.MO_ONCE),
-                newLocal(resultRegister, new Atom(dummy, EQ, new IValue(BigInteger.ZERO, precision))),
+                newLocal(resultRegister, expressions.makeEqual(dummy, expressions.makeZero(type))),
                 Linux.newMemoryBarrier()
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWOpReturn(RMWOpReturn e) {
+    @Override
+    public List<Event> visitRMWOpReturn(RMWOpReturn e) {
         Register resultRegister = e.getResultRegister();
-        IExpr address = e.getAddress();
+        ExprInterface address = e.getAddress();
         String mo = e.getMo();
-        
-		Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-		Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
-		Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
+
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
+        Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
+        Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
         Fence optionalMbAfter = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
 
         return eventSequence(
                 optionalMbBefore,
                 load,
-                newLocal(dummy, new IExprBin(dummy, e.getOp(), (IExpr) e.getMemValue())),
+                newLocal(dummy, expressions.makeBinary(dummy, e.getOp(), e.getMemValue())),
                 newRMWStore(load, address, dummy, Tag.Linux.storeMO(mo)),
                 newLocal(resultRegister, dummy),
                 optionalMbAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitRMWXchg(RMWXchg e) {
+    @Override
+    public List<Event> visitRMWXchg(RMWXchg e) {
         Register resultRegister = e.getResultRegister();
         String mo = e.getMo();
-        IExpr address = e.getAddress();
+        ExprInterface address = e.getAddress();
 
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-		Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
-		Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
+        Register dummy = e.getThread().newRegister(resultRegister.getType());
+        Load load = newRMWLoad(dummy, address, Tag.Linux.loadMO(mo));
+        Fence optionalMbBefore = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
         Fence optionalMbAfter = mo.equals(Tag.Linux.MO_MB) ? Linux.newMemoryBarrier() : null;
 
         return eventSequence(
@@ -218,20 +219,21 @@ public class VisitorLKMM extends VisitorBase {
                 newLocal(resultRegister, dummy),
                 optionalMbAfter
         );
-	}
+    }
 
-	@Override
-	public List<Event> visitLKMMLock(LKMMLock e) {
-		Register dummy = e.getThread().newRegister(GlobalSettings.getArchPrecision());
+    @Override
+    public List<Event> visitLKMMLock(LKMMLock e) {
+        Register dummy = e.getThread().newRegister(types.getArchType());
+        ExprInterface zero = expressions.makeZero(dummy.getType());
         // In litmus tests, spin locks are guaranteed to succeed, i.e. its read part gets value 0
         Load lockRead = Linux.newLockRead(dummy, e.getLock());
-		Event middle = e.getThread().getProgram().getFormat().equals(LITMUS) ?
-				newAssume(new Atom(dummy, EQ, IValue.ZERO)) :
-				newJump(new Atom(dummy, NEQ, IValue.ZERO), (Label)e.getThread().getExit());
-		return eventSequence(
+        Event middle = e.getThread().getProgram().getFormat().equals(LITMUS) ?
+                newAssume(expressions.makeEqual(dummy, zero)) :
+                newJump(expressions.makeNotEqual(dummy, zero), (Label)e.getThread().getExit());
+        return eventSequence(
                 lockRead,
                 middle,
                 Linux.newLockWrite(lockRead, e.getLock())
         );
-	}
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
@@ -62,7 +62,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-		ExprInterface zero = expressions.makeZero(resultRegister.getType());
+		Expression zero = expressions.makeZero(resultRegister.getType());
 		Load load = newLoad(resultRegister, e.getAddress(), "");
         load.addTags(C11.PTHREAD);
         Label label = newLabel("Jump_" + e.getGlobalId());
@@ -80,7 +80,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
-		ExprInterface one = expressions.makeOne(resultRegister.getType());
+		Expression one = expressions.makeOne(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), e.getMo());
 		load.addTags(Tag.STARTLOAD);
 		Label label = newLabel("Jump_" + e.getGlobalId());
@@ -106,7 +106,7 @@ public class VisitorPower extends VisitorBase {
     @Override
     public List<Event> visitLock(Lock e) {
         Register dummy = e.getThread().newRegister(types.getArchType());
-		ExprInterface zero = expressions.makeZero(dummy.getType());
+		Expression zero = expressions.makeZero(dummy.getType());
         Label label = newLabel("FakeDep");
         // We implement locks as spinlocks which are guaranteed to succeed, i.e. we can
         // use assumes. The fake control dependency + isync guarantee acquire semantics.
@@ -202,7 +202,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitLlvmXchg(LlvmXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface address = e.getAddress();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		// Power does not have mo tags, thus we use null
@@ -248,7 +248,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitLlvmRMW(LlvmRMW e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface address = e.getAddress();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
@@ -305,8 +305,8 @@ public class VisitorPower extends VisitorBase {
 		Register oldValueRegister = e.getStructRegister(0);
 		Register resultRegister = e.getStructRegister(1);
 
-		ExprInterface one = expressions.makeOne(resultRegister.getType());
-		ExprInterface address = e.getAddress();
+		Expression one = expressions.makeOne(resultRegister.getType());
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, e.getExpectedValue()));
@@ -367,11 +367,11 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface one = expressions.makeOne(resultRegister.getType());
-		ExprInterface address = e.getAddress();
-		ExprInterface value = e.getMemValue();
+		Expression one = expressions.makeOne(resultRegister.getType());
+		Expression address = e.getAddress();
+		Expression value = e.getMemValue();
 		String mo = e.getMo();
-		ExprInterface expectedAddr = e.getExpectedAddr();
+		Expression expectedAddr = e.getExpectedAddr();
 		IntegerType type = resultRegister.getType();
 
 		Register regExpected = e.getThread().newRegister(type);
@@ -442,8 +442,8 @@ public class VisitorPower extends VisitorBase {
 	public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
@@ -497,7 +497,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicLoad(AtomicLoad e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface address = e.getAddress();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Fence optionalBarrierBefore = null;
@@ -541,8 +541,8 @@ public class VisitorPower extends VisitorBase {
 
 	@Override
 	public List<Event> visitAtomicStore(AtomicStore e) {
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
         Fence optionalBarrierBefore = null;
@@ -583,8 +583,8 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicXchg(AtomicXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
         // Power does not have mo tags, thus we use the emptz string
@@ -637,7 +637,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitLKMMLoad(LKMMLoad e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface address = e.getAddress();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		// Power does not have mo tags, thus we use the empty string
@@ -654,8 +654,8 @@ public class VisitorPower extends VisitorBase {
 	//		https://elixir.bootlin.com/linux/v5.18/source/arch/powerpc/include/asm/barrier.h
 	@Override
 	public List<Event> visitLKMMStore(LKMMStore e) {
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
         // Power does not have mo tags, thus we use the empty string
@@ -733,8 +733,8 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface address = e.getAddress();
-		ExprInterface value = e.getMemValue();
+		Expression address = e.getAddress();
+		Expression value = e.getMemValue();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(e.getResultRegister().getType());
@@ -769,8 +769,8 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitRMWXchg(RMWXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(resultRegister.getType());
@@ -800,8 +800,8 @@ public class VisitorPower extends VisitorBase {
 	public List<Event> visitRMWOp(RMWOp e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(resultRegister.getType());
@@ -831,8 +831,8 @@ public class VisitorPower extends VisitorBase {
 	public List<Event> visitRMWOpReturn(RMWOpReturn e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(resultRegister.getType());
@@ -863,8 +863,8 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitRMWFetchOp(RMWFetchOp e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(resultRegister.getType());
@@ -897,11 +897,11 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitRMWAddUnless(RMWAddUnless e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface address = e.getAddress();
-		ExprInterface value = e.getMemValue();
+		Expression address = e.getAddress();
+		Expression value = e.getMemValue();
 		String mo = e.getMo();
 		IntegerType type = resultRegister.getType();
-		ExprInterface zero = expressions.makeZero(type);
+		Expression zero = expressions.makeZero(type);
 
         Register regValue = e.getThread().newRegister(type);
         // Power does not have mo tags, thus we use the empty string
@@ -911,7 +911,7 @@ public class VisitorPower extends VisitorBase {
         Event fakeCtrlDep = newFakeCtrlDep(regValue, label);
 
         Register dummy = e.getThread().newRegister(type);
-		ExprInterface unless = e.getCmp();
+		Expression unless = e.getCmp();
         Label cauEnd = newLabel("CAddU_end");
         CondJump branchOnCauCmpResult = newJump(expressions.makeEqual(dummy, zero), cauEnd);
 
@@ -943,10 +943,10 @@ public class VisitorPower extends VisitorBase {
 	public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
-		ExprInterface zero = expressions.makeZero(type);
+		Expression zero = expressions.makeZero(type);
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(type);
@@ -981,8 +981,8 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitLKMMLock(LKMMLock e) {
 		IntegerType type = types.getArchType();
-		ExprInterface zero = expressions.makeZero(type);
-		ExprInterface one = expressions.makeOne(type);
+		Expression zero = expressions.makeZero(type);
+		Expression one = expressions.makeOne(type);
 		Register dummy = e.getThread().newRegister(type);
 		Label label = newLabel("FakeDep");
     // Spinlock events are guaranteed to succeed, i.e. we can use assumes

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -1,10 +1,8 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.GlobalSettings;
-import com.dat3m.dartagnan.expression.*;
-import com.dat3m.dartagnan.expression.op.BOpUn;
-import com.dat3m.dartagnan.expression.op.COpBin;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.op.IOpBin;
+import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.Tag.C11;
@@ -16,8 +14,6 @@ import com.dat3m.dartagnan.program.event.lang.pthread.*;
 
 import java.util.List;
 
-import static com.dat3m.dartagnan.expression.op.COpBin.EQ;
-import static com.dat3m.dartagnan.expression.op.COpBin.NEQ;
 import static com.dat3m.dartagnan.program.event.EventFactory.*;
 import static com.dat3m.dartagnan.program.processing.compilation.VisitorPower.PowerScheme.LEADING_SYNC;
 
@@ -26,21 +22,21 @@ public class VisitorPower extends VisitorBase {
 	// The compilation schemes below follows the paper
 	// "Clarifying and Compiling C/C++ Concurrency: from C++11 to POWER"
 	// The paper does not define the mappings for RMW, but we derive them
-	// using the same pattern as for Load/Store	
+	// using the same pattern as for Load/Store
 	private final PowerScheme cToPowerScheme;
-	// Some language memory models (e.g. RC11) are non-dependency tracking and might need a 
+	// Some language memory models (e.g. RC11) are non-dependency tracking and might need a
 	// strong version of no-OOTA, thus we need to strength the compilation following the papers
 	// "Repairing Sequential Consistency in C/C++11"
 	// "Outlawing Ghosts: Avoiding Out-of-Thin-Air Results"
-	private final boolean useRC11Scheme; 
+	private final boolean useRC11Scheme;
 
 	protected VisitorPower(boolean forceStart, boolean useRC11Scheme, PowerScheme cToPowerScheme) {
 		super(forceStart);
 		this.useRC11Scheme = useRC11Scheme;
 		this.cToPowerScheme = cToPowerScheme;
 	}
-	
-    // =============================================================================================
+
+	// =============================================================================================
     // ========================================= PTHREAD ===========================================
     // =============================================================================================
 
@@ -58,14 +54,15 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitEnd(End e) {
         return eventSequence(
-        		Power.newSyncBarrier(),
-        		newStore(e.getAddress(), IValue.ZERO, e.getMo())
+				Power.newSyncBarrier(),
+				newStore(e.getAddress(), expressions.makeZero(types.getArchType()), e.getMo())
         );
 	}
 
 	@Override
 	public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
+		ExprInterface zero = expressions.makeZero(resultRegister.getType());
 		Load load = newLoad(resultRegister, e.getAddress(), "");
         load.addTags(C11.PTHREAD);
         Label label = newLabel("Jump_" + e.getGlobalId());
@@ -76,25 +73,26 @@ public class VisitorPower extends VisitorBase {
                 fakeCtrlDep,
                 label,
                 Power.newISyncBarrier(),
-                newJumpUnless(new Atom(resultRegister, EQ, IValue.ZERO), (Label) e.getThread().getExit())
+                newJump(expressions.makeNotEqual(resultRegister, zero), (Label) e.getThread().getExit())
         );
 	}
 
 	@Override
 	public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
+		ExprInterface one = expressions.makeOne(resultRegister.getType());
         Load load = newLoad(resultRegister, e.getAddress(), e.getMo());
 		load.addTags(Tag.STARTLOAD);
 		Label label = newLabel("Jump_" + e.getGlobalId());
         CondJump fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
-		
+
 		return eventSequence(
                 load,
                 fakeCtrlDep,
                 label,
                 Power.newISyncBarrier(),
 				super.visitStart(e),
-                newJumpUnless(new Atom(resultRegister, EQ, IValue.ONE), (Label) e.getThread().getExit())
+                newJump(expressions.makeNotEqual(resultRegister, one), (Label) e.getThread().getExit())
         );
 	}
 
@@ -107,14 +105,15 @@ public class VisitorPower extends VisitorBase {
 
     @Override
     public List<Event> visitLock(Lock e) {
-        Register dummy = e.getThread().newRegister(GlobalSettings.getArchPrecision());
+        Register dummy = e.getThread().newRegister(types.getArchType());
+		ExprInterface zero = expressions.makeZero(dummy.getType());
         Label label = newLabel("FakeDep");
         // We implement locks as spinlocks which are guaranteed to succeed, i.e. we can
         // use assumes. The fake control dependency + isync guarantee acquire semantics.
         return eventSequence(
                 newRMWLoadExclusive(dummy, e.getAddress(), ""),
-                newAssume(new Atom(dummy, COpBin.EQ, IValue.ZERO)),
-                Power.newRMWStoreConditional(e.getAddress(), IValue.ONE, "", true),
+                newAssume(expressions.makeEqual(dummy, zero)),
+                Power.newRMWStoreConditional(e.getAddress(), expressions.makeOne(types.getArchType()), "", true),
                 // Fake dependency to guarantee acquire semantics
                 newFakeCtrlDep(dummy, label),
                 label,
@@ -125,7 +124,7 @@ public class VisitorPower extends VisitorBase {
     public List<Event> visitUnlock(Unlock e) {
         return eventSequence(
                 Power.newLwSyncBarrier(),
-                newStore(e.getAddress(), IValue.ZERO, ""));
+                newStore(e.getAddress(), expressions.makeZero(types.getArchType()), ""));
     }
     
     // =============================================================================================
@@ -203,7 +202,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitLlvmXchg(LlvmXchg e) {
 		Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
 		// Power does not have mo tags, thus we use null
@@ -249,11 +248,11 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitLlvmRMW(LlvmRMW e) {
 		Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
-		Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
-		Local localOp = newLocal(dummyReg, new IExprBin(resultRegister, e.getOp(), (IExpr) e.getMemValue()));
+		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+		Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, e.getOp(), e.getMemValue()));
 
 		// Power does not have mo tags, thus we use null
 		Load load = newRMWLoadExclusive(resultRegister, address, "");
@@ -301,17 +300,18 @@ public class VisitorPower extends VisitorBase {
 				optionalBarrierAfter);
 	}
 
- 	@Override
+	@Override
 	public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
 		Register oldValueRegister = e.getStructRegister(0);
 		Register resultRegister = e.getStructRegister(1);
 
-		IExpr address = e.getAddress();
+		ExprInterface one = expressions.makeOne(resultRegister.getType());
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
-		Local casCmpResult = newLocal(resultRegister, new Atom(oldValueRegister, EQ, e.getExpectedValue()));
+		Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, e.getExpectedValue()));
 		Label casEnd = newLabel("CAS_end");
-		CondJump branchOnCasCmpResult = newJump(new Atom(resultRegister, NEQ, IValue.ONE), casEnd);
+		CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casEnd);
 
 		Load load = newRMWLoadExclusive(oldValueRegister, address, "");
 		Store store = Power.newRMWStoreConditional(address, e.getMemValue(), "", true);
@@ -367,20 +367,21 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
 		Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		ExprInterface one = expressions.makeOne(resultRegister.getType());
+		ExprInterface address = e.getAddress();
 		ExprInterface value = e.getMemValue();
 		String mo = e.getMo();
-		IExpr expectedAddr = e.getExpectedAddr();
-		int precision = resultRegister.getPrecision();
+		ExprInterface expectedAddr = e.getExpectedAddr();
+		IntegerType type = resultRegister.getType();
 
-		Register regExpected = e.getThread().newRegister(precision);
-        Register regValue = e.getThread().newRegister(precision);
+		Register regExpected = e.getThread().newRegister(type);
+        Register regValue = e.getThread().newRegister(type);
         Load loadExpected = newLoad(regExpected, expectedAddr, "");
         Store storeExpected = newStore(expectedAddr, regValue, "");
         Label casFail = newLabel("CAS_fail");
         Label casEnd = newLabel("CAS_end");
-        Local casCmpResult = newLocal(resultRegister, new Atom(regValue, EQ, regExpected));
-        CondJump branchOnCasCmpResult = newJump(new Atom(resultRegister, NEQ, IValue.ONE), casFail);
+        Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(regValue, regExpected));
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casFail);
         CondJump gotoCasEnd = newGoto(casEnd);
 
         // Power does not have mo tags, thus we use the emptz string
@@ -389,9 +390,9 @@ public class VisitorPower extends VisitorBase {
         ExecutionStatus optionalExecStatus = null;
         Local optionalUpdateCasCmpResult = null;
         if (e.isWeak()) {
-            Register statusReg = e.getThread().newRegister(precision);
+            Register statusReg = e.getThread().newRegister(type);
             optionalExecStatus = newExecutionStatus(statusReg, storeValue);
-            optionalUpdateCasCmpResult = newLocal(resultRegister, new BExprUn(BOpUn.NOT, statusReg));
+            optionalUpdateCasCmpResult = newLocal(resultRegister, expressions.makeNot(statusReg));
         }
 
         Fence optionalBarrierBefore = null;
@@ -441,12 +442,12 @@ public class VisitorPower extends VisitorBase {
 	public List<Event> visitAtomicFetchOp(AtomicFetchOp e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		IExpr value = (IExpr) e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface value = e.getMemValue();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
-		
-        Register dummyReg = e.getThread().newRegister(resultRegister.getPrecision());
-        Local localOp = newLocal(dummyReg, new IExprBin(resultRegister, op, value));
+
+		Register dummyReg = e.getThread().newRegister(resultRegister.getType());
+        Local localOp = newLocal(dummyReg, expressions.makeBinary(resultRegister, op, value));
 
         // Power does not have mo tags, thus we use the emptz string
         Load load = newRMWLoadExclusive(resultRegister, address, "");
@@ -483,7 +484,7 @@ public class VisitorPower extends VisitorBase {
 		}
 
         return eventSequence(
-        		optionalBarrierBefore,
+				optionalBarrierBefore,
                 load,
                 fakeCtrlDep,
                 label,
@@ -496,9 +497,9 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicLoad(AtomicLoad e) {
 		Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
-		
+
 		Fence optionalBarrierBefore = null;
         Load load = newLoad(resultRegister, address, mo);
         Label optionalLabel = null;
@@ -524,7 +525,7 @@ public class VisitorPower extends VisitorBase {
 			case C11.MO_RELAXED:
 				if(useRC11Scheme) {
 					optionalLabel = newLabel("FakeDep");
-					optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);					
+					optionalFakeCtrlDep = newFakeCtrlDep(resultRegister, optionalLabel);
 				}
 				break;
 		}
@@ -541,7 +542,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicStore(AtomicStore e) {
 		ExprInterface value = e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
         Fence optionalBarrierBefore = null;
@@ -583,7 +584,7 @@ public class VisitorPower extends VisitorBase {
 	public List<Event> visitAtomicXchg(AtomicXchg e) {
 		Register resultRegister = e.getResultRegister();
 		ExprInterface value = e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
         // Power does not have mo tags, thus we use the emptz string
@@ -618,7 +619,7 @@ public class VisitorPower extends VisitorBase {
 		}
         
         return eventSequence(
-        		optionalBarrierBefore,
+				optionalBarrierBefore,
                 load,
                 fakeCtrlDep,
                 label,
@@ -636,10 +637,10 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitLKMMLoad(LKMMLoad e) {
 		Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
-		
-        // Power does not have mo tags, thus we use the empty string
+
+		// Power does not have mo tags, thus we use the empty string
         Load load = newLoad(resultRegister, address, "");
         Fence optionalMemoryBarrier = mo.equals(Tag.Linux.MO_ACQUIRE) ? Power.newLwSyncBarrier() : null;
         
@@ -654,7 +655,7 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitLKMMStore(LKMMStore e) {
 		ExprInterface value = e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
         // Power does not have mo tags, thus we use the empty string
@@ -680,7 +681,7 @@ public class VisitorPower extends VisitorBase {
 			case Tag.Linux.AFTER_ATOMIC:
 				optionalMemoryBarrier = Power.newSyncBarrier();
 				break;
-        	// #define smp_mb__after_spinlock()	smp_mb()       
+			// #define smp_mb__after_spinlock()	smp_mb()
             // 		https://elixir.bootlin.com/linux/v6.1/source/arch/powerpc/include/asm/spinlock.h#L14
             case Tag.Linux.AFTER_SPINLOCK:
 				optionalMemoryBarrier = Power.newSyncBarrier();
@@ -695,12 +696,12 @@ public class VisitorPower extends VisitorBase {
 			default:
 				throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
 		}
-		
-        return eventSequence(
+
+		return eventSequence(
                 optionalMemoryBarrier
         );
 	}
-	
+
 	// =============================================================================================
 	// 										GENERAL COMMENTS
 	// =============================================================================================
@@ -732,13 +733,13 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
 		Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		ExprInterface value = e.getMemValue();
 		String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(e.getResultRegister().getPrecision());
+		Register dummy = e.getThread().newRegister(e.getResultRegister().getType());
         Label casEnd = newLabel("CAS_end");
-        CondJump branchOnCasCmpResult = newJump(new Atom(dummy, NEQ, e.getCmp()), casEnd);
+        CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(dummy, e.getCmp()), casEnd);
 
         // Power does not have mo tags, thus we use the empty string
         Load load = newRMWLoadExclusive(dummy, address, "");
@@ -749,7 +750,7 @@ public class VisitorPower extends VisitorBase {
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-        		: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
 
         return eventSequence(
                 // Indentation shows the branching structure
@@ -764,15 +765,15 @@ public class VisitorPower extends VisitorBase {
                 newLocal(resultRegister, dummy)
         );
 	}
-	
+
 	@Override
 	public List<Event> visitRMWXchg(RMWXchg e) {
 		Register resultRegister = e.getResultRegister();
 		ExprInterface value = e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
 
-		Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
+		Register dummy = e.getThread().newRegister(resultRegister.getType());
         // Power does not have mo tags, thus we use the empty string
         Load load = newRMWLoadExclusive(dummy, address, "");
         Store store = Power.newRMWStoreConditional(address, value, "", true);
@@ -782,7 +783,7 @@ public class VisitorPower extends VisitorBase {
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-        		: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
 
         return eventSequence(
                 optionalMemoryBarrierBefore,
@@ -794,26 +795,26 @@ public class VisitorPower extends VisitorBase {
                 optionalMemoryBarrierAfter
         );
 	}
-	
+
 	@Override
 	public List<Event> visitRMWOp(RMWOp e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		IExpr value = (IExpr) e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface value = e.getMemValue();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
-		
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
+
+		Register dummy = e.getThread().newRegister(resultRegister.getType());
         // Power does not have mo tags, thus we use the empty string
         Load load = newRMWLoadExclusive(dummy, address, "");
-        Store store = Power.newRMWStoreConditional(address, new IExprBin(dummy, op, value), "", true);
+        Store store = Power.newRMWStoreConditional(address, expressions.makeBinary(dummy, op, value), "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-        		: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
 
         
         return eventSequence(
@@ -830,11 +831,11 @@ public class VisitorPower extends VisitorBase {
 	public List<Event> visitRMWOpReturn(RMWOpReturn e) {
 		Register resultRegister = e.getResultRegister();
 		IOpBin op = e.getOp();
-		IExpr value = (IExpr) e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface value = e.getMemValue();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
-		
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
+
+		Register dummy = e.getThread().newRegister(resultRegister.getType());
         // Power does not have mo tags, thus we use the empty string
         Load load = newRMWLoadExclusive(dummy, address, "");
         Store store = Power.newRMWStoreConditional(address, dummy, "", true);
@@ -844,13 +845,13 @@ public class VisitorPower extends VisitorBase {
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-        		: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
 
         
         return eventSequence(
                 optionalMemoryBarrierBefore,
                 load,
-                newLocal(dummy, new IExprBin(dummy, op, value)),
+                newLocal(dummy, expressions.makeBinary(dummy, op, value)),
                 store,
                 newLocal(resultRegister, dummy),
                 fakeCtrlDep,
@@ -862,23 +863,23 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitRMWFetchOp(RMWFetchOp e) {
 		Register resultRegister = e.getResultRegister();
-		IExpr value = (IExpr) e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface value = e.getMemValue();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
-		
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
+
+		Register dummy = e.getThread().newRegister(resultRegister.getType());
 		Load load = newRMWLoadExclusive(dummy, address, "");
-        Store store = Power.newRMWStoreConditional(address, new IExprBin(dummy, e.getOp(), value), "", true);
+        Store store = Power.newRMWStoreConditional(address, expressions.makeBinary(dummy, e.getOp(), value), "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(dummy, label);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-        		: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
 
         return eventSequence(
-        		optionalMemoryBarrierBefore,
+				optionalMemoryBarrierBefore,
                 load,
                 store,
                 newLocal(resultRegister, dummy),
@@ -887,7 +888,7 @@ public class VisitorPower extends VisitorBase {
                 optionalMemoryBarrierAfter
         );
 	}
-	
+
 	// The implementation relies on arch_atomic_fetch_add_unless
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/add_unless
 	// which uses a sub at the end to return the value before the operation
@@ -896,33 +897,34 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitRMWAddUnless(RMWAddUnless e) {
 		Register resultRegister = e.getResultRegister();
-		IExpr address = e.getAddress();
+		ExprInterface address = e.getAddress();
 		ExprInterface value = e.getMemValue();
 		String mo = e.getMo();
-		int precision = resultRegister.getPrecision();
+		IntegerType type = resultRegister.getType();
+		ExprInterface zero = expressions.makeZero(type);
 
-        Register regValue = e.getThread().newRegister(precision);
+        Register regValue = e.getThread().newRegister(type);
         // Power does not have mo tags, thus we use the empty string
         Load load = newRMWLoadExclusive(regValue, address, "");
-        Store store = Power.newRMWStoreConditional(address, new IExprBin(regValue, IOpBin.PLUS, (IExpr) value), "", true);
+        Store store = Power.newRMWStoreConditional(address, expressions.makePlus(regValue, value), "", true);
         Label label = newLabel("FakeDep");
         Event fakeCtrlDep = newFakeCtrlDep(regValue, label);
 
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
+        Register dummy = e.getThread().newRegister(type);
 		ExprInterface unless = e.getCmp();
         Label cauEnd = newLabel("CAddU_end");
-        CondJump branchOnCauCmpResult = newJump(new Atom(dummy, EQ, IValue.ZERO), cauEnd);
+        CondJump branchOnCauCmpResult = newJump(expressions.makeEqual(dummy, zero), cauEnd);
 
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-        		: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
 
         return eventSequence(
                 // Indentation shows the branching structure
                 optionalMemoryBarrierBefore,
                 load,
-                newLocal(dummy, new Atom(regValue, NEQ, unless)),
+                newLocal(dummy, expressions.makeNotEqual(regValue, unless)),
                 branchOnCauCmpResult,
                     store,
                     fakeCtrlDep,
@@ -932,7 +934,7 @@ public class VisitorPower extends VisitorBase {
                 newLocal(resultRegister, dummy)
         );
 	};
-	
+
 	// The implementation is arch_${atomic}_op_return(i, v) == 0;
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/sub_and_test
 	// 		https://elixir.bootlin.com/linux/v5.18/source/scripts/atomic/fallbacks/inc_and_test
@@ -940,15 +942,17 @@ public class VisitorPower extends VisitorBase {
 	@Override
 	public List<Event> visitRMWOpAndTest(RMWOpAndTest e) {
 		Register resultRegister = e.getResultRegister();
+		IntegerType type = resultRegister.getType();
+		ExprInterface zero = expressions.makeZero(type);
 		IOpBin op = e.getOp();
-		IExpr value = (IExpr) e.getMemValue();
-		IExpr address = e.getAddress();
+		ExprInterface value = e.getMemValue();
+		ExprInterface address = e.getAddress();
 		String mo = e.getMo();
-		
-        Register dummy = e.getThread().newRegister(resultRegister.getPrecision());
-        Register retReg = e.getThread().newRegister(resultRegister.getPrecision());
-        Local localOp = newLocal(retReg, new IExprBin(dummy, op, value));
-        Local testOp = newLocal(resultRegister, new Atom(retReg, EQ, IValue.ZERO));
+
+		Register dummy = e.getThread().newRegister(type);
+        Register retReg = e.getThread().newRegister(type);
+        Local localOp = newLocal(retReg, expressions.makeBinary(dummy, op, value));
+        Local testOp = newLocal(resultRegister, expressions.makeEqual(retReg, zero));
 
         // Power does not have mo tags, thus we use the empty string
         Load load = newRMWLoadExclusive(dummy, address, "");
@@ -959,7 +963,7 @@ public class VisitorPower extends VisitorBase {
         Fence optionalMemoryBarrierBefore = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
                 : mo.equals(Tag.Linux.MO_RELEASE) ? Power.newLwSyncBarrier() : null;
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? Power.newSyncBarrier()
-        		: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
+				: mo.equals(Tag.Linux.MO_ACQUIRE)? Power.newISyncBarrier() : null;
 
         
         return eventSequence(
@@ -973,16 +977,19 @@ public class VisitorPower extends VisitorBase {
                 testOp
         );
 	};
-	
+
 	@Override
 	public List<Event> visitLKMMLock(LKMMLock e) {
-	Register dummy = e.getThread().newRegister(GlobalSettings.getArchPrecision());
-	Label label = newLabel("FakeDep");
+		IntegerType type = types.getArchType();
+		ExprInterface zero = expressions.makeZero(type);
+		ExprInterface one = expressions.makeOne(type);
+		Register dummy = e.getThread().newRegister(type);
+		Label label = newLabel("FakeDep");
     // Spinlock events are guaranteed to succeed, i.e. we can use assumes
-	return eventSequence(
+		return eventSequence(
 				newRMWLoadExclusive(dummy, e.getLock(), ""),
-                newAssume(new Atom(dummy, COpBin.EQ, IValue.ZERO)),
-                Power.newRMWStoreConditional(e.getLock(), IValue.ONE, "", true),
+                newAssume(expressions.makeEqual(dummy, zero)),
+                Power.newRMWStoreConditional(e.getLock(), one, "", true),
 				// Fake dependency to guarantee acquire semantics
 				newFakeCtrlDep(dummy, label),
 				label,
@@ -991,16 +998,16 @@ public class VisitorPower extends VisitorBase {
 	}
 
         @Override
-	public List<Event> visitLKMMUnlock(LKMMUnlock e) {
-	return eventSequence(
-				Power.newLwSyncBarrier(),
-                newStore(e.getAddress(), IValue.ZERO, "")
+		public List<Event> visitLKMMUnlock(LKMMUnlock e) {
+			return eventSequence(
+					Power.newLwSyncBarrier(),
+                newStore(e.getAddress(), expressions.makeZero(types.getArchType()), "")
         );
-	}
+		}
 
 	public enum PowerScheme {
 
 		LEADING_SYNC, TRAILING_SYNC;
-		
+
 	}
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
@@ -66,7 +66,7 @@ class VisitorRISCV extends VisitorBase {
 	@Override
 	public List<Event> visitJoin(Join e) {
         Register resultRegister = e.getResultRegister();
-		ExprInterface zero = expressions.makeZero(resultRegister.getType());
+		Expression zero = expressions.makeZero(resultRegister.getType());
 		Load load = newLoad(resultRegister, e.getAddress(), Tag.RISCV.MO_ACQ);
         load.addTags(C11.PTHREAD);
 
@@ -79,7 +79,7 @@ class VisitorRISCV extends VisitorBase {
 	@Override
 	public List<Event> visitStart(Start e) {
         Register resultRegister = e.getResultRegister();
-		ExprInterface one = expressions.makeOne(resultRegister.getType());
+		Expression one = expressions.makeOne(resultRegister.getType());
 		Load load = newLoad(resultRegister, e.getAddress(), Tag.RISCV.MO_ACQ);
         load.addTags(Tag.STARTLOAD);
 
@@ -101,8 +101,8 @@ class VisitorRISCV extends VisitorBase {
     public List<Event> visitLock(Lock e) {
 		IntegerType type = types.getArchType();
         Register dummy = e.getThread().newRegister(type);
-		ExprInterface zero = expressions.makeZero(type);
-		ExprInterface one = expressions.makeOne(type);
+		Expression zero = expressions.makeZero(type);
+		Expression one = expressions.makeOne(type);
         // We implement locks as spinlocks which are guaranteed to succeed, i.e. we can use
         // assumes. With this we miss a ctrl dependency, but this does not matter
         // because of the fence.
@@ -152,8 +152,8 @@ class VisitorRISCV extends VisitorBase {
 	@Override
 	public List<Event> visitLlvmXchg(LlvmXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Load load = newRMWLoadExclusive(resultRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
@@ -178,8 +178,8 @@ class VisitorRISCV extends VisitorBase {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummyReg = e.getThread().newRegister(type);
@@ -208,12 +208,12 @@ class VisitorRISCV extends VisitorBase {
 	public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
 		Register oldValueRegister = e.getStructRegister(0);
 		Register resultRegister = e.getStructRegister(1);
-		ExprInterface one = expressions.makeOne(resultRegister.getType());
+		Expression one = expressions.makeOne(resultRegister.getType());
 
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
-		ExprInterface expectedValue = e.getExpectedValue();
+		Expression expectedValue = e.getExpectedValue();
 
 		Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
 		Label casEnd = newLabel("CAS_end");
@@ -261,11 +261,11 @@ class VisitorRISCV extends VisitorBase {
 	public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
-		ExprInterface one = expressions.makeOne(type);
-		ExprInterface address = e.getAddress();
-		ExprInterface value = e.getMemValue();
+		Expression one = expressions.makeOne(type);
+		Expression address = e.getAddress();
+		Expression value = e.getMemValue();
 		String mo = e.getMo();
-		ExprInterface expectedAddr = e.getExpectedAddr();
+		Expression expectedAddr = e.getExpectedAddr();
 
 		Register regExpected = e.getThread().newRegister(type);
         Register regValue = e.getThread().newRegister(type);
@@ -306,8 +306,8 @@ class VisitorRISCV extends VisitorBase {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummyReg = e.getThread().newRegister(type);
@@ -383,8 +383,8 @@ class VisitorRISCV extends VisitorBase {
 	@Override
 	public List<Event> visitAtomicXchg(AtomicXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
         Load load = newRMWLoadExclusive(resultRegister, address, Tag.RISCV.extractLoadMoFromCMo(mo));
@@ -480,8 +480,8 @@ class VisitorRISCV extends VisitorBase {
 
 	public List<Event> visitRMWCmpXchg(RMWCmpXchg e) {
 		Register resultRegister = e.getResultRegister();
-		ExprInterface address = e.getAddress();
-		ExprInterface value = e.getMemValue();
+		Expression address = e.getAddress();
+		Expression value = e.getMemValue();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(e.getResultRegister().getType());
@@ -519,8 +519,8 @@ class VisitorRISCV extends VisitorBase {
 	public List<Event> visitRMWXchg(RMWXchg e) {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(type);
@@ -553,8 +553,8 @@ class VisitorRISCV extends VisitorBase {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
         Register dummy = e.getThread().newRegister(type);
@@ -585,8 +585,8 @@ class VisitorRISCV extends VisitorBase {
 	public List<Event> visitRMWFetchOp(RMWFetchOp e) {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(type);
@@ -621,10 +621,10 @@ class VisitorRISCV extends VisitorBase {
 	public List<Event> visitRMWOpReturn(RMWOpReturn e) {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
-		ExprInterface zero = expressions.makeZero(type);
+		Expression zero = expressions.makeZero(type);
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(type);
@@ -660,8 +660,8 @@ class VisitorRISCV extends VisitorBase {
 	public List<Event> visitRMWAddUnless(RMWAddUnless e) {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
-		ExprInterface address = e.getAddress();
-		ExprInterface value = e.getMemValue();
+		Expression address = e.getAddress();
+		Expression value = e.getMemValue();
 		String mo = e.getMo();
 
         Register regValue = e.getThread().newRegister(type);
@@ -675,7 +675,7 @@ class VisitorRISCV extends VisitorBase {
         Event fakeCtrlDep = newFakeCtrlDep(regValue, label);
 
         Register dummy = e.getThread().newRegister(resultRegister.getType());
-		ExprInterface unless = e.getCmp();
+		Expression unless = e.getCmp();
         Label cauEnd = newLabel("CAddU_end");
         CondJump branchOnCauCmpResult = newJump(expressions.makeEqual(dummy, expressions.makeZero(type)), cauEnd);
         Fence optionalMemoryBarrierAfter = mo.equals(Tag.Linux.MO_MB) ? RISCV.newRWRWFence() : mo.equals(Tag.Linux.MO_ACQUIRE) ? RISCV.newRRWFence() : null;
@@ -704,8 +704,8 @@ class VisitorRISCV extends VisitorBase {
 		Register resultRegister = e.getResultRegister();
 		IntegerType type = resultRegister.getType();
 		IOpBin op = e.getOp();
-		ExprInterface value = e.getMemValue();
-		ExprInterface address = e.getAddress();
+		Expression value = e.getMemValue();
+		Expression address = e.getAddress();
 		String mo = e.getMo();
 
 		Register dummy = e.getThread().newRegister(type);
@@ -736,8 +736,8 @@ class VisitorRISCV extends VisitorBase {
 	@Override
 	public List<Event> visitLKMMLock(LKMMLock e) {
 		IntegerType type = types.getArchType();
-		ExprInterface one = expressions.makeOne(type);
-		ExprInterface zero = expressions.makeZero(type);
+		Expression one = expressions.makeOne(type);
+		Expression zero = expressions.makeZero(type);
 		Register dummy = e.getThread().newRegister(type);
     // From this "unofficial" source (there is no RISCV specific implementation in the kernel)
 		// 		https://github.com/westerndigitalcorporation/RISC-V-Linux/blob/master/linux/arch/riscv/include/asm/spinlock.h

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -65,7 +65,7 @@ class VisitorTso extends VisitorBase {
 
                 return tagList(eventSequence(
                                 load,
-                                newJump(expressions.makeNotEqual(resultRegister, zero),
+                                newJump(expressions.makeNEQ(resultRegister, zero),
                                                 (Label) e.getThread().getExit())));
         }
 
@@ -79,7 +79,7 @@ class VisitorTso extends VisitorBase {
                 return tagList(eventSequence(
                                 load,
                                 super.visitStart(e),
-                                newJump(expressions.makeNotEqual(resultRegister, one),
+                                newJump(expressions.makeNEQ(resultRegister, one),
                                                 (Label) e.getThread().getExit())));
         }
 
@@ -98,7 +98,7 @@ class VisitorTso extends VisitorBase {
             Load load = newRMWLoad(dummy, e.getAddress(), "");
             return eventSequence(
                     load,
-                    newAssume(expressions.makeEqual(dummy, expressions.makeZero(type))),
+                    newAssume(expressions.makeEQ(dummy, expressions.makeZero(type))),
                     newRMWStore(load, e.getAddress(), expressions.makeOne(type), ""));
         }
 
@@ -162,9 +162,9 @@ class VisitorTso extends VisitorBase {
                 Expression address = e.getAddress();
                 Expression expectedValue = e.getExpectedValue();
 
-                Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
+                Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(oldValueRegister, expectedValue));
                 Label casEnd = newLabel("CAS_end");
-                CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casEnd);
+                CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casEnd);
 
                 Load load = newRMWLoad(oldValueRegister, address, "");
                 Store store = newRMWStore(load, address, value, "");
@@ -204,9 +204,9 @@ class VisitorTso extends VisitorBase {
                 Load loadExpected = newLoad(regExpected, expectedAddr, "");
                 Register regValue = e.getThread().newRegister(type);
                 Load loadValue = newRMWLoad(regValue, address, mo);
-                Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(regValue, regExpected));
+                Local casCmpResult = newLocal(resultRegister, expressions.makeEQ(regValue, regExpected));
                 Label casFail = newLabel("CAS_fail");
-                CondJump branchOnCasCmpResult = newJump(expressions.makeNotEqual(resultRegister, one), casFail);
+                CondJump branchOnCasCmpResult = newJump(expressions.makeNEQ(resultRegister, one), casFail);
                 Store storeValue = newRMWStore(loadValue, address, value, mo);
                 Label casEnd = newLabel("CAS_end");
                 CondJump gotoCasEnd = newGoto(casEnd);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.program.processing.compilation;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -24,7 +24,7 @@ class VisitorTso extends VisitorBase {
         @Override
         public List<Event> visitXchg(Xchg e) {
                 Register resultRegister = e.getResultRegister();
-                ExprInterface address = e.getAddress();
+                Expression address = e.getAddress();
 
                 Register dummyReg = e.getThread().newRegister(resultRegister.getType());
                 Load load = newRMWLoad(dummyReg, address, "");
@@ -59,7 +59,7 @@ class VisitorTso extends VisitorBase {
         @Override
         public List<Event> visitJoin(Join e) {
                 Register resultRegister = e.getResultRegister();
-                ExprInterface zero = expressions.makeZero(resultRegister.getType());
+                Expression zero = expressions.makeZero(resultRegister.getType());
                 Load load = newLoad(resultRegister, e.getAddress(), "");
                 load.addTags(C11.PTHREAD);
 
@@ -72,7 +72,7 @@ class VisitorTso extends VisitorBase {
         @Override
         public List<Event> visitStart(Start e) {
                 Register resultRegister = e.getResultRegister();
-                ExprInterface one = expressions.makeOne(resultRegister.getType());
+                Expression one = expressions.makeOne(resultRegister.getType());
                 Load load = newLoad(resultRegister, e.getAddress(), "");
                 load.addTags(Tag.STARTLOAD);
 
@@ -130,7 +130,7 @@ class VisitorTso extends VisitorBase {
 
         @Override
         public List<Event> visitLlvmXchg(LlvmXchg e) {
-                ExprInterface address = e.getAddress();
+                Expression address = e.getAddress();
                 Load load = newRMWLoad(e.getResultRegister(), address, "");
 
                 return tagList(eventSequence(
@@ -143,7 +143,7 @@ class VisitorTso extends VisitorBase {
                 Register resultRegister = e.getResultRegister();
                 Register dummyReg = e.getThread().newRegister(resultRegister.getType());
 
-                ExprInterface address = e.getAddress();
+                Expression address = e.getAddress();
                 Load load = newRMWLoad(resultRegister, address, "");
 
                 return tagList(eventSequence(
@@ -156,11 +156,11 @@ class VisitorTso extends VisitorBase {
         public List<Event> visitLlvmCmpXchg(LlvmCmpXchg e) {
                 Register oldValueRegister = e.getStructRegister(0);
                 Register resultRegister = e.getStructRegister(1);
-                ExprInterface one = expressions.makeOne(resultRegister.getType());
+                Expression one = expressions.makeOne(resultRegister.getType());
 
-                ExprInterface value = e.getMemValue();
-                ExprInterface address = e.getAddress();
-                ExprInterface expectedValue = e.getExpectedValue();
+                Expression value = e.getMemValue();
+                Expression address = e.getAddress();
+                Expression expectedValue = e.getExpectedValue();
 
                 Local casCmpResult = newLocal(resultRegister, expressions.makeEqual(oldValueRegister, expectedValue));
                 Label casEnd = newLabel("CAS_end");
@@ -193,12 +193,12 @@ class VisitorTso extends VisitorBase {
         @Override
         public List<Event> visitAtomicCmpXchg(AtomicCmpXchg e) {
                 Register resultRegister = e.getResultRegister();
-                ExprInterface address = e.getAddress();
-                ExprInterface value = e.getMemValue();
+                Expression address = e.getAddress();
+                Expression value = e.getMemValue();
                 String mo = e.getMo();
-                ExprInterface expectedAddr = e.getExpectedAddr();
+                Expression expectedAddr = e.getExpectedAddr();
                 IntegerType type = resultRegister.getType();
-                ExprInterface one = expressions.makeOne(type);
+                Expression one = expressions.makeOne(type);
 
                 Register regExpected = e.getThread().newRegister(type);
                 Load loadExpected = newLoad(regExpected, expectedAddr, "");
@@ -230,7 +230,7 @@ class VisitorTso extends VisitorBase {
                 Register resultRegister = e.getResultRegister();
                 Register dummyReg = e.getThread().newRegister(resultRegister.getType());
 
-                ExprInterface address = e.getAddress();
+                Expression address = e.getAddress();
                 String mo = e.getMo();
                 Load load = newRMWLoad(resultRegister, address, mo);
 
@@ -265,7 +265,7 @@ class VisitorTso extends VisitorBase {
 
         @Override
         public List<Event> visitAtomicXchg(AtomicXchg e) {
-            ExprInterface address = e.getAddress();
+            Expression address = e.getAddress();
             String mo = e.getMo();
             Load load = newRMWLoad(e.getResultRegister(), address, mo);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/specification/AssertBasic.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/specification/AssertBasic.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program.specification;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.op.COpBin;
 import com.dat3m.dartagnan.program.Register;
 import org.sosy_lab.java_smt.api.BooleanFormula;
@@ -11,11 +11,11 @@ import java.util.List;
 
 public class AssertBasic extends AbstractAssert {
 
-    private final ExprInterface e1;
-    private final ExprInterface e2;
+    private final Expression e1;
+    private final Expression e2;
     private final COpBin op;
 
-    public AssertBasic(ExprInterface e1, COpBin op, ExprInterface e2){
+    public AssertBasic(Expression e1, COpBin op, Expression e2){
         this.e1 = e1;
         this.e2 = e2;
         this.op = op;
@@ -33,7 +33,7 @@ public class AssertBasic extends AbstractAssert {
         return valueToString(e1) + op + valueToString(e2);
     }
 
-    private String valueToString(ExprInterface value){
+    private String valueToString(Expression value){
         if(value instanceof Register){
             return ((Register)value).getThreadId() + ":" + value;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.utils.visualization;
 
-import com.dat3m.dartagnan.expression.IExpr;
+import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
@@ -40,7 +40,7 @@ public class ExecutionGraphVisualizer {
     private BiPredicate<EventData, EventData> rfFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> frFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> coFilter = (x, y) -> true;
-    private Map<BigInteger, IExpr> addresses = new HashMap<BigInteger, IExpr>();
+    private final Map<BigInteger, ExprInterface> addresses = new HashMap<>();
 
     public ExecutionGraphVisualizer() {
         this.graphviz = new Graphviz();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/visualization/ExecutionGraphVisualizer.java
@@ -1,6 +1,6 @@
 package com.dat3m.dartagnan.utils.visualization;
 
-import com.dat3m.dartagnan.expression.ExprInterface;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
@@ -40,7 +40,7 @@ public class ExecutionGraphVisualizer {
     private BiPredicate<EventData, EventData> rfFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> frFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> coFilter = (x, y) -> true;
-    private final Map<BigInteger, ExprInterface> addresses = new HashMap<>();
+    private final Map<BigInteger, Expression> addresses = new HashMap<>();
 
     public ExecutionGraphVisualizer() {
         this.graphviz = new Graphviz();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
@@ -66,7 +66,7 @@ public class ExceptionsTest {
         // Both arguments should have same precision
         Register a = new Register("a", 0, types.getIntegerType(32));
         Register b = new Register("b", 0, types.getIntegerType(64));
-        ExpressionFactory.getInstance().makePlus(a, b);
+        ExpressionFactory.getInstance().makeADD(a, b);
     }
 
     @Test(expected = NullPointerException.class)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/exceptions/ExceptionsTest.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.exceptions;
 
 import com.dat3m.dartagnan.exception.MalformedProgramException;
 import com.dat3m.dartagnan.expression.*;
-import com.dat3m.dartagnan.expression.op.IOpBin;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
@@ -37,9 +36,9 @@ public class ExceptionsTest {
         ProgramBuilder pb = new ProgramBuilder(SourceLanguage.LITMUS);
         pb.initThread(0);
         Thread t = pb.build().getThreads().get(0);
-        t.newRegister("r1", -1);
+        t.newRegister("r1", types.getIntegerType());
         // Adding same register a second time
-        t.newRegister("r1", -1);
+        t.newRegister("r1", types.getIntegerType());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -67,7 +66,7 @@ public class ExceptionsTest {
         // Both arguments should have same precision
         Register a = new Register("a", 0, types.getIntegerType(32));
         Register b = new Register("b", 0, types.getIntegerType(64));
-        new IExprBin(a, IOpBin.PLUS, b);
+        ExpressionFactory.getInstance().makePlus(a, b);
     }
 
     @Test(expected = NullPointerException.class)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -2,8 +2,8 @@ package com.dat3m.dartagnan.miscellaneous;
 
 import com.dat3m.dartagnan.configuration.Alias;
 import com.dat3m.dartagnan.expression.BNonDet;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.ExprInterface;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
@@ -379,27 +379,27 @@ public class AnalysisTest {
         assertAlias(expect[5], a, me2, me3);
     }
 
-    private Load newLoad(Register value, ExprInterface address) {
+    private Load newLoad(Register value, Expression address) {
         return EventFactory.newLoad(value, address, "");
     }
 
-    private Store newStore(ExprInterface address) {
+    private Store newStore(Expression address) {
         return newStore(address, expressions.makeZero(types.getArchType()));
     }
 
-    private Store newStore(ExprInterface address, ExprInterface value) {
+    private Store newStore(Expression address, Expression value) {
         return EventFactory.newStore(address, value, "");
     }
 
-    private ExprInterface value(long v) {
+    private Expression value(long v) {
         return expressions.makeValue(BigInteger.valueOf(v), types.getArchType());
     }
 
-    private ExprInterface plus(ExprInterface lhs, long rhs) {
+    private Expression plus(Expression lhs, long rhs) {
         return expressions.makePlus(lhs, value(rhs));
     }
 
-    private ExprInterface mult(ExprInterface lhs, long rhs) {
+    private Expression mult(Expression lhs, long rhs) {
         return expressions.makeMultiply(lhs, value(rhs));
     }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -213,8 +213,8 @@ public class AnalysisTest {
         b.addChild(0, newLocal(r0, b.newConstant(type, true)));
         Label l0 = b.getOrCreateLabel("l0");
         b.addChild(0, newJump(expressions.makeOr(
-                expressions.makeGreater(r0, expressions.makeOne(type), true),
-                expressions.makeLess(r0, expressions.makeZero(type), true)), l0));
+                expressions.makeGT(r0, expressions.makeOne(type), true),
+                expressions.makeLT(r0, expressions.makeZero(type), true)), l0));
         Store e0 = newStore(x);
         b.addChild(0, e0);
         Store e1 = newStore(plus(x, 1));
@@ -223,8 +223,8 @@ public class AnalysisTest {
         b.addChild(0, e2);
         Register r1 = b.getOrNewRegister(0, "r1");
         b.addChild(0, newLocal(r1, expressions.makeZero(type)));
-        Store e3 = newStore(expressions.makePlus(
-                expressions.makePlus(x, mult(r0, 2)),
+        Store e3 = newStore(expressions.makeADD(
+                expressions.makeADD(x, mult(r0, 2)),
                 mult(r1, 4)));
         b.addChild(0, e3);
         b.addChild(0, l0);
@@ -396,11 +396,11 @@ public class AnalysisTest {
     }
 
     private Expression plus(Expression lhs, long rhs) {
-        return expressions.makePlus(lhs, value(rhs));
+        return expressions.makeADD(lhs, value(rhs));
     }
 
     private Expression mult(Expression lhs, long rhs) {
-        return expressions.makeMultiply(lhs, value(rhs));
+        return expressions.makeMUL(lhs, value(rhs));
     }
 
     private AliasAnalysis analyze(Program program, Alias method) throws InvalidConfigurationException {


### PR DESCRIPTION
Redirects most direct expression constructors all over the project to the new class `ExpressionFactory`.  Currently, this class is a singleton, like `TypeFactory`.  Eventually, there would be a configurable instance linked to the input program.

`ExprInterface` has been renamed to `Expression`.  `IExpr.getPrecision()` has been completely replaced with `Expression.getType()`.  The sections most affected by these changes are the parsers and compilers.

Usages of the architecture type, a unification of a pointer type and a pointer difference type, were replaced by a syntactically fitting type, if available.  This includes `IValue.ZERO` and `IValue.ONE`, which were removed.