### PR TITLE
Remove id from recomputed co

### DIFF
--- a/cat/ptx-v6.0.cat
+++ b/cat/ptx-v6.0.cat
@@ -17,7 +17,7 @@ PTX
 (*******************)
 
 // Explicitly add transitivity for coherence since the co in PTX is not total
-let co = co+
+let co = co+ \ id
 
 (* Events *)
 let strong-write = W & (RLX | REL)

--- a/cat/ptx-v7.5.cat
+++ b/cat/ptx-v7.5.cat
@@ -31,7 +31,7 @@ PTX
 (*******************)
 
 // Explicitly add transitivity for coherence since the co in PTX is not total
-let co = co+
+let co = co+ \ id
 
 (* Events *)
 let strong-write = W & (RLX | REL)


### PR DESCRIPTION
In PTX, coherence is [a partial transitive order](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#coherence-order) which clearly does not include `id`.

@natgavrilenko noticed that due to how we recompute coherence to guarantee transitivity, the `id`-pairs end up in the may set of coherence. This does not affect correctness because of some axioms, e.g. "SC-per-Location". However, we should not rely on axioms to guarantee the semantics of base relations.