### PR TITLE
Benchmarks

### DIFF
--- a/benchmarks/lfds/dglm.c
+++ b/benchmarks/lfds/dglm.c
@@ -1,6 +1,5 @@
 #include "dglm.h"
 #include <pthread.h>
-#include <assert.h>
 
 #ifndef NTHREADS
 #define NTHREADS 3

--- a/benchmarks/lfds/dglm.c
+++ b/benchmarks/lfds/dglm.c
@@ -26,7 +26,7 @@ int main()
     init();
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, worker, (void *)i);
+        pthread_create(&t[i], 0, worker, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/lfds/dglm.h
+++ b/benchmarks/lfds/dglm.h
@@ -1,4 +1,6 @@
 #include <stdatomic.h>
+#include <assert.h>
+#include <stdlib.h>
 
 #ifdef FAIL
 #define CAS(ptr, expected, desired) (atomic_compare_exchange_strong_explicit(ptr, expected, desired, __ATOMIC_RELAXED, __ATOMIC_RELAXED))

--- a/benchmarks/lfds/hash_table.c
+++ b/benchmarks/lfds/hash_table.c
@@ -46,10 +46,10 @@ int main()
     init();
 
     for (int i = 0; i < PAIRS; i++)
-        pthread_create(&t[i], 0, thread_1, (void *)i);
+        pthread_create(&t[i], 0, thread_1, (void *)(size_t)i);
 
     for (int i = 0; i < PAIRS; i++)
-        pthread_create(&t[PAIRS + i], 0, thread_2, (void *)i);
+        pthread_create(&t[PAIRS + i], 0, thread_2, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/lfds/ms.c
+++ b/benchmarks/lfds/ms.c
@@ -25,7 +25,7 @@ int main()
     init();
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, worker, (void *)i);
+        pthread_create(&t[i], 0, worker, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/lfds/ms.h
+++ b/benchmarks/lfds/ms.h
@@ -1,4 +1,6 @@
 #include <stdatomic.h>
+#include <assert.h>
+#include <stdlib.h>
 
 #ifdef FAIL
 #define CAS(ptr, expected, desired) (atomic_compare_exchange_strong_explicit(ptr, expected, desired, __ATOMIC_RELAXED, __ATOMIC_RELAXED))

--- a/benchmarks/lfds/treiber.c
+++ b/benchmarks/lfds/treiber.c
@@ -26,7 +26,7 @@ int main()
     init();
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, worker, (void *)i);
+        pthread_create(&t[i], 0, worker, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/lfds/treiber.h
+++ b/benchmarks/lfds/treiber.h
@@ -1,4 +1,5 @@
 #include <stdatomic.h>
+#include <stdlib.h>
 
 #ifdef FAIL
 #define CAS(ptr, expected, desired) (atomic_compare_exchange_strong_explicit(ptr, expected, desired, __ATOMIC_RELAXED, __ATOMIC_RELAXED))

--- a/benchmarks/locks/clh_mutex.c
+++ b/benchmarks/locks/clh_mutex.c
@@ -30,7 +30,7 @@ int main()
     clh_mutex_init(&lock);
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, thread_n, (void *)i);
+        pthread_create(&t[i], 0, thread_n, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/locks/cna.c
+++ b/benchmarks/locks/cna.c
@@ -30,7 +30,7 @@ int main()
     pthread_t t[NTHREADS];
  
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, thread_n, (void *)i);
+        pthread_create(&t[i], 0, thread_n, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/locks/mutex.c
+++ b/benchmarks/locks/mutex.c
@@ -30,7 +30,7 @@ int main()
     mutex_init(&mutex);
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, thread_n, (void *)i);
+        pthread_create(&t[i], 0, thread_n, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/locks/mutex_musl.c
+++ b/benchmarks/locks/mutex_musl.c
@@ -30,7 +30,7 @@ int main()
     mutex_init(&mutex);
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, thread_n, (void *)i);
+        pthread_create(&t[i], 0, thread_n, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/locks/seqlock.c
+++ b/benchmarks/locks/seqlock.c
@@ -1,6 +1,5 @@
 #include "seqlock.h"
 #include <pthread.h>
-#include <assert.h>
 
 #ifndef NREADERS
 #define NREADERS 3

--- a/benchmarks/locks/seqlock.h
+++ b/benchmarks/locks/seqlock.h
@@ -1,4 +1,5 @@
 #include <stdatomic.h>
+#include <assert.h>
 
 struct seqlock_s {
     // Sequence for reader consistency check

--- a/benchmarks/locks/spinlock.c
+++ b/benchmarks/locks/spinlock.c
@@ -30,7 +30,7 @@ int main()
     spinlock_init(&lock);
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, thread_n, (void *)i);
+        pthread_create(&t[i], 0, thread_n, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/locks/ticket_awnsb_mutex.c
+++ b/benchmarks/locks/ticket_awnsb_mutex.c
@@ -30,7 +30,7 @@ int main()
     ticket_awnsb_mutex_init(&lock, DEFAULT_MAX_WAITERS);
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, thread_n, (void *)i);
+        pthread_create(&t[i], 0, thread_n, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/locks/ticket_awnsb_mutex.h
+++ b/benchmarks/locks/ticket_awnsb_mutex.h
@@ -131,7 +131,7 @@ typedef struct
     atomic_int egress;
     char padding2[8];
     int maxArrayWaiters;
-    _Atomic(struct awnsb_node_t *)* waitersArray;
+    _Atomic(awnsb_node_t *)* waitersArray;
 } ticket_awnsb_mutex_t;
 
 /*
@@ -155,7 +155,7 @@ void ticket_awnsb_mutex_init(ticket_awnsb_mutex_t * self, int maxArrayWaiters)
     atomic_init(&self->ingress, 0);
     atomic_init(&self->egress, 0);
     self->maxArrayWaiters = maxArrayWaiters;
-    self->waitersArray = (awnsb_node_t **)malloc(self->maxArrayWaiters*sizeof(awnsb_node_t *));
+    self->waitersArray = (_Atomic(awnsb_node_t *)*)malloc(self->maxArrayWaiters*sizeof(awnsb_node_t *));
     __VERIFIER_loop_bound(DEFAULT_MAX_WAITERS+1);
     for (int i = 0; i < self->maxArrayWaiters; i++) atomic_init(&self->waitersArray[i], NULL);
 }

--- a/benchmarks/locks/ticketlock.c
+++ b/benchmarks/locks/ticketlock.c
@@ -30,7 +30,7 @@ int main()
     ticketlock_init(&lock);
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, thread_n, (void *)i);
+        pthread_create(&t[i], 0, thread_n, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/benchmarks/locks/ttas.c
+++ b/benchmarks/locks/ttas.c
@@ -30,7 +30,7 @@ int main()
     ttaslock_init(&lock);
 
     for (int i = 0; i < NTHREADS; i++)
-        pthread_create(&t[i], 0, thread_n, (void *)i);
+        pthread_create(&t[i], 0, thread_n, (void *)(size_t)i);
 
     for (int i = 0; i < NTHREADS; i++)
         pthread_join(t[i], 0);

--- a/include/dat3m.h
+++ b/include/dat3m.h
@@ -1,4 +1,6 @@
 extern int __VERIFIER_nondet_int(void);
+extern int __VERIFIER_nondet_uint(void);
+extern _Bool __VERIFIER_nondet_bool(void);
 extern void __VERIFIER_assume(int cond);
 extern void __VERIFIER_loop_bound(int);
 


### PR DESCRIPTION
This PR solves several compiler warning in the locks and lfds benchmarks. With these changes I should be able to regenerate the llvm files having problems in #493 