### PR TITLE
Better symmetry reasoning in CAAT

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat/CAATModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat/CAATModel.java
@@ -5,7 +5,6 @@ import com.dat3m.dartagnan.solver.caat.domain.Domain;
 import com.dat3m.dartagnan.solver.caat.predicates.CAATPredicate;
 import com.dat3m.dartagnan.solver.caat.predicates.PredicateHierarchy;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -14,7 +13,6 @@ public class CAATModel {
 
     // ======================================== Fields ==============================================
 
-    private final Map<String, CAATPredicate> predicateMap;
     private final Set<Constraint> constraints;
     private final PredicateHierarchy hierarchy;
 
@@ -26,7 +24,6 @@ public class CAATModel {
 
         this.constraints = constraints;
         this.hierarchy = hierarchy;
-        this.predicateMap = Maps.uniqueIndex(hierarchy.getPredicateList(), CAATPredicate::getName);
 
         for (Constraint c : this.constraints) {
             hierarchy.addListener(c.getConstrainedPredicate(), c);
@@ -53,10 +50,6 @@ public class CAATModel {
     public Set<Constraint> getConstraints() { return constraints; }
     public Domain<?> getDomain() { return hierarchy.getDomain(); }
     public Set<CAATPredicate> getBasePredicates() { return hierarchy.getBasePredicates(); }
-
-    public CAATPredicate getPredicateByName(String name) {
-        return predicateMap.get(name);
-    }
 
     // ======================================== Initialization ==============================================
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
@@ -259,7 +259,7 @@ public class ExecutionGraph {
         } else if (relClass == Internal.class) {
             graph = new InternalGraph();
         } else if (relClass == Fences.class) {
-            graph = new FenceGraph(((Fences) rel.getDefinition()).getFilter());
+            throw new UnsupportedOperationException("fencerel is not supported in CAAT.");
         } else if (relClass == SetIdentity.class) {
             SetPredicate set = getOrCreateSetFromFilter(((SetIdentity) rel.getDefinition()).getFilter());
             graph = new SetIdentityGraph(set);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.solver.caat4wmm;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.solver.caat.CAATSolver;
-import com.dat3m.dartagnan.solver.caat.reasoning.CAATLiteral;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreLiteral;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreReasoner;
 import com.dat3m.dartagnan.utils.logic.Conjunction;
@@ -14,8 +13,7 @@ import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.api.Model;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 
 /*
     This is our domain-specific bridging component that specializes the CAATSolver to the WMM setting.
@@ -64,10 +62,7 @@ public class WMMSolver {
         if (result.getStatus() == CAATSolver.Status.INCONSISTENT) {
             // ============== Compute Core reasons ==============
             curTime = System.currentTimeMillis();
-            List<Conjunction<CoreLiteral>> coreReasons = new ArrayList<>(caatResult.getBaseReasons().getNumberOfCubes());
-            for (Conjunction<CAATLiteral> baseReason : caatResult.getBaseReasons().getCubes()) {
-                coreReasons.addAll(reasoner.toCoreReasons(baseReason));
-            }
+            Set<Conjunction<CoreLiteral>> coreReasons = reasoner.toCoreReasons(caatResult.getBaseReasons());
             stats.numComputedCoreReasons = coreReasons.size();
             result.coreReasons = new DNF<>(coreReasons);
             stats.numComputedReducedCoreReasons = result.coreReasons.getNumberOfCubes();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
@@ -4,7 +4,6 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.ThreadSymmetry;
 import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.solver.caat.predicates.relationGraphs.Edge;
 import com.dat3m.dartagnan.solver.caat.reasoning.CAATLiteral;
 import com.dat3m.dartagnan.solver.caat.reasoning.EdgeLiteral;
 import com.dat3m.dartagnan.solver.caat.reasoning.ElementLiteral;
@@ -13,47 +12,81 @@ import com.dat3m.dartagnan.solver.caat4wmm.ExecutionGraph;
 import com.dat3m.dartagnan.solver.caat4wmm.basePredicates.FenceGraph;
 import com.dat3m.dartagnan.utils.equivalence.EquivalenceClass;
 import com.dat3m.dartagnan.utils.logic.Conjunction;
+import com.dat3m.dartagnan.utils.logic.DNF;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.model.EventData;
 import com.dat3m.dartagnan.wmm.Relation;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.definition.Fences;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.dat3m.dartagnan.GlobalSettings.REFINEMENT_SYMMETRIC_LEARNING;
 import static com.dat3m.dartagnan.wmm.RelationNameRepository.*;
 
 // The CoreReasoner transforms base reasons of the CAATSolver to core reason of the WMMSolver.
 public class CoreReasoner {
 
-    public enum SymmetricLearning { NONE, LINEAR, QUADRATIC, FULL }
+    private final static int MAX_NUM_COMPUTED_REASONS = 1000;
+
+    public enum SymmetricLearning { NONE, FULL }
 
     private final ExecutionGraph executionGraph;
     private final ExecutionAnalysis exec;
     private final RelationAnalysis ra;
-
-    private final ThreadSymmetry symm;
-    private final List<Function<Event, Event>> symmPermutations;
-    private final SymmetricLearning learningOption;
+    private final List<Function<Event, Event>> symmGenerators;
 
     public CoreReasoner(Context analysisContext, ExecutionGraph executionGraph) {
         this.executionGraph = executionGraph;
         this.exec = analysisContext.requires(ExecutionAnalysis.class);
         this.ra = analysisContext.requires(RelationAnalysis.class);
-        this.symm = analysisContext.requires(ThreadSymmetry.class);
-        this.learningOption = SymmetricLearning.LINEAR;
-        this.symmPermutations = computeSymmetryPermutations();
+        this.symmGenerators = computeSymmetryGenerators(
+                analysisContext.requires(ThreadSymmetry.class), REFINEMENT_SYMMETRIC_LEARNING);
     }
 
-    public Set<Conjunction<CoreLiteral>> toCoreReasonsNew(Conjunction<CAATLiteral> baseReason) {
+    public Set<Conjunction<CoreLiteral>> toCoreReasons(DNF<CAATLiteral> baseReasons) {
+
+        // (1) Find valuable base reasons by reducing them to simplified core reasons first
+        // and filtering out duplicates
+        BiMap<Conjunction<CAATLiteral>, Conjunction<CoreLiteral>> base2core = HashBiMap.create(baseReasons.getNumberOfCubes());
+        BiMap<Conjunction<CoreLiteral>, Conjunction<CAATLiteral>> core2base = base2core.inverse();
+        for (Conjunction<CAATLiteral> baseReason : baseReasons.getCubes()) {
+            final Conjunction<CoreLiteral> coreReason = toCoreReasonNoSymmetry(baseReason);
+            if (!base2core.containsValue(coreReason)) {
+                base2core.put(baseReason, coreReason);
+            }
+        }
+
+        // (2) Remove dominated core reasons and sort by reason length
+        List<Conjunction<CoreLiteral>> reducedCoreReasons = new ArrayList<>(new DNF<>(base2core.values()).getCubes());
+        reducedCoreReasons.sort(Comparator.comparingInt(Conjunction::getSize));
+
+        // (3) Translate back to base reasons (we need the original base reasons for symmetry reasoning)
+        List<Conjunction<CAATLiteral>> reducedBaseReasons = reducedCoreReasons.stream().map(core2base::get).toList();
+
+        // (4) Recompute core reasons with symmetry reasoning.
+        //  Stop early, if the number of reasons gets too large.
+        final Set<Conjunction<CoreLiteral>> coreReasons = new HashSet<>();
+        for (Conjunction<CAATLiteral> baseReason : reducedBaseReasons) {
+            coreReasons.addAll(toCoreReasons(baseReason));
+            if (coreReasons.size() > MAX_NUM_COMPUTED_REASONS) {
+                break;
+            }
+        }
+
+        return coreReasons;
+    }
+
+    public Set<Conjunction<CoreLiteral>> toCoreReasons(Conjunction<CAATLiteral> baseReason) {
         final EventDomain domain = executionGraph.getDomain();
-        final List<Function<Event, Event>> symmGenerators = symmPermutations;
 
         final Set<List<CoreLiteral>> orbit = new HashSet<>();
         final Deque<List<CoreLiteral>> workqueue = new ArrayDeque<>();
-        workqueue.add(asUnreducedCoreReason(baseReason, domain));
+        workqueue.add(toUnreducedCoreReason(baseReason, domain));
 
         while (!workqueue.isEmpty()) {
             final List<CoreLiteral> reason = workqueue.removeFirst();
@@ -65,55 +98,11 @@ public class CoreReasoner {
             }
         }
 
-        return orbit.stream().map(this::simplify).map(Conjunction::new).collect(Collectors.toSet());
+        return orbit.stream().map(this::reduce).map(Conjunction::new).collect(Collectors.toSet());
     }
 
-    private List<CoreLiteral> simplify(List<CoreLiteral> reason) {
-        final List<CoreLiteral> simplified = new ArrayList<>();
-        for (CoreLiteral lit : reason) {
-            if (lit instanceof ExecLiteral execLiteral) {
-                simplified.add(execLiteral);
-            } else if (lit instanceof RelLiteral relLiteral) {
-                final Event e1 = relLiteral.getSource();
-                final Event e2 = relLiteral.getTarget();
-                final Relation rel = relLiteral.getRelation();
-                if (relLiteral.isPositive() && ra.getKnowledge(rel).getMustSet().contains(e1, e2)) {
-                    addExecReason(e1, e2, simplified);
-                } else if (relLiteral.isNegative() && !ra.getKnowledge(rel).getMaySet().contains(e1, e2)) {
-
-                } else {
-                    String name = rel.getName().orElse(null);
-                    if (RF.equals(name) || CO.equals(name) || executionGraph.getCutRelations().contains(rel)) {
-                        simplified.add(lit);
-                    } else if (LOC.equals(name)) {
-                        simplified.add(new AddressLiteral(e1, e2, lit.isPositive()));
-                    } else if (rel.getDefinition() instanceof Fences) {
-                        // This is a special case since "fencerel(F) = po;[F];po".
-                        // We should do this transformation directly on the Wmm to avoid this special reasoning
-                        if (lit.isNegative()) {
-                            throw new UnsupportedOperationException(String.format("FenceRel %s is not allowed on the rhs of differences.", rel));
-                        }
-                        FenceGraph fenceGraph = (FenceGraph) executionGraph.getRelationGraph(rel);
-                        EventDomain domain = executionGraph.getDomain();
-                        EventData ed1 = domain.getExecution().getData(e1).get();
-                        EventData f = fenceGraph.getNextFence(ed1);
-
-                        simplified.add(new ExecLiteral(f.getEvent()));
-                        if (!exec.isImplied(f.getEvent(), e1)) {
-                            simplified.add(new ExecLiteral(e1));
-                        }
-                        if (!exec.isImplied(f.getEvent(), e2)) {
-                            simplified.add(new ExecLiteral(e2));
-                        }
-                    } else {
-                        throw new UnsupportedOperationException(String.format("Literals of type %s are not supported.", rel));
-                    }
-                }
-            }
-        }
-
-        minimize(simplified);
-        return simplified;
+    private Conjunction<CoreLiteral> toCoreReasonNoSymmetry(Conjunction<CAATLiteral> baseReason) {
+        return new Conjunction<>(reduce(toUnreducedCoreReason(baseReason, executionGraph.getDomain())));
     }
 
     private List<CoreLiteral> getPermuted(List<CoreLiteral> reason, Function<Event, Event> perm) {
@@ -128,13 +117,13 @@ public class CoreReasoner {
                 final Event e2 = perm.apply(relLiteral.getTarget());
                 permuted.add(new RelLiteral(relLiteral.getRelation(), e1, e2, relLiteral.isPositive()));
             } else {
-                assert false;
+                assert false : "Unexpected core literal type: violated invariant.";
             }
         }
         return permuted;
     }
 
-    private List<CoreLiteral> asUnreducedCoreReason(Conjunction<CAATLiteral> baseReason, EventDomain domain) {
+    private List<CoreLiteral> toUnreducedCoreReason(Conjunction<CAATLiteral> baseReason, EventDomain domain) {
         final List<CoreLiteral> coreReason = new ArrayList<>(baseReason.getSize());
         for (CAATLiteral lit : baseReason.getLiterals()) {
             if (lit instanceof ElementLiteral eleLit) {
@@ -150,67 +139,45 @@ public class CoreReasoner {
         return coreReason;
     }
 
-    // Returns the (reduced) core reason of a base reason. If symmetry reasoning is enabled,
-    // this can return multiple core reasons corresponding to symmetric versions of the base reason.
-    public Set<Conjunction<CoreLiteral>> toCoreReasons(Conjunction<CAATLiteral> baseReason) {
-        final EventDomain domain = executionGraph.getDomain();
-        final Set<Conjunction<CoreLiteral>> symmetricReasons = new HashSet<>();
-
-        final Set<Conjunction<CoreLiteral>> test = toCoreReasonsNew(baseReason);
-        return test;
-        /*
-
-        //TODO: A specialized algorithm that computes the orbit under permutation may be better,
-        // since most violations involve only few threads and hence the orbit is far smaller than the full
-        // set of permutations.
-        for (Function<Event, Event> perm : symmPermutations) {
-            List<CoreLiteral> coreReason = new ArrayList<>(baseReason.getSize());
-            for (CAATLiteral lit : baseReason.getLiterals()) {
-                if (lit instanceof ElementLiteral elLit) {
-                    // We only have static tags, so all of them reduce to execution literals
-                    final Event e = perm.apply(domain.getObjectById(elLit.getData().getId()).getEvent());
-                    coreReason.add(new ExecLiteral(e, lit.isPositive()));
+    // Reduce a core reason by applying knowledge about the semantics of its literals
+    // (relation analysis / base semantics / control-flow information etc.)
+    private List<CoreLiteral> reduce(List<CoreLiteral> reason) {
+        final List<CoreLiteral> simplified = new ArrayList<>();
+        for (CoreLiteral lit : reason) {
+            if (lit instanceof ExecLiteral execLiteral) {
+                simplified.add(execLiteral);
+            } else if (lit instanceof RelLiteral relLiteral) {
+                final Event e1 = relLiteral.getSource();
+                final Event e2 = relLiteral.getTarget();
+                final Relation rel = relLiteral.getRelation();
+                if (relLiteral.isPositive() && ra.getKnowledge(rel).getMustSet().contains(e1, e2)) {
+                    addExecReason(e1, e2, simplified);
+                } else if (relLiteral.isNegative() && !ra.getKnowledge(rel).getMaySet().contains(e1, e2)) {
+                    // Negated literal is always true, no need to remember it.
                 } else {
-                    final EdgeLiteral edgeLit = (EdgeLiteral) lit;
-                    final Edge edge = edgeLit.getData();
-                    final Event e1 = perm.apply(domain.getObjectById(edge.getFirst()).getEvent());
-                    final Event e2 = perm.apply(domain.getObjectById(edge.getSecond()).getEvent());
-                    final Relation rel = executionGraph.getRelationGraphMap().inverse().get(edgeLit.getPredicate());
-
-                    if (lit.isPositive() && ra.getKnowledge(rel).getMustSet().contains(e1, e2)) {
-                        // Statically present edges
-                        addExecReason(e1, e2, coreReason);
-                    } else if (lit.isNegative() && !ra.getKnowledge(rel).getMaySet().contains(e1, e2)) {
-                        // Statically absent edges
-                    } else {
-                        // Dynamic edges
-                        String name = rel.getName().orElse(null);
-                        if (RF.equals(name) || CO.equals(name) || executionGraph.getCutRelations().contains(rel)) {
-                            coreReason.add(new RelLiteral(rel, e1, e2, lit.isPositive()));
-                        } else if (LOC.equals(name)) {
-                            coreReason.add(new AddressLiteral(e1, e2, lit.isPositive()));
-                        } else if (rel.getDefinition() instanceof Fences) {
-                            // This is a special case since "fencerel(F) = po;[F];po".
-                            // We should do this transformation directly on the Wmm to avoid this special reasoning
-                            if (lit.isNegative()) {
-                                throw new UnsupportedOperationException(String.format("FenceRel %s is not allowed on the rhs of differences.", rel));
-                            }
-                            addFenceReason(rel, edge, coreReason);
-                        } else {
-                            throw new UnsupportedOperationException(String.format("Literals of type %s are not supported.", rel));
+                    String name = rel.getName().orElse(null);
+                    if (RF.equals(name) || CO.equals(name) || executionGraph.getCutRelations().contains(rel)) {
+                        simplified.add(lit);
+                    } else if (LOC.equals(name)) {
+                        simplified.add(new AddressLiteral(e1, e2, lit.isPositive()));
+                    } else if (rel.getDefinition() instanceof Fences) {
+                        // This is a special case since "fencerel(F) = po;[F];po".
+                        // We should do this transformation directly on the Wmm to avoid this special reasoning
+                        if (lit.isNegative()) {
+                            throw new UnsupportedOperationException(String.format("FenceRel %s is not allowed on the rhs of differences.", rel));
                         }
+                        addFenceReason(rel, e1, e2, simplified);
+                    } else {
+                        throw new UnsupportedOperationException(String.format("Literals of type %s are not supported.", rel));
                     }
                 }
             }
-            minimize(coreReason);
-            symmetricReasons.add(new Conjunction<>(coreReason));
         }
-
-        return symmetricReasons;*/
+        removeDominatedLiterals(simplified);
+        return simplified;
     }
 
-
-    private void minimize(List<CoreLiteral> reason) {
+    private void removeDominatedLiterals(List<CoreLiteral> reason) {
         reason.removeIf( lit -> {
             if (!(lit instanceof ExecLiteral execLit) || lit.isNegative()) {
                 return false;
@@ -219,8 +186,8 @@ public class CoreReasoner {
             return reason.stream().filter(e -> e instanceof RelLiteral && e.isPositive())
                     .map(RelLiteral.class::cast)
                     .anyMatch(e -> exec.isImplied(e.getSource(), ev) || exec.isImplied(e.getTarget(), ev));
-
         });
+        //TODO: Remove dominated exec literals and maybe address literals
     }
 
     private void addExecReason(Event e1, Event e2, List<CoreLiteral> coreReasons) {
@@ -241,19 +208,17 @@ public class CoreReasoner {
         }
     }
 
-    private void addFenceReason(Relation rel, Edge edge, List<CoreLiteral> coreReasons) {
-        FenceGraph fenceGraph = (FenceGraph) executionGraph.getRelationGraph(rel);
-        EventDomain domain = executionGraph.getDomain();
-        EventData e1 = domain.getObjectById(edge.getFirst());
-        EventData e2 = domain.getObjectById(edge.getSecond());
-        EventData f = fenceGraph.getNextFence(e1);
+    private void addFenceReason(Relation rel, Event e1, Event e2, List<CoreLiteral> coreReasons) {
+        final FenceGraph fenceGraph = (FenceGraph) executionGraph.getRelationGraph(rel);
+        final EventData ed1 = executionGraph.getDomain().getExecution().getData(e1).get();
+        final Event f = fenceGraph.getNextFence(ed1).getEvent();
 
-        coreReasons.add(new ExecLiteral(f.getEvent()));
-        if (!exec.isImplied(f.getEvent(), e1.getEvent())) {
-            coreReasons.add(new ExecLiteral(e1.getEvent()));
+        coreReasons.add(new ExecLiteral(f));
+        if (!exec.isImplied(f, e1)) {
+            coreReasons.add(new ExecLiteral(e1));
         }
-        if (!exec.isImplied(f.getEvent(), e2.getEvent())) {
-            coreReasons.add(new ExecLiteral(e2.getEvent()));
+        if (!exec.isImplied(f, e2)) {
+            coreReasons.add(new ExecLiteral(e2));
         }
     }
 
@@ -261,42 +226,25 @@ public class CoreReasoner {
     // ======================================== Symmetry ===========================================
     // =============================================================================================
 
-    // Computes a list of permutations between events of symmetric threads.
-    // Depending on the <learningOption>, the set of computed permutations differs.
-    // In particular, for the option NONE, only the identity permutation will be returned.
-    private List<Function<Event, Event>> computeSymmetryPermutations() {
+    // Computes a list of generators for the symmetry group of threads.
+    private List<Function<Event, Event>> computeSymmetryGenerators(
+            ThreadSymmetry symm, SymmetricLearning learningOption) {
         final Set<? extends EquivalenceClass<Thread>> symmClasses = symm.getNonTrivialClasses();
         final List<Function<Event, Event>> perms = new ArrayList<>();
         perms.add(Function.identity());
 
+        if (learningOption == SymmetricLearning.NONE) {
+            return perms;
+        }
+
+        assert learningOption == SymmetricLearning.FULL;
+
         for (EquivalenceClass<Thread> c : symmClasses) {
             final List<Thread> threads = new ArrayList<>(c);
             threads.sort(Comparator.comparingInt(Thread::getId));
-
-            switch (learningOption) {
-                case NONE:
-                    break;
-                case LINEAR:
-                    for (int i = 0; i < threads.size(); i++) {
-                        final int j = (i + 1) % threads.size();
-                        perms.add(symm.createEventTransposition(threads.get(i), threads.get(j)));
-                    }
-                    break;
-                case QUADRATIC:
-                    for (int i = 0; i < threads.size(); i++) {
-                        for (int j = i + 1; j < threads.size(); j++) {
-                            perms.add(symm.createEventTransposition(threads.get(i), threads.get(j)));
-                        }
-                    }
-                    break;
-                case FULL:
-                    final List<Function<Event, Event>> allPerms = symm.createAllEventPermutations(c);
-                    allPerms.remove(Function.identity()); // We avoid adding multiple identities
-                    perms.addAll(allPerms);
-                    break;
-                default:
-                    throw new UnsupportedOperationException("Symmetry learning option: "
-                            + learningOption + " is not recognized.");
+            for (int i = 0; i < threads.size(); i++) {
+                final int j = (i + 1) % threads.size();
+                perms.add(symm.createEventTransposition(threads.get(i), threads.get(j)));
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/RelLiteral.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/RelLiteral.java
@@ -39,7 +39,7 @@ public final class RelLiteral implements CoreLiteral {
 
     @Override
     public String toString() {
-        return getName() + "(" + e1.getGlobalId() + "," + e2.getGlobalId() + ")";
+        return (isNegative() ? "!" : "") + getName() + "(" + e1.getGlobalId() + "," + e2.getGlobalId() + ")";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -496,8 +496,9 @@ public class RefinementSolver extends ModelChecker {
                     constraintsToCut.add(c);
                 }
             } else if (c instanceof Definition def && def instanceof Fences) {
-                // (iii) continued: fencerel(F) is unsupported in CAAT
-                //  It should get rewritten to "po;[F];po" but if it was not, we cut it instead.
+                // (iii) continued: fencerel(F) is unsupported in CAAT.
+                //  It should get rewritten to "po;[F];po" by our passes,
+                //  but if it was not, we cut it instead.
                 constraintsToCut.add(c);
             }
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -486,8 +486,7 @@ public class RefinementSolver extends ModelChecker {
                         // The following three definitions are "semi-derived" and need to get cut
                         // to get a semi-positive model.
                         || subDef instanceof SetIdentity
-                        || subDef instanceof CartesianProduct
-                        || subDef instanceof Fences) {
+                        || subDef instanceof CartesianProduct) {
                     constraintsToCut.add(subDef);
                 }
             } else if (c instanceof Definition def && def.getDefinedRelation().hasName()) {
@@ -496,6 +495,10 @@ public class RefinementSolver extends ModelChecker {
                 if (name.equals(DATA) || name.equals(CTRL) || name.equals(ADDR) || name.equals(CRIT)) {
                     constraintsToCut.add(c);
                 }
+            } else if (c instanceof Definition def && def instanceof Fences) {
+                // (iii) continued: fencerel(F) is unsupported in CAAT
+                //  It should get rewritten to "po;[F];po" but if it was not, we cut it instead.
+                constraintsToCut.add(c);
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/NormalizeFenceRelations.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/NormalizeFenceRelations.java
@@ -1,10 +1,10 @@
 package com.dat3m.dartagnan.wmm.processing;
 
 import com.dat3m.dartagnan.wmm.Relation;
+import com.dat3m.dartagnan.wmm.RelationNameRepository;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.definition.Composition;
 import com.dat3m.dartagnan.wmm.definition.Fences;
-import com.dat3m.dartagnan.wmm.definition.ProgramOrder;
 import com.dat3m.dartagnan.wmm.definition.SetIdentity;
 
 import java.util.List;
@@ -23,10 +23,7 @@ public class NormalizeFenceRelations implements WmmProcessor {
 
     @Override
     public void run(Wmm wmm) {
-
-        final Relation po = wmm.getRelations()
-                .stream().filter(r -> r.getDefinition() instanceof ProgramOrder)
-                .findFirst().orElseThrow();
+        final Relation po = wmm.getRelation(RelationNameRepository.PO);
 
         for (Relation rel : List.copyOf(wmm.getRelations())) {
             if (rel.getDefinition() instanceof Fences fence) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/NormalizeFenceRelations.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/NormalizeFenceRelations.java
@@ -1,0 +1,40 @@
+package com.dat3m.dartagnan.wmm.processing;
+
+import com.dat3m.dartagnan.wmm.Relation;
+import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.wmm.definition.Composition;
+import com.dat3m.dartagnan.wmm.definition.Fences;
+import com.dat3m.dartagnan.wmm.definition.ProgramOrder;
+import com.dat3m.dartagnan.wmm.definition.SetIdentity;
+
+import java.util.List;
+
+/*
+    This pass replaces "fencerel(F)" by "po;[F];po"
+ */
+public class NormalizeFenceRelations implements WmmProcessor {
+
+    private NormalizeFenceRelations() {
+    }
+
+    public static NormalizeFenceRelations newInstance() {
+        return new NormalizeFenceRelations();
+    }
+
+    @Override
+    public void run(Wmm wmm) {
+
+        final Relation po = wmm.getRelations()
+                .stream().filter(r -> r.getDefinition() instanceof ProgramOrder)
+                .findFirst().orElseThrow();
+
+        for (Relation rel : List.copyOf(wmm.getRelations())) {
+            if (rel.getDefinition() instanceof Fences fence) {
+                final Relation fenceId = wmm.addDefinition(new SetIdentity(wmm.newRelation(), fence.getFilter()));
+                final Relation intermediate = wmm.addDefinition(new Composition(wmm.newRelation(), po, fenceId));
+                wmm.removeDefinition(rel);
+                wmm.addDefinition(new Composition(rel, intermediate, po));
+            }
+        }
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessingManager.java
@@ -26,6 +26,7 @@ public class WmmProcessingManager implements WmmProcessor {
     private WmmProcessingManager(Configuration config) throws InvalidConfigurationException {
         config.inject(this);
         processors.addAll(Arrays.asList(
+                NormalizeFenceRelations.newInstance(),
                 AddInitReadHandling.newInstance(),
                 RemoveDeadRelations.newInstance(),
                 MergeEquivalentRelations.newInstance(),


### PR DESCRIPTION
This PR improves symmetry reasoning in CAAT for benchmarks with large symmetries.

EDIT: To streamline some code and avoid special corner cases, I also added a `NormalizeFenceRelations` pass that rewrites `fencerel(F)` to `po;[F];po`. CAAT no longer supports the standard `fencerel`.