### PR TITLE
Fix uninit read benchmark

### DIFF
--- a/benchmarks/c/miscellaneous/uninitRead.c
+++ b/benchmarks/c/miscellaneous/uninitRead.c
@@ -4,15 +4,14 @@
 /*
     This test shows that we can read from uninitialized memory.
     EXPECTED: FAIL
-    PREVIOUSLY: We returned PASS because the array read had no possible rf-edge and thus the program had no valid executions.
-    WARNING: We still cannot correctly handle overflowing accesses to initialized(!) memory.
 */
 
 #define SIZE 10
-volatile int array[SIZE];
+volatile int *array;
 
 int main()
 {
-    assert (array[SIZE + 100000] == 42);
+    array = (int*)malloc(SIZE * sizeof(int));
+    assert (array[0] == 42);
     return 0;
 }

--- a/benchmarks/c/miscellaneous/uninitRead.c
+++ b/benchmarks/c/miscellaneous/uninitRead.c
@@ -5,6 +5,7 @@
     This test shows that we can read from uninitialized memory.
     EXPECTED: FAIL
     PREVIOUSLY: We returned PASS because the array read had no possible rf-edge and thus the program had no valid executions.
+    WARNING: We still cannot correctly handle overflowing accesses to initialized(!) memory.
 */
 
 #define SIZE 10
@@ -12,6 +13,6 @@ volatile int array[SIZE];
 
 int main()
 {
-    assert (array[SIZE] == 42);
+    assert (array[SIZE + 100000] == 42);
     return 0;
 }

--- a/dartagnan/src/test/resources/miscellaneous/uninitRead.ll
+++ b/dartagnan/src/test/resources/miscellaneous/uninitRead.ll
@@ -3,51 +3,57 @@ source_filename = "/Users/thomashaas/IdeaProjects/Dat3M/benchmarks/c/miscellaneo
 target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
 target triple = "arm64-apple-macosx13.0.0"
 
-@array = dso_local global [10 x i32] zeroinitializer, align 4, !dbg !0
+@array = dso_local global i32* null, align 8, !dbg !0
 @__func__.main = private unnamed_addr constant [5 x i8] c"main\00", align 1
 @.str = private unnamed_addr constant [13 x i8] c"uninitRead.c\00", align 1
-@.str.1 = private unnamed_addr constant [27 x i8] c"array[SIZE + 100000] == 42\00", align 1
+@.str.1 = private unnamed_addr constant [15 x i8] c"array[0] == 42\00", align 1
 
 ; Function Attrs: noinline nounwind ssp uwtable
 define dso_local i32 @main() #0 !dbg !21 {
-  %1 = load volatile i32, i32* getelementptr inbounds ([10 x i32], [10 x i32]* @array, i64 10001, i64 0), align 4, !dbg !24
-  %2 = icmp eq i32 %1, 42, !dbg !24
-  %3 = xor i1 %2, true, !dbg !24
-  %4 = zext i1 %3 to i32, !dbg !24
-  %5 = sext i32 %4 to i64, !dbg !24
-  br i1 %3, label %6, label %7, !dbg !24
+  %1 = call i8* @malloc(i64 40), !dbg !24
+  %2 = bitcast i8* %1 to i32*, !dbg !25
+  store i32* %2, i32** @array, align 8, !dbg !26
+  %3 = load volatile i32, i32* %2, align 4, !dbg !27
+  %4 = icmp eq i32 %3, 42, !dbg !27
+  %5 = xor i1 %4, true, !dbg !27
+  %6 = zext i1 %5 to i32, !dbg !27
+  %7 = sext i32 %6 to i64, !dbg !27
+  br i1 %5, label %8, label %9, !dbg !27
 
-6:                                                ; preds = %0
-  call void @__assert_rtn(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @__func__.main, i64 0, i64 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str, i64 0, i64 0), i32 16, i8* getelementptr inbounds ([27 x i8], [27 x i8]* @.str.1, i64 0, i64 0)) #2, !dbg !24
-  unreachable, !dbg !24
+8:                                                ; preds = %0
+  call void @__assert_rtn(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @__func__.main, i64 0, i64 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str, i64 0, i64 0), i32 15, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @.str.1, i64 0, i64 0)) #3, !dbg !27
+  unreachable, !dbg !27
 
