### PR TITLE
Fix error in C litmus visitor for while rule

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -228,20 +228,20 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
 
 	@Override
     public Object visitWhileExpression(LitmusCParser.WhileExpressionContext ctx) {
-        Expression expr = (Expression) ctx.re().accept(this);
-
         whileId++;
         Label headL = programBuilder.getOrCreateLabel(currentThread,"head_" + whileId);
         Label endL = programBuilder.getOrCreateLabel(currentThread,"end_" + whileId);
 
         programBuilder.addChild(currentThread, headL);
-        CondJump breakEvent = EventFactory.newJumpUnless(expr, endL);
-        programBuilder.addChild(currentThread, breakEvent);
+        Expression expr = (Expression) ctx.re().accept(this);
+
+        programBuilder.addChild(currentThread, EventFactory.newJumpUnless(expr, endL));
 
         for(LitmusCParser.ExpressionContext expressionContext : ctx.expression()) {
             expressionContext.accept(this);
         }
 
+        programBuilder.addChild(currentThread, EventFactory.newGoto(headL));
         programBuilder.addChild(currentThread, endL);
         return null;
     }

--- a/dartagnan/src/test/resources/RC11-expected.csv
+++ b/dartagnan/src/test/resources/RC11-expected.csv
@@ -134,4 +134,3 @@ litmus/C11/manual/imm-R2-alt.litmus,1
 litmus/C11/manual/mp_relaxed.litmus,1
 litmus/C11/manual/IRIW-sc-sc-acq-sc-acq-sc.litmus,1
 litmus/C11/manual/imm-E3.7.litmus,0
-litmus/C11/manual/TSan,0


### PR DESCRIPTION
There was an error in #542: the while condition can generate events and thus needs to be inside the body. Also, the back jumping to head was missing.