### PR TITLE
Accept llvm files as input

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
@@ -44,13 +44,14 @@ public class ProgramParser {
     }
 
     private boolean needsSmack(File f) {
-        return needsClang(f);
+        return needsClang(f) || f.getPath().endsWith(".ll");
     }
 
     public Program parse(String raw, String path, String format, String cflags) throws Exception {
         switch (format) {
         	case "c":
         	case "i":
+        	case "ll":
 				File parsedFile = path.isEmpty() ?
 						// This is for the case where the user fully typed the program instead of loading it
 						File.createTempFile("dat3m", ".c") :


### PR DESCRIPTION
Small changes to be able to parse llvm files. Notice `.ll` was already listed in `supportedFormats` in `Dartagnan.java`