### PR TITLE
Parse poison values as non-deterministic values

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
@@ -868,9 +868,7 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
     @Override
     public Expression visitPoisonConst(PoisonConstContext ctx) {
         // It is correct to replace a poison value with an undef value or any value of the type.
-        BooleanType booleanType = types.getBooleanType();
-        var nondeterministicExpression = new BNonDet(booleanType);
-        return expressions.makeCast(nondeterministicExpression, expectedType);
+        return makeNonDetOfType(expectedType);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
@@ -866,6 +866,14 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
     }
 
     @Override
+    public Expression visitPoisonConst(PoisonConstContext ctx) {
+        // It is correct to replace a poison value with an undef value or any value of the type.
+        BooleanType booleanType = types.getBooleanType();
+        var nondeterministicExpression = new BNonDet(booleanType);
+        return expressions.makeCast(nondeterministicExpression, expectedType);
+    }
+
+    @Override
     public Expression visitStructConst(StructConstContext ctx) {
         List<Expression> structMembers = new ArrayList<>();
         for (TypeConstContext typeCtx : ctx.typeConst()) {


### PR DESCRIPTION
The [LLVM documentation](https://llvm.org/docs/LangRef.html#poison-values) states that "It is correct to replace a poison value with an undef value or any value of the type.", thus we parse poision values as non-deterministic values.