### PR TITLE
add memalloy-ptx tests

### DIFF
--- a/dartagnan/src/main/antlr4/LitmusPTX.g4
+++ b/dartagnan/src/main/antlr4/LitmusPTX.g4
@@ -107,7 +107,7 @@ loadInstruction
     ;
 
 localValue
-    :   load Period mo (Period scope)? register Comma value
+    :   load register Comma value
     ;
 
 localAdd

--- a/dartagnan/src/test/resources/PTXv6_0-expected.csv
+++ b/dartagnan/src/test/resources/PTXv6_0-expected.csv
@@ -78,3 +78,9 @@ litmus/PTX/Manual/PC-bar-sync-sync-1.litmus,1
 litmus/PTX/Manual/PC-bar-sync-sync-2.litmus,1
 litmus/PTX/Manual/PC-bar-sync-sync-3.litmus,1
 litmus/PTX/Manual/PC-bar-sync-sync-4.litmus,1
+litmus/PTX/Memalloy/IRIW_gl_cta.litmus,1
+litmus/PTX/Memalloy/IRIW_uniproc.litmus,1
+litmus/PTX/Memalloy/IRRWIW_uniproc.litmus,1
+litmus/PTX/Memalloy/IRWIW_gl_cta.litmus,1
+litmus/PTX/Memalloy/RWC_uniproc.litmus,1
+litmus/PTX/Memalloy/WRR+2W.litmus,1

--- a/dartagnan/src/test/resources/PTXv7_5-expected.csv
+++ b/dartagnan/src/test/resources/PTXv7_5-expected.csv
@@ -207,3 +207,9 @@ litmus/PTX/Manual/PC-bar-sync-sync-1.litmus,1
 litmus/PTX/Manual/PC-bar-sync-sync-2.litmus,1
 litmus/PTX/Manual/PC-bar-sync-sync-3.litmus,1
 litmus/PTX/Manual/PC-bar-sync-sync-4.litmus,1
+litmus/PTX/Memalloy/IRIW_gl_cta.litmus,1
+litmus/PTX/Memalloy/IRIW_uniproc.litmus,1
+litmus/PTX/Memalloy/IRRWIW_uniproc.litmus,1
+litmus/PTX/Memalloy/IRWIW_gl_cta.litmus,1
+litmus/PTX/Memalloy/RWC_uniproc.litmus,1
+litmus/PTX/Memalloy/WRR+2W.litmus,1

--- a/litmus/PTX/Manual/LB-dlb-no-fence-1.litmus
+++ b/litmus/PTX/Manual/LB-dlb-no-fence-1.litmus
@@ -8,8 +8,8 @@ h=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0                   | P1@cta 1,gpu 0                   ;
- atom.relaxed.gpu.cas r0, h, 0, 1 | ld.relaxed.gpu r1, t             ;
+ atom.relaxed.gpu.cas r0, h, 0, 1 | ld.weak r1, t                    ;
                                   | fence.sc.gpu                     ;
- st.relaxed.gpu t, 1              | atom.relaxed.gpu.cas r3, h, 0, 1 ;
+ st.weak t, 1                     | atom.relaxed.gpu.cas r3, h, 0, 1 ;
 exists
  (P0:r0 == 1 /\ P1:r1 == 1)

--- a/litmus/PTX/Manual/LB-dlb-no-fence-2.litmus
+++ b/litmus/PTX/Manual/LB-dlb-no-fence-2.litmus
@@ -8,8 +8,8 @@ h=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0                   | P1@cta 1,gpu 0                   ;
- atom.relaxed.gpu.cas r0, h, 0, 1 | ld.relaxed.gpu r1, t             ;
+ atom.relaxed.gpu.cas r0, h, 0, 1 | ld.weak r1, t                    ;
  fence.sc.gpu                     |                                  ;
- st.relaxed.gpu t, 1              | atom.relaxed.gpu.cas r3, h, 0, 1 ;
+ st.weak t, 1                     | atom.relaxed.gpu.cas r3, h, 0, 1 ;
 exists
  (P0:r0 == 1 /\ P1:r1 == 1)

