### PR TITLE
Free relations in CAT

### DIFF
--- a/dartagnan/src/main/antlr4/Cat.g4
+++ b/dartagnan/src/main/antlr4/Cat.g4
@@ -49,6 +49,7 @@ expression
     |   FENCEREL LPAR e = expression RPAR                               # exprFencerel
     |   LPAR e = expression RPAR                                        # expr
     |   n = NAME                                                        # exprBasic
+    |   call = FREE LPAR RPAR                                           # exprFree
     ;
 
 LET     :   'let';
@@ -81,6 +82,7 @@ RBRAC   :   ']';
 FENCEREL    :   'fencerel';
 DOMAIN      :   'domain';
 RANGE       :   'range';
+FREE        :   'free';
 
 FLAG       :   'flag';
 

--- a/dartagnan/src/main/antlr4/Cat.g4
+++ b/dartagnan/src/main/antlr4/Cat.g4
@@ -49,7 +49,7 @@ expression
     |   FENCEREL LPAR e = expression RPAR                               # exprFencerel
     |   LPAR e = expression RPAR                                        # expr
     |   n = NAME                                                        # exprBasic
-    |   call = FREE LPAR RPAR                                           # exprFree
+    |   call = NEW LPAR RPAR                                            # exprNew
     ;
 
 LET     :   'let';
@@ -82,7 +82,7 @@ RBRAC   :   ']';
 FENCEREL    :   'fencerel';
 DOMAIN      :   'domain';
 RANGE       :   'range';
-FREE        :   'free';
+NEW         :   'new';
 
 FLAG       :   'flag';
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -154,6 +154,14 @@ public class WmmEncoder implements Encoder {
         }
 
         @Override
