### PR TITLE
Allow unary relation operators (^-1, *, +, etc.) in recursive definitions

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorBase.java
@@ -214,58 +214,50 @@ class VisitorBase extends CatBaseVisitor<Object> {
 
     @Override
     public Relation visitExprInverse(ExprInverseContext c) {
-        checkNoRecursion(c);
-        Relation r0 = wmm.newRelation();
+        Relation r0 = getAndResetRelationToBeDefined().orElseGet(wmm::newRelation);
         Relation r1 = parseAsRelation(c.e);
         return addDefinition(new Inverse(r0, r1));
     }
 
     @Override
     public Relation visitExprTransitive(ExprTransitiveContext c) {
-        checkNoRecursion(c);
-        Relation r0 = wmm.newRelation();
+        Relation r0 = getAndResetRelationToBeDefined().orElseGet(wmm::newRelation);
         Relation r1 = parseAsRelation(c.e);
         return addDefinition(new TransitiveClosure(r0, r1));
     }
 
     @Override
     public Relation visitExprTransRef(ExprTransRefContext c) {
-        checkNoRecursion(c);
-        Relation r0 = wmm.newRelation();
-        Relation r1 = wmm.newRelation();
-        Relation r2 = wmm.getOrCreatePredefinedRelation(ID);
-        Relation r3 = parseAsRelation(c.e);
-        return addDefinition(new TransitiveClosure(r0, addDefinition(new Union(r1, r2, r3))));
+        Relation r0 = getAndResetRelationToBeDefined().orElseGet(wmm::newRelation);
+        Relation r1 = parseAsRelation(c.e);
+        Relation transClosure = addDefinition(new TransitiveClosure(wmm.newRelation(), r1));
+        return addDefinition(new Union(r0, transClosure, wmm.getOrCreatePredefinedRelation(ID)));
     }
 
     @Override
     public Relation visitExprDomainIdentity(ExprDomainIdentityContext c) {
-        checkNoRecursion(c);
-        Relation r0 = wmm.newRelation();
+        Relation r0 = getAndResetRelationToBeDefined().orElseGet(wmm::newRelation);
         Relation r1 = parseAsRelation(c.e);
         return addDefinition(new DomainIdentity(r0, r1));
     }
 
     @Override
     public Relation visitExprRangeIdentity(ExprRangeIdentityContext c) {
-        checkNoRecursion(c);
-        Relation r0 = wmm.newRelation();
+        Relation r0 = getAndResetRelationToBeDefined().orElseGet(wmm::newRelation);
         Relation r1 = parseAsRelation(c.e);
         return addDefinition(new RangeIdentity(r0, r1));
     }
 
     @Override
     public Relation visitExprOptional(ExprOptionalContext c) {
-        checkNoRecursion(c);
-        Relation r0 = wmm.newRelation();
+        Relation r0 = getAndResetRelationToBeDefined().orElseGet(wmm::newRelation);
         Relation r1 = parseAsRelation(c.e);
-        return addDefinition(new Union(r0, wmm.getOrCreatePredefinedRelation(ID), r1));
+        return addDefinition(new Union(r0, r1, wmm.getOrCreatePredefinedRelation(ID)));
     }
 
     @Override
     public Relation visitExprIdentity(ExprIdentityContext c) {
-        checkNoRecursion(c);
-        Relation r0 = wmm.newRelation();
+        Relation r0 = getAndResetRelationToBeDefined().orElseGet(wmm::newRelation);
         Filter s1 = parseAsFilter(c.e);
         return addDefinition(new SetIdentity(r0, s1));
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/WmmAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/WmmAnalysis.java
@@ -6,7 +6,7 @@ import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.wmm.Definition;
 import com.dat3m.dartagnan.wmm.Relation;
 import com.dat3m.dartagnan.wmm.Wmm;
-import com.dat3m.dartagnan.wmm.definition.*;
+import com.dat3m.dartagnan.wmm.definition.Difference;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
@@ -66,12 +66,7 @@ public class WmmAnalysis {
         for (Set<DependencyGraph<Relation>.Node> scc : depGraph.getSCCs()) {
             for (DependencyGraph<Relation>.Node node : scc) {
                 final Definition d = node.getContent().getDefinition();
-                if ((d instanceof Inverse || d instanceof DomainIdentity || d instanceof RangeIdentity || d instanceof TransitiveClosure) && scc.size() > 1) {
-                    // Unary relations are not implemented in recursions right now
-                    throw new UnsupportedOperationException(String.format(
-                            "Unary relation %s not supported in recursive definitions.", node.getContent()
-                    ));
-                } else if (d instanceof Difference diff && scc.contains(depGraph.get(diff.getSubtrahend()))) {
+                if (d instanceof Difference diff && scc.contains(depGraph.get(diff.getSubtrahend()))) {
                     // Non-monotonic recursion gives ill-defined memory models.
                     throw new MalformedMemoryModelException(String.format(
                             "Non-monotonic recursion is not supported: %s", node.getContent()


### PR DESCRIPTION
This PR removes a restriction we imposed on recursive definitions that is not necessary anymore.