### PR TITLE
Update workflows with latest versions of the actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
         path: badges
         
     - name: Set up the Java JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'adopt'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,16 +16,16 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Checkout badges branch dedicated to storing badges only
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: badges
         path: badges
         
     - name: Set up the Java JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'adopt'


### PR DESCRIPTION
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/