### PR TITLE
Call witness builder only for LLVM code

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -218,7 +218,7 @@ public class Dartagnan extends BaseOptions {
     private static void generateWitnessIfAble(VerificationTask task, ProverEnvironment prover, ModelChecker modelChecker, String summary) {
         // ------------------ Generate Witness, if possible ------------------
         final EnumSet<Property> properties = task.getProperty();
-        if (modelChecker.hasModel() && properties.contains(PROGRAM_SPEC)) {
+        if (task.getProgram().getFormat().equals(SourceLanguage.LLVM) && modelChecker.hasModel() && properties.contains(PROGRAM_SPEC)) {
             try {
                 WitnessBuilder w = WitnessBuilder.of(modelChecker.getEncodingContext(), prover, modelChecker.getResult(), summary);
                 if (w.canBeBuilt()) {


### PR DESCRIPTION
Due to the recent changes in #592, we get an exception when the encoding is SAT for litmus tests
```
[20.12.2023] 09:11:32 [INFO] AssumeSolver.run - Verification finished with result PASS
Condition exists (1:bv64 r1==bv64(2) && 1:bv64 r2==bv64(0))
Ok
Total verification time(ms): 431
[20.12.2023] 09:11:33 [ERROR] Dartagnan.main - Violation found for unsupported property
java.lang.UnsupportedOperationException: Violation found for unsupported property
        at com.dat3m.dartagnan.witness.WitnessBuilder.getLtlPropertyFromSummary(WitnessBuilder.java:89) ~[dartagnan.jar:?]
        at com.dat3m.dartagnan.witness.WitnessBuilder.<init>(WitnessBuilder.java:69) ~[dartagnan.jar:?]
        at com.dat3m.dartagnan.witness.WitnessBuilder.of(WitnessBuilder.java:74) ~[dartagnan.jar:?]
        at com.dat3m.dartagnan.Dartagnan.generateWitnessIfAble(Dartagnan.java:223) ~[dartagnan.jar:?]
        at com.dat3m.dartagnan.Dartagnan.main(Dartagnan.java:204) [dartagnan.jar:?]
ERROR
```
The witness builder is only related to SVCOMP and thus should only be called for LLVM code.