### PR TITLE
Avoid re-using register in ticketlock

### DIFF
--- a/litmus/PTX/Manual/Ticketlock-acq2rlx-1.litmus
+++ b/litmus/PTX/Manual/Ticketlock-acq2rlx-1.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.release.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
+ atom.release.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-acq2rlx-1.litmus
+++ b/litmus/PTX/Manual/Ticketlock-acq2rlx-1.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.release.gpu.plus r1, out, 1  | atom.release.gpu.plus r1, out, 1 ;
+ atom.release.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-acq2rlx-1.litmus
+++ b/litmus/PTX/Manual/Ticketlock-acq2rlx-1.litmus
@@ -15,4 +15,4 @@ x=0;
  st.weak x, 1                      | st.weak x, 2                     ;
  atom.release.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
-(P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)
+(P0:r1 == P0:r2 /\ P1:r1 == P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-acq2rlx-2.litmus
+++ b/litmus/PTX/Manual/Ticketlock-acq2rlx-2.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.release.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
+ atom.release.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-acq2rlx-2.litmus
+++ b/litmus/PTX/Manual/Ticketlock-acq2rlx-2.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.release.gpu.plus r1, out, 1  | atom.release.gpu.plus r1, out, 1 ;
+ atom.release.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-acq2rlx-2.litmus
+++ b/litmus/PTX/Manual/Ticketlock-acq2rlx-2.litmus
@@ -15,4 +15,4 @@ x=0;
  st.weak x, 1                      | st.weak x, 2                     ;
  atom.release.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
-(P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)
+(P0:r1 == P0:r2 /\ P1:r1 == P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-diff-gpu.litmus
+++ b/litmus/PTX/Manual/Ticketlock-diff-gpu.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.release.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
+ atom.release.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-diff-gpu.litmus
+++ b/litmus/PTX/Manual/Ticketlock-diff-gpu.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.release.gpu.plus r1, out, 1  | atom.release.gpu.plus r1, out, 1 ;
+ atom.release.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-diff-gpu.litmus
+++ b/litmus/PTX/Manual/Ticketlock-diff-gpu.litmus
@@ -15,4 +15,4 @@ x=0;
  st.weak x, 1                      | st.weak x, 2                     ;
  atom.release.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
-(P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)
+(P0:r1 == P0:r2 /\ P1:r1 == P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-rel2rlx.litmus
+++ b/litmus/PTX/Manual/Ticketlock-rel2rlx.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.relaxed.gpu.plus r1, out, 1  | atom.release.gpu.plus r1, out, 1 ;
+ atom.relaxed.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-rel2rlx.litmus
+++ b/litmus/PTX/Manual/Ticketlock-rel2rlx.litmus
@@ -15,4 +15,4 @@ x=0;
  st.weak x, 1                      | st.weak x, 2                     ;
  atom.relaxed.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
-(P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)
+(P0:r1 == P0:r2 /\ P1:r1 == P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-rel2rlx.litmus
+++ b/litmus/PTX/Manual/Ticketlock-rel2rlx.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.relaxed.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
+ atom.relaxed.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-same-gpu.litmus
+++ b/litmus/PTX/Manual/Ticketlock-same-gpu.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.release.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
+ atom.release.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-same-gpu.litmus
+++ b/litmus/PTX/Manual/Ticketlock-same-gpu.litmus
@@ -13,6 +13,6 @@ x=0;
  LC01:                             | LC01:                            ;
  ld.weak r3, x                     | ld.weak r3, x                    ;
  st.weak x, 1                      | st.weak x, 2                     ;
- atom.release.gpu.plus r1, out, 1  | atom.release.gpu.plus r1, out, 1 ;
+ atom.release.gpu.plus r3, out, 1  | atom.release.gpu.plus r3, out, 1 ;
 exists
 (P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/Ticketlock-same-gpu.litmus
+++ b/litmus/PTX/Manual/Ticketlock-same-gpu.litmus
@@ -15,4 +15,4 @@ x=0;
  st.weak x, 1                      | st.weak x, 2                     ;
  atom.release.gpu.plus r4, out, 1  | atom.release.gpu.plus r4, out, 1 ;
 exists
-(P0:r1 != P1:r1 /\ P0:r2 != P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)
+(P0:r1 == P0:r2 /\ P1:r1 == P1:r2 /\ P0:r3 == 0 /\ P1:r3 == 0)


### PR DESCRIPTION
The idea of the final condition is to check that each lock reads a different ticket. While I think in a correct implementation, we would still check `original-read-r1-T0 + != original-read-r1-T1`, I don't think this is guaranteed if the mutual exclusion does not hold.

This PR solves the issue by simply using a fresh register for the release store.