### PR TITLE
Generate knowledge from SVCOMP witness

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/witness/visitors/VisitorXML.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/witness/visitors/VisitorXML.java
@@ -14,64 +14,67 @@ import static com.dat3m.dartagnan.witness.NodeAttributes.*;
 import java.util.stream.Collectors;
 
 public class VisitorXML extends XMLParserBaseVisitor<Object> {
-	
-	private final WitnessGraph graph = new WitnessGraph();
-    private String lastAddedNodeId;
-	
-	@Override
-	public WitnessGraph visitDocument(XMLParser.DocumentContext ctx) {
-		visitChildren(ctx);
-		if(!graph.hasAttributed(PRODUCER.toString())) {
-			throw new ParsingException("The witness does not have a producer tag");
-		}
-		return graph;
-	}
 
-	@Override 
-	public Object visitElement(XMLParser.ElementContext ctx) {
-		if(ctx.content() != null) {
-			if(ctx.Name(0).getText().equals("data")) {
-				if(ctx.content() != null) {
-					String key = ctx.attribute(0).STRING().getText();
-					key = key.substring(1, key.length()-1);
-					String value = ctx.content().getText();
-					if(key.equals(PROGRAMFILE.toString()) || key.equals(PRODUCER.toString()) || key.equals(UNROLLBOUND.toString())) {
-						graph.addAttribute(key, value);	
-					}
-					if(key.equals(WITNESSTYPE.toString()) && !value.equals("violation_witness")) {
-						throw new ParsingException("Dartagnan can only validate violation witnesses");	
-					}
-					if(key.equals(ENTRY.toString()) || key.equals(VIOLATION.toString())) {
-						graph.getNode(lastAddedNodeId).addAttribute(key, value);	
-					}
-				}
-			}
-			if(ctx.Name(0).getText().equals("node")) {
-				String name = ctx.attribute(0).STRING().toString();
-				lastAddedNodeId = name.substring(1, name.length()-1);
-				graph.addNode(lastAddedNodeId);
-			}
-			if(ctx.Name(0).getText().equals("edge")) {
-				int idx = ctx.attribute().stream().map(a -> a.Name().toString()).collect(Collectors.toList()).indexOf("source");
-				String name = ctx.attribute(idx).STRING().toString();
-				name = name.substring(1, name.length()-1);
-				Node v0 = graph.hasNode(name) ? graph.getNode(name) : new Node(name);
-				idx = ctx.attribute().stream().map(a -> a.Name().toString()).collect(Collectors.toList()).indexOf("target");
-				name = ctx.attribute(idx).STRING().toString();
-				name = name.substring(1, name.length()-1);
-				Node v1 = graph.hasNode(name) ? graph.getNode(name) : new Node(name);
-				Edge edge = new Edge(v0, v1);
-				if(ctx.content() != null) {
-					for(ElementContext elem : ctx.content().element()) {
-						String key = elem.attribute(0).STRING().getText();
-						key = key.substring(1, key.length()-1);
-						String value = elem.content().getText();
-						edge.addAttribute(key, value);
-					}
-				}
-				graph.addEdge(edge);
-			}
-		}
-		return visitChildren(ctx);
-	}		
+    private final WitnessGraph graph = new WitnessGraph();
+    private String lastAddedNodeId;
+
+    @Override
+    public WitnessGraph visitDocument(XMLParser.DocumentContext ctx) {
+        visitChildren(ctx);
+        if (!graph.hasAttributed(PRODUCER.toString())) {
+            throw new ParsingException("The witness does not have a producer tag");
+        }
+        return graph;
+    }
+
+    @Override
+    public Object visitElement(XMLParser.ElementContext ctx) {
+        if (ctx.content() != null) {
+            if (ctx.Name(0).getText().equals("data")) {
+                if (ctx.content() != null) {
+                    String key = ctx.attribute(0).STRING().getText();
+                    key = key.substring(1, key.length() - 1);
+                    String value = ctx.content().getText();
+                    if (key.equals(PROGRAMFILE.toString()) || key.equals(PRODUCER.toString())
+                            || key.equals(UNROLLBOUND.toString())) {
+                        graph.addAttribute(key, value);
+                    }
+                    if (key.equals(WITNESSTYPE.toString()) && !value.equals("violation_witness")) {
+                        throw new ParsingException("Dartagnan can only validate violation witnesses");
+                    }
+                    if (key.equals(ENTRY.toString()) || key.equals(VIOLATION.toString())) {
+                        graph.getNode(lastAddedNodeId).addAttribute(key, value);
+                    }
+                }
+            }
+            if (ctx.Name(0).getText().equals("node")) {
+                String name = ctx.attribute(0).STRING().toString();
+                lastAddedNodeId = name.substring(1, name.length() - 1);
+                graph.addNode(lastAddedNodeId);
+            }
+            if (ctx.Name(0).getText().equals("edge")) {
+                int idx = ctx.attribute().stream().map(a -> a.Name().toString()).collect(Collectors.toList())
+                        .indexOf("source");
+                String name = ctx.attribute(idx).STRING().toString();
+                name = name.substring(1, name.length() - 1);
+                Node v0 = graph.hasNode(name) ? graph.getNode(name) : new Node(name);
+                idx = ctx.attribute().stream().map(a -> a.Name().toString()).collect(Collectors.toList())
+                        .indexOf("target");
+                name = ctx.attribute(idx).STRING().toString();
+                name = name.substring(1, name.length() - 1);
+                Node v1 = graph.hasNode(name) ? graph.getNode(name) : new Node(name);
+                Edge edge = new Edge(v0, v1);
+                if (ctx.content() != null) {
+                    for (ElementContext elem : ctx.content().element()) {
+                        String key = elem.attribute(0).STRING().getText();
+                        key = key.substring(1, key.length() - 1);
+                        String value = elem.content().getText();
+                        edge.addAttribute(key, value);
+                    }
+                }
+                graph.addEdge(edge);
+            }
+        }
+        return visitChildren(ctx);
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/witness/visitors/VisitorXML.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/witness/visitors/VisitorXML.java
@@ -9,12 +9,14 @@ import com.dat3m.dartagnan.witness.Node;
 import com.dat3m.dartagnan.witness.WitnessGraph;
 
 import static com.dat3m.dartagnan.witness.GraphAttributes.*;
+import static com.dat3m.dartagnan.witness.NodeAttributes.*;
 
 import java.util.stream.Collectors;
 
 public class VisitorXML extends XMLParserBaseVisitor<Object> {
 	
 	private final WitnessGraph graph = new WitnessGraph();
+    private String lastAddedNodeId;
 	
 	@Override
 	public WitnessGraph visitDocument(XMLParser.DocumentContext ctx) {
@@ -33,24 +35,21 @@ public class VisitorXML extends XMLParserBaseVisitor<Object> {
 					String key = ctx.attribute(0).STRING().getText();
 					key = key.substring(1, key.length()-1);
 					String value = ctx.content().getText();
-					if(key.equals(PROGRAMFILE.toString())) {
-						graph.addAttribute(key, value);	
-					}
-					if(key.equals(PRODUCER.toString())) {
-						graph.addAttribute(key, value);	
-					}
-					if(key.equals(UNROLLBOUND.toString())) {
+					if(key.equals(PROGRAMFILE.toString()) || key.equals(PRODUCER.toString()) || key.equals(UNROLLBOUND.toString())) {
 						graph.addAttribute(key, value);	
 					}
 					if(key.equals(WITNESSTYPE.toString()) && !value.equals("violation_witness")) {
 						throw new ParsingException("Dartagnan can only validate violation witnesses");	
 					}
+					if(key.equals(ENTRY.toString()) || key.equals(VIOLATION.toString())) {
+						graph.getNode(lastAddedNodeId).addAttribute(key, value);	
+					}
 				}
 			}
 			if(ctx.Name(0).getText().equals("node")) {
 				String name = ctx.attribute(0).STRING().toString();
-				name = name.substring(1, name.length()-1);
-				graph.addNode(name);
+				lastAddedNodeId = name.substring(1, name.length()-1);
+				graph.addNode(lastAddedNodeId);
 			}
 			if(ctx.Name(0).getText().equals("edge")) {
 				int idx = ctx.attribute().stream().map(a -> a.Name().toString()).collect(Collectors.toList()).indexOf("source");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/EdgeAttributes.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/EdgeAttributes.java
@@ -2,9 +2,7 @@ package com.dat3m.dartagnan.witness;
 
 public enum EdgeAttributes {
 
-	CREATETHREAD, THREADID, ENTERFUNCTION, STARTLINE,
-	// Dartagnan specific attributes
-	EVENTID, LOADEDVALUE, STOREDVALUE;
+	CREATETHREAD, THREADID, ENTERFUNCTION, STARTLINE;
 
 	@Override
 	public String toString() {
@@ -17,12 +15,6 @@ public enum EdgeAttributes {
 			return "enterFunction";
 		case STARTLINE:
 			return "startline";
-		case EVENTID:
-			return "event-id";
-		case LOADEDVALUE:
-			return "loaded-value";
-		case STOREDVALUE:
-			return "stored-value";
 		default:
 			throw new UnsupportedOperationException(this + " cannot be converted to String");
 		}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessBuilder.java
@@ -7,7 +7,6 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Assert;
 import com.dat3m.dartagnan.program.event.core.Event;
-import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.lang.svcomp.EndAtomic;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
@@ -154,22 +153,6 @@ public class WitnessBuilder {
                 if (e.hasTag(WRITE) && e.hasTag(PTHREAD)) {
                     edge.addAttribute(CREATETHREAD.toString(), valueOf(threads));
                     threads++;
-                }
-
-                // FIXME: The tracking of "globalId" here is very fragile
-                // If we generate a Witness and try to use it after adapting any processing pass
-                // the matching will fail. In particular, a Witness can only be validated
-                // by the version of Dartagnan that created it and only with identical
-                // configurations.
-                if (e instanceof Load l) {
-                    edge.addAttribute(EVENTID.toString(), valueOf(e.getGlobalId()));
-                    edge.addAttribute(LOADEDVALUE.toString(), String.valueOf(model.evaluate(context.result(l))));
-                }
-
-                if (e instanceof Store s) {
-                    edge.addAttribute(EVENTID.toString(), valueOf(e.getGlobalId()));
-                    Object valueObject = checkNotNull(model.evaluate(context.value(s)));
-                    edge.addAttribute(STOREDVALUE.toString(), valueObject.toString());
                 }
 
                 graph.addEdge(edge);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
@@ -167,7 +167,7 @@ public class WitnessGraph extends ElemWithAttributes {
             currents = getEventsFromEdge(program, e);
             current = currents.size() == 1 ? currents.get(0) : null;
             // If a graph edge implies a hb-relation, inter-thread communication guarantees
-            // same address and thus rf
+            // same address and thus rf.
             if (last != null && current != null && last instanceof Store && current instanceof Load
                     && ((graphEdgeImpliesHbEdge() && !last.getThread().equals(current.getThread()))
                             || alias.mustAlias(last, current))) {
@@ -191,14 +191,16 @@ public class WitnessGraph extends ElemWithAttributes {
                 last = null;
                 continue;
             }
-            // If a graph edge implies a hb-relation, inter-thread communication guarantees same address and thus co
+            // If a graph edge implies a hb-relation, inter-thread communication guarantees same address and thus co.
             if (last != null && last instanceof Store && graphEdgeImpliesHbEdge()
                     && !last.getThread().equals(current.getThread())) {
                 k.add(last, current);
             }
-            // Previous stores to the same address are guaranteed to be in co
+            // Previous stores to the same address are guaranteed to be in co.
+            // Some tools create two edges for the same store (e.g. CPAChecker for pthread_create)
+            // We avoid adding self loops.
             for (MemoryCoreEvent s : lasts) {
-                if (alias.mustAlias(s, current)) {
+                if (alias.mustAlias(s, current) && s != current) {
                     k.add(s, current);
                 }
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
@@ -29,6 +29,10 @@ public class WitnessGraph extends ElemWithAttributes {
     // The order in which we add / traverse edges is important, thus a List
     private final List<Edge> edges = new ArrayList<>();
 
+    public boolean isEmpty() {
+        return edges.isEmpty();
+    }
+
     public void addNode(String id) {
         nodes.add(new Node(id));
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
@@ -24,92 +24,95 @@ import static com.dat3m.dartagnan.witness.GraphAttributes.PROGRAMFILE;
 
 public class WitnessGraph extends ElemWithAttributes {
 
-	private final SortedSet<Node> nodes = new TreeSet<>();
-	// The order in which we add / traverse edges is important, thus a List
-	private final List<Edge> edges = new ArrayList<>();
+    private final SortedSet<Node> nodes = new TreeSet<>();
+    // The order in which we add / traverse edges is important, thus a List
+    private final List<Edge> edges = new ArrayList<>();
 
-	public void addNode(String id) {
-		nodes.add(new Node(id));
-	}
+    public void addNode(String id) {
+        nodes.add(new Node(id));
+    }
 
-	public boolean hasNode(String id) {
-		return nodes.stream().anyMatch(n -> n.getId().equals(id));
-	}
+    public boolean hasNode(String id) {
+        return nodes.stream().anyMatch(n -> n.getId().equals(id));
+    }
 
-	public Node getNode(String id) {
-		return nodes.stream().filter(n -> n.getId().equals(id)).findFirst().get();
-	}
+    public Node getNode(String id) {
+        return nodes.stream().filter(n -> n.getId().equals(id)).findFirst().get();
+    }
 
-	public void addEdge(Edge e) {
-		nodes.add(e.getSource());
-		nodes.add(e.getTarget());
-		edges.add(e);
-	}
+    public void addEdge(Edge e) {
+        nodes.add(e.getSource());
+        nodes.add(e.getTarget());
+        edges.add(e);
+    }
 
-	public Set<Node> getNodes() {
-		return nodes;
-	}
+    public Set<Node> getNodes() {
+        return nodes;
+    }
 
-	public List<Edge> getEdges() {
-		return edges;
-	}
+    public List<Edge> getEdges() {
+        return edges;
+    }
 
-	public String getProgram() {
-		return attributes.get(PROGRAMFILE.toString());
-	}
+    public String getProgram() {
+        return attributes.get(PROGRAMFILE.toString());
+    }
 
-	public String toXML() {
-		StringBuilder str = new StringBuilder();
-		str.append("<graph edgedefault=\"directed\">\n");
-		for (String attr : attributes.keySet()) {
-			str.append("  <data key=\"").append(attr).append("\">").append(attributes.get(attr)).append("</data>\n");
-		}
-		for (Node n : nodes) {
-			str.append(n.toXML());
-		}
-		for (Edge e : edges) {
-			str.append(e.toXML());
-		}
-		str.append("</graph>");
-		return str.toString();
-	}
+    public String toXML() {
+        StringBuilder str = new StringBuilder();
+        str.append("<graph edgedefault=\"directed\">\n");
+        for (String attr : attributes.keySet()) {
+            str.append("  <data key=\"").append(attr).append("\">").append(attributes.get(attr)).append("</data>\n");
+        }
+        for (Node n : nodes) {
+            str.append(n.toXML());
+        }
+        for (Edge e : edges) {
+            str.append(e.toXML());
+        }
+        str.append("</graph>");
+        return str.toString();
+    }
 
-	public BooleanFormula encode(EncodingContext context) {
-		Program program = context.getTask().getProgram();
-		BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
-		FormulaManager fmgr = context.getFormulaManager();
-		List<BooleanFormula> enc = new ArrayList<>();
-		List<MemoryEvent> previous = new ArrayList<>();
-		for (Edge edge : edges.stream().filter(Edge::hasCline).toList()) {
-			List<MemoryEvent> events = getEventsFromEdge(program, edge);
-			if (!previous.isEmpty() && !events.isEmpty()) {
-				enc.add(bmgr.or(Lists.cartesianProduct(previous, events).stream()
-						.map(p -> context.edgeVariable("hb", p.get(0), p.get(1)))
-						.toArray(BooleanFormula[]::new)));
-			}
-			if (!events.isEmpty()) {
-				previous = events;
-			}
-			// FIXME: The reliance on "globalId" for matching is very fragile (see comment in WitnessBuilder)
-			if (edge.hasAttributed(EVENTID.toString()) && edge.hasAttributed(LOADEDVALUE.toString())) {
-				int id = Integer.parseInt(edge.getAttributed(EVENTID.toString()));
-				Optional<Load> load = program.getThreadEvents(Load.class).stream().filter(e -> e.getGlobalId() == id).findFirst();
-				if (load.isPresent()) {
-					String loadedValue = edge.getAttributed(LOADEDVALUE.toString());
-					enc.add(equalsParsedValue(context.result(load.get()), loadedValue, fmgr));
-				}
-			}
-			if (edge.hasAttributed(EVENTID.toString()) && edge.hasAttributed(STOREDVALUE.toString())) {
-				int id = Integer.parseInt(edge.getAttributed(EVENTID.toString()));
-				Optional<Store> store = program.getThreadEvents(Store.class).stream().filter(e -> e.getGlobalId() == id).findFirst();
-				if (store.isPresent()) {
-					String storedValue = edge.getAttributed(STOREDVALUE.toString());
-					enc.add(equalsParsedValue(context.value(store.get()), storedValue, fmgr));
-				}
-			}
-		}
-		return bmgr.and(enc);
-	}
+    public BooleanFormula encode(EncodingContext context) {
+        Program program = context.getTask().getProgram();
+        BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
+        FormulaManager fmgr = context.getFormulaManager();
+        List<BooleanFormula> enc = new ArrayList<>();
+        List<MemoryEvent> previous = new ArrayList<>();
+        for (Edge edge : edges.stream().filter(Edge::hasCline).toList()) {
+            List<MemoryEvent> events = getEventsFromEdge(program, edge);
+            if (!previous.isEmpty() && !events.isEmpty()) {
+                enc.add(bmgr.or(Lists.cartesianProduct(previous, events).stream()
+                        .map(p -> context.edgeVariable("hb", p.get(0), p.get(1)))
+                        .toArray(BooleanFormula[]::new)));
+            }
+            if (!events.isEmpty()) {
+                previous = events;
+            }
+            // FIXME: The reliance on "globalId" for matching is very fragile (see comment
+            // in WitnessBuilder)
+            if (edge.hasAttributed(EVENTID.toString()) && edge.hasAttributed(LOADEDVALUE.toString())) {
+                int id = Integer.parseInt(edge.getAttributed(EVENTID.toString()));
+                Optional<Load> load = program.getThreadEvents(Load.class).stream().filter(e -> e.getGlobalId() == id)
+                        .findFirst();
+                if (load.isPresent()) {
+                    String loadedValue = edge.getAttributed(LOADEDVALUE.toString());
+                    enc.add(equalsParsedValue(context.result(load.get()), loadedValue, fmgr));
+                }
+            }
+            if (edge.hasAttributed(EVENTID.toString()) && edge.hasAttributed(STOREDVALUE.toString())) {
+                int id = Integer.parseInt(edge.getAttributed(EVENTID.toString()));
+                Optional<Store> store = program.getThreadEvents(Store.class).stream().filter(e -> e.getGlobalId() == id)
+                        .findFirst();
+                if (store.isPresent()) {
+                    String storedValue = edge.getAttributed(STOREDVALUE.toString());
+                    enc.add(equalsParsedValue(context.value(store.get()), storedValue, fmgr));
+                }
+            }
+        }
+        return bmgr.and(enc);
+    }
 
     private List<MemoryEvent> getEventsFromEdge(Program program, Edge edge) {
         Stream<MemoryEvent> res = Stream.empty();
@@ -125,7 +128,8 @@ public class WitnessGraph extends ElemWithAttributes {
         return res.collect(Collectors.toList());
     }
 
-    private <T1 extends Event, T2 extends Event> EventGraph getHbKnowledge(Program program, Class<T1> c1, Class<T2> c2) {
+    private <T1 extends Event, T2 extends Event> EventGraph getHbKnowledge(Program program, Class<T1> c1,
+            Class<T2> c2) {
         EventGraph k = new EventGraph();
         MemoryEvent current = null;
         MemoryEvent last = null;
@@ -150,45 +154,49 @@ public class WitnessGraph extends ElemWithAttributes {
         return getHbKnowledge(program, Store.class, Store.class);
     }
 
-	private static BooleanFormula equalsParsedValue(Formula operand, String value, FormulaManager formulaManager) {
-		if (operand instanceof BooleanFormula bool) {
-			return switch (value) {
-				case "false", "0" -> formulaManager.getBooleanFormulaManager().not(bool);
-				default -> bool;
-			};
-		}
-		BigInteger integerValue = switch (value) {
-			case "false" -> BigInteger.ZERO;
-			case "true" -> BigInteger.ONE;
-			default -> new BigInteger(value);
-		};
-		if (operand instanceof NumeralFormula.IntegerFormula integer) {
-			IntegerFormulaManager imgr = formulaManager.getIntegerFormulaManager();
-			return imgr.equal(integer, imgr.makeNumber(integerValue));
-		}
-		assert operand instanceof BitvectorFormula;
-		BitvectorFormula bitvector = (BitvectorFormula) operand;
-		BitvectorFormulaManager bvmgr = formulaManager.getBitvectorFormulaManager();
-		return bvmgr.equal(bitvector, bvmgr.makeBitvector(bvmgr.getLength(bitvector), integerValue));
-	}
+    private static BooleanFormula equalsParsedValue(Formula operand, String value, FormulaManager formulaManager) {
+        if (operand instanceof BooleanFormula bool) {
+            return switch (value) {
+                case "false", "0" -> formulaManager.getBooleanFormulaManager().not(bool);
+                default -> bool;
+            };
+        }
+        BigInteger integerValue = switch (value) {
+            case "false" -> BigInteger.ZERO;
+            case "true" -> BigInteger.ONE;
+            default -> new BigInteger(value);
+        };
+        if (operand instanceof NumeralFormula.IntegerFormula integer) {
+            IntegerFormulaManager imgr = formulaManager.getIntegerFormulaManager();
+            return imgr.equal(integer, imgr.makeNumber(integerValue));
+        }
+        assert operand instanceof BitvectorFormula;
+        BitvectorFormula bitvector = (BitvectorFormula) operand;
+        BitvectorFormulaManager bvmgr = formulaManager.getBitvectorFormulaManager();
+        return bvmgr.equal(bitvector, bvmgr.makeBitvector(bvmgr.getLength(bitvector), integerValue));
+    }
 
-	public void write() {
-		try (FileWriter fw = new FileWriter(String.format("%s/witness.graphml", getOrCreateOutputDirectory()))) {
-			fw.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
-			fw.write("<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n");
-			for (GraphAttributes attr : GraphAttributes.values()) {
-				fw.write("<key attr.name=\"" + attr.toString() + "\" attr.type=\"string\" for=\"graph\" id=\"" + attr + "\"/>\n");
-			}
-			for (NodeAttributes attr : NodeAttributes.values()) {
-				fw.write("<key attr.name=\"" + attr.toString() + "\" attr.type=\"boolean\" for=\"node\" id=\"" + attr + "\"/>\n");
-			}
-			for (EdgeAttributes attr : EdgeAttributes.values()) {
-				fw.write("<key attr.name=\"" + attr.toString() + "\" attr.type=\"string\" for=\"edge\" id=\"" + attr + "\"/>\n");
-			}
-			fw.write(toXML());
-			fw.write("</graphml>\n");
-		} catch (IOException e1) {
-			e1.printStackTrace();
-		}
-	}
+    public void write() {
+        try (FileWriter fw = new FileWriter(String.format("%s/witness.graphml", getOrCreateOutputDirectory()))) {
+            fw.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
+            fw.write(
+                    "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n");
+            for (GraphAttributes attr : GraphAttributes.values()) {
+                fw.write("<key attr.name=\"" + attr.toString() + "\" attr.type=\"string\" for=\"graph\" id=\"" + attr
+                        + "\"/>\n");
+            }
+            for (NodeAttributes attr : NodeAttributes.values()) {
+                fw.write("<key attr.name=\"" + attr.toString() + "\" attr.type=\"boolean\" for=\"node\" id=\"" + attr
+                        + "\"/>\n");
+            }
+            for (EdgeAttributes attr : EdgeAttributes.values()) {
+                fw.write("<key attr.name=\"" + attr.toString() + "\" attr.type=\"string\" for=\"edge\" id=\"" + attr
+                        + "\"/>\n");
+            }
+            fw.write(toXML());
+            fw.write("</graphml>\n");
+        } catch (IOException e1) {
+            e1.printStackTrace();
+        }
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
@@ -119,7 +119,6 @@ public class WitnessGraph extends ElemWithAttributes {
         if (edge.hasAttributed(EVENTID.toString())) {
             res = program.getThreadEvents(MemoryEvent.class).stream()
                     .filter(e -> e.getGlobalId() == Integer.parseInt(edge.getAttributed(EVENTID.toString())));
-            assert (res.count() == 1);
         } else if (edge.hasCline()) {
             res = program.getThreadEvents(MemoryEvent.class).stream()
                     .filter(e -> e.hasMetadata(SourceLocation.class))

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/WitnessGraph.java
@@ -38,17 +38,15 @@ public class WitnessGraph extends ElemWithAttributes {
     }
 
     public Node getNode(String id) {
-        return nodes.stream().filter(n -> n.getId().equals(id)).findFirst().get();
+        return nodes.stream().filter(n -> n.getId().equals(id)).findFirst().orElseThrow(() -> new RuntimeException("Witness graph does not contain node with id " + id));
     }
 
     public Node getEntryNode() {
-        assert(nodes.stream().anyMatch(n -> n.hasAttributed(ENTRY.toString())));
-        return nodes.stream().filter(n -> n.hasAttributed(ENTRY.toString())).findFirst().get();
+        return nodes.stream().filter(n -> n.hasAttributed(ENTRY.toString())).findFirst().orElseThrow(() -> new RuntimeException("Witness graph does not contain entry node"));
     }
 
     public Node getViolationNode() {
-        assert(nodes.stream().anyMatch(n -> n.hasAttributed(VIOLATION.toString())));
-        return nodes.stream().filter(n -> n.hasAttributed(VIOLATION.toString())).findAny().get();
+        return nodes.stream().filter(n -> n.hasAttributed(VIOLATION.toString())).findAny().orElseThrow(() -> new RuntimeException("Witness graph does not contain violation node"));
     }
 
     public void addEdge(Edge e) {
@@ -117,6 +115,8 @@ public class WitnessGraph extends ElemWithAttributes {
         for (Edge edge : edges.stream().filter(Edge::hasCline).toList()) {
             List<MemoryCoreEvent> events = getEventsFromEdge(program, edge);
             if (!previous.isEmpty() && !events.isEmpty()) {
+                // This generates hb-constraints between events that might not be in the may-set.
+                // However, this is required to obtain the desired ordering constraint between non-neighboring events.
                 enc.add(bmgr.or(Lists.cartesianProduct(previous, events).stream()
                         .map(p -> context.edgeVariable("hb", p.get(0), p.get(1)))
                         .toArray(BooleanFormula[]::new)));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
@@ -864,7 +864,11 @@ public class RelationAnalysis {
 
             // Must-rf from violation witness
             if(witness != null) {
-                must.addAll(witness.getReadFromKnowledge(program));
+                EventGraph g = witness.getReadFromKnowledge(program);
+                must.addAll(g);
+                for(Event r : g.getRange()) {
+                    may.removeIf((e1, e2) -> e2 == r);
+                }
             }
 
             logger.debug("Initial may set size for read-from: {}", may.size());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
@@ -743,7 +743,7 @@ public class RelationAnalysis {
             }
 
             // Must-co from violation witness
-            if(witness != null) {
+            if(!witness.isEmpty()) {
                 must.addAll(witness.getCoherenceKnowledge(program, alias));
             }
 
@@ -863,7 +863,7 @@ public class RelationAnalysis {
             }
 
             // Must-rf from violation witness
-            if(witness != null) {
+            if(!witness.isEmpty()) {
                 EventGraph g = witness.getReadFromKnowledge(program, alias);
                 must.addAll(g);
                 for(Event r : g.getRange()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
@@ -21,6 +21,7 @@ import com.dat3m.dartagnan.program.memory.VirtualMemoryObject;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
+import com.dat3m.dartagnan.witness.WitnessGraph;
 import com.dat3m.dartagnan.wmm.Constraint;
 import com.dat3m.dartagnan.wmm.Definition;
 import com.dat3m.dartagnan.wmm.Relation;
@@ -421,6 +422,7 @@ public class RelationAnalysis {
 
     private final class Initializer implements Definition.Visitor<Knowledge> {
         final Program program = task.getProgram();
+        final WitnessGraph witness = task.getWitness();
         final Knowledge defaultKnowledge;
 
         Initializer() {
@@ -739,6 +741,12 @@ public class RelationAnalysis {
                     }
                 });
             }
+
+            // Must-co from violation witness
+            if(witness != null) {
+                must.addAll(witness.getCoherenceKnowledge(program));
+            }
+
             logger.debug("Initial may set size for memory order: {}", may.size());
             return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
         }
@@ -853,6 +861,12 @@ public class RelationAnalysis {
                 }
                 logger.debug("Atomic block optimization eliminated {} reads", sizeBefore - may.size());
             }
+
+            // Must-rf from violation witness
+            if(witness != null) {
+                must.addAll(witness.getReadFromKnowledge(program));
+            }
+
             logger.debug("Initial may set size for read-from: {}", may.size());
             return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
@@ -744,7 +744,7 @@ public class RelationAnalysis {
 
             // Must-co from violation witness
             if(witness != null) {
-                must.addAll(witness.getCoherenceKnowledge(program));
+                must.addAll(witness.getCoherenceKnowledge(program, alias));
             }
 
             logger.debug("Initial may set size for memory order: {}", may.size());
@@ -864,7 +864,7 @@ public class RelationAnalysis {
 
             // Must-rf from violation witness
             if(witness != null) {
-                EventGraph g = witness.getReadFromKnowledge(program);
+                EventGraph g = witness.getReadFromKnowledge(program, alias);
                 must.addAll(g);
                 for(Event r : g.getRange()) {
                     may.removeIf((e1, e2) -> e2 == r);


### PR DESCRIPTION
This PR adds must knowledge to XRA from SVCOMP witnesses. It simply iterates over the witness edges and if it finds a store-load (resp. store-store) edge from different threads, it adds the pair to the must set of `rf` (resp. `co`). The definition of SC + the semantics of the witness guarantee that this knowledge is correct.

There is no point in trying to be smart and extract e.g., `fr` knowledge or edges within the same thread. XRA is supposed to take care of propagating information and deriving those (keep in mind we assume the memory model is locally consistent). 

In the few examples I tried, the number of encoded edges (the number logged as `Acyclic.getEncodeGraph - reduced encodeGraph size` is reduced by ~10%)