### PR TITLE
Add atomicity axiom to sc.cat

### DIFF
--- a/cat/sc.cat
+++ b/cat/sc.cat
@@ -8,3 +8,6 @@ let com = (rf | fr | co)
 
 (* Sequential consistency *)
 acyclic po | com as sc
+
+(* Atomicity *)
+empty rmw & (fre;coe)


### PR DESCRIPTION
We are currently failing this `java -jar dartagnan/target/dartagnan.jar cat/sc.cat benchmarks/locks/ttas.c` due to the missing atomicity axiom in SC.