--- a/litmus/PTX/Manual/LB-dlb.litmus
+++ b/litmus/PTX/Manual/LB-dlb.litmus
@@ -8,8 +8,8 @@ h=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0                   | P1@cta 1,gpu 0                   ;
- atom.relaxed.gpu.cas r0, h, 0, 1 | ld.relaxed.gpu r1, t             ;
+ atom.relaxed.gpu.cas r0, h, 0, 1 | ld.weak r1, t                    ;
  fence.sc.gpu                     | fence.sc.gpu                     ;
- st.relaxed.gpu t, 1              | atom.relaxed.gpu.cas r3, h, 0, 1 ;
+ st.weak t, 1                     | atom.relaxed.gpu.cas r3, h, 0, 1 ;
 exists
  (P0:r0 == 1 /\ P1:r1 == 1)

--- a/litmus/PTX/Manual/MP-dlb-no-fence-1.litmus
+++ b/litmus/PTX/Manual/MP-dlb-no-fence-1.litmus
@@ -8,10 +8,10 @@ d=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0      | P1@cta 1,gpu 0       ;
- st.relaxed.gpu d, 1 | ld.weak r0, t        ;
+ st.weak d, 1        | ld.weak r0, t        ;
                      | beq r0, r3, LC00     ;
  ld.weak r2, t       | fence.sc.gpu         ;
- add r2, r2, 1       | ld.relaxed.gpu r1, d ;
+ add r2, r2, 1       | ld.weak r1, d        ;
  st.weak t, r2       | LC00:                ;
 exists
 (P1:r0 == 1 /\ P1:r1 == 0)

--- a/litmus/PTX/Manual/MP-dlb-no-fence-2.litmus
+++ b/litmus/PTX/Manual/MP-dlb-no-fence-2.litmus
@@ -8,10 +8,10 @@ d=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0      | P1@cta 1,gpu 0       ;
- st.relaxed.gpu d, 1 | ld.weak r0, t        ;
+ st.weak d, 1        | ld.weak r0, t        ;
  fence.sc.gpu        | beq r0, r3, LC00     ;
  ld.weak r2, t       |                      ;
- add r2, r2, 1       | ld.relaxed.gpu r1, d ;
+ add r2, r2, 1       | ld.weak r1, d        ;
  st.weak t, r2       | LC00:                ;
 exists
 (P1:r0 == 1 /\ P1:r1 == 0)

--- a/litmus/PTX/Manual/SL-cas-minus.litmus
+++ b/litmus/PTX/Manual/SL-cas-minus.litmus
@@ -11,9 +11,9 @@ P1:r2=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0                 | P1@cta 1,gpu 0                   ;
- st.relaxed.gpu x, 1            | atom.relaxed.gpu.cas r1, m, 0, 1 ;
+ st.weak x, 1                   | atom.relaxed.gpu.cas r1, m, 0, 1 ;
  atom.relaxed.gpu.exch r0, m, 0 | bne r1, 0, LC00                  ;
-                                | ld.relaxed.gpu r3, x             ;
+                                | ld.weak r3, x                    ;
                                 | LC00:                            ;
 exists
  (P1:r1 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/SL-cas-plus.litmus
+++ b/litmus/PTX/Manual/SL-cas-plus.litmus
@@ -11,10 +11,10 @@ P1:r2=0;
 P1:r3=0;
 }
  P0@cta 0,gpu 0                 | P1@cta 1,gpu 0                   ;
- st.relaxed.gpu x, 1            | atom.relaxed.gpu.cas r1, m, 0, 1 ;
+ st.weak x, 1                   | atom.relaxed.gpu.cas r1, m, 0, 1 ;
  fence.sc.gpu                   | bne r1, 0, LC00                  ;
  atom.relaxed.gpu.exch r0, m, 0 | fence.sc.gpu                     ;
-                                | ld.relaxed.gpu r3, x             ;
+                                | ld.weak r3, x                    ;
                                 | LC00:                            ;
 exists
  (P1:r1 == 0 /\ P1:r3 == 0)

--- a/litmus/PTX/Manual/SL-future-minus.litmus
+++ b/litmus/PTX/Manual/SL-future-minus.litmus
@@ -10,9 +10,9 @@ P0:r1=0;
 P1:r2=0;
 }
  P0@cta 0,gpu 0       | P1@cta 1,gpu 0                   ;
