### PR TITLE
Function pointers in initial memory

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.parsers.program.utils;
 
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.exception.MalformedProgramException;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.INonDet;
@@ -28,7 +29,9 @@ import com.dat3m.dartagnan.program.specification.AbstractAssert;
 import com.google.common.base.Verify;
 import com.google.common.collect.Iterables;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.dat3m.dartagnan.program.Program.SourceLanguage.LITMUS;
 import static com.dat3m.dartagnan.program.event.Tag.NOOPT;
@@ -204,7 +207,7 @@ public class ProgramBuilder {
         initLocEqConst(leftName,getInitialValue(rightName));
     }
 
-    public void initLocEqConst(String locName, IConst iValue){
+    public void initLocEqConst(String locName, Expression iValue){
         getOrNewMemoryObject(locName).setInitialValue(0,iValue);
     }
 
@@ -223,7 +226,7 @@ public class ProgramBuilder {
         addChild(regThread, EventFactory.newLocal(getOrNewRegister(regThread, regName, iValue.getType()), iValue));
     }
 
-    private IConst getInitialValue(String name) {
+    private Expression getInitialValue(String name) {
         return getOrNewMemoryObject(name).getInitialValue(0);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.parsers.program.visitors;
 import com.dat3m.dartagnan.exception.ParsingException;
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.IValue;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.parsers.LitmusCBaseVisitor;
@@ -134,7 +133,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         }
         if(ctx.initArray() != null){
             if(size == null || ctx.initArray().arrayElement().size() == size){
-                List<IConst> values = new ArrayList<>();
+                List<Expression> values = new ArrayList<>();
                 for(LitmusCParser.ArrayElementContext elCtx : ctx.initArray().arrayElement()){
                     if(elCtx.constant() != null){
                         values.add(expressions.parseValue(elCtx.constant().getText(), archType));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.expression.Expression;
-import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.visitors.EventVisitor;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -46,7 +45,7 @@ public class Init extends Store {
      *
      * @return Content of the location at the start of each execution.
      */
-    public IConst getValue() {
+    public Expression getValue() {
         return base.getInitialValue(offset);
     }
 
@@ -56,7 +55,7 @@ public class Init extends Store {
     }
 
     @Override
-    public IConst getMemValue() { return getValue(); }
+    public Expression getMemValue() { return getValue(); }
 
     @Override
     public <T> T accept(EventVisitor<T> visitor) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
@@ -1,5 +1,6 @@
 package com.dat3m.dartagnan.program.memory;
 
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
@@ -23,15 +24,15 @@ public class MemoryObject extends IConst {
     private String cVar;
     private boolean isThreadLocal;
 
-    // TODO
+    //TODO
     // Right now we assume that either the whole object is atomic or it is not.
-    // Generally, this is no necessarily true for structs, but right now we
+    // Generally, this is not necessarily true for structs, but right now we
     // don't have a way of marking anything as atomic for bpl files. 
     private boolean atomic = false;
 
     private final boolean isStatic;
 
-    private final HashMap<Integer, IConst> initialValues = new HashMap<>();
+    private final HashMap<Integer, Expression> initialValues = new HashMap<>();
 
     MemoryObject(int index, int size, boolean isStaticallyAllocated) {
         super(TypeFactory.getInstance().getArchType());
@@ -75,7 +76,7 @@ public class MemoryObject extends IConst {
      * @param offset Non-negative number of fields before the target.
      * @return Readable value at the start of each execution.
      */
-    public IConst getInitialValue(int offset) {
+    public Expression getInitialValue(int offset) {
         checkArgument(offset >= 0 && offset < size, "array index out of bounds");
         return initialValues.getOrDefault(offset, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getArchType()));
     }
@@ -86,7 +87,7 @@ public class MemoryObject extends IConst {
      * @param offset Non-negative number of fields before the target.
      * @param value  New value to be read at the start of each execution.
      */
-    public void setInitialValue(int offset, IConst value) {
+    public void setInitialValue(int offset, Expression value) {
         checkArgument(offset >= 0 && offset < size, "array index out of bounds");
         initialValues.put(offset, value);
     }
@@ -98,7 +99,7 @@ public class MemoryObject extends IConst {
      * @param offset Non-negative number of fields before the target.
      * @param value  New value to be read at the start of each execution.
      */
-    public void appendInitialValue(int offset, IConst value) {
+    public void appendInitialValue(int offset, Expression value) {
         checkArgument(offset >= 0, "array index out of bounds");
         //The current implementation of Smack does not provide proper size information on static arrays.
         //Instead, it indicates the size in the Boogie file by initializing each of the fields in a special procedure.


### PR DESCRIPTION
This PR generalizes `MemoryObject`'s initial values to contain any expression rather than just `IConst`. This is currently needed to hold other types of constants like `Function`. 

The LLVM parser can now parse functions referenced in initializers.

Devirtualisation has been extended to include function pointers referenced in initial memory.