### PR TITLE
SVCOMP qualification

### DIFF
--- a/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
@@ -19,6 +19,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import static com.dat3m.dartagnan.configuration.OptionInfo.collectOptions;
 import static com.dat3m.dartagnan.configuration.OptionNames.*;

--- a/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
@@ -29,6 +29,8 @@ import static java.lang.Integer.parseInt;
 @Options
 public class SVCOMPRunner extends BaseOptions {
 
+    private static final Logger logger = LogManager.getLogger(SVCOMPRunner.class);
+
     private Property property;
     
     @Option(
@@ -96,6 +98,7 @@ public class SVCOMPRunner extends BaseOptions {
         config.recursiveInject(r);
 
         if(r.property == null) {
+            logger.warn("Unrecognized property");
             System.out.println("UNKNOWN");
             return;
         }

--- a/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
@@ -42,7 +42,9 @@ public class SVCOMPRunner extends BaseOptions {
 		} else if(p.contains("unreach-call")) {
 			property = Property.PROGRAM_SPEC;
 		} else {
-			throw new IllegalArgumentException("Unrecognized property " + p);
+            // To comply with SVCOMP qualification rules, we should return UNKNOWN
+            // instead of throwing an exception for unhandled properties
+            property = null;
 		}
 	}
 
@@ -92,6 +94,11 @@ public class SVCOMPRunner extends BaseOptions {
 		Configuration config = Configuration.fromCmdLineArguments(argKeyword);
 		SVCOMPRunner r = new SVCOMPRunner();
 		config.recursiveInject(r);
+
+        if(r.property == null) {
+            System.out.println("UNKNOWN");
+            return;
+        }
 
         WitnessGraph witness = new WitnessGraph(); 
         if(r.witnessPath != null) {


### PR DESCRIPTION
SVCOMP qualification rules requires to "start the verification" for at least half of the tasks.
Thus, we should return UNKNOWN instead of throwing an exception for SVCOMP unsupported properties.