- ld.relaxed.gpu r0, x | atom.relaxed.gpu.cas r2, m, 0, 1 ;
- st.relaxed.gpu m, 0  | bne r2, 0, LC00                  ;
- fence.sc.gpu         | st.relaxed.gpu x, 1              ;
+ ld.weak r0, x        | atom.relaxed.gpu.cas r2, m, 0, 1 ;
+ st.weak m, 0         | bne r2, 0, LC00                  ;
+ fence.sc.gpu         | st.weak x, 1                     ;
                       | LC00:                            ;
 exists
  (P0:r0 == 1 /\ P1:r2 == 0)

--- a/litmus/PTX/Manual/SL-future-plus.litmus
+++ b/litmus/PTX/Manual/SL-future-plus.litmus
@@ -10,10 +10,10 @@ P0:r1=0;
 P1:r2=0;
 }
  P0@cta 0,gpu 0                 | P1@cta 1,gpu 0                   ;
- ld.relaxed.gpu r0, x           | atom.relaxed.gpu.cas r2, m, 0, 1 ;
+ ld.weak r0, x                  | atom.relaxed.gpu.cas r2, m, 0, 1 ;
  fence.sc.gpu                   | bne r2, 0, LC00                  ;
  atom.relaxed.gpu.exch r1, m, 0 | fence.sc.gpu                     ;
-                                | st.relaxed.gpu x, 1              ;
+                                | st.weak x, 1                     ;
                                 | LC00:                            ;
 exists
  (P0:r0 == 1 /\ P1:r2 == 0)

--- a/litmus/PTX/Memalloy/IRIW_gl_cta.litmus
+++ b/litmus/PTX/Memalloy/IRIW_gl_cta.litmus
@@ -1,0 +1,18 @@
+PTX IRIW_gl_cta
+"CoRR"
+"https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/IRIW_gl_cta/IRIW_gl_cta.txt"
+{
+P0:r0=0;
+P1:r0=0;
+P1:r2=0;
+P2:r0=0;
+P3:r0=0;
+P3:r2=0;
+x=0;
+}
+ P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
+ ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            | ld.weak r0, x            ;
+ st.weak x, r0            | fence.acq_rel.gpu        | st.weak x, r0            | fence.acq_rel.cta        ;
+                          | ld.weak r2, x            |                          | ld.weak r2, x            ;
+exists
+(P1:r0 == 1 /\ P1:r2 == 0 /\ P3:r0 == 1 /\ P3:r2 == 0)

--- a/litmus/PTX/Memalloy/IRIW_gl_cta.litmus
+++ b/litmus/PTX/Memalloy/IRIW_gl_cta.litmus
@@ -12,7 +12,7 @@ x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
  ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            | ld.weak r0, x            ;
- st.weak x, r0            | fence.acq_rel.gpu        | st.weak x, r0            | fence.acq_rel.cta        ;
+ st.weak x, r0            | fence.sc.gpu             | st.weak x, r0            | fence.sc.cta             ;
                           | ld.weak r2, x            |                          | ld.weak r2, x            ;
 exists
 (P1:r0 == 1 /\ P1:r2 == 0 /\ P3:r0 == 1 /\ P3:r2 == 0)

--- a/litmus/PTX/Memalloy/IRIW_gl_cta.litmus
+++ b/litmus/PTX/Memalloy/IRIW_gl_cta.litmus
@@ -11,7 +11,7 @@ P3:r2=0;
 x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
- ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            | ld.weak r0, x            ;
+ ld r0, 1                 | ld.weak r0, x            | ld r0, 1                 | ld.weak r0, x            ;
  st.weak x, r0            | fence.sc.gpu             | st.weak x, r0            | fence.sc.cta             ;
                           | ld.weak r2, x            |                          | ld.weak r2, x            ;
 exists

--- a/litmus/PTX/Memalloy/IRIW_uniproc.litmus
+++ b/litmus/PTX/Memalloy/IRIW_uniproc.litmus
@@ -11,7 +11,7 @@ P3:r2=0;
 x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
- ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            | ld.weak r0, x            ;
+ ld r0, 1                 | ld.weak r0, x            | ld r0, 2                 | ld.weak r0, x            ;
  st.weak x, r0            | fence.sc.cta             | st.weak x, r0            | fence.sc.gpu             ;
                           | ld.weak r2, x            |                          | ld.weak r2, x            ;
 exists

