### PR TITLE
Svcomp witness file must be named witness.graphml (new rule)

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
@@ -136,8 +136,7 @@ public class WitnessGraph extends ElemWithAttributes {
 	}
 
 	public void write() {
-		try (FileWriter fw = new FileWriter(String.format("%s/%s.graphml",
-				getOrCreateOutputDirectory(), Files.getNameWithoutExtension(getProgram())))) {
+		try (FileWriter fw = new FileWriter(String.format("%s/witness.graphml", getOrCreateOutputDirectory()))) {
 			fw.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
 			fw.write("<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n");
 			for (GraphAttributes attr : GraphAttributes.values()) {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/witness/BuildWitnessTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/witness/BuildWitnessTest.java
@@ -47,7 +47,7 @@ public class BuildWitnessTest {
             WitnessBuilder witnessBuilder = WitnessBuilder.of(modelChecker.getEncodingContext(), prover, res);
             config.inject(witnessBuilder);
             WitnessGraph graph = witnessBuilder.build();
-            File witnessFile = new File(getOutputDirectory() + "/lazy01-for-witness.graphml");
+            File witnessFile = new File(getOutputDirectory() + "/witness.graphml");
             // The file should not exist
             assertFalse(witnessFile.exists());
             // Write to file


### PR DESCRIPTION
New rule about witnesses in svcomp ... this PR adapts the code accordingly.