+        public Void visitFree(Free def) {
+            final Relation rel = def.getDefinedRelation();
+            EncodingContext.EdgeEncoder edge = context.edge(rel);
+            encodeSets.get(rel).apply((e1, e2) -> enc.add(bmgr.implication(edge.encode(e1, e2), execution(e1, e2))));
+            return null;
+        }
+
+        @Override
         public Void visitUnion(Union union) {
             final Relation rel = union.getDefinedRelation();
             final List<Relation> operands = union.getOperands();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
@@ -144,7 +144,7 @@ class VisitorBase extends CatBaseVisitor<Object> {
     }
 
     @Override
-    public Object visitExprFree(ExprFreeContext ctx) {
+    public Object visitExprNew(ExprNewContext ctx) {
         return addDefinition(new Free(wmm.newRelation()));
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
@@ -144,6 +144,11 @@ class VisitorBase extends CatBaseVisitor<Object> {
     }
 
     @Override
+    public Object visitExprFree(ExprFreeContext ctx) {
+        return addDefinition(new Free(wmm.newRelation()));
+    }
+
+    @Override
     public Object visitExprBasic(ExprBasicContext ctx) {
         String name = ctx.n.getText();
         Object predicate = namespace.computeIfAbsent(name,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Constraint.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Constraint.java
@@ -90,6 +90,7 @@ public interface Constraint {
 
         // Base
         default T visitUndefined(Definition.Undefined def) { return visitDefinition(def); }
+        default T visitFree(Free def) { return visitDefinition(def); }
         default T visitEmpty(Empty def) { return visitDefinition(def); }
         default T visitProgramOrder(ProgramOrder po) { return visitDefinition(po); }
         default T visitExternal(External ext) { return visitDefinition(ext); }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
@@ -443,6 +443,21 @@ public class RelationAnalysis {
         }
 
         @Override
+        public Knowledge visitFree(Free def) {
+            final List<Event> visibleEvents = program.getThreadEventsWithAllTags(VISIBLE);
+            EventGraph must = new EventGraph();
+            EventGraph may = new EventGraph();
+
+            for (Event e1 : visibleEvents) {
+                for (Event e2 : visibleEvents) {
+                    may.add(e1, e2);
+                }
+            }
+
+            return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
+        }
+
+        @Override
         public Knowledge visitProduct(CartesianProduct prod) {
             final Filter domain = prod.getFirstFilter();
             final Filter range = prod.getSecondFilter();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
@@ -227,6 +227,9 @@ public class RelationAnalysis {
         Map<Relation, List<Delta>> qGlobal = new HashMap<>();
         for (Relation r : memoryModel.getRelations()) {
             Knowledge k = r.getDefinition().accept(initializer);
+            if (!enableMustSets) {
+                k = new Knowledge(k.getMaySet(), EventGraph.empty());
+            }
             knowledgeMap.put(r, k);
             if (!k.may.isEmpty() || !k.must.isEmpty()) {
                 qGlobal.computeIfAbsent(r, x -> new ArrayList<>(1))
@@ -445,7 +448,7 @@ public class RelationAnalysis {
         @Override
         public Knowledge visitFree(Free def) {
             final List<Event> visibleEvents = program.getThreadEventsWithAllTags(VISIBLE);
-            EventGraph must = new EventGraph();
+            EventGraph must = EventGraph.empty();
             EventGraph may = new EventGraph();
 
             for (Event e1 : visibleEvents) {
@@ -454,7 +457,7 @@ public class RelationAnalysis {
                 }
             }
 
-            return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
+            return new Knowledge(may, must);
         }
 
         @Override
@@ -470,19 +473,15 @@ public class RelationAnalysis {
                         .collect(toSet());
                 must.addRange(e1, rangeEvents);
             }
-            return new Knowledge(must, enableMustSets ? new EventGraph(must) : EventGraph.empty());
+            return new Knowledge(must, new EventGraph(must));
         }
 
         @Override
         public Knowledge visitSetIdentity(SetIdentity id) {
             final Filter set = id.getFilter();
             EventGraph must = new EventGraph();
-            for (Event e : program.getThreadEvents()) {
-                if (set.apply(e)) {
-                    must.add(e, e);
-                }
-            }
-            return new Knowledge(must, enableMustSets ? new EventGraph(must) : EventGraph.empty());
+            program.getThreadEvents().stream().filter(set::apply).forEach(e -> must.add(e, e));
+            return new Knowledge(must, new EventGraph(must));
         }
 
         @Override
@@ -503,7 +502,7 @@ public class RelationAnalysis {
                     }
                 }
             }
-            return new Knowledge(must, enableMustSets ? new EventGraph(must) : EventGraph.empty());
+            return new Knowledge(must, new EventGraph(must));
         }
 
         @Override
@@ -518,7 +517,7 @@ public class RelationAnalysis {
                     must.addRange(e1, rangeEvents);
                 }
             }
-            return new Knowledge(must, enableMustSets ? new EventGraph(must) : EventGraph.empty());
+            return new Knowledge(must, new EventGraph(must));
         }
 
         @Override
@@ -537,7 +536,7 @@ public class RelationAnalysis {
                     }
                 }
             }
-            return new Knowledge(must, enableMustSets ? new EventGraph(must) : EventGraph.empty());
+            return new Knowledge(must, new EventGraph(must));
         }
 
         @Override
@@ -568,7 +567,7 @@ public class RelationAnalysis {
                     }
                 }
             }
-            return new Knowledge(must, enableMustSets ? new EventGraph(must) : EventGraph.empty());
+            return new Knowledge(must, new EventGraph(must));
         }
 
         @Override
@@ -599,20 +598,20 @@ public class RelationAnalysis {
                         if (exec.areMutuallyExclusive(x, f)) {
                             continue;
                         }
-                        boolean implies = enableMustSets && exec.isImplied(x, f);
+                        boolean implies = exec.isImplied(x, f);
                         for (Event y : events.subList(i + 1, end)) {
                             if (exec.areMutuallyExclusive(x, y) || exec.areMutuallyExclusive(f, y)) {
                                 continue;
                             }
                             may.add(x, y);
-                            if (implies || enableMustSets && exec.isImplied(y, f)) {
+                            if (implies || exec.isImplied(y, f)) {
                                 must.add(x, y);
                             }
                         }
                     }
                 }
             }
-            return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
+            return new Knowledge(may, must);
         }
 
         @Override
@@ -624,7 +623,7 @@ public class RelationAnalysis {
                     must.add(e, e.getSuccessor());
                 }
             }
-            return new Knowledge(must, enableMustSets ? new EventGraph(must) : EventGraph.empty());
+            return new Knowledge(must, new EventGraph(must));
         }
 
         @Override