--- a/litmus/PTX/Memalloy/IRIW_uniproc.litmus
+++ b/litmus/PTX/Memalloy/IRIW_uniproc.litmus
@@ -1,0 +1,18 @@
+PTX IRIW_uniproc
+"CoRR"
+"https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/IRIW_uniproc/IRIW_uniproc.litmus"
+{
+P0:r0=0;
+P1:r0=0;
+P1:r2=0;
+P2:r0=0;
+P3:r0=0;
+P3:r2=0;
+x=0;
+}
+ P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
+ ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            | ld.weak r0, x            ;
+ st.weak x, r0            | fence.acq_rel.cta        | st.weak x, r0            | fence.acq_rel.gpu        ;
+                          | ld.weak r2, x            |                          | ld.weak r2, x            ;
+exists
+(P1:r0 == 1 /\ P1:r2 == 0 /\ P3:r0 == 2 /\ P3:r2 == 2 /\ x == 1)

--- a/litmus/PTX/Memalloy/IRIW_uniproc.litmus
+++ b/litmus/PTX/Memalloy/IRIW_uniproc.litmus
@@ -12,7 +12,7 @@ x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
  ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            | ld.weak r0, x            ;
- st.weak x, r0            | fence.acq_rel.cta        | st.weak x, r0            | fence.acq_rel.gpu        ;
+ st.weak x, r0            | fence.sc.cta             | st.weak x, r0            | fence.sc.gpu             ;
                           | ld.weak r2, x            |                          | ld.weak r2, x            ;
 exists
 (P1:r0 == 1 /\ P1:r2 == 0 /\ P3:r0 == 2 /\ P3:r2 == 2 /\ x == 1)

--- a/litmus/PTX/Memalloy/IRRWIW_uniproc.litmus
+++ b/litmus/PTX/Memalloy/IRRWIW_uniproc.litmus
@@ -12,8 +12,8 @@ x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
  ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            | ld.weak r2, 3            ;
- st.weak x, r0            | fence.acq_rel.cta        | st.weak x, r0            | ld.weak r0, x            ;
-                          | ld.weak r2, x            |                          | fence.acq_rel.gpu        ;
+ st.weak x, r0            | fence.sc.cta             | st.weak x, r0            | ld.weak r0, x            ;
+                          | ld.weak r2, x            |                          | fence.sc.gpu             ;
                           |                          |                          | st.weak x, r2            ;
 exists
 (P1:r0 == 1 /\ P1:r2 == 0 /\ P3:r0 == 2 /\ x == 1)

--- a/litmus/PTX/Memalloy/IRRWIW_uniproc.litmus
+++ b/litmus/PTX/Memalloy/IRRWIW_uniproc.litmus
@@ -11,7 +11,7 @@ P3:r2=0;
 x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
- ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            | ld.weak r2, 3            ;
+ ld r0, 1                 | ld.weak r0, x            | ld r0, 2                 | ld r2, 3                 ;
  st.weak x, r0            | fence.sc.cta             | st.weak x, r0            | ld.weak r0, x            ;
                           | ld.weak r2, x            |                          | fence.sc.gpu             ;
                           |                          |                          | st.weak x, r2            ;

--- a/litmus/PTX/Memalloy/IRRWIW_uniproc.litmus
+++ b/litmus/PTX/Memalloy/IRRWIW_uniproc.litmus
@@ -1,0 +1,19 @@
+PTX IRRWIW_uniproc
+"CoRR"
+"https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/IRRWIW_uniproc/IRRWIW_uniproc.litmus"
+{
+P0:r0=0;
+P1:r0=0;
+P1:r2=0;
+P2:r0=0;
+P3:r0=0;
+P3:r2=0;
+x=0;
+}
+ P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
+ ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            | ld.weak r2, 3            ;
+ st.weak x, r0            | fence.acq_rel.cta        | st.weak x, r0            | ld.weak r0, x            ;
+                          | ld.weak r2, x            |                          | fence.acq_rel.gpu        ;
+                          |                          |                          | st.weak x, r2            ;
+exists
+(P1:r0 == 1 /\ P1:r2 == 0 /\ P3:r0 == 2 /\ x == 1)

