### PR TITLE
Benchmarks coming from GPU concurrency: Weak behaviours and programming assumptions

### DIFF
--- a/litmus/PTX/Manual/LB-dlb-no-fence-1.litmus
+++ b/litmus/PTX/Manual/LB-dlb-no-fence-1.litmus
@@ -8,8 +8,8 @@ h=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0                   | P1@cta 1,gpu 0                   ;
- atom.relaxed.cta.cas r0, h, 0, 1 | ld.weak r1, t                    ;
+ atom.relaxed.gpu.cas r0, h, 0, 1 | ld.relaxed.gpu r1, t             ;
                                   | fence.sc.gpu                     ;
- st.weak t, 1                     | atom.relaxed.cta.cas r3, h, 0, 1 ;
+ st.relaxed.gpu t, 1              | atom.relaxed.gpu.cas r3, h, 0, 1 ;
 exists
  (P0:r0 == 1 /\ P1:r1 == 1)

--- a/litmus/PTX/Manual/LB-dlb-no-fence-2.litmus
+++ b/litmus/PTX/Manual/LB-dlb-no-fence-2.litmus
@@ -8,8 +8,8 @@ h=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0                   | P1@cta 1,gpu 0                   ;
- atom.relaxed.cta.cas r0, h, 0, 1 | ld.weak r1, t                    ;
+ atom.relaxed.gpu.cas r0, h, 0, 1 | ld.relaxed.gpu r1, t             ;
  fence.sc.gpu                     |                                  ;
- st.weak t, 1                     | atom.relaxed.cta.cas r3, h, 0, 1 ;
+ st.relaxed.gpu t, 1              | atom.relaxed.gpu.cas r3, h, 0, 1 ;
 exists
  (P0:r0 == 1 /\ P1:r1 == 1)

--- a/litmus/PTX/Manual/LB-dlb.litmus
+++ b/litmus/PTX/Manual/LB-dlb.litmus
@@ -8,8 +8,8 @@ h=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0                   | P1@cta 1,gpu 0                   ;
- atom.relaxed.cta.cas r0, h, 0, 1 | ld.weak r1, t                    ;
+ atom.relaxed.gpu.cas r0, h, 0, 1 | ld.relaxed.gpu r1, t             ;
  fence.sc.gpu                     | fence.sc.gpu                     ;
- st.weak t, 1                     | atom.relaxed.cta.cas r3, h, 0, 1 ;
+ st.relaxed.gpu t, 1              | atom.relaxed.gpu.cas r3, h, 0, 1 ;
 exists
  (P0:r0 == 1 /\ P1:r1 == 1)

--- a/litmus/PTX/Manual/MP-dlb-no-fence-1.litmus
+++ b/litmus/PTX/Manual/MP-dlb-no-fence-1.litmus
@@ -8,10 +8,10 @@ d=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0      | P1@cta 1,gpu 0       ;
- st.relaxed.cta d, 1 | ld.weak r0, t        ;
+ st.relaxed.gpu d, 1 | ld.weak r0, t        ;
                      | beq r0, r3, LC00     ;
  ld.weak r2, t       | fence.sc.gpu         ;
- add r2, r2, 1       | ld.relaxed.cta r1, d ;
+ add r2, r2, 1       | ld.relaxed.gpu r1, d ;
  st.weak t, r2       | LC00:                ;
 exists
 (P1:r0 == 1 /\ P1:r1 == 0)

--- a/litmus/PTX/Manual/MP-dlb-no-fence-2.litmus
+++ b/litmus/PTX/Manual/MP-dlb-no-fence-2.litmus
@@ -8,10 +8,10 @@ d=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0      | P1@cta 1,gpu 0       ;
- st.relaxed.cta d, 1 | ld.weak r0, t        ;
+ st.relaxed.gpu d, 1 | ld.weak r0, t        ;
  fence.sc.gpu        | beq r0, r3, LC00     ;
  ld.weak r2, t       |                      ;
- add r2, r2, 1       | ld.relaxed.cta r1, d ;
+ add r2, r2, 1       | ld.relaxed.gpu r1, d ;
  st.weak t, r2       | LC00:                ;
 exists
 (P1:r0 == 1 /\ P1:r1 == 0)

--- a/litmus/PTX/Manual/MP-dlb.litmus
+++ b/litmus/PTX/Manual/MP-dlb.litmus
@@ -8,10 +8,10 @@ d=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0      | P1@cta 1,gpu 0       ;
- st.relaxed.cta d, 1 | ld.weak r0, t        ;
+ st.relaxed.gpu d, 1 | ld.weak r0, t        ;
  fence.sc.gpu        | beq r0, r3, LC00     ;
  ld.weak r2, t       | fence.sc.gpu         ;
- add r2, r2, 1       | ld.relaxed.cta r1, d ;
+ add r2, r2, 1       | ld.relaxed.gpu r1, d ;
  st.weak t, r2       | LC00:                ;
 exists
 (P1:r0 == 1 /\ P1:r1 == 0)

--- a/litmus/PTX/Manual/SL-cas-minus.litmus
+++ b/litmus/PTX/Manual/SL-cas-minus.litmus
@@ -10,10 +10,10 @@ P1:r1=0;
 P1:r2=0;
 P1:r3=0;
 }
