### PR TITLE
Better support for parsing of LLVM globals

### DIFF
--- a/dartagnan/src/main/antlr4/LLVMIR.g4
+++ b/dartagnan/src/main/antlr4/LLVMIR.g4
@@ -33,7 +33,6 @@ topLevelEntity:
 	| moduleAsm
 	| typeDef
 	| comdatDef
-	| globalDecl
 	| globalDef
 	| indirectSymbolDef
 	| funcDecl
@@ -53,14 +52,9 @@ comdatDef:
 		| 'nodeduplicate'
 		| 'samesize'
 	);
-globalDecl:
-	GlobalIdent '=' externalLinkage preemption? visibility? dllStorageClass? threadLocal?
-		unnamedAddr? addrSpace? externallyInitialized? immutable type (
-		',' globalField
-	)* (',' metadataAttachment)* funcAttribute*;
 globalDef:
-	GlobalIdent '=' internalLinkage? preemption? visibility? dllStorageClass? threadLocal?
-		unnamedAddr? addrSpace? externallyInitialized? immutable type constant (
+	GlobalIdent '=' (externalLinkage | internalLinkage)? preemption? visibility? dllStorageClass? threadLocal?
+		unnamedAddr? addrSpace? externallyInitialized? immutable type constant? (
 		',' globalField
 	)* (',' metadataAttachment)* funcAttribute*;
 


### PR DESCRIPTION
This PR:
- adds parsing of externally defined variables (with non-deterministic initializers, always signed).
- simplifies the LLVM grammar by combining `globalDecl` and `globalDef` into one rule.
- adds support for initializers of globals referencing each other.

@hernanponcedeleon 
I added a helper method that generates a non-det value for an arbitrary type. You can use that one for poison values in #565.