-7:                                                ; preds = %0
-  ret i32 0, !dbg !25
+9:                                                ; preds = %0
+  ret i32 0, !dbg !28
 }
 
+declare i8* @malloc(i64) #1
+
 ; Function Attrs: cold noreturn
-declare void @__assert_rtn(i8*, i8*, i32, i8*) #1
+declare void @__assert_rtn(i8*, i8*, i32, i8*) #2
 
 attributes #0 = { noinline nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-a12" "target-features"="+aes,+crc,+crypto,+fp-armv8,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+v8.3a,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { cold noreturn "disable-tail-calls"="true" "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-a12" "target-features"="+aes,+crc,+crypto,+fp-armv8,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+v8.3a,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { cold noreturn }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-a12" "target-features"="+aes,+crc,+crypto,+fp-armv8,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+v8.3a,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { cold noreturn "disable-tail-calls"="true" "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-a12" "target-features"="+aes,+crc,+crypto,+fp-armv8,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+v8.3a,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { cold noreturn }
 
 !llvm.dbg.cu = !{!2}
 !llvm.module.flags = !{!12, !13, !14, !15, !16, !17, !18, !19}
 !llvm.ident = !{!20}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
-!1 = distinct !DIGlobalVariable(name: "array", scope: !2, file: !6, line: 12, type: !7, isLocal: false, isDefinition: true)
-!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "Homebrew clang version 12.0.1", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: None, sysroot: "/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk", sdk: "MacOSX13.sdk")
+!1 = distinct !DIGlobalVariable(name: "array", scope: !2, file: !9, line: 10, type: !10, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "Homebrew clang version 12.0.1", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !5, globals: !8, nameTableKind: None, sysroot: "/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk", sdk: "MacOSX13.sdk")
 !3 = !DIFile(filename: "/Users/thomashaas/IdeaProjects/Dat3M/benchmarks/c/miscellaneous/uninitRead.c", directory: "/Users/thomashaas/IdeaProjects/Dat3M")
 !4 = !{}
-!5 = !{!0}
-!6 = !DIFile(filename: "benchmarks/c/miscellaneous/uninitRead.c", directory: "/Users/thomashaas/IdeaProjects/Dat3M")
-!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 320, elements: !10)
-!8 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !9)
-!9 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!10 = !{!11}
-!11 = !DISubrange(count: 10)
+!5 = !{!6}
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!8 = !{!0}
+!9 = !DIFile(filename: "benchmarks/c/miscellaneous/uninitRead.c", directory: "/Users/thomashaas/IdeaProjects/Dat3M")
+!10 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !11, size: 64)
+!11 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !7)
 !12 = !{i32 7, !"Dwarf Version", i32 4}
 !13 = !{i32 2, !"Debug Info Version", i32 3}
 !14 = !{i32 1, !"wchar_size", i32 4}
@@ -57,8 +63,11 @@ attributes #2 = { cold noreturn }
 !18 = !{i32 1, !"sign-return-address-with-bkey", i32 0}
 !19 = !{i32 7, !"PIC Level", i32 2}
 !20 = !{!"Homebrew clang version 12.0.1"}
