### PR TITLE
Thread cf & must edges

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
@@ -112,7 +112,7 @@ public class ProgramEncoder implements Encoder {
 
     private BooleanFormula encodeThreadCF(Thread thread) {
         final BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
-        final ThreadStart startEvent = (ThreadStart) thread.getEntry();
+        final ThreadStart startEvent = thread.getEntry();
         final List<BooleanFormula> enc = new ArrayList<>();
 
         final BooleanFormula cfStart = context.controlFlow(startEvent);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -104,13 +104,12 @@ public class ProgramBuilder {
     // ----------------------------------------------------------------------------------------------------------------
     // Threads and Functions
 
+    // This method creates a "default" thread that has no parameters, no return value, and runs unconditionally.
+    // It is only useful for creating threads of Litmus code.
     public Thread newThread(String name, int tid) {
         if(id2FunctionsMap.containsKey(tid)) {
             throw new MalformedProgramException("Function or thread with id " + tid + " already exists.");
         }
-        // TODO: We use a default thread type with no parameters and no return type for now
-        //  because the function type is still ignored for threads. In the future, we will assign
-        //  proper types.
         final Thread thread = new Thread(name, DEFAULT_THREAD_TYPE, List.of(), tid, EventFactory.newThreadStart(null));
         id2FunctionsMap.put(tid, thread);
         program.addThread(thread);
@@ -291,6 +290,7 @@ public class ProgramBuilder {
         if(id2FunctionsMap.containsKey(id)) {
             throw new MalformedProgramException("Function or thread with id " + id + " already exists.");
         }
+        // Litmus threads run unconditionally (have no creator) and have no parameters/return types.
         ThreadStart threadEntry = EventFactory.newThreadStart(null);
         PTXThread ptxThread = new PTXThread(name, DEFAULT_THREAD_TYPE, List.of(), id, threadEntry, gpuID, ctaID);
         id2FunctionsMap.put(id, ptxThread);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -20,7 +20,6 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Label;
-import com.dat3m.dartagnan.program.event.core.Skip;
 import com.dat3m.dartagnan.program.event.metadata.OriginalId;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -111,7 +110,7 @@ public class ProgramBuilder {
         // TODO: We use a default thread type with no parameters and no return type for now
         //  because the function type is still ignored for threads. In the future, we will assign
         //  proper types.
-        final Thread thread = new Thread(name, DEFAULT_THREAD_TYPE, List.of(), tid, EventFactory.newSkip());
+        final Thread thread = new Thread(name, DEFAULT_THREAD_TYPE, List.of(), tid, EventFactory.newThreadStart(null));
         id2FunctionsMap.put(tid, thread);
         program.addThread(thread);
         return thread;
@@ -291,7 +290,7 @@ public class ProgramBuilder {
         if(id2FunctionsMap.containsKey(id)) {
             throw new MalformedProgramException("Function or thread with id " + id + " already exists.");
         }
-        Skip threadEntry = EventFactory.newSkip();
+        Event threadEntry = EventFactory.newThreadStart(null);
         PTXThread ptxThread = new PTXThread(name, DEFAULT_THREAD_TYPE, List.of(), id, threadEntry, gpuID, ctaID);
         id2FunctionsMap.put(id, ptxThread);
         program.addThread(ptxThread);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -20,6 +20,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
 import com.dat3m.dartagnan.program.event.core.Label;
+import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.dat3m.dartagnan.program.event.metadata.OriginalId;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -290,7 +291,7 @@ public class ProgramBuilder {
         if(id2FunctionsMap.containsKey(id)) {
             throw new MalformedProgramException("Function or thread with id " + id + " already exists.");
         }
-        Event threadEntry = EventFactory.newThreadStart(null);
+        ThreadStart threadEntry = EventFactory.newThreadStart(null);
         PTXThread ptxThread = new PTXThread(name, DEFAULT_THREAD_TYPE, List.of(), id, threadEntry, gpuID, ctaID);
         id2FunctionsMap.put(id, ptxThread);
         program.addThread(ptxThread);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/ScopedThread/PTXThread.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/ScopedThread/PTXThread.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.ScopedThread;
 
 import com.dat3m.dartagnan.expression.type.FunctionType;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 
 import java.util.List;
 
@@ -10,7 +10,7 @@ public class PTXThread extends ScopedThread {
 
     // There is a unique system level
 
-    public PTXThread(String name, FunctionType funcType, List<String> parameterNames, int id, Event entry,
+    public PTXThread(String name, FunctionType funcType, List<String> parameterNames, int id, ThreadStart entry,
                      int GpuId, int CtaId) {
         super(name, funcType, parameterNames, id,  entry);
         this.scopeIds.put(Tag.PTX.SYS, 0);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/ScopedThread/ScopedThread.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/ScopedThread/ScopedThread.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.program.ScopedThread;
 
 import com.dat3m.dartagnan.expression.type.FunctionType;
 import com.dat3m.dartagnan.program.Thread;
-import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -17,7 +17,7 @@ public class ScopedThread extends Thread {
     // is important, thus we use a LinkedHashMap
     protected final Map<String, Integer> scopeIds = new LinkedHashMap<>();
 
-    public ScopedThread(String name, FunctionType funcType, List<String> parameterNames, int id, Event entry) {
+    public ScopedThread(String name, FunctionType funcType, List<String> parameterNames, int id, ThreadStart entry) {
         super(name, funcType, parameterNames, id,  entry);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program;
 
 import com.dat3m.dartagnan.expression.type.FunctionType;
-import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.google.common.base.Preconditions;
 
@@ -18,11 +17,6 @@ public class Thread extends Function {
     @Override
     public ThreadStart getEntry() {
         return (ThreadStart) entry;
-    }
-
-    @Override
-    public Label getExit() {
-        return (Label) exit;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.program;
 
 import com.dat3m.dartagnan.expression.type.FunctionType;
+import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.google.common.base.Preconditions;
 
@@ -12,6 +13,16 @@ public class Thread extends Function {
         super(name, funcType, parameterNames, id,  entry);
         Preconditions.checkArgument(id >= 0, "Invalid thread ID");
         Preconditions.checkNotNull(entry, "Thread entry event must be not null");
+    }
+
+    @Override
+    public ThreadStart getEntry() {
+        return (ThreadStart) entry;
+    }
+
+    @Override
+    public Label getExit() {
+        return (Label) exit;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Thread.java
@@ -1,14 +1,14 @@
 package com.dat3m.dartagnan.program;
 
 import com.dat3m.dartagnan.expression.type.FunctionType;
-import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.google.common.base.Preconditions;
 
 import java.util.List;
 
 public class Thread extends Function {
 
-    public Thread(String name, FunctionType funcType, List<String> parameterNames, int id, Event entry) {
+    public Thread(String name, FunctionType funcType, List<String> parameterNames, int id, ThreadStart entry) {
         super(name, funcType, parameterNames, id,  entry);
         Preconditions.checkArgument(id >= 0, "Invalid thread ID");
         Preconditions.checkNotNull(entry, "Thread entry event must be not null");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
@@ -213,7 +213,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
 
         final List<Branch> unconditionalThreadInitialBranches = new ArrayList<>();
         for (Thread thread : decomposition.program.getThreads()) {
-            final ThreadStart start = (ThreadStart) thread.getEntry();
+            final ThreadStart start = thread.getEntry();
             final Branch threadInitialBranch = decomposition.event2BranchMap.get(start);
 
             if (start.isSpawned()) {
@@ -305,7 +305,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
 
         // -------------------------- Find initial class --------------------------
         initialClass = decomposition.program.getThreads().stream()
-                .map(e -> (ThreadStart)e.getEntry())
+                .map(Thread::getEntry)
                 .filter(e -> !e.isSpawned())
                 .map(this::<BranchClass>getTypedEqClass)
                 .findFirst()

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -21,6 +21,7 @@ import com.dat3m.dartagnan.program.event.core.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.core.rmw.RMWStoreExclusive;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadArgument;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadCreate;
+import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.dat3m.dartagnan.program.event.functions.AbortIf;
 import com.dat3m.dartagnan.program.event.functions.DirectValueFunctionCall;
 import com.dat3m.dartagnan.program.event.functions.DirectVoidFunctionCall;
@@ -260,6 +261,10 @@ public class EventFactory {
 
     public static ThreadArgument newThreadArgument(Register resultReg, ThreadCreate creator, int argIndex) {
         return new ThreadArgument(resultReg, creator, argIndex);
+    }
+
+    public static ThreadStart newThreadStart(ThreadCreate creator) {
+        return new ThreadStart(creator);
     }
 
     // =============================================================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadStart.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadStart.java
@@ -44,7 +44,7 @@ public class ThreadStart extends AbstractEvent implements EventUser {
         if ( isSpawned()) {
             return String.format("ThreadStart by %s::%s", creator.getThread(), creator);
         } else {
-            return "ThreadStart (unconditional)";
+            return "ThreadStart";
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadStart.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadStart.java
@@ -1,0 +1,71 @@
+package com.dat3m.dartagnan.program.event.core.threading;
+
+import com.dat3m.dartagnan.program.event.EventUser;
+import com.dat3m.dartagnan.program.event.core.AbstractEvent;
+import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
+
+import java.util.Map;
+import java.util.Set;
+
+public class ThreadStart extends AbstractEvent implements EventUser {
+
+    // May be NULL, if this thread is not spawned.
+    private ThreadCreate creator;
+    //TODO: It is probably better to make the ThreadCreate conditional rather than
+    // allow ThreadStart to fail spuriously.
+    private boolean mayFailSpuriously;
+
+    public ThreadStart(ThreadCreate creator) {
+        this.creator = creator;
+
+        mayFailSpuriously = (creator != null);
+        if (creator != null) {
+            creator.registerUser(this);
+        }
+    }
+
+    protected ThreadStart(ThreadStart other) {
+        super(other);
+        this.creator = other.creator;
+        this.mayFailSpuriously = other.mayFailSpuriously;
+
+        creator.registerUser(this);
+    }
+
+    public boolean mayFailSpuriously() { return mayFailSpuriously; }
+    public void setMayFailSpuriously(boolean value) { this.mayFailSpuriously = value;}
+
+    public boolean isSpawned() { return creator != null; }
+    public ThreadCreate getCreator() { return creator; }
+
+    @Override
+    public String defaultString() {
+        if ( isSpawned()) {
+            return String.format("ThreadStart by %s::%s", creator.getThread(), creator);
+        } else {
+            return "ThreadStart (unconditional)";
+        }
+    }
+
+    @Override
+    public ThreadStart getCopy() {
+        return new ThreadStart(this);
+    }
+
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        // TODO
+        return visitor.visitEvent(this);
+    }
+
+    @Override
+    public Set<Event> getReferencedEvents() {
+        return Set.of(creator);
+    }
+
+    @Override
+    public void updateReferences(Map<Event, Event> updateMapping) {
+        creator = (ThreadCreate) EventUser.moveUserReference(this, creator, updateMapping);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/CoreCodeVerification.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/CoreCodeVerification.java
@@ -9,6 +9,7 @@ import com.dat3m.dartagnan.program.event.core.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.core.rmw.RMWStoreExclusive;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadArgument;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadCreate;
+import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.dat3m.dartagnan.program.event.lang.svcomp.BeginAtomic;
 import com.dat3m.dartagnan.program.event.lang.svcomp.EndAtomic;
 import org.sosy_lab.common.configuration.Configuration;
@@ -36,7 +37,7 @@ public class CoreCodeVerification implements FunctionProcessor {
             Load.class, Store.class, Init.class, GenericMemoryEvent.class, Fence.class,
             CondJump.class, IfAsJump.class, ExecutionStatus.class, Label.class, Local.class,
             Skip.class, Assume.class, RMWStore.class, RMWStoreExclusive.class,
-            ThreadCreate.class, ThreadArgument.class,
+            ThreadCreate.class, ThreadArgument.class, ThreadStart.class,
             PTXFenceWithId.class, // For PTX
             BeginAtomic.class, EndAtomic.class
             // We add SVCOMP atomic blocks here as well, despite them not being part of the core package.

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LogThreadStatistics.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LogThreadStatistics.java
@@ -44,7 +44,7 @@ public class LogThreadStatistics implements ProgramProcessor {
             }
         }
 
-        int numNonInitThreads = (int)threads.stream().filter(t -> !(t.getEntry() instanceof Init)).count();
+        int numNonInitThreads = (int)threads.stream().filter(t -> !(t.getEntry().getSuccessor() instanceof Init)).count();
         int staticAddressSpaceSize = program.getMemory().getObjects().stream()
                 .filter(MemoryObject::isStaticallyAllocated).mapToInt(MemoryObject::size).sum();
         int dynamicAddressSpaceSize = program.getMemory().getObjects().stream()

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemoryAllocation.java
@@ -98,12 +98,14 @@ public class MemoryAllocation implements ProgramProcessor {
             for(int i : fieldsToInit) {
                 final Event init = EventFactory.newInit(memObj, i);
                 // NOTE: We use different names to avoid symmetry detection treating all inits as symmetric.
-                final Thread thread = new Thread("Init_" + nextThreadId, initThreadType, List.of(), nextThreadId, init);
+                final Thread thread = new Thread("Init_" + nextThreadId, initThreadType, List.of(), nextThreadId,
+                        EventFactory.newThreadStart(null));
+                thread.append(init);
                 nextThreadId++;
 
                 program.addThread(thread);
                 thread.setProgram(program);
-                thread.getEntry().insertAfter(EventFactory.newLabel("END_OF_T" + thread.getId()));
+                thread.append(EventFactory.newLabel("END_OF_T" + thread.getId()));
             }
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ThreadCreation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ThreadCreation.java
@@ -166,7 +166,7 @@ public class ThreadCreation implements ProgramProcessor {
                         final Register joinDummyReg = thread.getOrNewRegister("__joinT" + tid, types.getBooleanType());
                         final List<Event> replacement = eventSequence(
                                 newAcquireLoad(joinDummyReg, comAddrOfThreadToJoinWith),
-                                newJump(joinDummyReg, thread.getExit()),
+                                newJump(joinDummyReg, (Label)thread.getExit()),
                                 // Note: In our modelling, pthread_join always succeeds if it returns
                                 newLocal(resultRegister, expressions.makeZero((IntegerType) resultRegister.getType()))
                         );

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ThreadCreation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ThreadCreation.java
@@ -166,7 +166,7 @@ public class ThreadCreation implements ProgramProcessor {
                         final Register joinDummyReg = thread.getOrNewRegister("__joinT" + tid, types.getBooleanType());
                         final List<Event> replacement = eventSequence(
                                 newAcquireLoad(joinDummyReg, comAddrOfThreadToJoinWith),
-                                newJump(joinDummyReg, (Label)thread.getExit()),
+                                newJump(joinDummyReg, thread.getExit()),
                                 // Note: In our modelling, pthread_join always succeeds if it returns
                                 newLocal(resultRegister, expressions.makeZero((IntegerType) resultRegister.getType()))
                         );

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ThreadCreation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ThreadCreation.java
@@ -22,6 +22,7 @@ import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.core.Local;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadCreate;
+import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
 import com.dat3m.dartagnan.program.event.core.utils.RegWriter;
 import com.dat3m.dartagnan.program.event.functions.AbortIf;
@@ -243,8 +244,10 @@ public class ThreadCreation implements ProgramProcessor {
         final TypeFactory types = TypeFactory.getInstance();
 
         // ------------------- Create new thread -------------------
+        final ThreadStart start = EventFactory.newThreadStart(creator);
+        start.setMayFailSpuriously(!forceStart);
         final Thread thread = new Thread(function.getName(), function.getFunctionType(),
-                Lists.transform(function.getParameterRegisters(), Register::getName), tid, EventFactory.newSkip());
+                Lists.transform(function.getParameterRegisters(), Register::getName), tid, start);
         thread.copyDummyCountFrom(function);
 
         // ------------------- Copy registers from target function into new thread -------------------

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
@@ -11,6 +11,7 @@ import com.dat3m.dartagnan.program.event.arch.StoreExclusive;
 import com.dat3m.dartagnan.program.event.arch.lisa.LISARMW;
 import com.dat3m.dartagnan.program.event.arch.tso.TSOXchg;
 import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.core.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.lang.linux.*;
@@ -37,7 +38,7 @@ class VisitorBase implements EventVisitor<List<Event>> {
 
     protected Event newTerminator(Expression guard) {
         if (funcToBeCompiled instanceof Thread thread) {
-            return newJump(guard, thread.getExit());
+            return newJump(guard, (Label)thread.getExit());
         } else {
             return newAbortIf(guard);
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorBase.java
@@ -11,7 +11,6 @@ import com.dat3m.dartagnan.program.event.arch.StoreExclusive;
 import com.dat3m.dartagnan.program.event.arch.lisa.LISARMW;
 import com.dat3m.dartagnan.program.event.arch.tso.TSOXchg;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.core.rmw.RMWStore;
 import com.dat3m.dartagnan.program.event.lang.linux.*;
@@ -37,8 +36,8 @@ class VisitorBase implements EventVisitor<List<Event>> {
     protected VisitorBase() { }
 
     protected Event newTerminator(Expression guard) {
-        if (funcToBeCompiled instanceof Thread) {
-            return newJump(guard, (Label)funcToBeCompiled.getExit());
+        if (funcToBeCompiled instanceof Thread thread) {
+            return newJump(guard, thread.getExit());
         } else {
             return newAbortIf(guard);
         }


### PR DESCRIPTION
This PR adds proper control-flow dependencies between spawned threads and their spawners/creators.

- Each thread's entry event is now a `ThreadStart` event that may have a `ThreadCreate` event as a `creator`. If `creator == null`, the thread is executed unconditionally (e.g, the `main` thread, init threads, and all threads in litmus tests).
- The control-flow encoding now allows the execution of `ThreadStart` only if its associated `creator` (if any) gets executed.
- `BranchEquivalence` has been reworked to respect this new control-flow and consider the control-flow relationship between a thread and its creator. 
- Synchronization events between spawning thread and spawned thread have been simplified.
- We now generate must-rf edges for synchronizing events.

Minor side changes:
- SCCP now properly recognizes `AbortIf (true)` for dead code detection
- SCCP now eliminates trivial casts that do not change types (e.g., `i64` to `i64` casts).
- `Thread.getEntry` and `Thread.getExit` now return `ThreadStart` resp. `Label`.