### PR TITLE
Remove term-based relation merging in CAT parser & fix duplicated free relations

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
@@ -292,19 +292,7 @@ class VisitorBase extends CatBaseVisitor<Object> {
     // ============================ Utility ============================
 
     private Relation addDefinition(Definition definition) {
-        Relation definedRelation = definition.getDefinedRelation();
-        String term = definition.getTerm();
-        Relation mappedRelation = termMap.get(definition.getTerm());
-        if (mappedRelation == null) {
-            // This is a new definition.
-            termMap.put(term, definedRelation);
-            return wmm.addDefinition(definition);
-        } else {
-            // We created an already existing definition, so we do not add this definition
-            // to the Wmm and instead delete the relation it is defining (redundantly)
-            wmm.deleteRelation(definedRelation);
-            return mappedRelation;
-        }
+        return wmm.addDefinition(definition);
     }
 
     private void checkNoRecursion(ExpressionContext c) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
@@ -33,8 +33,6 @@ class VisitorBase extends CatBaseVisitor<Object> {
     private final Map<String, Integer> nameOccurrenceCounter = new HashMap<>();
     // Used to handle recursive definitions properly
     private Relation relationToBeDefined;
-    // Used as optimization to avoid creating multiple relations with (structurally) identical definitions.
-    private final Map<String, Relation> termMap = new HashMap<>();
 
     VisitorBase() {
         this.wmm = new Wmm();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/MarkFreeRelations.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/MarkFreeRelations.java
@@ -1,0 +1,35 @@
+package com.dat3m.dartagnan.wmm.processing;
+
+import com.dat3m.dartagnan.wmm.Relation;
+import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.wmm.definition.Free;
+
+/*
+    This pass makes sure that differently freely defined relations have different names, in particular,
+    unnamed relations will get a dummy name.
+    This makes sure that we generate different encoding variables for different relations
+    (there is no name collision).
+
+    NOTE: We could generalize this pass to give distinguishing names to any pair of different relations
+    if they are unnamed but have the same term. However, this is should only happen to free relations right now.
+ */
+public class MarkFreeRelations implements WmmProcessor {
+
+    private MarkFreeRelations() {
+    }
+
+    public static MarkFreeRelations newInstance() {
+        return new MarkFreeRelations();
+    }
+
+    @Override
+    public void run(Wmm wmm) {
+        int counter = 0;
+        for (Relation rel : wmm.getRelations()) {
+            if (rel.getDefinition() instanceof Free && !rel.hasName()) {
+                wmm.addAlias("free#" + counter, rel);
+                counter++;
+            }
+        }
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/MergeEquivalentRelations.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/MergeEquivalentRelations.java
@@ -118,6 +118,8 @@ public class MergeEquivalentRelations implements WmmProcessor {
             }
 
             if (c instanceof Definition def && eqMap.get(def.getDefinedRelation()) != def.getDefinedRelation()) {
+                logger.trace("Merging relation {} into relation {}",
+                        def.getDefinedRelation(), eqMap.get(def.getDefinedRelation()));
                 wmm.removeConstraint(c);
             } else if (!(c instanceof Definition.Undefined)) {
                 wmm.removeConstraint(c);
@@ -127,7 +129,6 @@ public class MergeEquivalentRelations implements WmmProcessor {
 
         eqMap.forEach((r, repr) -> {
             if (r != repr) {
-                logger.debug("Merged relation {} into relation {}", r, repr);
                 wmm.deleteRelation(r);
                 // Transfer names to representative relation.
                 r.getNames().forEach(name -> wmm.addAlias(name, repr));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessingManager.java
@@ -28,7 +28,8 @@ public class WmmProcessingManager implements WmmProcessor {
         processors.addAll(Arrays.asList(
                 RemoveDeadRelations.newInstance(),
                 MergeEquivalentRelations.newInstance(),
-                FlattenAssociatives.newInstance()
+                FlattenAssociatives.newInstance(),
+                MarkFreeRelations.newInstance()
         ));
         processors.removeIf(Objects::isNull);
     }


### PR DESCRIPTION
The CAT parser merges relations that have the same defining term.
This is somewhat redundant with the new pass that also merges equivalent relations, so I removed the merging in the parser.
Also, the CAT parser accidentally merges different freely defined relations (`let r1 = new()  <->  let r2 = new()`) because their terms are equivalent. This wrong behavior is fixed in this PR.

Furthermore, even if the free relations are not merged, we ended up creating the same variables for the different relations because they had the same name/term. I added another pass that makes sure free relations get different names to avoid this.