@@ -635,8 +634,6 @@ public class RelationAnalysis {
             Map<Event, Set<Event>> mayMap = new HashMap<>();
             Map<Event, Set<Event>> mustMap = new HashMap<>();
             for (Thread thread : program.getThreads()) {
-                // assume order by cId
-                // assume cId describes a topological sorting over the control flow
                 List<Event> locks = reverse(thread.getEvents().stream().filter(e -> e.hasTag(Linux.RCU_LOCK)).collect(toList()));
                 for (Event unlock : thread.getEvents()) {
                     if (!unlock.hasTag(Linux.RCU_UNLOCK)) {
@@ -651,7 +648,7 @@ public class RelationAnalysis {
                                         .anyMatch(e -> exec.isImplied(lock, e) || exec.isImplied(unlock, e))) {
                             continue;
                         }
-                        boolean noIntermediary = enableMustSets &&
+                        boolean noIntermediary =
                                 mayMap.getOrDefault(unlock, Set.of()).stream()
                                         .allMatch(e -> exec.areMutuallyExclusive(lock, e)) &&
                                 mayMap.getOrDefault(lock, Set.of()).stream()
@@ -667,7 +664,7 @@ public class RelationAnalysis {
                     }
                 }
             }
-            return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
+            return new Knowledge(may, must);
         }
 
         @Override
@@ -717,15 +714,14 @@ public class RelationAnalysis {
                             continue;
                         }
                         may.add(load, store);
-                        if (enableMustSets &&
-                                intermediaries.stream().allMatch(e -> exec.areMutuallyExclusive(load, e)) &&
+                        if (intermediaries.stream().allMatch(e -> exec.areMutuallyExclusive(load, e)) &&
                                 (store.doesRequireMatchingAddresses() || alias.mustAlias((Load) load, store))) {
                             must.add(load, store);
                         }
                     }
                 }
             }
-            return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
+            return new Knowledge(may, must);
         }
 
         @Override
@@ -743,7 +739,7 @@ public class RelationAnalysis {
                 }
             }
             EventGraph must = new EventGraph();
