### PR TITLE
Support for GEP in init values & pointer subtraction in alias analysis

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/FieldSensitiveAndersen.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/FieldSensitiveAndersen.java
@@ -320,12 +320,12 @@ public class FieldSensitiveAndersen implements AliasAnalysis {
                 }
                 return new Result(null, null, l.offset.multiply(r.offset), min(min(l.alignment,l.register)*r.offset.intValue(), min(r.alignment,r.register)*l.offset.intValue()));
             }
-            if(x.getOp() == ADD) {
+            if(x.getOp() == ADD || x.getOp() == SUB) {
                 if(l.address!=null && r.address!=null) {
                     return null;
                 }
                 MemoryObject base = l.address!=null ? l.address : r.address;
-                BigInteger offset = l.offset.add(r.offset);
+                BigInteger offset = x.getOp() == ADD ? l.offset.add(r.offset) : l.offset.subtract(r.offset);
                 if(base!=null) {
                     return new Result(base,null,offset,min(min(l.alignment,l.register), min(r.alignment,r.register)));
                 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/GEPToAddition.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/GEPToAddition.java
@@ -10,6 +10,7 @@ import com.dat3m.dartagnan.expression.type.*;
 import com.dat3m.dartagnan.program.Function;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.core.utils.RegReader;
+import com.dat3m.dartagnan.program.memory.MemoryObject;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -28,6 +29,12 @@ public class GEPToAddition implements ProgramProcessor {
         for (Function function : program.getFunctions()) {
             for (RegReader reader : function.getEvents(RegReader.class)) {
                 reader.transformExpressions(transformer);
+            }
+        }
+
+        for (MemoryObject memoryObject : program.getMemory().getObjects()) {
+            for (int field : memoryObject.getStaticallyInitializedFields()) {
+                memoryObject.setInitialValue(field, memoryObject.getInitialValue(field).accept(transformer));
             }
         }
     }


### PR DESCRIPTION
This PR fixes the following two problems.

(1) #567 added support for parsing GEPs in initializers of globals, however, our `GEPToAddition` didn't lower those GEPs to additions which caused exceptions during encoding (cause GEPs were not encodable).

(2) When dealing with code that uses `container_of`-magic, the IR ends up having pointer subtractions (e.g. `ptr - 12`).
Our alias analysis wrongly handled those (it was not just imprecise but also incorrect!).
I added handling for subtraction. @xeren Can you check that my simple fix makes sense?