### PR TITLE
Add fix-irreducible and loop-simplify passes to ATOMIC_REPLACE_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ At least the following compiler flag needs to be set, further can be added (only
 ```
 export CFLAGS="-I$DAT3M_HOME/include"
 export SMACK_FLAGS="-q -t --no-memory-splitting"
-export ATOMIC_REPLACE_OPTS="-mem2reg -sroa -early-cse -indvars -loop-unroll -simplifycfg -gvn"
+export ATOMIC_REPLACE_OPTS="-mem2reg -sroa -early-cse -indvars -loop-unroll -fix-irreducible -loop-simplify -simplifycfg -gvn"
 ```
 
 If you are verifying C code, be sure both `clang` and `smack` are in your `PATH`.


### PR DESCRIPTION
This fixes #489 and #465 

I manually tested in some of the C benchmarks, and we get the expected results.