### PR TITLE
Add 4 litmus tests demonstrating unordered failing cmpxchg. 

### DIFF
--- a/dartagnan/src/test/resources/LKMM-expected.csv
+++ b/dartagnan/src/test/resources/LKMM-expected.csv
@@ -5066,6 +5066,10 @@ litmus/LKMM/manual/srcu/C-SRCU-LB-42R-A.litmus,0
 litmus/LKMM/manual/srcu/C-SRCU-misnest-not.litmus,1
 litmus/LKMM/manual/srcu/C-SRCU-misnest.litmus,1
 litmus/LKMM/manual/srcu/C-SRCU2-LB-split.litmus,0
+litmus/LKMM/tree/cmpxchg-fail-ordered-1.litmus,0
+litmus/LKMM/tree/cmpxchg-fail-ordered-2.litmus,0
+litmus/LKMM/tree/cmpxchg-fail-unordered-1.litmus,1
+litmus/LKMM/tree/cmpxchg-fail-unordered-2.litmus,1
 litmus/LKMM/tree/CoRR+poonceonce+Once.litmus,0
 litmus/LKMM/tree/CoRW+poonceonce+Once.litmus,0
 litmus/LKMM/tree/CoWR+poonceonce+Once.litmus,0

--- a/dartagnan/src/test/resources/LKMM-v00-expected.csv
+++ b/dartagnan/src/test/resources/LKMM-v00-expected.csv
@@ -4941,6 +4941,10 @@ litmus/LKMM/manual/plain/strong-vis.litmus,0
 litmus/LKMM/manual/rcu/C-rcu-link-after-rf.litmus,1
 litmus/LKMM/manual/rcu/C-rcu-link-after.litmus,1
 litmus/LKMM/manual/rcu/C-rcu-link-before.litmus,1
+litmus/LKMM/tree/cmpxchg-fail-ordered-1.litmus,0
+litmus/LKMM/tree/cmpxchg-fail-ordered-2.litmus,0
+litmus/LKMM/tree/cmpxchg-fail-unordered-1.litmus,1
+litmus/LKMM/tree/cmpxchg-fail-unordered-2.litmus,1
 litmus/LKMM/tree/CoRR+poonceonce+Once.litmus,0
 litmus/LKMM/tree/CoRW+poonceonce+Once.litmus,0
 litmus/LKMM/tree/CoWR+poonceonce+Once.litmus,0

--- a/dartagnan/src/test/resources/LKMM-v01-expected.csv
+++ b/dartagnan/src/test/resources/LKMM-v01-expected.csv
@@ -4941,6 +4941,10 @@ litmus/LKMM/manual/plain/strong-vis.litmus,0
 litmus/LKMM/manual/rcu/C-rcu-link-after-rf.litmus,1
 litmus/LKMM/manual/rcu/C-rcu-link-after.litmus,1
 litmus/LKMM/manual/rcu/C-rcu-link-before.litmus,1
+litmus/LKMM/tree/cmpxchg-fail-ordered-1.litmus,0
+litmus/LKMM/tree/cmpxchg-fail-ordered-2.litmus,0
+litmus/LKMM/tree/cmpxchg-fail-unordered-1.litmus,1
+litmus/LKMM/tree/cmpxchg-fail-unordered-2.litmus,1
 litmus/LKMM/tree/CoRR+poonceonce+Once.litmus,0
 litmus/LKMM/tree/CoRW+poonceonce+Once.litmus,0
 litmus/LKMM/tree/CoWR+poonceonce+Once.litmus,0

