### PR TITLE
Streamline printing of time statistics

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -15,6 +15,7 @@ import com.dat3m.dartagnan.program.event.core.Assert;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.VerificationTask.VerificationTaskBuilder;
@@ -43,8 +44,8 @@ import java.io.File;
 import java.math.BigInteger;
 import java.util.*;
 
-import static com.dat3m.dartagnan.GlobalSettings.logGlobalSettings;
 import static com.dat3m.dartagnan.GlobalSettings.getOrCreateOutputDirectory;
+import static com.dat3m.dartagnan.GlobalSettings.logGlobalSettings;
 import static com.dat3m.dartagnan.configuration.OptionInfo.collectOptions;
 import static com.dat3m.dartagnan.configuration.OptionNames.PHANTOM_REFERENCES;
 import static com.dat3m.dartagnan.configuration.OptionNames.TARGET;
@@ -192,7 +193,7 @@ public class Dartagnan extends BaseOptions {
                 long endTime = System.currentTimeMillis();
                 String summary = generateResultSummary(task, prover, modelChecker);
                 System.out.print(summary);
-                System.out.println("Total verification time(ms): " + (endTime - startTime));
+                System.out.println("Total verification time: " + Utils.toTimeString(endTime - startTime));
 
                 if (!o.runValidator()) {
                     // We only generate witnesses if we are not validating one.

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -13,6 +13,7 @@ import com.dat3m.dartagnan.program.event.core.FenceWithId;
 import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.core.RMWStoreExclusive;
 import com.dat3m.dartagnan.program.filter.Filter;
+import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.wmm.Constraint;
 import com.dat3m.dartagnan.wmm.Definition;
@@ -70,7 +71,7 @@ public class WmmEncoder implements Encoder {
         } else {
             encoder.initializeAlternative();
         }
-        logger.info("Finished active sets in {}ms", System.currentTimeMillis() - t0);
+        logger.info("Finished active sets in {}", Utils.toTimeString(System.currentTimeMillis() - t0));
         RelationAnalysis ra = context.getAnalysisContext().get(RelationAnalysis.class);
         logger.info("Number of unknown edges: {}", context.getTask().getMemoryModel().getRelations().stream()
                 .filter(r -> !r.isInternal())

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AliasAnalysis.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.event.MemoryEvent;
 import com.dat3m.dartagnan.program.event.core.Init;
 import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
+import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.visualization.Graphviz;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -55,7 +56,7 @@ public interface AliasAnalysis {
         }
 
         long t1 = System.currentTimeMillis();
-        logger.info("Finished alias analysis in {}ms", t1 - t0);
+        logger.info("Finished alias analysis in {}", Utils.toTimeString(t1 - t0));
         return a;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
@@ -1,0 +1,26 @@
+package com.dat3m.dartagnan.utils;
+
+import java.util.concurrent.TimeUnit;
+
+public class Utils {
+
+    private Utils() {
+    }
+
+    public static String toTimeString(long milliseconds) {
+        final long hours = TimeUnit.MILLISECONDS.toHours(milliseconds);
+        milliseconds -= TimeUnit.HOURS.toMillis(hours);
+        final long minutes = TimeUnit.MILLISECONDS.toMinutes(milliseconds);
+        milliseconds -= TimeUnit.MINUTES.toMillis(minutes);
+        final long seconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds);
+        milliseconds -= TimeUnit.SECONDS.toMillis(seconds);
+
+        if (hours == 0 && minutes == 0) {
+            return String.format("%d.%d secs", seconds, milliseconds);
+        } else if (hours == 0) {
+            return String.format("%d:%d mins", minutes, seconds);
+        } else {
+            return String.format("%d:%d:%d hours", hours, minutes, seconds);
+        }
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTask.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTask.java
@@ -44,7 +44,7 @@ public class VerificationTask {
     public Wmm getMemoryModel() { return memoryModel; }
     public Configuration getConfig() { return this.config; }
     public WitnessGraph getWitness() { return witness; }
-	public EnumSet<Property> getProperty() { return property; }
+    public EnumSet<Property> getProperty() { return property; }
 
 
     // ==================== Builder =====================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -57,6 +57,7 @@ import static com.dat3m.dartagnan.configuration.OptionNames.COVERAGE;
 import static com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis.*;
 import static com.dat3m.dartagnan.solver.caat.CAATSolver.Status.*;
 import static com.dat3m.dartagnan.utils.Result.*;
+import static com.dat3m.dartagnan.utils.Utils.toTimeString;
 import static com.dat3m.dartagnan.utils.visualization.ExecutionGraphVisualizer.generateGraphvizFile;
 import static com.dat3m.dartagnan.wmm.RelationNameRepository.*;
 
@@ -516,14 +517,14 @@ public class RefinementSolver extends ModelChecker {
         StringBuilder message = new StringBuilder().append("Summary").append("\n")
                 .append(" ======== Summary ========").append("\n")
                 .append("Number of iterations: ").append(trace.iterations.size()).append("\n")
-                .append("Total native solving time(ms): ").append(totalNativeSolvingTime).append("\n")
-                .append("   -- Bound check time(ms): ").append(boundCheckTime).append("\n")
-                .append("Total CAAT solving time(ms): ").append(totalCaatTime).append("\n")
-                .append("   -- Model extraction time(ms): ").append(totalModelExtractTime).append("\n")
-                .append("   -- Population time(ms): ").append(totalPopulationTime).append("\n")
-                .append("   -- Consistency check time(ms): ").append(totalConsistencyCheckTime).append("\n")
-                .append("   -- Reason computation time(ms): ").append(totalReasonComputationTime).append("\n")
-                .append("   -- Refining time(ms): ").append(totalRefiningTime).append("\n")
+                .append("Total native solving time: ").append(toTimeString(totalNativeSolvingTime)).append("\n")
+                .append("   -- Bound check time: ").append(toTimeString(boundCheckTime)).append("\n")
+                .append("Total CAAT solving time: ").append(toTimeString(totalCaatTime)).append("\n")
+                .append("   -- Model extraction time: ").append(toTimeString(totalModelExtractTime)).append("\n")
+                .append("   -- Population time: ").append(toTimeString(totalPopulationTime)).append("\n")
+                .append("   -- Consistency check time: ").append(toTimeString(totalConsistencyCheckTime)).append("\n")
+                .append("   -- Reason computation time: ").append(toTimeString(totalReasonComputationTime)).append("\n")
+                .append("   -- Refining time: ").append(toTimeString(totalRefiningTime)).append("\n")
                 .append("   -- #Computed core reasons: ").append(totalNumReasons).append("\n")
                 .append("   -- #Computed core reduced reasons: ").append(totalNumReducedReasons).append("\n");
         if (!statList.isEmpty()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/RelationAnalysis.java
@@ -16,6 +16,7 @@ import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.lang.svcomp.EndAtomic;
 import com.dat3m.dartagnan.program.filter.Filter;
 import com.dat3m.dartagnan.program.memory.VirtualMemoryObject;
+import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
@@ -129,7 +130,7 @@ public class RelationAnalysis {
         long t0 = System.currentTimeMillis();
         a.run();
         long t1 = System.currentTimeMillis();
-        logger.info("Finished regular analysis in {}ms", t1 - t0);
+        logger.info("Finished regular analysis in {}", Utils.toTimeString(t1 - t0));
 
         final StringBuilder summary = new StringBuilder()
                 .append("\n======== RelationAnalysis summary ======== \n");
@@ -139,7 +140,7 @@ public class RelationAnalysis {
             long mayCount = a.countMaySet();
             long mustCount = a.countMustSet();
             a.runExtended();
-            logger.info("Finished extended analysis in {}ms", System.currentTimeMillis() - t1);
+            logger.info("Finished extended analysis in {}", Utils.toTimeString(System.currentTimeMillis() - t1));
             summary.append("\t#may-edges removed (extended): ").append(mayCount - a.countMaySet()).append("\n");
             summary.append("\t#must-edges added (extended): ").append(a.countMustSet() - mustCount).append("\n");
         }


### PR DESCRIPTION
This PR streamlines all printing to use a function `Utils.toTimeString` that converts milliseconds dynamically to one of the following formats:
```
secs.milliseconds
minutes:seconds
hours:minutes:seconds
```
The used format depends on the magnitude of time, e.g., if it is below a minute the first format is used, if it is below an hour the second one is used.