### PR TITLE
Preliminary support for llvm.objectsize & __memset_chk

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/IRHelper.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/IRHelper.java
@@ -26,8 +26,8 @@ public class IRHelper {
     }
 
     /*
-        Returns true if the syntactic successor of <e> is not (generally) a semantic successor, because
-        <e> always jumps/branches/terminates etc.
+        Returns true if the syntactic successor of <e> (e.getSuccessor()) is not (generally) a semantic successor,
+        because <e> always jumps/branches/terminates etc.
      */
     public static boolean isAlwaysBranching(Event e) {
         return e instanceof Return

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/IRHelper.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/IRHelper.java
@@ -1,6 +1,10 @@
 package com.dat3m.dartagnan.program;
 
+import com.dat3m.dartagnan.expression.BConst;
+import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.functions.AbortIf;
+import com.dat3m.dartagnan.program.event.functions.Return;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -19,5 +23,15 @@ public class IRHelper {
             }
         }
         return nonDeleted;
+    }
+
+    /*
+        Returns true if the syntactic successor of <e> is not (generally) a semantic successor, because
+        <e> always jumps/branches/terminates etc.
+     */
+    public static boolean isAlwaysBranching(Event e) {
+        return e instanceof Return
+                || e instanceof AbortIf abort && abort.getCondition() instanceof BConst b && b.getValue()
+                || e instanceof CondJump jump && jump.isGoto();
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/BranchReordering.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/BranchReordering.java
@@ -1,12 +1,10 @@
 package com.dat3m.dartagnan.program.processing;
 
-import com.dat3m.dartagnan.expression.BConst;
 import com.dat3m.dartagnan.program.Function;
+import com.dat3m.dartagnan.program.IRHelper;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.functions.AbortIf;
-import com.dat3m.dartagnan.program.event.functions.Return;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.google.common.collect.Lists;
 import org.sosy_lab.common.configuration.Configuration;
@@ -111,19 +109,13 @@ public class BranchReordering implements FunctionProcessor {
                 if (e.equals(exit)) {
                     break;
                 }
-                if (isAlwaysBranching(e)) {
+                if (IRHelper.isAlwaysBranching(e)) {
                     curBranch = new MovableBranch();
                     curBranch.id = id++;
                     branches.add(curBranch);
                 }
                 e = e.getSuccessor();
             }
-        }
-
-        private boolean isAlwaysBranching(Event e) {
-            return e instanceof Return
-                    || e instanceof AbortIf abort && abort.getCondition() instanceof BConst b && b.getValue()
-                    || e instanceof CondJump jump && jump.isGoto();
         }
 
         private List<MovableBranch> computeReordering(final List<MovableBranch> movables) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Intrinsics.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Intrinsics.java
@@ -776,6 +776,9 @@ public class Intrinsics {
         //FIXME: Handle memset_chk correctly. For now, we ignore the bound check parameter because that one is
         // usually provided by llvm.objectsize which we cannot resolve for now. Since we usually assume UB-freedom,
         // the check can be ignored for the most part.
+        if (call.getCalledFunction().getName().equals("__memset_chk")) {
+            logger.warn("Treating call to \"__memset_chk\" as call to \"memset\": skipping bound checks.");
+        }
 
         if (!(countExpr instanceof IValue countValue)) {
             final String error = "Cannot handle memset with dynamic count argument: " + call;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Intrinsics.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Intrinsics.java
@@ -119,6 +119,7 @@ public class Intrinsics {
                 false, false, true, true, Intrinsics::handleLLVMIntrinsic),
         LLVM_ASSUME("llvm.assume", false, false, true, true, Intrinsics::inlineLLVMAssume),
         LLVM_META(List.of("llvm.stacksave", "llvm.stackrestore", "llvm.lifetime"), false, false, true, true, Intrinsics::inlineAsZero),
+        LLVM_OBJECTSIZE("llvm.objectsize", false, false, true, false, null),
         LLVM_EXPECT("llvm.expect", false, false, true, true, Intrinsics::inlineLLVMExpect),
         LLVM_MEMCPY("llvm.memcpy", true, true, true, false, Intrinsics::inlineMemCpy),
         LLVM_MEMSET("llvm.memset", true, false, true, false, Intrinsics::inlineMemSet),
@@ -135,7 +136,7 @@ public class Intrinsics {
         LKMM_FENCE("__LKMM_FENCE", false, false, false, true, Intrinsics::handleLKMMIntrinsic),
         // --------------------------- Misc ---------------------------
         STD_MEMCPY("memcpy", true, true, true, false, Intrinsics::inlineMemCpy),
-        STD_MEMSET("memset", true, false, true, false, Intrinsics::inlineMemSet),
+        STD_MEMSET(List.of("memset", "__memset_chk"), true, false, true, false, Intrinsics::inlineMemSet),
         STD_MEMCMP("memcmp", false, true, true, false, Intrinsics::inlineMemCmp),
         STD_MALLOC("malloc", false, false, true, true, Intrinsics::inlineMalloc),
         STD_FREE("free", true, false, true, true, Intrinsics::inlineAsZero),//TODO support free
@@ -189,7 +190,7 @@ public class Intrinsics {
 
         private boolean matches(String funcName) {
             boolean isPrefix = switch(this) {
-                case LLVM, LLVM_ASSUME, LLVM_META, LLVM_MEMCPY, LLVM_MEMSET, LLVM_EXPECT -> true;
+                case LLVM, LLVM_ASSUME, LLVM_META, LLVM_MEMCPY, LLVM_MEMSET, LLVM_EXPECT, LLVM_OBJECTSIZE -> true;
                 default -> false;
             };
             BiPredicate<String, String> matchingFunction = isPrefix ? String::startsWith : String::equals;
@@ -764,12 +765,17 @@ public class Intrinsics {
         return replacement;
     }
 
-    // Handles both std.memset and llvm.memset
+    // Handles, std.memset, llvm.memset and __memset_chk (checked memset)
     private List<Event> inlineMemSet(FunctionCall call) {
         final Expression dest = call.getArguments().get(0);
         final Expression fillExpr = call.getArguments().get(1);
         final Expression countExpr = call.getArguments().get(2);
         // final Expression isVolatile = call.getArguments.get(3) // LLVM's memset has an extra argument
+        // final Expression boundExpr = call.getArguments.get(3) // __memset_chk has an extra argument
+
+        //FIXME: Handle memset_chk correctly. For now, we ignore the bound check parameter because that one is
+        // usually provided by llvm.objectsize which we cannot resolve for now. Since we usually assume UB-freedom,
+        // the check can be ignored for the most part.
 
         if (!(countExpr instanceof IValue countValue)) {
             final String error = "Cannot handle memset with dynamic count argument: " + call;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -108,6 +108,7 @@ public class ProcessingManager implements ProgramProcessor {
                 dynamicPureLoopCutting ? DynamicPureLoopCutting.fromConfig(config) : null,
                 ProgramProcessor.fromFunctionProcessor(
                         FunctionProcessor.chain(
+                                ResolveLLVMObjectSizeCalls.fromConfig(config),
                                 sccp,
                                 dce ? DeadAssignmentElimination.fromConfig(config) : null,
                                 RemoveDeadCondJumps.fromConfig(config)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ResolveLLVMObjectSizeCalls.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ResolveLLVMObjectSizeCalls.java
@@ -1,0 +1,61 @@
+package com.dat3m.dartagnan.program.processing;
+
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.IValue;
+import com.dat3m.dartagnan.expression.type.IntegerType;
+import com.dat3m.dartagnan.program.Function;
+import com.dat3m.dartagnan.program.event.EventFactory;
+import com.dat3m.dartagnan.program.event.core.Event;
+import com.dat3m.dartagnan.program.event.functions.ValueFunctionCall;
+import org.sosy_lab.common.configuration.Configuration;
+
+import java.math.BigInteger;
+
+/*
+    https://llvm.org/docs/LangRef.html#llvm-objectsize-intrinsic
+    A call to llvm.objectsize(ptr, ...) returns the size of the (accessible) object pointed to by <ptr>.
+    For example, if ptr_base is returned by alloc(100), then llvm.objectsize(ptr_base) == 100,
+    but llvm.objectsize(ptr_base + 80) == 20 (~ there are only 20 accessible bytes at that offset).
+    If the size cannot be determined statically, the call is replaced by either 0 or -1.
+    The intrinsic is typically used together with bound-checked memset/memcpy calls (e.g. __memset_chk) where the bound
+    check may get statically eliminated.
+
+    NOTE: For simplicity, we will always assume the object size to be statically unknown and return -1/0.
+
+    FIXME: A correct implementation needs to traverse the use-def chain from a llvm.objectsize call back to
+     the allocation site while tracking offset computations.
+     Unfortunately, this is quite hard to do in the presence of array indexing which can result in dynamic offsets.
+     A way around this is to rely on unrolling + CP to resolve dynamic offsets, then run this pass, and finally
+     run a second CP to propagate the resolved object sizes.
+ */
+public class ResolveLLVMObjectSizeCalls implements FunctionProcessor {
+
+    private ResolveLLVMObjectSizeCalls() {}
+
+    public static ResolveLLVMObjectSizeCalls fromConfig(Configuration config) {
+        return new ResolveLLVMObjectSizeCalls();
+    }
+
+    @Override
+    public void run(Function function) {
+        function.getEvents(ValueFunctionCall.class)
+                .stream().filter(call -> call.isDirectCall() && call.getCalledFunction().getIntrinsicInfo() == Intrinsics.Info.LLVM_OBJECTSIZE)
+                .forEach(this::resolveObjectSizeCall);
+    }
+
+    private void resolveObjectSizeCall(ValueFunctionCall call) {
+        //final Expression ptr = call.getArguments().get(0);
+        final IValue zeroIfUnknown = (IValue)call.getArguments().get(1); // else -1 if unknown
+        //final IValue nullIsUnknown = (IValue)call.getArguments().get(2);
+        //final IValue isDynamic = (IValue) call.getArguments().get(3); // Meaning of this is unclear
+
+        // TODO: We treat all pointers as unknown for now.
+        final ExpressionFactory exprs = ExpressionFactory.getInstance();
+        final BigInteger value = zeroIfUnknown.isOne() ? BigInteger.ZERO : BigInteger.ONE.negate();
+        final Event constAssignment = EventFactory.newLocal(
+                call.getResultRegister(), exprs.makeValue(value, (IntegerType) call.getResultRegister().getType())
+        );
+        constAssignment.copyAllMetadataFrom(call);
+        call.replaceBy(constAssignment);
+    }
+}


### PR DESCRIPTION
This PR adds very rudimentary support for the intrinsics `llvm.objectsize` and `__memset_chk`.

`llvm.objectsize(ptr, ...)` returns the size of an object pointed to by `ptr` but may return 0 or -1 if the size cannot be statically determined. For now, I just always assumed the second case, so `llvm.objectsize` gets replaced by 0/-1 no matter what.
There is a dedicated pass (rather than `Inlining`) that makes this replacement, because in principle this replacement would require a global analysis to determine the object sizes (*).

`__memset_chk` is just a regular memset that additionally checks if the range of the memset is within a given bound.
If it is not, `__memset_chk` is supposed to abort the program.
However, the bound parameter is given by `llvm.objectsize` which for now always returns 0/-1 and hence the memset would always be out-of-bounds (**).
So what we do for now is to just ignore the bounds check and treat `__memset_chk` as identical to `memset`.

(*) I originally implemented an analysis that traverses use-def-chains to find the allocation site of the pointer. However, a correct implementation also has to track pointer offsets on the way, and this makes the analysis quite complicated especially when the array indexing is involved.

(**) I do not understand what llvm does if it fails to resolve `llvm.objectsize` because then  `__memset_chk` cannot possibly work. Unfortunately, the documentation of `llvm.objectsize` and its interaction with `__memset_chk` is not well-documented.