### PR TITLE
Improved reporting and detection of CAAT non-termination

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/Dependency.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/Dependency.java
@@ -8,6 +8,8 @@ import com.dat3m.dartagnan.program.event.RegReader;
 import com.dat3m.dartagnan.program.event.RegWriter;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.verification.Context;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
@@ -34,7 +36,10 @@ public final class Dependency {
     private final HashMap<Event, Map<Register, State>> map = new HashMap<>();
     private final Map<Register, State> finalWriters = new HashMap<>();
 
-    private Dependency() {
+    private final Supplier<SyntacticContextAnalysis> synCtx;
+
+    private Dependency(Program program) {
+        synCtx = Suppliers.memoize(() -> SyntacticContextAnalysis.newInstance(program));
     }
 
     /**
@@ -51,7 +56,7 @@ public final class Dependency {
     public static Dependency fromConfig(Program program, Context analysisContext, Configuration config) throws InvalidConfigurationException {
         logger.info("Analyze dependencies");
         ExecutionAnalysis exec = analysisContext.requires(ExecutionAnalysis.class);
-        Dependency result = new Dependency();
+        Dependency result = new Dependency(program);
         for (Thread t : program.getThreads()) {
             result.process(t, exec);
         }
@@ -126,10 +131,9 @@ public final class Dependency {
                     } else {
                         writers = process(event, state, register, exec);
                         if (!writers.initialized) {
-                            logger.warn("Uninitialized register {} read by event {} of thread {}",
-                                    register,
-                                    event,
-                                    thread.getId());
+                            logger.warn("Uninitialized register {} read by event {}\n {}",
+                                    register, event,
+                                    synCtx.get().getSourceLocationWithContext(event, true));
                         }
                     }
                     result.put(register, writers);
@@ -170,7 +174,7 @@ public final class Dependency {
                 .filter(e -> e.register.equals(register))
                 .map(e -> e.event)
                 .filter(e -> reader == null || !exec.areMutuallyExclusive(reader, e))
-                .collect(toList());
+                .toList();
         //NOTE if candidates is empty, the reader is unreachable
         List<Event> mays = candidates.stream()
                 .filter(Objects::nonNull)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
@@ -124,6 +124,19 @@ public class SyntacticContextAnalysis {
         return new SyntacticContextAnalysis();
     }
 
+    public String getSourceLocationWithContext(Event e, boolean addGlobalId) {
+        final StringBuilder builder = new StringBuilder();
+        final String ctx = makeContextString(this.getContextInfo(e).getContextStack(), " -> ");
+        if (addGlobalId) {
+            builder.append("E").append(e.getGlobalId()).append(": \t");
+        }
+        builder
+                .append(ctx.isEmpty() ? ctx : ctx + " -> ")
+                .append(getSourceLocationString(e));
+
+        return builder.toString();
+    }
+
     // ============================================================================
     // ============================== Analysis logic ==============================
     // ============================================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -34,8 +34,7 @@ import java.util.Optional;
 
 import static com.dat3m.dartagnan.configuration.Property.CAT_SPEC;
 import static com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis.*;
-import static com.dat3m.dartagnan.utils.Result.FAIL;
-import static com.dat3m.dartagnan.utils.Result.PASS;
+import static com.dat3m.dartagnan.utils.Result.*;
 import static java.lang.Boolean.FALSE;
 
 public abstract class ModelChecker {
@@ -58,7 +57,8 @@ public abstract class ModelChecker {
         final Property.Type propType = Property.getCombinedType(context.getTask().getProperty(), context.getTask());
         final boolean hasViolationWitnesses = res == FAIL && propType == Property.Type.SAFETY;
         final boolean hasPositiveWitnesses = res == PASS && propType == Property.Type.REACHABILITY;
-        return (hasViolationWitnesses || hasPositiveWitnesses);
+        final boolean hasReachedBounds = res == UNKNOWN && propType == Property.Type.SAFETY;
+        return (hasViolationWitnesses || hasPositiveWitnesses || hasReachedBounds);
     }
 
     /**

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -410,13 +410,10 @@ public class RefinementSolver extends ModelChecker {
     }
 
     private boolean checkProgress(List<RefinementIteration> trace) {
-        if (trace.size() < 2) {
+        if (trace.size() < 2 || trace.getLast().isConclusive()) {
             return true;
         }
         final RefinementIteration last = trace.get(trace.size() - 1);
-        if (last.isConclusive()) {
-            return true;
-        }
         final RefinementIteration prev = trace.get(trace.size() - 2);
         return !last.inconsistencyReasons.equals(prev.inconsistencyReasons);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -325,21 +325,12 @@ public class RefinementSolver extends ModelChecker {
 
                     final StringBuilder builder = new StringBuilder();
                     builder.append("Found aliasing problem between:\n");
-
-                    final String ctx1 = makeContextString(synContext.getContextInfo(e1).getContextStack(), " -> ");
-                    final String ctx2 = makeContextString(synContext.getContextInfo(e2).getContextStack(), " -> ");
-                    builder
-                            .append("\tE").append(e1.getGlobalId())
-                            .append(":\t")
-                            .append(ctx1.isEmpty() ? ctx1 : ctx1 + " -> ")
-                            .append(getSourceLocationString(e1))
-                            .append("\n");
-                    builder.append("AND\n");
-                    builder
-                            .append("\tE").append(e2.getGlobalId())
-                            .append(":\t")
-                            .append(ctx2.isEmpty() ? ctx2 : ctx2 + " -> ")
-                            .append(getSourceLocationString(e2))
+                    builder.append("\t")
+                            .append(synContext.getSourceLocationWithContext(e1, true))
+                            .append("\n")
+                            .append("AND\n")
+                            .append("\t")
+                            .append(synContext.getSourceLocationWithContext(e2, true))
                             .append("\n");
                     builder.append("Possible out-of-bounds access in source code or error in alias analysis.");
 
@@ -423,6 +414,9 @@ public class RefinementSolver extends ModelChecker {
             return true;
         }
         final RefinementIteration last = trace.get(trace.size() - 1);
+        if (last.isConclusive()) {
+            return true;
+        }
         final RefinementIteration prev = trace.get(trace.size() - 2);
         return !last.inconsistencyReasons.equals(prev.inconsistencyReasons);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -410,7 +410,7 @@ public class RefinementSolver extends ModelChecker {
     }
 
     private boolean checkProgress(List<RefinementIteration> trace) {
-        if (trace.size() < 2 || trace.getLast().isConclusive()) {
+        if (trace.size() < 2 || trace.get(trace.size() - 1).isConclusive()) {
             return true;
         }
         final RefinementIteration last = trace.get(trace.size() - 1);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -324,7 +324,7 @@ public class RefinementSolver extends ModelChecker {
                     final Event e2 = relLit.getTarget();
 
                     final StringBuilder builder = new StringBuilder();
-                    builder.append("Found aliasing problem between:\n");
+                    builder.append("Found unexpected aliasing between:\n");
                     builder.append("\t")
                             .append(synContext.getSourceLocationWithContext(e1, true))
                             .append("\n")


### PR DESCRIPTION
This PR adds a check to prevent CAAT from not terminating.
It further tries to figure out the source of non-termination and report it to the user.
Also, the `Dependency` analysis now reports accesses to uninitialized registers with source information (this is related to #647)

I might also add source location reporting for reachable bounds, so the user knows which loops are not unrolled.
Are there any other places that would benefit from better reporting? If so, I would add them.