--- a/litmus/LKMM/tree/cmpxchg-fail-ordered-1.litmus
+++ b/litmus/LKMM/tree/cmpxchg-fail-ordered-1.litmus
@@ -1,0 +1,34 @@
+C cmpxchg-fail-ordered-1
+
+(*
+ * Result: Never
+ *
+ * Demonstrate that a failing cmpxchg() operation will act as a full
+ * barrier when followed by smp_mb__after_atomic().
+ *)
+
+{}
+
+P0(int *x, int *y, int *z)
+{
+	int r0;
+	int r1;
+
+	WRITE_ONCE(*x, 1);
+	r1 = cmpxchg(z, 1, 0);
+	smp_mb__after_atomic();
+	r0 = READ_ONCE(*y);
+}
+
+P1(int *x, int *y, int *z)
+{
+	int r0;
+
+	WRITE_ONCE(*y, 1);
+	r1 = cmpxchg(z, 1, 0);
+	smp_mb__after_atomic();
+	r0 = READ_ONCE(*x);
+}
+
+locations[0:r1;1:r1]
+exists (0:r0=0 /\ 1:r0=0)

--- a/litmus/LKMM/tree/cmpxchg-fail-ordered-2.litmus
+++ b/litmus/LKMM/tree/cmpxchg-fail-ordered-2.litmus
@@ -1,0 +1,30 @@
+C cmpxchg-fail-ordered-2
+
+(*
+ * Result: Never
+ *
+ * Demonstrate use of smp_mb__after_atomic() to make a failing cmpxchg
+ * operation have acquire ordering.
+ *)
+
+{}
+
+P0(int *x, int *y)
+{
+	int r0;
+	int r1;
+
+	WRITE_ONCE(*x, 1);
+	r1 = cmpxchg(y, 0, 1);
+}
+
+P1(int *x, int *y)
+{
+	int r0;
+
+	r1 = cmpxchg(y, 0, 1);
+	smp_mb__after_atomic();
+	r2 = READ_ONCE(*x);
+}
+
+exists (0:r1=0 /\ 1:r1=1 /\ 1:r2=0)

--- a/litmus/LKMM/tree/cmpxchg-fail-unordered-1.litmus
+++ b/litmus/LKMM/tree/cmpxchg-fail-unordered-1.litmus
@@ -1,0 +1,33 @@
+C cmpxchg-fail-unordered-1
+
+(*
+ * Result: Sometimes
+ *
+ * Demonstrate that a failing cmpxchg() operation does not act as a
+ * full barrier.  (In contrast, a successful cmpxchg() does act as a
+ * full barrier.)
+ *)
+
+{}
+
+P0(int *x, int *y, int *z)
+{
+	int r0;
+	int r1;
+
+	WRITE_ONCE(*x, 1);
+	r1 = cmpxchg(z, 1, 0);
+	r0 = READ_ONCE(*y);
+}
+
+P1(int *x, int *y, int *z)
+{
+	int r0;
+
+	WRITE_ONCE(*y, 1);
+	r1 = cmpxchg(z, 1, 0);
+	r0 = READ_ONCE(*x);
+}
+
+locations[0:r1;1:r1]
+exists (0:r0=0 /\ 1:r0=0)

--- a/litmus/LKMM/tree/cmpxchg-fail-unordered-2.litmus
+++ b/litmus/LKMM/tree/cmpxchg-fail-unordered-2.litmus
@@ -1,0 +1,30 @@
+C cmpxchg-fail-unordered-2
+
+(*
+ * Result: Sometimes
+ *
+ * Demonstrate that a failing cmpxchg() operation does not act as either
+ * an acquire release operation.  (In contrast, a successful cmpxchg()
+ * does act as both an acquire and a release operation.)
+ *)
+
+{}
+
+P0(int *x, int *y)
+{
+	int r0;
+	int r1;
+
+	WRITE_ONCE(*x, 1);
+	r1 = cmpxchg(y, 0, 1);
+}
+
+P1(int *x, int *y)
+{
+	int r0;
+
+	r1 = cmpxchg(y, 0, 1);
+	r2 = READ_ONCE(*x);
+}
+
+exists (0:r1=0 /\ 1:r1=1 /\ 1:r2=0)


### PR DESCRIPTION
This PR adds 4 litmus test from [here](https://lkml.org/lkml/2024/5/1/952).

While testing this I noticed we are missing a RMW tag to read in the failing CAS case.
This can be seen in this rule of `linux-kernel.cat` + the comment in the `*-ordered-*` litmus tests
```
([M] ; po? ; [RMW] ; fencerel(After-atomic) ; [M]) |
```