-!21 = distinct !DISubprogram(name: "main", scope: !6, file: !6, line: 14, type: !22, scopeLine: 15, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
+!21 = distinct !DISubprogram(name: "main", scope: !9, file: !9, line: 12, type: !22, scopeLine: 13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !22 = !DISubroutineType(types: !23)
-!23 = !{!9}
-!24 = !DILocation(line: 16, column: 5, scope: !21)
-!25 = !DILocation(line: 17, column: 5, scope: !21)
+!23 = !{!7}
+!24 = !DILocation(line: 14, column: 19, scope: !21)
+!25 = !DILocation(line: 14, column: 13, scope: !21)
+!26 = !DILocation(line: 14, column: 11, scope: !21)
+!27 = !DILocation(line: 15, column: 5, scope: !21)
+!28 = !DILocation(line: 16, column: 5, scope: !21)

--- a/dartagnan/src/test/resources/miscellaneous/uninitRead.ll
+++ b/dartagnan/src/test/resources/miscellaneous/uninitRead.ll
@@ -6,11 +6,11 @@ target triple = "arm64-apple-macosx13.0.0"
 @array = dso_local global [10 x i32] zeroinitializer, align 4, !dbg !0
 @__func__.main = private unnamed_addr constant [5 x i8] c"main\00", align 1
 @.str = private unnamed_addr constant [13 x i8] c"uninitRead.c\00", align 1
-@.str.1 = private unnamed_addr constant [18 x i8] c"array[SIZE] == 42\00", align 1
+@.str.1 = private unnamed_addr constant [27 x i8] c"array[SIZE + 100000] == 42\00", align 1
 
 ; Function Attrs: noinline nounwind ssp uwtable
 define dso_local i32 @main() #0 !dbg !21 {
-  %1 = load volatile i32, i32* getelementptr inbounds ([10 x i32], [10 x i32]* @array, i64 1, i64 0), align 4, !dbg !24
+  %1 = load volatile i32, i32* getelementptr inbounds ([10 x i32], [10 x i32]* @array, i64 10001, i64 0), align 4, !dbg !24
   %2 = icmp eq i32 %1, 42, !dbg !24
   %3 = xor i1 %2, true, !dbg !24
   %4 = zext i1 %3 to i32, !dbg !24
@@ -18,7 +18,7 @@ define dso_local i32 @main() #0 !dbg !21 {
   br i1 %3, label %6, label %7, !dbg !24
 
 6:                                                ; preds = %0
-  call void @__assert_rtn(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @__func__.main, i64 0, i64 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str, i64 0, i64 0), i32 15, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @.str.1, i64 0, i64 0)) #2, !dbg !24
+  call void @__assert_rtn(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @__func__.main, i64 0, i64 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str, i64 0, i64 0), i32 16, i8* getelementptr inbounds ([27 x i8], [27 x i8]* @.str.1, i64 0, i64 0)) #2, !dbg !24
   unreachable, !dbg !24
 
 7:                                                ; preds = %0
@@ -37,7 +37,7 @@ attributes #2 = { cold noreturn }
 !llvm.ident = !{!20}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
-!1 = distinct !DIGlobalVariable(name: "array", scope: !2, file: !6, line: 11, type: !7, isLocal: false, isDefinition: true)
+!1 = distinct !DIGlobalVariable(name: "array", scope: !2, file: !6, line: 12, type: !7, isLocal: false, isDefinition: true)
 !2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "Homebrew clang version 12.0.1", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: None, sysroot: "/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk", sdk: "MacOSX13.sdk")
 !3 = !DIFile(filename: "/Users/thomashaas/IdeaProjects/Dat3M/benchmarks/c/miscellaneous/uninitRead.c", directory: "/Users/thomashaas/IdeaProjects/Dat3M")
 !4 = !{}
@@ -57,8 +57,8 @@ attributes #2 = { cold noreturn }
 !18 = !{i32 1, !"sign-return-address-with-bkey", i32 0}
 !19 = !{i32 7, !"PIC Level", i32 2}
 !20 = !{!"Homebrew clang version 12.0.1"}
-!21 = distinct !DISubprogram(name: "main", scope: !6, file: !6, line: 13, type: !22, scopeLine: 14, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
+!21 = distinct !DISubprogram(name: "main", scope: !6, file: !6, line: 14, type: !22, scopeLine: 15, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
 !22 = !DISubroutineType(types: !23)
 !23 = !{!9}
-!24 = !DILocation(line: 15, column: 5, scope: !21)
-!25 = !DILocation(line: 16, column: 5, scope: !21)
+!24 = !DILocation(line: 16, column: 5, scope: !21)
+!25 = !DILocation(line: 17, column: 5, scope: !21)


### PR DESCRIPTION
This fixes the `uninitRead.c` benchmark to work independent of the `RemoveUnusedMemory` pass and adds a clarifying warning that this test is about accessing uninitialized memory and not initialized memory via overflows (we do not handle the latter correctly).