### PR TITLE
[Prototype] Core memory events

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/Register.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/Register.java
@@ -25,7 +25,7 @@ public class Register extends LeafExpressionBase<Type, ExpressionKind.Leaf> {
         return new Register(type, name, owner);
     }
 
-    public static void collectRegisterReads(Expression expr, UsageType depType, Set<Read> collector) {
+    public static Set<Read> collectRegisterReads(Expression expr, UsageType depType, Set<Read> collector) {
         if (expr instanceof Register reg) {
             collector.add(new Read(reg, depType));
         } else {
@@ -33,6 +33,7 @@ public class Register extends LeafExpressionBase<Type, ExpressionKind.Leaf> {
                 collectRegisterReads(child, depType, collector);
             }
         }
+        return collector;
     }
 
     public String getName() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/MemoryAccess.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/MemoryAccess.java
@@ -5,7 +5,7 @@ import com.dat3m.dartagnan.prototype.expr.Type;
 
 public record MemoryAccess(Expression address, Type accessType, Mode mode) {
     public enum Mode {
-        LOAD, STORE, OTHER;
+        LOAD, STORE, RMW, OTHER;
     }
 
     public MemoryAccess withAddress(Expression address) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/AbstractCoreMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/AbstractCoreMemoryEvent.java
@@ -1,0 +1,31 @@
+package com.dat3m.dartagnan.prototype.program.event.core.memory;
+
+import com.dat3m.dartagnan.prototype.expr.Expression;
+import com.dat3m.dartagnan.prototype.expr.Type;
+import com.dat3m.dartagnan.prototype.program.event.AbstractEvent;
+
+public abstract class AbstractCoreMemoryEvent extends AbstractEvent implements MemoryCoreEvent {
+
+    protected Expression address;
+    protected Type accessType;
+    protected String memoryOrder;
+
+    protected AbstractCoreMemoryEvent(Expression address, Type type, String mo) {
+        this.address = address;
+        this.accessType = type;
+        this.memoryOrder = mo;
+    }
+
+    @Override
+    public Expression getAddress() { return address; }
+    @Override
+    public void setAddress(Expression address) { this.address = address; }
+
+    @Override
+    public Type getAccessType() { return accessType; }
+    @Override
+    public void setAccessType(Type type) { this.accessType = type; }
+
+    @Override
+    public String getMo() { return memoryOrder; }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/GenericMemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/GenericMemoryEvent.java
@@ -1,0 +1,22 @@
+package com.dat3m.dartagnan.prototype.program.event.core.memory;
+
+import com.dat3m.dartagnan.prototype.expr.Expression;
+import com.dat3m.dartagnan.prototype.expr.types.VoidType;
+import com.dat3m.dartagnan.prototype.program.event.MemoryAccess;
+
+/*
+    A GenericMemoryEvent is used as the basis for implementing special (abstract) memory events like
+    SRCU and Hazard pointers.
+    For now, generic memory events are type-less.
+ */
+public abstract class GenericMemoryEvent extends AbstractCoreMemoryEvent {
+
+    protected GenericMemoryEvent(Expression address) {
+        super(address, VoidType.get(), "");
+    }
+
+    @Override
+    public MemoryAccess.Mode getAccessMode() {
+        return MemoryAccess.Mode.OTHER;
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/Init.java
@@ -2,40 +2,16 @@ package com.dat3m.dartagnan.prototype.program.event.core.memory;
 
 import com.dat3m.dartagnan.prototype.expr.Constant;
 import com.dat3m.dartagnan.prototype.expr.Expression;
-import com.dat3m.dartagnan.prototype.expr.Type;
-import com.dat3m.dartagnan.prototype.program.Register;
-import com.dat3m.dartagnan.prototype.program.event.AbstractEvent;
-import com.dat3m.dartagnan.prototype.program.event.MemoryAccess;
-import com.dat3m.dartagnan.prototype.program.event.MemoryEvent;
-
-import java.util.List;
-import java.util.Set;
 
 // TODO: "abstract" is only here to avoid providing a complete implementation for now
-public abstract class Init extends AbstractEvent implements MemoryEvent {
-    protected final MemoryAccess memoryAccess;
-    protected final Constant value;
+public abstract class Init extends Store {
 
     protected Init(Expression address, Constant value) {
-        this.memoryAccess = new MemoryAccess(address, value.getType(), MemoryAccess.Mode.STORE);
-        this.value = value;
+        super(address, value);
     }
 
-    public Expression getAddress() {
-        return memoryAccess.address();
-    }
-    public Expression getValue() {
-        return value;
-    }
-    public Type getValueType() { return value.getType(); }
-
-    @Override
-    public List<MemoryAccess> getMemoryAccesses() {
-        return List.of(memoryAccess);
+    public Constant getValue() {
+        return (Constant) value;
     }
 
-    @Override
-    public Set<Register.Read> getRegisterReads() {
-        return Set.of();
-    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/Load.java
@@ -1,34 +1,24 @@
 package com.dat3m.dartagnan.prototype.program.event.core.memory;
 
 import com.dat3m.dartagnan.prototype.expr.Expression;
-import com.dat3m.dartagnan.prototype.expr.Type;
 import com.dat3m.dartagnan.prototype.program.Register;
-import com.dat3m.dartagnan.prototype.program.event.AbstractEvent;
 import com.dat3m.dartagnan.prototype.program.event.MemoryAccess;
-import com.dat3m.dartagnan.prototype.program.event.MemoryEvent;
-
-import java.util.List;
 
 // TODO: "abstract" is only here to avoid providing a complete implementation for now
-public abstract class Load extends AbstractEvent implements MemoryEvent, Register.Writer {
+public abstract class Load extends AbstractCoreMemoryEvent implements Register.Writer {
     private final Register resultRegister;
-    private final MemoryAccess memoryAccess;
 
     protected Load(Register resultRegister, Expression address) {
+        super(address, resultRegister.getType(), "");
         this.resultRegister = resultRegister;
-        this.memoryAccess = new MemoryAccess(address, resultRegister.getType(), MemoryAccess.Mode.LOAD);
     }
 
-    public Expression getAddress() {
-        return memoryAccess.address();
-    }
-    public Type getValueType() { return memoryAccess.accessType(); }
 
     @Override
     public Register getResultRegister() { return resultRegister; }
 
     @Override
-    public List<MemoryAccess> getMemoryAccesses() {
-        return List.of(memoryAccess);
+    public MemoryAccess.Mode getAccessMode() {
+        return MemoryAccess.Mode.LOAD;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/MemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/MemoryCoreEvent.java
@@ -1,0 +1,46 @@
+package com.dat3m.dartagnan.prototype.program.event.core.memory;
+
+import com.dat3m.dartagnan.prototype.expr.Expression;
+import com.dat3m.dartagnan.prototype.expr.Type;
+import com.dat3m.dartagnan.prototype.program.Register;
+import com.dat3m.dartagnan.prototype.program.event.MemoryAccess;
+import com.dat3m.dartagnan.prototype.program.event.MemoryEvent;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/*
+
+    Core memory events are the only memory events whose analysis and encoding we fully support.
+    These memory events are "simple" in the sense that they always access a single address with a single access type.
+    There are 4 major types of core memory events: Load, Store, ReadModifyWrite, and "Generic".
+        - Load/Store are as expected, but they may have more specialized subclasses like Init, RMWLoadExclusive, and RMWStore
+        - ReadModifyWrite is a core event that represents single-node(!) RMWs.
+          Typically, RMWs can also be implemented with two events using LL/SC (i.e. Load + Store).
+        - "GenericMemoryEvent" is a baseclass for abstract notions of memory events that neither load nor store,
+           but still have a memory address (e.g., SRCU or hazard pointers).
+
+     All other high-level/complex memory events need to get compiled down to one or more core memory events.
+ */
+public interface MemoryCoreEvent extends MemoryEvent {
+
+    Expression getAddress();
+    void setAddress(Expression address);
+
+    Type getAccessType();
+    void setAccessType(Type type);
+
+    MemoryAccess.Mode getAccessMode(); // Not sure if needed anymore.
+    String getMo(); // Not sure if needed...
+
+    @Override
+    default List<MemoryAccess> getMemoryAccesses() {
+        return List.of(new MemoryAccess(getAddress(), getAccessType(), getAccessMode()));
+    }
+
+    @Override
+    default Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(getAddress(), Register.UsageType.ADDR, new HashSet<>());
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/ReadModifyWrite.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/ReadModifyWrite.java
@@ -1,0 +1,27 @@
+package com.dat3m.dartagnan.prototype.program.event.core.memory;
+
+import com.dat3m.dartagnan.prototype.expr.Expression;
+import com.dat3m.dartagnan.prototype.expr.ExpressionKind;
+import com.dat3m.dartagnan.prototype.program.event.MemoryAccess;
+
+// TODO: "abstract" is only here to avoid providing a complete implementation for now
+// This is used to model RMW/AMO as a single core event. This cannot model CAS.
+public abstract class ReadModifyWrite extends AbstractCoreMemoryEvent {
+
+    protected ExpressionKind.IntBinary opCode; // TODO: Can we allow for any binary operator?
+    protected Expression operand;
+
+    protected ReadModifyWrite(Expression address, Expression operand, ExpressionKind.IntBinary opCode) {
+        super(address, operand.getType(), "");
+        this.opCode = opCode;
+        this.operand = operand;
+    }
+
+    public ExpressionKind.IntBinary getOpCode() {
+        return opCode;
+    }
+    public Expression getOperand() { return operand;}
+
+    @Override
+    public MemoryAccess.Mode getAccessMode() { return MemoryAccess.Mode.RMW; }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/prototype/program/event/core/memory/Store.java
@@ -1,42 +1,21 @@
 package com.dat3m.dartagnan.prototype.program.event.core.memory;
 
 import com.dat3m.dartagnan.prototype.expr.Expression;
-import com.dat3m.dartagnan.prototype.expr.Type;
-import com.dat3m.dartagnan.prototype.program.Register;
-import com.dat3m.dartagnan.prototype.program.event.AbstractEvent;
 import com.dat3m.dartagnan.prototype.program.event.MemoryAccess;
-import com.dat3m.dartagnan.prototype.program.event.MemoryEvent;
-
-import java.util.List;
-import java.util.Set;
 
 // TODO: "abstract" is only here to avoid providing a complete implementation for now
-public abstract class Store extends AbstractEvent implements MemoryEvent {
-    protected final MemoryAccess memoryAccess;
+public abstract class Store extends AbstractCoreMemoryEvent {
     protected final Expression value;
 
     protected Store(Expression address, Expression value) {
-        this.memoryAccess = new MemoryAccess(address, value.getType(), MemoryAccess.Mode.STORE);
+        super(address, value.getType(), "");
         this.value = value;
     }
 
-    public Expression getAddress() {
-        return memoryAccess.address();
-    }
     public Expression getValue() {
         return value;
     }
-    public Type getValueType() { return value.getType(); }
 
     @Override
-    public List<MemoryAccess> getMemoryAccesses() {
-        return List.of(memoryAccess);
-    }
-
-    @Override
-    public Set<Register.Read> getRegisterReads() {
-        final Set<Register.Read> regReads = MemoryEvent.super.getRegisterReads();
-        Register.collectRegisterReads(value, Register.UsageType.DATA, regReads);
-        return regReads;
-    }
+    public MemoryAccess.Mode getAccessMode() { return MemoryAccess.Mode.STORE; }
 }


### PR DESCRIPTION
This PR updates only the prototype code (according to #446 ).

This PR adds a `CoreMemoryEvent` interface that has essentially 4 implementations: `Load`, `Store`, `ReadModifyWrite`, and `GenericMemoryEvent`.
The former two are self-explanatory. `ReadModifyWrite` is for single-event RMWs/AMOs and essentially amounts to a `RMWOp` event (read -> local op -> write).
`GenericMemoryEvent` is used for more abstract kinds of memory events like "SRCU", "Hazard Pointers (SMR)", or abstract locking. This event has an address but no access type (since it neither loads nor stores values).

I want to use this PR for discussions about how memory events should be modelled, what we want to support in the core, etc.
Depending on the result of this discussion, I will update PR #456 accordingly.