--- a/litmus/PTX/Memalloy/IRWIW_gl_cta.litmus
+++ b/litmus/PTX/Memalloy/IRWIW_gl_cta.litmus
@@ -14,7 +14,7 @@ y=0;
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
  ld.weak r0, 2            | ld.weak r2, 1            | ld.weak r0, 2            | ld.weak r2, 2            ;
  st.weak x, r0            | ld.weak r0, x            | st.weak y, r0            | ld.weak r0, y            ;
-                          | fence.acq_rel.gpu        |                          | fence.acq_rel.cta        ;
+                          | fence.sc.gpu             |                          | fence.sc.cta             ;
                           | st.weak y, r2            |                          | st.weak x, r2            ;
 exists
 (P1:r0 == 2 /\ P3:r0 == 2 /\ x == 2 /\ y == 2)

--- a/litmus/PTX/Memalloy/IRWIW_gl_cta.litmus
+++ b/litmus/PTX/Memalloy/IRWIW_gl_cta.litmus
@@ -1,6 +1,6 @@
 PTX IRWIW_gl_cta
 "CoRR"
-"https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/IRRWIW_uniproc/IRRWIW_uniproc.litmus"
+"https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/IRWIW_gl_cta/IRWIW_gl_cta.litmus"
 {
 P0:r0=0;
 P1:r0=0;
@@ -12,7 +12,7 @@ x=0;
 y=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
- ld.weak r0, 2            | ld.weak r2, 1            | ld.weak r0, 2            | ld.weak r2, 2            ;
+ ld r0, 2                 | ld r2, 1                 | ld r0, 2                 | ld r2, 2                 ;
  st.weak x, r0            | ld.weak r0, x            | st.weak y, r0            | ld.weak r0, y            ;
                           | fence.sc.gpu             |                          | fence.sc.cta             ;
                           | st.weak y, r2            |                          | st.weak x, r2            ;

--- a/litmus/PTX/Memalloy/IRWIW_gl_cta.litmus
+++ b/litmus/PTX/Memalloy/IRWIW_gl_cta.litmus
@@ -1,0 +1,20 @@
+PTX IRWIW_gl_cta
+"CoRR"
+"https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/IRRWIW_uniproc/IRRWIW_uniproc.litmus"
+{
+P0:r0=0;
+P1:r0=0;
+P1:r2=0;
+P2:r0=0;
+P3:r0=0;
+P3:r2=0;
+x=0;
+y=0;
+}
+ P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           | P3@cta 1,gpu 0           ;
+ ld.weak r0, 2            | ld.weak r2, 1            | ld.weak r0, 2            | ld.weak r2, 2            ;
+ st.weak x, r0            | ld.weak r0, x            | st.weak y, r0            | ld.weak r0, y            ;
+                          | fence.acq_rel.gpu        |                          | fence.acq_rel.cta        ;
+                          | st.weak y, r2            |                          | st.weak x, r2            ;
+exists
+(P1:r0 == 2 /\ P3:r0 == 2 /\ x == 2 /\ y == 2)

--- a/litmus/PTX/Memalloy/README.md
+++ b/litmus/PTX/Memalloy/README.md
@@ -1,0 +1,1 @@
+The tests in this folder were manually written using the tests from the [memalloy](https://github.com/johnwickerson/memalloy) repository as a guide.

--- a/litmus/PTX/Memalloy/RWC_uniproc.litmus
+++ b/litmus/PTX/Memalloy/RWC_uniproc.litmus
@@ -1,0 +1,18 @@
+PTX RWC_uniproc
+"CoRR"
+"https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/RWC_uniproc/RWC_uniproc.litmus"
+{
+P0:r0=0;
+P1:r0=0;
+P1:r2=0;
+P2:r0=0;
+P2:r2=0;
+x=0;
+}
+ P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           ;
+ ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            ;
+ st.weak x, r0            | fence.acq_rel.cta        | st.weak x, r0            ;
+                          | ld.weak r2, x            | fence.acq_rel.gpu        ;
+                          |                          | ld.weak r2, x            ;
+exists
+(P1:r0 == 1 /\ P1:r2 == 0 /\ P2:r2 == 2 /\ x == 1)

--- a/litmus/PTX/Memalloy/RWC_uniproc.litmus
+++ b/litmus/PTX/Memalloy/RWC_uniproc.litmus
@@ -10,7 +10,7 @@ P2:r2=0;
 x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           ;
- ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            ;
+ ld r0, 1                 | ld.weak r0, x            | ld r0, 2                 ;
  st.weak x, r0            | fence.sc.cta             | st.weak x, r0            ;
                           | ld.weak r2, x            | fence.sc.gpu             ;
                           |                          | ld.weak r2, x            ;

--- a/litmus/PTX/Memalloy/RWC_uniproc.litmus
+++ b/litmus/PTX/Memalloy/RWC_uniproc.litmus
@@ -11,8 +11,8 @@ x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           ;
  ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            ;
- st.weak x, r0            | fence.acq_rel.cta        | st.weak x, r0            ;
-                          | ld.weak r2, x            | fence.acq_rel.gpu        ;
+ st.weak x, r0            | fence.sc.cta             | st.weak x, r0            ;
+                          | ld.weak r2, x            | fence.sc.gpu             ;
                           |                          | ld.weak r2, x            ;
 exists
 (P1:r0 == 1 /\ P1:r2 == 0 /\ P2:r2 == 2 /\ x == 1)

--- a/litmus/PTX/Memalloy/WRR+2W.litmus
+++ b/litmus/PTX/Memalloy/WRR+2W.litmus
@@ -10,8 +10,8 @@ P2:r2=0;
 x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           ;
- ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            ;
- st.weak x, r0            | fence.sc.cta             | ld.weak r2, 3            ;
+ ld r0, 1                 | ld.weak r0, x            | ld r0, 2                 ;
+ st.weak x, r0            | fence.sc.cta             | ld r2, 3                 ;
                           | ld.weak r2, x            | st.weak x, r0            ;
                           |                          | fence.sc.gpu             ;
                           |                          | st.weak x, r2            ;

--- a/litmus/PTX/Memalloy/WRR+2W.litmus
+++ b/litmus/PTX/Memalloy/WRR+2W.litmus
@@ -11,9 +11,9 @@ x=0;
 }
  P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           ;
  ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            ;
- st.weak x, r0            | fence.acq_rel.cta        | ld.weak r2, 3            ;
+ st.weak x, r0            | fence.sc.cta             | ld.weak r2, 3            ;
                           | ld.weak r2, x            | st.weak x, r0            ;
-                          |                          | fence.acq_rel.gpu        ;
+                          |                          | fence.sc.gpu             ;
                           |                          | st.weak x, r2            ;
 exists
 (P1:r0 == 1 /\ P1:r2 == 0 /\ x == 1)

--- a/litmus/PTX/Memalloy/WRR+2W.litmus
+++ b/litmus/PTX/Memalloy/WRR+2W.litmus
@@ -1,0 +1,19 @@
+PTX WRR+2W
+"CoRR"
+"https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/WRR%2B2W_uniproc/WRR%2B2W.litmus"
+{
+P0:r0=0;
+P1:r0=0;
+P1:r2=0;
+P2:r0=0;
+P2:r2=0;
+x=0;
+}
+ P0@cta 0,gpu 0           | P1@cta 1,gpu 0           | P2@cta 1,gpu 0           ;
+ ld.weak r0, 1            | ld.weak r0, x            | ld.weak r0, 2            ;
+ st.weak x, r0            | fence.acq_rel.cta        | ld.weak r2, 3            ;
+                          | ld.weak r2, x            | st.weak x, r0            ;
+                          |                          | fence.acq_rel.gpu        ;
+                          |                          | st.weak x, r2            ;
+exists
+(P1:r0 == 1 /\ P1:r2 == 0 /\ x == 1)


### PR DESCRIPTION
For the IRIW_gl_cta test, the [litmus](https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/IRIW_gl_cta/IRIW_gl_cta.litmus) seems not matching with the [output](https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/IRIW_gl_cta/IRIW_gl_cta.txt). Since this IRIW_gl_cta litmus is identical to the [IRRWIW_uniproc](https://github.com/johnwickerson/memalloy/blob/master/ptx_testing/IRRWIW_uniproc/IRRWIW_uniproc.litmus) test, the IRIW_gl_cta in this PR is written based on the output file.