- P0@cta 0,gpu 0                   | P1@cta 1,gpu 0                   ;
- st.weak x, 1                     | atom.relaxed.cta.cas r1, m, 0, 1 ;
- atom.relaxed.cta.exch r0, m, 0   | bne r1, 0, LC00                  ;
-                                  | ld.weak r3, x                    ;
-                                  | LC00:                            ;
+ P0@cta 0,gpu 0                 | P1@cta 1,gpu 0                   ;
+ st.relaxed.gpu x, 1            | atom.relaxed.gpu.cas r1, m, 0, 1 ;
+ atom.relaxed.gpu.exch r0, m, 0 | bne r1, 0, LC00                  ;
+                                | ld.relaxed.gpu r3, x             ;
+                                | LC00:                            ;
 exists
  (P1:r1 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/SL-cas-plus.litmus
+++ b/litmus/PTX/Manual/SL-cas-plus.litmus
@@ -10,11 +10,11 @@ P1:r1=0;
 P1:r2=0;
 P1:r3=0;
 }
- P0@cta 0,gpu 0                   | P1@cta 1,gpu 0                   ;
- st.weak x, 1                     | atom.relaxed.cta.cas r1, m, 0, 1 ;
- fence.sc.gpu                     | bne r1, 0, LC00                  ;
- atom.relaxed.cta.exch r0, m, 0   | fence.sc.gpu                     ;
-                                  | ld.weak r3, x                    ;
-                                  | LC00:                            ;
+ P0@cta 0,gpu 0                 | P1@cta 1,gpu 0                   ;
+ st.weak x, 1                   | atom.relaxed.cta.cas r1, m, 0, 1 ;
+ fence.sc.gpu                   | bne r1, 0, LC00                  ;
+ atom.relaxed.cta.exch r0, m, 0 | fence.sc.gpu                     ;
+                                | ld.weak r3, x                    ;
+                                | LC00:                            ;
 exists
  (P1:r1 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/SL-cas-plus.litmus
+++ b/litmus/PTX/Manual/SL-cas-plus.litmus
@@ -11,10 +11,10 @@ P1:r2=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0                 | P1@cta 1,gpu 0                   ;
- st.weak x, 1                   | atom.relaxed.cta.cas r1, m, 0, 1 ;
+ st.relaxed.gpu x, 1            | atom.relaxed.gpu.cas r1, m, 0, 1 ;
  fence.sc.gpu                   | bne r1, 0, LC00                  ;
- atom.relaxed.cta.exch r0, m, 0 | fence.sc.gpu                     ;
-                                | ld.weak r3, x                    ;
+ atom.relaxed.gpu.exch r0, m, 0 | fence.sc.gpu                     ;
+                                | ld.relaxed.gpu r3, x             ;
                                 | LC00:                            ;
 exists
  (P1:r1 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/SL-future-minus.litmus
+++ b/litmus/PTX/Manual/SL-future-minus.litmus
@@ -9,10 +9,10 @@ P0:r0=0;
 P0:r1=0;
 P1:r2=0;
 }
- P0@cta 0,gpu 0 | P1@cta 1,gpu 0                   ;
- ld.weak r0, x  | atom.relaxed.cta.cas r2, m, 0, 1 ;
- st.weak m, 0   | bne r2, 0, LC00                  ;
- fence.sc.gpu   | st.weak x, 1                     ;
-                | LC00:                            ;
+ P0@cta 0,gpu 0       | P1@cta 1,gpu 0                   ;
+ ld.relaxed.gpu r0, x | atom.relaxed.gpu.cas r2, m, 0, 1 ;
+ st.relaxed.gpu m, 0  | bne r2, 0, LC00                  ;
+ fence.sc.gpu         | st.relaxed.gpu x, 1              ;
+                      | LC00:                            ;
 exists
  (P0:r0 == 1 /\ P1:r2 == 0)

--- a/litmus/PTX/Manual/SL-future-plus.litmus
+++ b/litmus/PTX/Manual/SL-future-plus.litmus
@@ -10,10 +10,10 @@ P0:r1=0;
 P1:r2=0;
 }
  P0@cta 0,gpu 0                 | P1@cta 1,gpu 0                   ;
- ld.weak r0, x                  | atom.relaxed.cta.cas r2, m, 0, 1 ;
+ ld.relaxed.gpu r0, x           | atom.relaxed.gpu.cas r2, m, 0, 1 ;
  fence.sc.gpu                   | bne r2, 0, LC00                  ;
- atom.relaxed.cta.exch r1, m, 0 | fence.sc.gpu                     ;
-                                | st.weak x, 1                     ;
+ atom.relaxed.gpu.exch r1, m, 0 | fence.sc.gpu                     ;
+                                | st.relaxed.gpu x, 1              ;
                                 | LC00:                            ;
 exists
  (P0:r0 == 1 /\ P1:r2 == 0)


### PR DESCRIPTION
I found two issues in the litmus tests coming from the "GPU concurrency: Weak behaviours and programming assumptions" paper.
- in the paper, loads and stores have (an old?) annotation called `.cg` which is supposed to invalidate the L2 cache. Since the L2 is shared between all threads in the GPU, it makes sense to me that this is actually related to the `.gpu` scope
- `st.cg` and `ld.cg` are relaxed stores and loads (volatile are the weak ones)

@tonghaining can you please check this makes sense?