### PR TITLE
Wmm preprocessing

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -44,7 +44,7 @@ public class AssumeSolver extends ModelChecker {
 
         memoryModel.configureAll(config);
         preprocessProgram(task, config);
-        preprocessMemoryModel(task);
+        preprocessMemoryModel(task, config);
         performStaticProgramAnalyses(task, analysisContext, config);
         performStaticWmmAnalyses(task, analysisContext, config);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
@@ -48,7 +48,7 @@ public class DataRaceSolver extends ModelChecker {
 
 		memoryModel.configureAll(config);
 		preprocessProgram(task, config);
-		preprocessMemoryModel(task);
+		preprocessMemoryModel(task, config);
 		performStaticProgramAnalyses(task, analysisContext, config);
 		performStaticWmmAnalyses(task, analysisContext, config);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/IncrementalSolver.java
@@ -43,7 +43,7 @@ public class IncrementalSolver extends ModelChecker {
 
         memoryModel.configureAll(config);
         preprocessProgram(task, config);
-        preprocessMemoryModel(task);
+        preprocessMemoryModel(task, config);
         performStaticProgramAnalyses(task, analysisContext, config);
         performStaticWmmAnalyses(task, analysisContext, config);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -22,6 +22,7 @@ import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.analysis.WmmAnalysis;
 import com.dat3m.dartagnan.wmm.axiom.Axiom;
+import com.dat3m.dartagnan.wmm.processing.WmmProcessingManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.api.Model;
@@ -75,8 +76,9 @@ public abstract class ModelChecker {
             computeSpecificationFromProgramAssertions(program);
         }
     }
-    public static void preprocessMemoryModel(VerificationTask task) {
-        task.getMemoryModel().simplify();
+    public static void preprocessMemoryModel(VerificationTask task, Configuration config) throws InvalidConfigurationException{
+        final Wmm memoryModel = task.getMemoryModel();
+        WmmProcessingManager.fromConfig(config).run(memoryModel);
     }
 
     /**

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -176,10 +176,10 @@ public class RefinementSolver extends ModelChecker {
 
         // ------------------------ Preprocessing / Analysis ------------------------
 
-        removeFlaggedAxiomsAndReduce(memoryModel);
+        removeFlaggedAxioms(memoryModel);
         memoryModel.configureAll(config);
         preprocessProgram(task, config);
-        preprocessMemoryModel(task);
+        preprocessMemoryModel(task, config);
 
         performStaticProgramAnalyses(task, analysisContext, config);
         // Copy context without WMM analyses because we want to analyse a second model later
@@ -470,7 +470,7 @@ public class RefinementSolver extends ModelChecker {
         }
     }
 
-    private static void removeFlaggedAxiomsAndReduce(Wmm memoryModel) {
+    private static void removeFlaggedAxioms(Wmm memoryModel) {
         // We remove flagged axioms.
         // NOTE: Theoretically, we could cut them but in practice this causes the whole model to get eagerly encoded,
         // resulting in the worst combination: eagerly encoded model relations + lazy axiom checks.
@@ -478,7 +478,6 @@ public class RefinementSolver extends ModelChecker {
         List.copyOf(memoryModel.getAxioms()).stream()
                 .filter(Axiom::isFlagged)
                 .forEach(memoryModel::removeConstraint);
-        memoryModel.removeUnconstrainedRelations();
     }
 
     // ================================================================================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/TwoSolvers.java
@@ -21,7 +21,7 @@ public class TwoSolvers extends ModelChecker {
     private static final Logger logger = LogManager.getLogger(TwoSolvers.class);
 
     private final SolverContext ctx;
-    private final ProverEnvironment prover1,prover2;
+    private final ProverEnvironment prover1, prover2;
     private final VerificationTask task;
 
     private TwoSolvers(SolverContext c, ProverEnvironment p1, ProverEnvironment p2, VerificationTask t) {
@@ -44,8 +44,8 @@ public class TwoSolvers extends ModelChecker {
         Configuration config = task.getConfig();
 
         memoryModel.configureAll(config);
-    	preprocessProgram(task, config);
-        preprocessMemoryModel(task);
+        preprocessProgram(task, config);
+        preprocessMemoryModel(task, config);
         performStaticProgramAnalyses(task, analysisContext, config);
         performStaticWmmAnalyses(task, analysisContext, config);
 
@@ -59,15 +59,15 @@ public class TwoSolvers extends ModelChecker {
         BooleanFormula encodeProg = programEncoder.encodeFullProgram();
         prover1.addConstraint(encodeProg);
         prover2.addConstraint(encodeProg);
-        
+
         BooleanFormula encodeWmm = wmmEncoder.encodeFullMemoryModel();
-		prover1.addConstraint(encodeWmm);
+        prover1.addConstraint(encodeWmm);
         prover2.addConstraint(encodeWmm);
-       	
+
         // For validation this contains information.
         // For verification graph.encode() just returns ctx.mkTrue()
         BooleanFormula encodeWitness = task.getWitness().encode(context);
-		prover1.addConstraint(encodeWitness);
+        prover1.addConstraint(encodeWitness);
         prover2.addConstraint(encodeWitness);
 
         BooleanFormula encodeSymm = symmetryEncoder.encodeFullSymmetryBreaking();
@@ -77,21 +77,21 @@ public class TwoSolvers extends ModelChecker {
         prover1.addConstraint(propertyEncoder.encodeProperties(task.getProperty()));
 
         logger.info("Starting first solver.check()");
-        if(prover1.isUnsat()) {
-			prover2.addConstraint(propertyEncoder.encodeBoundEventExec());
+        if (prover1.isUnsat()) {
+            prover2.addConstraint(propertyEncoder.encodeBoundEventExec());
             logger.info("Starting second solver.check()");
             res = prover2.isUnsat() ? PASS : UNKNOWN;
         } else {
-        	res = FAIL;
+            res = FAIL;
             saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover1, context, task.getProgram());
         }
 
-        if(logger.isDebugEnabled()) {
-    		String smtStatistics = "\n ===== SMT Statistics ===== \n";
-    		for(String key : prover1.getStatistics().keySet()) {
-    			smtStatistics += String.format("\t%s -> %s\n", key, prover1.getStatistics().get(key));
-    		}
-    		logger.debug(smtStatistics);
+        if (logger.isDebugEnabled()) {
+            String smtStatistics = "\n ===== SMT Statistics ===== \n";
+            for (String key : prover1.getStatistics().keySet()) {
+                smtStatistics += String.format("\t%s -> %s\n", key, prover1.getStatistics().get(key));
+            }
+            logger.debug(smtStatistics);
         }
 
         // For Safety specs, we have SAT=FAIL, but for reachability specs, we have SAT=PASS

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/FlattenAssociatives.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/FlattenAssociatives.java
@@ -1,0 +1,59 @@
+package com.dat3m.dartagnan.wmm.processing;
+
+import com.dat3m.dartagnan.wmm.Constraint;
+import com.dat3m.dartagnan.wmm.Definition;
+import com.dat3m.dartagnan.wmm.Relation;
+import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.wmm.definition.Intersection;
+import com.dat3m.dartagnan.wmm.definition.Union;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+// Flattens nested binary unions/intersections into n-ary ones.
+public class FlattenAssociatives implements WmmProcessor {
+
+    private FlattenAssociatives() {
+    }
+
+    public static FlattenAssociatives newInstance() {
+        return new FlattenAssociatives();
+    }
+
+    @Override
+    public void run(Wmm wmm) {
+        flattenAssociatives(wmm, Union.class, Union::new);
+        flattenAssociatives(wmm, Intersection.class, Intersection::new);
+    }
+
+    private void flattenAssociatives(Wmm wmm,
+                                     Class<? extends Definition> cls,
+                                     BiFunction<Relation, Relation[], Definition> constructor
+    ) {
+        final List<Relation> relations = List.copyOf(wmm.getRelations());
+        final List<Constraint> constraints = wmm.getConstraints().stream()
+                .filter(c -> !(c instanceof Definition)).toList();
+
+        for (Relation r : relations) {
+            if (r.hasName() || !cls.isInstance(r.getDefinition())
+                    || constraints.stream().anyMatch(c -> c.getConstrainedRelations().contains(r))) {
+                continue;
+            }
+            final List<Relation> dependents = relations.stream().filter(x -> x.getDependencies().contains(r)).toList();
+            final Relation p = (dependents.size() == 1 ? dependents.get(0) : null);
+            if (p != null && cls.isInstance(p.getDefinition())) {
+                final Relation[] o = Stream.of(r, p)
+                        .flatMap(x -> x.getDependencies().stream())
+                        .filter(x -> !r.equals(x))
+                        .distinct()
+                        .toArray(Relation[]::new);
+                wmm.removeDefinition(p);
+                wmm.addDefinition(constructor.apply(p, o));
+                wmm.removeDefinition(r);
+                wmm.deleteRelation(r);
+            }
+        }
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/MergeEquivalentRelations.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/MergeEquivalentRelations.java
@@ -1,0 +1,130 @@
+package com.dat3m.dartagnan.wmm.processing;
+
+import com.dat3m.dartagnan.wmm.Constraint;
+import com.dat3m.dartagnan.wmm.Definition;
+import com.dat3m.dartagnan.wmm.Relation;
+import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.wmm.definition.CartesianProduct;
+import com.dat3m.dartagnan.wmm.definition.Fences;
+import com.dat3m.dartagnan.wmm.definition.SetIdentity;
+import com.dat3m.dartagnan.wmm.utils.ConstraintCopier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class MergeEquivalentRelations implements WmmProcessor {
+
+    private static final Logger logger = LogManager.getLogger(MergeEquivalentRelations.class);
+
+    private MergeEquivalentRelations() {
+    }
+
+    public static MergeEquivalentRelations newInstance() {
+        return new MergeEquivalentRelations();
+    }
+
+    @Override
+    public void run(Wmm wmm) {
+        final Map<Relation, Relation> rel2class = computeEquivalenceClasses(wmm);
+        mergeEquivalentRelations(wmm, rel2class);
+    }
+
+    private Map<Relation, Relation> computeEquivalenceClasses(Wmm wmm) {
+        final Map<Relation, Relation> rel2class = new IdentityHashMap<>();
+        final Predicate<Relation> hasNontrivialClass = r -> rel2class.get(r) != r;
+        final List<Relation> relations = List.copyOf(wmm.getRelations());
+        relations.forEach(r -> rel2class.put(r, r));
+
+        // TODO: Could be done more efficiently by computing equivalence bottom-up along a stratification
+        //  and reusing previous equivalence queries.
+        //  However, even on large memory models like LKMM, this code takes less than 10ms.
+        for (int i = 0; i < relations.size(); i++) {
+            final Relation r1 = relations.get(i);
+            if (hasNontrivialClass.test(r1)) {
+                continue;
+            }
+            for (int j = i + 1; j < relations.size(); j++) {
+                final Relation r2 = relations.get(j);
+                if (!hasNontrivialClass.test(r2) && areEquivalent(r1, r2)) {
+                    rel2class.put(r2, r1);
+                }
+            }
+        }
+
+        return rel2class;
+    }
+
+    private boolean areEquivalent(Relation r1, Relation r2) {
+        if (r1 == r2)  {
+            return true;
+        }
+        final Definition def1 = r1.getDefinition();
+        final Definition def2 = r2.getDefinition();
+        if (def1.getClass() != def2.getClass()) {
+            return false;
+        }
+
+        if (r1.isRecursive() || r2.isRecursive()) {
+            // For now, we return false for different recursive relations.
+            return false;
+        }
+
+        if (def1 instanceof Definition.Undefined) {
+            // Different undefined relations are not equal.
+            return false;
+        }
+
+        // Special case for "semi-derived" relations
+        if (def1 instanceof SetIdentity s1 && def2 instanceof SetIdentity s2) {
+            return s1.getFilter().equals(s2.getFilter());
+        }
+        if (def1 instanceof CartesianProduct p1 && def2 instanceof CartesianProduct p2) {
+            return p1.getFirstFilter().equals(p2.getFirstFilter()) && p1.getSecondFilter().equals(p2.getSecondFilter());
+        }
+        if (def1 instanceof Fences f1 && def2 instanceof Fences f2) {
+            return f1.getFilter().equals(f2.getFilter());
+        }
+
+        // Standard derived relations are equal if their dependencies are equal.
+        // TODO 1: Do we want to merge different versions of the same base relation?
+        //  For static relations it makes sense, but for dynamic relations it is not clear
+        //  (technically a single execution could have, e.g., different coherences)
+        // TODO 2: Could be done more efficiently by using memoization.
+        final List<Relation> deps1 = r1.getDependencies();
+        final List<Relation> deps2 = r2.getDependencies();
+        for (int i = 0; i < deps1.size(); i++) {
+            if (!areEquivalent(deps1.get(i), deps2.get(i))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void mergeEquivalentRelations(Wmm wmm, Map<Relation, Relation> eqMap) {
+        final ConstraintCopier copier = new ConstraintCopier(eqMap);
+
+        final List<Constraint> constraints = List.copyOf(wmm.getConstraints());
+        for (Constraint c : constraints) {
+            if (c instanceof Definition def && eqMap.get(def.getDefinedRelation()) != def.getDefinedRelation()) {
+                wmm.removeConstraint(c);
+            } else if (!(c instanceof Definition.Undefined)) {
+                wmm.removeConstraint(c);
+                wmm.addConstraint(c.accept(copier));
+            }
+        }
+
+        eqMap.forEach((r, repr) -> {
+            if (r != repr) {
+                logger.debug("Merged relation {} into relation {}", r, repr);
+                wmm.deleteRelation(r);
+                // Transfer names to representative relation.
+                r.getNames().forEach(name -> wmm.addAlias(name, repr));
+            }
+        });
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/RemoveDeadRelations.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/RemoveDeadRelations.java
@@ -1,0 +1,52 @@
+package com.dat3m.dartagnan.wmm.processing;
+
+import com.dat3m.dartagnan.wmm.Constraint;
+import com.dat3m.dartagnan.wmm.Definition;
+import com.dat3m.dartagnan.wmm.Relation;
+import com.dat3m.dartagnan.wmm.Wmm;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RemoveDeadRelations implements WmmProcessor {
+
+    private RemoveDeadRelations() {
+
+    }
+    public static RemoveDeadRelations newInstance() {
+        return new RemoveDeadRelations();
+    }
+
+    @Override
+    public void run(Wmm memoryModel) {
+        // A relation is considered "unconstrained" if it does not (directly or indirectly) contribute to a
+        // non-defining constraint. Such relations (and their defining constraints) can safely be deleted
+        // without changing the semantics of the memory model.
+        final List<Constraint> constraints = List.copyOf(memoryModel.getConstraints());
+        final DependencyCollector collector = new DependencyCollector();
+        constraints.stream().filter(c -> !(c instanceof Definition)).forEach(c -> c.accept(collector));
+        final Set<Relation> relevantRelations = new HashSet<>(collector.collectedRelations);
+        Wmm.ANARCHIC_CORE_RELATIONS.forEach(n -> relevantRelations.add(memoryModel.getRelation(n)));
+
+        constraints.stream()
+                .filter(c -> !relevantRelations.containsAll(c.getConstrainedRelations()))
+                .forEach(memoryModel::removeConstraint);
+        List.copyOf(memoryModel.getRelations())
+                .stream().filter(r -> !relevantRelations.contains(r))
+                .forEach(memoryModel::deleteRelation);
+    }
+
+    private final static class DependencyCollector implements Constraint.Visitor<Void> {
+        private final Set<Relation> collectedRelations = new HashSet<>();
+        @Override
+        public Void visitConstraint(Constraint constraint) {
+            for (Relation rel : constraint.getConstrainedRelations()) {
+                if (collectedRelations.add(rel)) {
+                    rel.getDefinition().accept(this);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessingManager.java
@@ -1,0 +1,47 @@
+package com.dat3m.dartagnan.wmm.processing;
+
+import com.dat3m.dartagnan.wmm.Wmm;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.configuration.Options;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@Options
+public class WmmProcessingManager implements WmmProcessor {
+
+    private final List<WmmProcessor> processors = new ArrayList<>();
+
+    // =========================== Configurables ===========================
+
+
+    // =========================== Debugging options =======================
+
+
+    // =====================================================================
+
+    private WmmProcessingManager(Configuration config) throws InvalidConfigurationException {
+        config.inject(this);
+        processors.addAll(Arrays.asList(
+                RemoveDeadRelations.newInstance(),
+                MergeEquivalentRelations.newInstance(),
+                FlattenAssociatives.newInstance()
+        ));
+        processors.removeIf(Objects::isNull);
+    }
+
+    public static WmmProcessingManager fromConfig(Configuration config) throws InvalidConfigurationException {
+        return new WmmProcessingManager(config);
+    }
+
+    // ==================================================
+
+    public void run(Wmm wmm) {
+        processors.forEach(p -> p.run(wmm));
+    }
+
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessor.java
@@ -1,0 +1,7 @@
+package com.dat3m.dartagnan.wmm.processing;
+
+import com.dat3m.dartagnan.wmm.Wmm;
+
+public interface WmmProcessor {
+    void run(Wmm wmm);
+}


### PR DESCRIPTION
This PR reworks Wmm preprocessing to work similar to how program preprocessing works.
It further adds the following passes
- `RemoveDeadRelations` which removes relations that do not contribute to axioms. This was already executed in the case of Refinement but now it runs also for the eager encoding although it shouldn't ever remove anything (though we could remove flagged axioms if we do not check for CAT properties which would create a lot of dead relations)
- `MergeEquivalentRelations` which attempts to find relations with equivalent relations, replacing them by a single representative. AFAIK, currently it only removes a single `rf^-1` from `riscv-orig.cat` because it matches with another `rf^-1` that was implicitly created by parsing `fr`.