### PR TITLE
Barrier

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
@@ -160,7 +160,7 @@ public final class Tag {
         public static final String MO_MB                    = "Mb";
         public static final String MO_RMB                   = "Rmb";
         public static final String MO_WMB                   = "Wmb";
-        public static final String BARRIER                  = "BARRIER";
+        public static final String BARRIER                  = "Barrier";
         public static final String MO_RELAXED               = "Relaxed";
         public static final String MO_RELEASE               = "Release";
         public static final String MO_ACQUIRE               = "Acquire";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
@@ -160,6 +160,7 @@ public final class Tag {
         public static final String MO_MB                    = "Mb";
         public static final String MO_RMB                   = "Rmb";
         public static final String MO_WMB                   = "Wmb";
+        public static final String BARRIER                  = "BARRIER";
         public static final String MO_RELAXED               = "Relaxed";
         public static final String MO_RELEASE               = "Release";
         public static final String MO_ACQUIRE               = "Acquire";
@@ -199,6 +200,7 @@ public final class Tag {
                 case 10:    return BEFORE_ATOMIC;
                 case 11:    return AFTER_ATOMIC;
                 case 12:    return AFTER_SPINLOCK;
+                case 13:    return BARRIER;
                 default:
                     throw new UnsupportedOperationException("The memory order is not recognized");
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -411,6 +411,10 @@ class VisitorArm8 extends VisitorBase {
             case Tag.Linux.AFTER_UNLOCK_LOCK:
                 optionalMemoryBarrier = AArch64.DSB.newISHBarrier();
                 break;
+            // https://elixir.bootlin.com/linux/v6.1/source/include/linux/compiler.h#L86
+            case Tag.Linux.BARRIER:
+                optionalMemoryBarrier = null;
+                break;
             default:
                 throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -692,6 +692,10 @@ public class VisitorPower extends VisitorBase {
             case Tag.Linux.AFTER_UNLOCK_LOCK:
 				optionalMemoryBarrier = Power.newSyncBarrier();
                 break;
+            // https://elixir.bootlin.com/linux/v6.1/source/include/linux/compiler.h#L86
+            case Tag.Linux.BARRIER:
+                optionalMemoryBarrier = null;
+                break;
 			default:
 				throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
 		}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -464,6 +464,10 @@ class VisitorRISCV extends VisitorBase {
             case Tag.Linux.AFTER_UNLOCK_LOCK:
 				optionalMemoryBarrier = RISCV.newRWRWFence();
 				break;
+            // https://elixir.bootlin.com/linux/v6.1/source/include/linux/compiler.h#L86
+            case Tag.Linux.BARRIER:
+                optionalMemoryBarrier = null;
+                break;
 			default:
 				throw new UnsupportedOperationException("Compilation of fence " + e.getName() + " is not supported");
 		}

--- a/include/lkmm.h
+++ b/include/lkmm.h
@@ -14,6 +14,7 @@ typedef enum memory_order {
   before_atomic,
   after_atomic,
   after_spinlock,
+  barrier,
 } memory_order;
 
 typedef enum operation {
@@ -42,7 +43,7 @@ extern int __LKMM_ATOMIC_OP_RETURN(int*, int, memory_order, operation);
 
 /* Fences */
 
-#define barrier() __asm__ __volatile__ (""   : : : "memory")
+#define barrier() __LKMM_FENCE(barrier)
 
 #define smp_mb()  __LKMM_FENCE(mb)
 #define smp_rmb() __LKMM_FENCE(rmb)


### PR DESCRIPTION
We have been treating compiler barriers as no ops in LKMM. [This is wrong](https://github.com/hernanponcedeleon/Dat3M/blob/b3c7d9a7ba5cd5230414bdcdfa3880abd44d9f84/cat/linux-kernel.cat#L75). For the architectures we support, the barrier is indeed a no op, thus the compilation to those archs has been updated.