### PR TITLE
Add IntegerType.isPointer()

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
@@ -98,11 +98,15 @@ public final class ExpressionFactory {
     }
 
     public Expression makeCast(Expression expression, Type type) {
+        return makeCast(expression, type, false);
+    }
+
+    public Expression makeCast(Expression expression, Type type, boolean signed) {
         if (type instanceof BooleanType) {
             return makeBooleanCast(expression);
         }
         if (type instanceof IntegerType integerType) {
-            return makeIntegerCast(expression, integerType, false);
+            return makeIntegerCast(expression, integerType, signed);
         }
         throw new UnsupportedOperationException(String.format("Cast %s into %s.", expression, type));
     }
@@ -242,9 +246,8 @@ public final class ExpressionFactory {
     // Pointers
 
     public Expression makeGetElementPointer(Type indexingType, Expression base, List<Expression> offsets) {
-        //TODO getPointerType()
-        Preconditions.checkArgument(base.getType().equals(types.getArchType()),
+        Preconditions.checkArgument(base.getType() instanceof IntegerType t && t.isPointer(),
                 "Applying offsets to non-pointer expression.");
-        return new GEPExpression(types.getArchType(), indexingType, base, offsets);
+        return new GEPExpression(base.getType(), indexingType, base, offsets);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/IExprBin.java
@@ -17,7 +17,10 @@ public class IExprBin extends IExpr {
 
     public IExprBin(IntegerType type, Expression lhs, IOpBin op, Expression rhs) {
         super(type);
-    	Preconditions.checkArgument(lhs.getType().equals(rhs.getType()),
+    	Preconditions.checkArgument(lhs.getType().equals(rhs.getType()) ||
+                        op.equals(IOpBin.ADD) &&
+                                lhs.getType() instanceof IntegerType leftType && leftType.isPointer() &&
+                                rhs.getType() instanceof IntegerType rightType && !rightType.isPointer(),
                 "The types of %s and %s do not match.", lhs, rhs);
         this.lhs = lhs;
         this.rhs = rhs;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/IntegerType.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/IntegerType.java
@@ -9,13 +9,19 @@ public final class IntegerType implements Type {
     final static int MATHEMATICAL = -1;
 
     private final int bitWidth;
+    private final boolean isPointer;
 
-    IntegerType(int bitWidth) {
+    IntegerType(int bitWidth, boolean isPointer) {
         this.bitWidth = bitWidth;
+        this.isPointer = isPointer;
     }
 
     public boolean isMathematical() {
         return bitWidth == MATHEMATICAL;
+    }
+
+    public boolean isPointer() {
+        return isPointer;
     }
 
     public int getBitWidth() {
@@ -59,16 +65,16 @@ public final class IntegerType implements Type {
         if (obj == this) {
             return true;
         }
-        return obj instanceof IntegerType other && other.bitWidth == this.bitWidth;
+        return obj instanceof IntegerType other && isPointer == other.isPointer && bitWidth == other.bitWidth;
     }
 
     @Override
     public int hashCode() {
-        return 31 * bitWidth;
+        return (isPointer ? 1 : 0) + 31 * bitWidth;
     }
 
     @Override
     public String toString() {
-        return isMathematical() ? "int" : "bv" + bitWidth;
+        return isPointer ? "ptr" : isMathematical() ? "int" : "bv" + bitWidth;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
@@ -15,8 +15,9 @@ public final class TypeFactory {
 
     private final VoidType voidType = new VoidType();
     private final BooleanType booleanType = new BooleanType();
+    private final IntegerType pointerType = new IntegerType(64, true);
     private final IntegerType pointerDifferenceType;
-    private final IntegerType mathematicalIntegerType = new IntegerType(IntegerType.MATHEMATICAL);
+    private final IntegerType mathematicalIntegerType = new IntegerType(IntegerType.MATHEMATICAL, false);
 
     private final Normalizer typeNormalizer = new Normalizer();
 
@@ -35,8 +36,8 @@ public final class TypeFactory {
 
     public VoidType getVoidType() { return voidType; }
 
-    public Type getPointerType() {
-        return pointerDifferenceType;
+    public IntegerType getPointerType() {
+        return pointerType;
     }
 
     public IntegerType getIntegerType() {
@@ -45,7 +46,7 @@ public final class TypeFactory {
 
     public IntegerType getIntegerType(int bitWidth) {
         checkArgument(bitWidth > 0, "Non-positive bit width %s.", bitWidth);
-        return typeNormalizer.normalize(new IntegerType(bitWidth));
+        return typeNormalizer.normalize(new IntegerType(bitWidth, false));
     }
 
     public FunctionType getFunctionType(Type returnType, List<? extends Type> parameterTypes) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -215,7 +215,7 @@ public class ProgramBuilder {
     public void initRegEqLocPtr(int regThread, String regName, String locName, Type type) {
         MemoryObject object = getOrNewMemoryObject(locName);
         Register reg = getOrNewRegister(regThread, regName, type);
-        addChild(regThread, EventFactory.newLocal(reg, object));
+        addChild(regThread, EventFactory.newLocal(reg, expressions.makeCast(object, type)));
     }
 
     public void initRegEqLocVal(int regThread, String regName, String locName, Type type) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -194,7 +194,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
                         }
                     }
                 }
-                Register register = programBuilder.getOrNewRegister(scope, name, archType);
+                Register register = programBuilder.getOrNewRegister(scope, name, object.getType());
                 programBuilder.addChild(currentThread, EventFactory.newLocal(register, object));
                 id++;
             }
@@ -499,15 +499,18 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     @Override
     public Object visitNreRegDeclaration(LitmusCParser.NreRegDeclarationContext ctx){
         Register register = programBuilder.getRegister(scope, ctx.varName().getText());
-        if(register == null){
-            register = programBuilder.getOrNewRegister(scope, ctx.varName().getText(), archType);
-            if(ctx.re() != null){
-                returnRegister = register;
-                ctx.re().accept(this);
-            }
-            return null;
+        if (register != null) {
+            throw new ParsingException("Register " + ctx.varName().getText() + " is already initialised");
         }
-        throw new ParsingException("Register " + ctx.varName().getText() + " is already initialised");
+        // More types are possible
+        final IntegerType type = ctx.typeSpecifier().Ast().isEmpty() ? archType :
+                programBuilder.getTypeFactory().getPointerType();
+        register = programBuilder.getOrNewRegister(scope, ctx.varName().getText(), type);
+        if (ctx.re() != null) {
+            returnRegister = register;
+            ctx.re().accept(this);
+        }
+        return null;
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
@@ -44,7 +44,7 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
     private final Program program = new Program(new Memory(), Program.SourceLanguage.LLVM);
     private final TypeFactory types = TypeFactory.getInstance();
     private final ExpressionFactory expressions = ExpressionFactory.getInstance();
-    private final Type pointerType = types.getPointerType();
+    private final IntegerType pointerType = types.getPointerType();
     private final IntegerType integerType = types.getArchType();
     private final Map<String, Expression> constantMap = new HashMap<>();
     private final Map<String, TypeDefContext> typeDefinitionMap = new HashMap<>();
@@ -818,7 +818,7 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
 
     @Override
     public Expression visitNullConst(NullConstContext ctx) {
-        return expressions.makeZero((IntegerType) pointerType);
+        return expressions.makeZero(pointerType);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Function.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Function.java
@@ -1,7 +1,7 @@
 package com.dat3m.dartagnan.program;
 
 import com.dat3m.dartagnan.exception.MalformedProgramException;
-import com.dat3m.dartagnan.expression.Expression;
+import com.dat3m.dartagnan.expression.IExpr;
 import com.dat3m.dartagnan.expression.IConst;
 import com.dat3m.dartagnan.expression.processing.ExpressionVisitor;
 import com.dat3m.dartagnan.expression.type.FunctionType;
@@ -17,7 +17,7 @@ import com.google.common.base.Preconditions;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class Function implements Expression {
+public class Function extends IExpr {
 
     protected String name;
     protected Event entry; // Can be null for intrinsics
@@ -34,6 +34,7 @@ public class Function implements Expression {
     protected int dummyCount = 0;
 
     public Function(String name, FunctionType type, List<String> parameterNames, int id, Event entry) {
+        super(TypeFactory.getInstance().getPointerType());
         Preconditions.checkArgument(type.getParameterTypes().size() == parameterNames.size());
         Preconditions.checkArgument(entry == null || entry.getPredecessor() == null,
                 "The entry event of a function is not allowed to have predecessors.");
@@ -55,11 +56,6 @@ public class Function implements Expression {
             exit = cur;
             cur = cur.getSuccessor();
         }
-    }
-
-    @Override
-    public Type getType() {
-        return TypeFactory.getInstance().getArchType();
     }
 
     public String getName() { return this.name; }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/Alloc.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/Alloc.java
@@ -33,8 +33,8 @@ public class Alloc extends AbstractEvent implements RegReader, RegWriter {
     private boolean isHeapAllocation;
 
     public Alloc(Register resultRegister, Type allocType, Expression arraySize, boolean isHeapAllocation) {
-        Preconditions.checkArgument(resultRegister.getType() == TypeFactory.getInstance().getArchType());
-        Preconditions.checkArgument(arraySize.getType() instanceof IntegerType);
+        Preconditions.checkArgument(resultRegister.getType() instanceof IntegerType t && t.isPointer());
+        Preconditions.checkArgument(arraySize.getType() instanceof IntegerType t && !t.isPointer());
         this.resultRegister = resultRegister;
         this.arraySize = arraySize;
         this.allocationType = allocType;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/MemoryObject.java
@@ -35,7 +35,7 @@ public class MemoryObject extends IConst {
     private final HashMap<Integer, Expression> initialValues = new HashMap<>();
 
     MemoryObject(int index, int size, boolean isStaticallyAllocated) {
-        super(TypeFactory.getInstance().getArchType());
+        super(TypeFactory.getInstance().getPointerType());
         this.index = index;
         this.size = size;
         this.isStatic = isStaticallyAllocated;

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -121,7 +121,7 @@ public class AnalysisTest {
         Register r0 = b.getOrNewRegister(0, "r0");
         //this is undefined behavior in C11
         //the expression does not match a sum, but x occurs in it
-        b.addChild(0, newLocal(r0, mult(x, 1)));
+        b.addChild(0, newLocal(r0, mult(expressions.makeIntegerCast(x, types.getArchType(), false), 1)));
         Store e0 = newStore(r0);
         b.addChild(0, e0);
         Store e1 = newStore(plus(r0, 1));
@@ -309,8 +309,8 @@ public class AnalysisTest {
 
         b.newThread(0);
         Register r0 = b.getOrNewRegister(0, "r0");
-        b.addChild(0, newLocal(r0, mult(x, 0)));
-        b.addChild(0, newLocal(r0, y));
+        b.addChild(0, newLocal(r0, mult(expressions.makeCast(x, types.getArchType(), false), 0)));
+        b.addChild(0, newLocal(r0, expressions.makeCast(y, types.getArchType(), false)));
         Store e0 = newStore(r0);
         b.addChild(0, e0);
         Store e1 = newStore(x);
@@ -353,10 +353,10 @@ public class AnalysisTest {
 
         b.newThread(0);
         Register r0 = b.getOrNewRegister(0, "r0");
-        b.addChild(0, newLocal(r0, y));
+        b.addChild(0, newLocal(r0, expressions.makeCast(y, types.getArchType(), false)));
         Store e0 = newStore(r0);
         b.addChild(0, e0);
-        b.addChild(0, newLocal(r0, mult(x, 0)));
+        b.addChild(0, newLocal(r0, mult(expressions.makeCast(x, types.getArchType(), false), 0)));
         Store e1 = newStore(x);
         b.addChild(0, e1);
         Store e2 = newStore(y);


### PR DESCRIPTION
This PR adds means to differentiate the types `ptr` and `bv64`.
This is a lightweight alternative to #550.  It does not forbid multiplications or bit operations on pointers, and does not require pointer expressions as addresses of memory events.  Assignments, however, raise an exception on type mismatch.