### PR TITLE
Introduce Event.localId

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/DominatorAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/DominatorAnalysis.java
@@ -18,14 +18,14 @@ public class DominatorAnalysis {
     public static DominatorTree<Event> computePreDominatorTree(Event from, Event to) {
         Preconditions.checkArgument(from.getFunction() == to.getFunction(),
                 "Cannot compute dominator tree between events of different functions.");
-        final Predicate<Event> isInRange = (e -> from.getGlobalId() <= e.getGlobalId() && e.getGlobalId() <= to.getGlobalId());
+        final Predicate<Event> isInRange = (e -> from.getLocalId() <= e.getLocalId() && e.getLocalId() <= to.getLocalId());
         return new DominatorTree<>(from, e -> Iterables.filter(getSuccessors(e), isInRange));
     }
 
     public static DominatorTree<Event> computePostDominatorTree(Event from, Event to) {
         Preconditions.checkArgument(from.getFunction() == to.getFunction(),
                 "Cannot compute dominator tree between events of different functions.");
-        final Predicate<Event> isInRange = (e -> from.getGlobalId() <= e.getGlobalId() && e.getGlobalId() <= to.getGlobalId());
+        final Predicate<Event> isInRange = (e -> from.getLocalId() <= e.getLocalId() && e.getLocalId() <= to.getLocalId());
         return new DominatorTree<>(to, e -> Iterables.filter(getPredecessors(e), isInRange));
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/LoopAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/LoopAnalysis.java
@@ -178,7 +178,7 @@ public class LoopAnalysis {
 
     private ImmutableList<LoopInfo> findLoopsInFunction(Function function) {
         final List<CondJump> backJumps = function.getEvents(CondJump.class).stream()
-                .filter(j -> j.getLabel().getGlobalId() < j.getGlobalId())
+                .filter(j -> j.getLabel().getLocalId() < j.getLocalId())
                 .toList();
 
         final List<LoopInfo> loops = new ArrayList<>();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Event.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Event.java
@@ -19,6 +19,9 @@ public interface Event extends Encoder, Comparable<Event> {
     int getGlobalId();
     void setGlobalId(int id);
 
+    int getLocalId();
+    void setLocalId(int id);
+
     // ============================== Metadata ==============================
 
     void copyAllMetadataFrom(Event other);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/svcomp/EndAtomic.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/svcomp/EndAtomic.java
@@ -52,12 +52,12 @@ public class EndAtomic extends AbstractEvent implements EventUser {
 
     private void findEnclosedEvents(BranchEquivalence eq) {
         enclosedEvents = new ArrayList<>();
-        if (eq.areMutuallyExclusive(begin, this) || this.getGlobalId() < begin.getGlobalId()) {
-            logger.warn("BeginAtomic" + begin.getGlobalId() + "can't reach EndAtomic " + this.getGlobalId());
+        if (eq.areMutuallyExclusive(begin, this) || this.getLocalId() < begin.getLocalId()) {
+            logger.warn("BeginAtomic" + begin.getLocalId() + "can't reach EndAtomic " + this.getLocalId());
         }
 
         Event e = begin.getSuccessor();
-        while (e.getGlobalId() < this.getGlobalId()) {
+        while (e.getLocalId() < this.getLocalId()) {
             if (!eq.areMutuallyExclusive(begin, e)) {
                 if (!eq.isImplied(e, begin)) {
                     logger.warn(e + " is inside atomic block but can be reached from the outside");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicSpinLoopDetection.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicSpinLoopDetection.java
@@ -233,7 +233,7 @@ public class DynamicSpinLoopDetection implements ProgramProcessor {
         @Override
         public String toString() {
             return String.format("(%d: %s) --to--> (%d: %s)",
-                    getStart().getGlobalId(), getStart(), getEnd().getGlobalId(), getEnd());
+                    getStart().getLocalId(), getStart(), getEnd().getLocalId(), getEnd());
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/IdReassignment.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/IdReassignment.java
@@ -5,7 +5,7 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.Event;
 import com.google.common.collect.Iterables;
 
-public class IdReassignment implements ProgramProcessor {
+public class IdReassignment implements ProgramProcessor, FunctionProcessor {
 
     private IdReassignment() {}
 
@@ -20,10 +20,22 @@ public class IdReassignment implements ProgramProcessor {
         for (Function func : Iterables.concat(program.getThreads(), program.getFunctions())) {
             func.setId(funcId++);
             Event cur = func.getEntry();
+            int localId = 0;
             while (cur != null) {
+                cur.setLocalId(localId++);
                 cur.setGlobalId(globalId++);
                 cur = cur.getSuccessor();
             }
+        }
+    }
+
+    @Override
+    public void run(Function function) {
+        Event cur = function.getEntry();
+        int localId = 0;
+        while (cur != null) {
+            cur.setLocalId(localId++);
+            cur = cur.getSuccessor();
         }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopFormVerification.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopFormVerification.java
@@ -41,7 +41,7 @@ public class LoopFormVerification implements ProgramProcessor {
     @Override
     public void run(Program program) {
         final int numberOfLoops = Stream.concat(program.getThreads().stream(), program.getFunctions().stream())
-                .mapToInt(f -> checkAndCountLoops(f, Event::getGlobalId)).sum();
+                .mapToInt(f -> checkAndCountLoops(f, Event::getLocalId)).sum();
         logger.info("Detected {} loops in the program.", numberOfLoops);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -107,7 +107,7 @@ public class LoopUnrolling implements ProgramProcessor {
                 curBoundAnnotation = boundAnnotation;
             } else if (event instanceof Label label) {
                 final Optional<CondJump> backjump = label.getJumpSet().stream()
-                        .filter(j -> j.getGlobalId() > label.getGlobalId()).findFirst();
+                        .filter(j -> j.getLocalId() > label.getLocalId()).findFirst();
                 final boolean isLoop = backjump.isPresent();
 
                 if (isLoop) {
@@ -125,7 +125,7 @@ public class LoopUnrolling implements ProgramProcessor {
     private void unrollLoop(CondJump loopBackJump, int bound) {
         final Label loopBegin = loopBackJump.getLabel();
         Preconditions.checkArgument(bound >= 1, "Positive unrolling bound expected.");
-        Preconditions.checkArgument(loopBegin.getGlobalId() < loopBackJump.getGlobalId(),
+        Preconditions.checkArgument(loopBegin.getLocalId() < loopBackJump.getLocalId(),
                 "The jump does not belong to a loop.");
 
         int iterCounter = 0;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemToReg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemToReg.java
@@ -258,8 +258,8 @@ public class MemToReg implements FunctionProcessor {
 
         @Override
         public Label visitLabel(Label label) {
-            final int globalId = label.getGlobalId();
-            final boolean looping = label.getJumpSet().stream().anyMatch(jump -> globalId < jump.getGlobalId());
+            final int localId = label.getLocalId();
+            final boolean looping = label.getJumpSet().stream().anyMatch(jump -> localId < jump.getLocalId());
             final Map<Object, AddressOffset> restoredState = looping ? jumps.get(label) : jumps.remove(label);
             if (restoredState != null) {
                 if (dead) {
@@ -284,7 +284,7 @@ public class MemToReg implements FunctionProcessor {
             // Give up on every address used in the condition.
             publishRegisters(jump.getGuard().getRegs());
             final Label label = jump.getLabel();
-            final boolean looping = label.getGlobalId() < jump.getGlobalId();
+            final boolean looping = label.getLocalId() < jump.getLocalId();
             final boolean isGoto = jump.isGoto();
             assert !looping || jumps.containsKey(label);
             // Prepare the current state for continuing from the label.

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/NormalizeLoops.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/NormalizeLoops.java
@@ -44,33 +44,30 @@ public class NormalizeLoops implements FunctionProcessor {
         int counter = 0;
         for (Label label : function.getEvents(Label.class)) {
             final List<CondJump> backJumps = label.getJumpSet().stream()
-                    .filter(j -> j.getGlobalId() > label.getGlobalId())
+                    .filter(j -> j.getLocalId() > label.getLocalId())
                     .sorted()
                     .toList();
 
             // LoopFormVerification requires a unique and unconditional backjump
-            if (backJumps.size() > 0) {
-
-                // We can skip if already satisfied
-                if (backJumps.size() == 1 && backJumps.get(0).isGoto()) {
-                    return;
-                }
-
-                final CondJump last = backJumps.get(backJumps.size() - 1);
-
-                final Label forwardLabel = EventFactory.newLabel("__repeatLoop_#" + counter);
-                final CondJump gotoRepeat = EventFactory.newGoto(label);
-
-                final Label breakLabel = EventFactory.newLabel("__breakLoop_#" + counter);
-                final CondJump gotoBreak = EventFactory.newGoto(breakLabel);
-
-                last.insertAfter(List.of(gotoBreak, forwardLabel, gotoRepeat, breakLabel));
-
-                for(CondJump j : backJumps) {
-                    j.updateReferences(Map.of(j.getLabel(), forwardLabel));
-                }
+            if (backJumps.isEmpty() || (backJumps.size() == 1 && backJumps.get(0).isGoto())) {
+                continue;
             }
+
+            final CondJump last = backJumps.get(backJumps.size() - 1);
+
+            final Label forwardLabel = EventFactory.newLabel("__repeatLoop_#" + counter);
+            final CondJump gotoRepeat = EventFactory.newGoto(label);
+
+            final Label breakLabel = EventFactory.newLabel("__breakLoop_#" + counter);
+            final CondJump gotoBreak = EventFactory.newGoto(breakLabel);
+
+            last.insertAfter(List.of(gotoBreak, forwardLabel, gotoRepeat, breakLabel));
+
+            for(CondJump j : backJumps) {
+                j.updateReferences(Map.of(j.getLabel(), forwardLabel));
+            }
+
+            counter++;
         }
-        counter++;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadCondJumps.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadCondJumps.java
@@ -102,7 +102,7 @@ public class RemoveDeadCondJumps implements FunctionProcessor {
                     label.getJumpSet().forEach(Event::tryDelete);
                 }
                 if (!cur.tryDelete()) {
-                    logger.warn("Failed to delete event: {}:   {}", cur.getGlobalId(), cur);
+                    logger.warn("Failed to delete event: {}:   {}", cur.getLocalId(), cur);
                 }
             }
             if (cur instanceof CondJump jump && jump.isGoto()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -170,7 +170,7 @@ public class SparseConditionalConstantPropagation implements FunctionProcessor {
         }
         final Set<Event> failedToDelete = IRHelper.bulkDelete(toBeDeleted);
         for (Event e : failedToDelete) {
-            logger.warn("Failed to delete unreachable event: {}:   {}", e.getGlobalId(), e);
+            logger.warn("Failed to delete unreachable event: {}:   {}", e.getLocalId(), e);
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -212,7 +212,7 @@ class VisitorArm8 extends VisitorBase {
         ExecutionStatus optionalExecStatus = null;
         Local optionalUpdateCasCmpResult = null;
         if (e.isWeak()) {
-            Register statusReg = e.getFunction().newRegister("status(" + e.getGlobalId() + ")", types.getBooleanType());
+            Register statusReg = e.getFunction().newRegister("status(" + e.getLocalId() + ")", types.getBooleanType());
             optionalExecStatus = newExecutionStatus(statusReg, storeValue);
             optionalUpdateCasCmpResult = newLocal(booleanResultRegister, expressions.makeNot(statusReg));
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -234,7 +234,7 @@ class VisitorRISCV extends VisitorBase {
         CondJump gotoCasEnd = newGoto(casEnd);
         Load loadValue = newRMWLoadExclusiveWithMo(regValue, address, Tag.RISCV.extractLoadMoFromCMo(mo));
         Store storeValue = RISCV.newRMWStoreConditional(address, value, Tag.RISCV.extractStoreMoFromCMo(mo), e.isStrong());
-        Register statusReg = e.getFunction().newRegister("status(" + e.getGlobalId() + ")", types.getBooleanType());
+        Register statusReg = e.getFunction().newRegister("status(" + e.getLocalId() + ")", types.getBooleanType());
         // We normally make the following two events optional.
         // Here we make them mandatory to guarantee correct dependencies.
         ExecutionStatus execStatus = newExecutionStatusWithDependencyTracking(statusReg, storeValue);


### PR DESCRIPTION
- Function-based analysis and passes now rely on local ids (e.g., for loop detection) for the most part.
- Fixed problems in NormalizeLoops.java (The class was broken :O)

The main purpose of introducing a local id is to make analyses/passes on isolated functions less reliant on ids of the whole program. This is particulary useful when manually constructing functions, e.g. by extracting fragments of other functions, and analysing them. Currently, to do loop analysis on a manually constructed function, one needs to add it to the program and perform a global `IdReassignment` before being able to look for loops in that function... or alternatively manually assign (wrong) global ids.
With this PR, it is possible to run `IdReassignment` on the constructed function to get local ids and then do a loop analysis (no ids of other functions are touched, nor does the constructed function need to be added to the program yet).

For now, the new local ids are mainly used in `LoopAnalysis`, `DominatorAnalysis` and in all cases where manual loop detection is done by id-comparison. In most other cases, the global ids are still used.