-            (enableMustSets ? may : EventGraph.empty()).apply((e1, e2) -> {
+            may.apply((e1, e2) -> {
                 MemoryCoreEvent w1 = (MemoryCoreEvent) e1;
                 MemoryCoreEvent w2 = (MemoryCoreEvent) e2;
                 if (!w2.hasTag(INIT) && alias.mustAlias(w1, w2) && w1.hasTag(INIT)) {
@@ -752,7 +748,7 @@ public class RelationAnalysis {
             });
             if (wmmAnalysis.isLocallyConsistent()) {
                 may.removeIf(Tuple::isBackward);
-                (enableMustSets ? may : EventGraph.empty()).apply((e1, e2) -> {
+                may.apply((e1, e2) -> {
                     MemoryCoreEvent w1 = (MemoryCoreEvent) e1;
                     MemoryCoreEvent w2 = (MemoryCoreEvent) e2;
                     if (alias.mustAlias(w1, w2) && Tuple.isForward(e1, e2)) {
@@ -767,7 +763,7 @@ public class RelationAnalysis {
             }
 
             logger.debug("Initial may set size for memory order: {}", may.size());
-            return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
+            return new Knowledge(may, must);
         }
 
         @Override
@@ -883,7 +879,7 @@ public class RelationAnalysis {
             }
 
             logger.debug("Initial may set size for read-from: {}", may.size());
-            return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
+            return new Knowledge(may, must);
         }
 
         @Override
@@ -898,12 +894,12 @@ public class RelationAnalysis {
                 }
             }
             EventGraph must = new EventGraph();
-            (enableMustSets ? may : EventGraph.empty()).apply((e1, e2) -> {
+            may.apply((e1, e2) -> {
                 if (alias.mustAlias((MemoryCoreEvent) e1, (MemoryCoreEvent) e2)) {
                     must.add(e1, e2);
                 }
             });
-            return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
+            return new Knowledge(may, must);
         }
 
         private Knowledge computeInternalDependencies(Set<UsageType> usageTypes) {
@@ -933,7 +929,7 @@ public class RelationAnalysis {
                     for (Event regWriter : r.may) {
                         may.add(regWriter, regReaderEvent);
                     }
-                    for (Event regWriter : enableMustSets ? r.must : List.<Event>of()) {
+                    for (Event regWriter : r.must) {
                         must.add(regWriter, regReaderEvent);
                     }
                 }
@@ -950,7 +946,7 @@ public class RelationAnalysis {
                 }
             }
 
-            return new Knowledge(may, enableMustSets ? must : EventGraph.empty());
+            return new Knowledge(may, must);
         }
 
         @Override
@@ -1008,6 +1004,7 @@ public class RelationAnalysis {
         @Override
         public Knowledge visitSyncFence(SyncFence syncFence) {
             EventGraph may = new EventGraph();
+            EventGraph must = EventGraph.empty();
             List<Event> fenceEventsSC = program.getThreadEventsWithAllTags(VISIBLE, FENCE, PTX.SC);
             for (Event e1 : fenceEventsSC) {
                 for (Event e2 : fenceEventsSC) {
@@ -1016,7 +1013,7 @@ public class RelationAnalysis {
                     }
                 }
             }
-            return new Knowledge(may, EventGraph.empty());
+            return new Knowledge(may, must);
         }
 
         @Override
@@ -1036,7 +1033,7 @@ public class RelationAnalysis {
                     }
                 }
             }
-            return new Knowledge(must, may);
+            return new Knowledge(may, must);
         }
 
         @Override
@@ -1056,7 +1053,7 @@ public class RelationAnalysis {
                     }
                 }
             }
-            return new Knowledge(must, enableMustSets ? must : EventGraph.empty());
+            return new Knowledge(must, new EventGraph(must));
         }
     }
 
@@ -1093,7 +1090,7 @@ public class RelationAnalysis {
         @Override
         public Delta visitUnion(Union union) {
             if (union.getOperands().contains(source)) {
-                return new Delta(may, enableMustSets ? must : EventGraph.empty());
+                return new Delta(may, must);
             }
             return EMPTY;
         }
@@ -1112,7 +1109,7 @@ public class RelationAnalysis {
                         .sorted(Comparator.comparingInt(EventGraph::size))
                         .reduce(EventGraph::intersection)
                         .orElseThrow();
-                return new Delta(maySet, enableMustSets ? mustSet : EventGraph.empty());
+                return new Delta(maySet, mustSet);
             }
             return EMPTY;
         }
@@ -1121,9 +1118,7 @@ public class RelationAnalysis {
         public Delta visitDifference(Difference diff) {
             if (diff.getMinuend().equals(source)) {
                 Knowledge k = knowledgeMap.get(diff.getSubtrahend());
-                return new Delta(
-                        enableMustSets ? difference(may, k.must) : may,
-                        enableMustSets ? difference(must, k.may) : EventGraph.empty());
+                return new Delta(difference(may, k.must), difference(must, k.may));
             }
             return EMPTY;
         }
@@ -1136,15 +1131,11 @@ public class RelationAnalysis {
             EventGraph mustSet = new EventGraph();
             if (r1.equals(source)) {
                 computeComposition(maySet, may, knowledgeMap.get(r2).may, true);
-                if (enableMustSets) {
-                    computeComposition(mustSet, must, knowledgeMap.get(r2).must, false);
-                }
+                computeComposition(mustSet, must, knowledgeMap.get(r2).must, false);
             }
             if (r2.equals(source)) {
                 computeComposition(maySet, knowledgeMap.get(r1).may, may, true);
-                if (enableMustSets) {
-                    computeComposition(mustSet, knowledgeMap.get(r1).must, must, false);
-                }
+                computeComposition(mustSet, knowledgeMap.get(r1).must, must, false);
             }
             return new Delta(maySet, mustSet);
         }
@@ -1170,10 +1161,12 @@ public class RelationAnalysis {
             if (domId.getOperand().equals(source)) {
                 EventGraph maySet = new EventGraph();
                 may.getDomain().forEach(e -> maySet.add(e, e));
-                EventGraph mustSet = enableMustSets ? new EventGraph() : EventGraph.empty();
-                if (enableMustSets) {
-                    must.getDomain().forEach(e -> mustSet.add(e, e));
-                }
+                EventGraph mustSet = new EventGraph();
+                must.apply((e1, e2) -> {
+                    if (exec.isImplied(e1, e2)) {
+                        mustSet.add(e1, e1);
+                    }
+                });
                 return new Delta(maySet, mustSet);
             }
             return EMPTY;
@@ -1184,10 +1177,12 @@ public class RelationAnalysis {
             if (rangeId.getOperand().equals(source)) {
                 EventGraph maySet = new EventGraph();
                 may.getRange().forEach(e -> maySet.add(e, e));
-                EventGraph mustSet = enableMustSets ? new EventGraph() : EventGraph.empty();
-                if (enableMustSets) {
-                    must.getRange().forEach(e -> mustSet.add(e, e));
-                }
+                EventGraph mustSet = new EventGraph();
+                must.apply((e1, e2) -> {
+                    if (exec.isImplied(e2, e1)) {
+                        mustSet.add(e2, e2);
+                    }
+                });
                 return new Delta(maySet, mustSet);
             }
             return EMPTY;
@@ -1196,7 +1191,7 @@ public class RelationAnalysis {
         @Override
         public Delta visitInverse(Inverse inv) {
             if (inv.getOperand().equals(source)) {
-                return new Delta(may.inverse(), enableMustSets ? must.inverse() : EventGraph.empty());
+                return new Delta(may.inverse(), must.inverse());
             }
             return EMPTY;
         }
@@ -1206,11 +1201,8 @@ public class RelationAnalysis {
             final Relation rel = trans.getDefinedRelation();
             if (trans.getOperand().equals(source)) {
                 EventGraph maySet = computeTransitiveClosure(knowledgeMap.get(rel).may, may, true);
-                if (enableMustSets) {
-                    EventGraph mustSet = computeTransitiveClosure(knowledgeMap.get(rel).must, must, false);
-                    return new Delta(maySet, mustSet);
-                }
-                return new Delta(maySet, EventGraph.empty());
+                EventGraph mustSet = computeTransitiveClosure(knowledgeMap.get(rel).must, must, false);
+                return new Delta(maySet, mustSet);
             }
             return EMPTY;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/definition/Free.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/definition/Free.java
@@ -1,0 +1,16 @@
+package com.dat3m.dartagnan.wmm.definition;
+
+import com.dat3m.dartagnan.wmm.Definition;
+import com.dat3m.dartagnan.wmm.Relation;
+
+public class Free extends Definition {
+
+    public Free(Relation r0) {
+        super(r0, "__free()");
+    }
+
+    @Override
+    public <T> T accept(Visitor<? extends T> v) {
+        return v.visitFree(this);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/definition/Free.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/definition/Free.java
@@ -3,6 +3,8 @@ package com.dat3m.dartagnan.wmm.definition;
 import com.dat3m.dartagnan.wmm.Definition;
 import com.dat3m.dartagnan.wmm.Relation;
 
+// A freely defined relation can take any value, i.e., there are no restrictions
+// (except that it is guaranteed to be only over visible and executed events).
 public class Free extends Definition {
 
     public Free(Relation r0) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/MergeEquivalentRelations.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/MergeEquivalentRelations.java
@@ -4,10 +4,7 @@ import com.dat3m.dartagnan.wmm.Constraint;
 import com.dat3m.dartagnan.wmm.Definition;
 import com.dat3m.dartagnan.wmm.Relation;
 import com.dat3m.dartagnan.wmm.Wmm;
-import com.dat3m.dartagnan.wmm.definition.CartesianProduct;
-import com.dat3m.dartagnan.wmm.definition.Fences;
-import com.dat3m.dartagnan.wmm.definition.SameScope;
-import com.dat3m.dartagnan.wmm.definition.SetIdentity;
+import com.dat3m.dartagnan.wmm.definition.*;
 import com.dat3m.dartagnan.wmm.utils.ConstraintCopier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -76,8 +73,8 @@ public class MergeEquivalentRelations implements WmmProcessor {
             return false;
         }
 
-        if (def1 instanceof Definition.Undefined) {
-            // Different undefined relations are not equal.
+        if (def1 instanceof Definition.Undefined || def1 instanceof Free) {
+            // Different undefined or free relations are never equal.
             return false;
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/ConstraintCopier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/ConstraintCopier.java
@@ -62,6 +62,11 @@ public final class ConstraintCopier implements Constraint.Visitor<Constraint> {
     }
 
     @Override
+    public Constraint visitFree(Free def) {
+        return new Free(translate(def.getDefinedRelation()));
+    }
+
+    @Override
     public Union visitUnion(Union def) {
         return new Union(translate(def.getDefinedRelation()), translate(def.getOperands()));
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/EmptyEventGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/EmptyEventGraph.java
@@ -21,7 +21,7 @@ public class EmptyEventGraph extends EventGraph {
 
     @Override
     public boolean remove(Event e1, Event e2) {
-        throw new UnsupportedOperationException();
+        return false;
     }
 
     @Override
@@ -31,17 +31,17 @@ public class EmptyEventGraph extends EventGraph {
 
     @Override
     public boolean removeAll(EventGraph other) {
-        throw new UnsupportedOperationException();
+        return false;
     }
 
     @Override
     public boolean retainAll(EventGraph other) {
-        throw new UnsupportedOperationException();
+        return false;
     }
 
     @Override
     public boolean removeIf(BiPredicate<Event, Event> f) {
-        throw new UnsupportedOperationException();
+        return false;
     }
 
     @Override

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/wmm/utils/EmptyEventGraphTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/wmm/utils/EmptyEventGraphTest.java
@@ -63,14 +63,14 @@ public class EmptyEventGraphTest {
         EventGraph.empty().add(e1, e2);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testRemove() {
         // given
         Event e1 = new Skip();
         Event e2 = new Skip();
 
         // when
-        EventGraph.empty().remove(e1, e2);
+        assertFalse(EventGraph.empty().remove(e1, e2));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -92,7 +92,7 @@ public class EmptyEventGraphTest {
         EventGraph.empty().addAll(EventGraph.empty());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testRemoveAll() {
         // given
         Event e1 = new Skip();
@@ -102,17 +102,11 @@ public class EmptyEventGraphTest {
         nonEmpty.add(e1, e2);
 
         // when
-        EventGraph.empty().removeAll(nonEmpty);
+        assertFalse(EventGraph.empty().removeAll(nonEmpty));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testRemoveAllEmpty() {
-        // when
-        EventGraph.empty().removeAll(EventGraph.empty());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testRetainAll() {
         // given
         Event e1 = new Skip();
         Event e2 = new Skip();
@@ -121,13 +115,20 @@ public class EmptyEventGraphTest {
         nonEmpty.add(e1, e2);
 
         // when
-        EventGraph.empty().retainAll(nonEmpty);
+        assertFalse(EventGraph.empty().removeAll(nonEmpty));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testRetainAllEmpty() {
+        // given
+        Event e1 = new Skip();
+        Event e2 = new Skip();
+
+        EventGraph nonEmpty = new EventGraph();
+        nonEmpty.add(e1, e2);
+
         // when
-        EventGraph.empty().retainAll(EventGraph.empty());
+        assertFalse(EventGraph.empty().retainAll(nonEmpty));
     }
 
     @Test
@@ -321,22 +322,22 @@ public class EmptyEventGraphTest {
         set.add(e);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testRemoveIfTrue() {
         // given
         EventGraph empty = EventGraph.empty();
 
         // when
-        empty.removeIf((x, y) -> true);
+        assertFalse(empty.removeIf((x, y) -> true));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testRemoveIfFalse() {
         // given
         EventGraph empty = EventGraph.empty();
 
         // when
-        empty.removeIf((x, y) -> false);
+        assertFalse(empty.removeIf((x, y) -> false));
     }
 
     @Test


### PR DESCRIPTION
This PR adds the ability to define free relations in CAT via `let r = free()` (using function call syntax).

For example, with this it is possible to define `co` entirely in CAT:
```
let co = (free() & W*W & loc) // co is a relation on same-address writes
let co = co | [IW];loc;[W] \ id // co orders init writes before all other writes
let co = co+ // co is transitive
empty ((W*W & loc) \ (co | co^-1 | id)) // Co orders every same-address pair of writes ...
acyclic (co) // ... and it is acyclic, meaning it is a total order (per address)
```
Such an encoding would actually be more interesting for partial order `co` as defined in GPU models(*).
This way, we could likely get rid of special case treatment for GPU architectures as suggested in #532 .

More generally, this feature can be used to experiment more easily with the CAT model. For example, we could easily define a total order on (abstract) lock events and encode that `hb` should adhere to that order.

(*) Defining `co` in CAT comes with another issue (as discussed in #532) though: we use the standard notion of `co` to encode liveness properties and final memory values.
One would likely need to add further primitives like `finalVal(co)` and `liveness(co)` to tell the encoding which relation is responsible for defining final values.