### PR TITLE
Generate SVCOMP witness if PROGRAM_SPEC is the only property

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -215,7 +215,7 @@ public class Dartagnan extends BaseOptions {
         // ------------------ Generate Witness, if possible ------------------
         final EnumSet<Property> properties = task.getProperty();
         if (task.getProgram().getFormat().equals(SourceLanguage.LLVM) && modelChecker.hasModel()
-                && properties.contains(PROGRAM_SPEC)) {
+                && properties.contains(PROGRAM_SPEC) && properties.size() == 1) {
             try {
                 WitnessBuilder w = WitnessBuilder.of(modelChecker.getEncodingContext(), prover,
                         modelChecker.getResult(), summary);


### PR DESCRIPTION
Witnesses only make sense for svcomp properties, all of which are covered by `PROGRAM_SPEC`.
If dartagnan is called e.g. with `--property=liveness,program_spec`, the solver could find a liveness violation and this would result in `getLtlPropertyFromSummary` throwing an `UnsupportedOperationException`.

We should only try to generate the witness if `PROGRAM_SPEC` is the only property (which is the case for svcomp).
