### PR TITLE
Fix size and offset computations of types

### DIFF
--- a/benchmarks/c/miscellaneous/offsetof.c
+++ b/benchmarks/c/miscellaneous/offsetof.c
@@ -1,0 +1,28 @@
+#include <stddef.h>
+#include <dat3m.h>
+
+#define container_of(ptr, type, member) ({                      \
+        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
+        (type *)((char *)__mptr - offsetof(type,member));})
+
+typedef struct {
+    int x; // 4 byte padding
+    struct {
+      long a;
+      char b; // 7 byte padding
+    };
+    int z; // 4 byte padding
+} myStruct_t; // Total size: 32 bytes, because all 4 members are 8-byte aligned
+
+myStruct_t myStruct;
+
+int main()
+{
+    // These assertions are trivialized by the compiler even without any opt passes
+    __VERIFIER_assert(sizeof(myStruct_t) == 32);
+    __VERIFIER_assert(offsetof(myStruct_t, z) == 24);
+
+    // This is not trivialized without optimizations (some standard opt passes can trivialize this though)
+    myStruct_t *container = container_of(&myStruct.z, myStruct_t, z);
+    __VERIFIER_assert(container == &myStruct);
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -219,7 +219,7 @@ public final class EncodingContext {
         //TODO match this with the actual type stored at the memory address
         // (we do not know and guess the arch type right now)
         TypeFactory types = TypeFactory.getInstance();
-        int archSize = types.getMemorySizeInBytes(types.getArchType()) * 8;
+        final int archSize = types.getMemorySizeInBits(types.getArchType());
         return formulaManager.getBitvectorFormulaManager().makeVariable(archSize, name);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
@@ -2,10 +2,7 @@ package com.dat3m.dartagnan.expression.type;
 
 import com.dat3m.dartagnan.expression.Type;
 import com.dat3m.dartagnan.utils.Normalizer;
-import com.google.common.base.Preconditions;
-import com.google.common.math.IntMath;
 
-import java.math.RoundingMode;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -87,57 +84,14 @@ public final class TypeFactory {
     }
 
     public int getMemorySizeInBytes(Type type) {
-        final int sizeInBytes;
-        if (type instanceof ArrayType arrayType) {
-            sizeInBytes = arrayType.getNumElements() * getMemorySizeInBytes(arrayType.getElementType());
-        } else if (type instanceof AggregateType aggregateType) {
-            int aggregateSize = 0;
-            for (Type fieldType : aggregateType.getDirectFields()) {
-                int size = getMemorySizeInBytes(fieldType);
-                //FIXME: We assume for now that a small type's (<= 8 byte) alignment coincides with its size.
-                // For all larger types, we assume 8 byte alignment
-                int alignment = Math.min(size, 8);
-                if (size != 0) {
-                    int padding = (-aggregateSize) % alignment;
-                    padding = padding < 0 ? padding + alignment : padding;
-                    aggregateSize += size + padding;
-                }
-            }
-            sizeInBytes = aggregateSize;
-        } else if (type instanceof IntegerType integerType) {
-            sizeInBytes = IntMath.divide(integerType.getBitWidth(), 8, RoundingMode.CEILING);
-        } else if (type instanceof FloatType floatType) {
-            sizeInBytes = IntMath.divide(floatType.getBitWidth(), 8, RoundingMode.CEILING);
-        } else {
-            throw new UnsupportedOperationException("Cannot compute the size of " + type);
-        }
-        return sizeInBytes;
+        return TypeLayout.of(type).totalSizeInBytes();
+    }
+
+    public int getMemorySizeInBits(Type type) {
+        return getMemorySizeInBytes(type) * 8;
     }
 
     public int getOffsetInBytes(Type type, int index) {
-        final int offsetInBytes;
-        if (type instanceof ArrayType arrayType) {
-            offsetInBytes = index * getMemorySizeInBytes(arrayType.getElementType());
-        } else if (type instanceof AggregateType aggregateType) {
-            final List<Type> fields = aggregateType.getDirectFields();
-            Preconditions.checkArgument(index < fields.size());
-            int offset = 0;
-            for (Type fieldType : aggregateType.getDirectFields().subList(0, index + 1)) {
-                int size = getMemorySizeInBytes(fieldType);
-                //FIXME: We assume for now that a small type's (<= 8 byte) alignment coincides with its size.
-                // For all larger types, we assume 8 byte alignment
-                int alignment = Math.min(size, 8);
-                if (size != 0) {
-                    int padding = (-offset) % alignment;
-                    padding = padding < 0 ? padding + alignment : padding;
-                    offset += size + padding;
-                }
-            }
-            offset -= getMemorySizeInBytes(fields.get(index));
-            offsetInBytes = offset;
-        } else {
-            throw new UnsupportedOperationException("Cannot index into type " + type);
-        }
-        return offsetInBytes;
+        return TypeOffset.of(type, index).offset();
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.expression.type;
 
 import com.dat3m.dartagnan.expression.Type;
 import com.dat3m.dartagnan.utils.Normalizer;
+import com.google.common.base.Preconditions;
 import com.google.common.math.IntMath;
 
 import java.math.RoundingMode;
@@ -111,5 +112,32 @@ public final class TypeFactory {
             throw new UnsupportedOperationException("Cannot compute the size of " + type);
         }
         return sizeInBytes;
+    }
+
+    public int getOffsetInBytes(Type type, int index) {
+        final int offsetInBytes;
+        if (type instanceof ArrayType arrayType) {
+            offsetInBytes = index * getMemorySizeInBytes(arrayType.getElementType());
+        } else if (type instanceof AggregateType aggregateType) {
+            final List<Type> fields = aggregateType.getDirectFields();
+            Preconditions.checkArgument(index < fields.size());
+            int offset = 0;
+            for (Type fieldType : aggregateType.getDirectFields().subList(0, index + 1)) {
+                int size = getMemorySizeInBytes(fieldType);
+                //FIXME: We assume for now that a small type's (<= 8 byte) alignment coincides with its size.
+                // For all larger types, we assume 8 byte alignment
+                int alignment = Math.min(size, 8);
+                if (size != 0) {
+                    int padding = (-offset) % alignment;
+                    padding = padding < 0 ? padding + alignment : padding;
+                    offset += size + padding;
+                }
+            }
+            offset -= getMemorySizeInBytes(fields.get(index));
+            offsetInBytes = offset;
+        } else {
+            throw new UnsupportedOperationException("Cannot index into type " + type);
+        }
+        return offsetInBytes;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeLayout.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeLayout.java
@@ -1,0 +1,59 @@
+package com.dat3m.dartagnan.expression.type;
+
+import com.dat3m.dartagnan.expression.Type;
+import com.google.common.math.IntMath;
+
+import java.math.RoundingMode;
+
+public record TypeLayout(int unpaddedSize, int alignment) {
+
+    public int totalSizeInBytes() { return paddedSize(unpaddedSize, alignment); }
+
+    @Override
+    public String toString() {
+        return String.format("[totalSize = %s bytes, unpaddedSize = %s bytes, alignment = %s bytes]",
+                totalSizeInBytes(), unpaddedSize(), alignment());
+    }
+
+    public static TypeLayout of(Type type) {
+        final int unpaddedSize;
+        final int alignment;
+
+        // For primitives, we assume that size and alignment requirement coincide
+        if (type instanceof IntegerType integerType) {
+            unpaddedSize = IntMath.divide(integerType.getBitWidth(), 8, RoundingMode.CEILING);
+            alignment = unpaddedSize;
+        } else if (type instanceof FloatType floatType) {
+            unpaddedSize = IntMath.divide(floatType.getBitWidth(), 8, RoundingMode.CEILING);
+            alignment = unpaddedSize;
+        } else if (type instanceof ArrayType arrayType) {
+            final TypeLayout elemTypeLayout = of(arrayType.getElementType());
+            unpaddedSize = elemTypeLayout.totalSizeInBytes() * arrayType.getNumElements();
+            alignment = elemTypeLayout.alignment();
+        } else if (type instanceof AggregateType aggregateType) {
+            return of(aggregateType.getDirectFields());
+        } else {
+            throw new UnsupportedOperationException("Cannot compute memory layout of type " + type);
+        }
+
+        return new TypeLayout(unpaddedSize, alignment);
+    }
+
+    public static TypeLayout of(Iterable<Type> aggregate) {
+        int aggregateSize = 0;
+        int maxAlignment = 1;
+        for (Type fieldType : aggregate) {
+            final TypeLayout layout = of(fieldType);
+            aggregateSize = paddedSize(aggregateSize, layout.alignment()) + layout.totalSizeInBytes();
+            maxAlignment = Math.max(maxAlignment, layout.alignment());
+        }
+        return new TypeLayout(aggregateSize, maxAlignment);
+    }
+
+    public static int paddedSize(int size, int alignment) {
+        final int mod = size % alignment;
+        final int padding = mod == 0 ? 0 : (alignment - mod);
+        return size + padding;
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeOffset.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeOffset.java
@@ -22,7 +22,7 @@ public record TypeOffset(Type type, int offset) {
             Preconditions.checkArgument(index < fields.size());
             final TypeLayout prefixLayout = TypeLayout.of(fields.subList(0, index));
             final TypeLayout fieldLayout = TypeLayout.of(fields.get(index));
-            final int offset = paddedSize(prefixLayout.totalSizeInBytes(), fieldLayout.alignment());
+            final int offset = paddedSize(prefixLayout.unpaddedSize(), fieldLayout.alignment());
             return new TypeOffset(fields.get(index), offset);
         } else {
             final String error = String.format("Cannot compute offset of index %d into type %s.", index, type);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeOffset.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeOffset.java
@@ -1,0 +1,43 @@
+package com.dat3m.dartagnan.expression.type;
+
+import com.dat3m.dartagnan.expression.Type;
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
+import static com.dat3m.dartagnan.expression.type.TypeLayout.paddedSize;
+
+public record TypeOffset(Type type, int offset) {
+
+    public static TypeOffset of(Type type, int index) {
+        if (index == 0) {
+            return new TypeOffset(type, 0);
+        }
+
+        if (type instanceof ArrayType arrayType) {
+            final Type elemType = arrayType.getElementType();
+            return new TypeOffset(elemType, TypeLayout.of(elemType).totalSizeInBytes() * index);
+        } else if (type instanceof AggregateType aggregateType) {
+            final List<Type> fields = aggregateType.getDirectFields();
+            Preconditions.checkArgument(index < fields.size());
+            final TypeLayout prefixLayout = TypeLayout.of(fields.subList(0, index));
+            final TypeLayout fieldLayout = TypeLayout.of(fields.get(index));
+            final int offset = paddedSize(prefixLayout.totalSizeInBytes(), fieldLayout.alignment());
+            return new TypeOffset(fields.get(index), offset);
+        } else {
+            final String error = String.format("Cannot compute offset of index %d into type %s.", index, type);
+            throw new UnsupportedOperationException(error);
+        }
+    }
+
+    public static TypeOffset of(Type type, Iterable<Integer> indices) {
+        int totalOffset = 0;
+        for (int i : indices) {
+            final TypeOffset inner = of(type, i);
+            type = inner.type();
+            totalOffset += inner.offset();
+        }
+
+        return new TypeOffset(type, totalOffset);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
@@ -272,18 +272,17 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
             assert constant instanceof ConstructExpr;
             final ConstructExpr constArray = (ConstructExpr) constant;
             final List<Expression> arrayElements = constArray.getOperands();
-            final int stepSize = types.getMemorySizeInBytes(arrayType.getElementType());
             for (int i = 0; i < arrayElements.size(); i++) {
-                setInitialMemoryFromConstant(memObj, offset + i * stepSize, arrayElements.get(i));
+                final int innerOffset = types.getOffsetInBytes(arrayType, i);
+                setInitialMemoryFromConstant(memObj, offset + innerOffset, arrayElements.get(i));
             }
-        } else if (constant.getType() instanceof AggregateType) {
+        } else if (constant.getType() instanceof AggregateType aggregateType) {
             assert constant instanceof ConstructExpr;
             final ConstructExpr constStruct = (ConstructExpr) constant;
             final List<Expression> structElements = constStruct.getOperands();
-            int currentOffset = offset;
-            for (Expression structElement : structElements) {
-                setInitialMemoryFromConstant(memObj, currentOffset, structElement);
-                currentOffset += types.getMemorySizeInBytes(structElement.getType());
+            for (int i = 0; i < structElements.size(); i++) {
+                int innerOffset = types.getOffsetInBytes(aggregateType, i);
+                setInitialMemoryFromConstant(memObj, offset + innerOffset, structElements.get(i));
             }
         } else if (constant.getType() instanceof IntegerType) {
             memObj.setInitialValue(offset, constant);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/GEPToAddition.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/GEPToAddition.java
@@ -7,10 +7,7 @@ import com.dat3m.dartagnan.expression.Type;
 import com.dat3m.dartagnan.expression.integers.IntLiteral;
 import com.dat3m.dartagnan.expression.misc.GEPExpr;
 import com.dat3m.dartagnan.expression.processing.ExprTransformer;
-import com.dat3m.dartagnan.expression.type.AggregateType;
-import com.dat3m.dartagnan.expression.type.ArrayType;
-import com.dat3m.dartagnan.expression.type.IntegerType;
-import com.dat3m.dartagnan.expression.type.TypeFactory;
+import com.dat3m.dartagnan.expression.type.*;
 import com.dat3m.dartagnan.program.Function;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.RegReader;
@@ -75,10 +72,9 @@ public class GEPToAddition implements ProgramProcessor {
                     throw new MalformedProgramException(
                             String.format("Non-constant field index %s for aggregate of type %s.", offset, type));
                 }
-                final int value = constant.getValueAsInt();
-                type = aggregateType.getDirectFields().get(value);
-                int o = TypeFactory.getInstance().getOffsetInBytes(aggregateType, value);
-                result = expressions.makeAdd(result, expressions.makeValue(o, archType));
+                final TypeOffset typeOffset = TypeOffset.of(aggregateType, constant.getValueAsInt());
+                type = typeOffset.type();
+                result = expressions.makeAdd(result, expressions.makeValue(typeOffset.offset(), archType));
             }
             return result;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/GEPToAddition.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/GEPToAddition.java
@@ -77,10 +77,7 @@ public class GEPToAddition implements ProgramProcessor {
                 }
                 final int value = constant.getValueAsInt();
                 type = aggregateType.getDirectFields().get(value);
-                int o = 0;
-                for (final Type elementType : aggregateType.getDirectFields().subList(0, value)) {
-                    o += types.getMemorySizeInBytes(elementType);
-                }
+                int o = TypeFactory.getInstance().getOffsetInBytes(aggregateType, value);
                 result = expressions.makeAdd(result, expressions.makeValue(o, archType));
             }
             return result;

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/MiscellaneousTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/MiscellaneousTest.java
@@ -86,7 +86,8 @@ public class MiscellaneousTest extends AbstractCTest {
                 {"verifierAssert", ARM8, FAIL, 1},
                 {"uninitRead", IMM, FAIL, 1},
                 {"multipleBackJumps", IMM, UNKNOWN, 1},
-                {"memcpy_s", IMM, PASS, 1}
+                {"memcpy_s", IMM, PASS, 1},
+                {"offsetof", IMM, PASS, 1}
         });
     }
 

--- a/dartagnan/src/test/resources/miscellaneous/offsetof.ll
+++ b/dartagnan/src/test/resources/miscellaneous/offsetof.ll
@@ -1,0 +1,95 @@
+; ModuleID = '/Users/thomashaas/IdeaProjects/Dat3M/benchmarks/c/miscellaneous/offsetof.c'
+source_filename = "/Users/thomashaas/IdeaProjects/Dat3M/benchmarks/c/miscellaneous/offsetof.c"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx13.0.0"
+
+%struct.myStruct_t = type { i32, %struct.anon, i32 }
+%struct.anon = type { i64, i8 }
+
+@myStruct = dso_local global %struct.myStruct_t zeroinitializer, align 8, !dbg !0
+
+; Function Attrs: noinline nounwind ssp uwtable
+define dso_local i32 @main() #0 !dbg !32 {
+  %1 = alloca %struct.myStruct_t*, align 8
+  %2 = alloca i32*, align 8
+  %3 = alloca %struct.myStruct_t*, align 8
+  call void @__VERIFIER_assert(i32 1), !dbg !35
+  call void @__VERIFIER_assert(i32 1), !dbg !36
+  call void @llvm.dbg.declare(metadata %struct.myStruct_t** %1, metadata !37, metadata !DIExpression()), !dbg !38
+  call void @llvm.dbg.declare(metadata i32** %2, metadata !39, metadata !DIExpression()), !dbg !43
+  store i32* getelementptr inbounds (%struct.myStruct_t, %struct.myStruct_t* @myStruct, i32 0, i32 2), i32** %2, align 8, !dbg !43
+  %4 = load i32*, i32** %2, align 8, !dbg !43
+  %5 = bitcast i32* %4 to i8*, !dbg !43
+  %6 = getelementptr inbounds i8, i8* %5, i64 -24, !dbg !43
+  %7 = bitcast i8* %6 to %struct.myStruct_t*, !dbg !43
+  store %struct.myStruct_t* %7, %struct.myStruct_t** %3, align 8, !dbg !43
+  %8 = load %struct.myStruct_t*, %struct.myStruct_t** %3, align 8, !dbg !43
+  store %struct.myStruct_t* %8, %struct.myStruct_t** %1, align 8, !dbg !38
+  %9 = load %struct.myStruct_t*, %struct.myStruct_t** %1, align 8, !dbg !44
+  %10 = icmp eq %struct.myStruct_t* %9, @myStruct, !dbg !45
+  %11 = zext i1 %10 to i32, !dbg !45
+  call void @__VERIFIER_assert(i32 %11), !dbg !46
+  ret i32 0, !dbg !47
+}
+
+declare void @__VERIFIER_assert(i32) #1
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #2
+
+attributes #0 = { noinline nounwind ssp uwtable "disable-tail-calls"="false" "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-a12" "target-features"="+aes,+crc,+crypto,+fp-armv8,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+v8.3a,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "disable-tail-calls"="false" "frame-pointer"="non-leaf" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-a12" "target-features"="+aes,+crc,+crypto,+fp-armv8,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+v8.3a,+zcm,+zcz" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nofree nosync nounwind readnone speculatable willreturn }
+
+!llvm.dbg.cu = !{!2}
+!llvm.module.flags = !{!23, !24, !25, !26, !27, !28, !29, !30}
+!llvm.ident = !{!31}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "myStruct", scope: !2, file: !8, line: 17, type: !7, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "Homebrew clang version 12.0.1", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !5, globals: !22, nameTableKind: None, sysroot: "/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk", sdk: "MacOSX13.sdk")
+!3 = !DIFile(filename: "/Users/thomashaas/IdeaProjects/Dat3M/benchmarks/c/miscellaneous/offsetof.c", directory: "/Users/thomashaas/IdeaProjects/Dat3M")
+!4 = !{}
+!5 = !{!6, !21}
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DIDerivedType(tag: DW_TAG_typedef, name: "myStruct_t", file: !8, line: 15, baseType: !9)
+!8 = !DIFile(filename: "benchmarks/c/miscellaneous/offsetof.c", directory: "/Users/thomashaas/IdeaProjects/Dat3M")
+!9 = distinct !DICompositeType(tag: DW_TAG_structure_type, file: !8, line: 8, size: 256, elements: !10)
+!10 = !{!11, !13, !20}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !9, file: !8, line: 9, baseType: !12, size: 32)
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !DIDerivedType(tag: DW_TAG_member, scope: !9, file: !8, line: 10, baseType: !14, size: 128, offset: 64)
+!14 = distinct !DICompositeType(tag: DW_TAG_structure_type, scope: !9, file: !8, line: 10, size: 128, elements: !15)
+!15 = !{!16, !18}
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !14, file: !8, line: 11, baseType: !17, size: 64)
+!17 = !DIBasicType(name: "long int", size: 64, encoding: DW_ATE_signed)
+!18 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !14, file: !8, line: 12, baseType: !19, size: 8, offset: 64)
+!19 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "z", scope: !9, file: !8, line: 14, baseType: !12, size: 32, offset: 192)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!22 = !{!0}
+!23 = !{i32 7, !"Dwarf Version", i32 4}
+!24 = !{i32 2, !"Debug Info Version", i32 3}
+!25 = !{i32 1, !"wchar_size", i32 4}
+!26 = !{i32 1, !"branch-target-enforcement", i32 0}
+!27 = !{i32 1, !"sign-return-address", i32 0}
+!28 = !{i32 1, !"sign-return-address-all", i32 0}
+!29 = !{i32 1, !"sign-return-address-with-bkey", i32 0}
+!30 = !{i32 7, !"PIC Level", i32 2}
+!31 = !{!"Homebrew clang version 12.0.1"}
+!32 = distinct !DISubprogram(name: "main", scope: !8, file: !8, line: 19, type: !33, scopeLine: 20, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
+!33 = !DISubroutineType(types: !34)
+!34 = !{!12}
+!35 = !DILocation(line: 22, column: 5, scope: !32)
+!36 = !DILocation(line: 23, column: 5, scope: !32)
+!37 = !DILocalVariable(name: "container", scope: !32, file: !8, line: 26, type: !6)
+!38 = !DILocation(line: 26, column: 17, scope: !32)
+!39 = !DILocalVariable(name: "__mptr", scope: !40, file: !8, line: 26, type: !41)
+!40 = distinct !DILexicalBlock(scope: !32, file: !8, line: 26, column: 29)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !12)
+!43 = !DILocation(line: 26, column: 29, scope: !40)
+!44 = !DILocation(line: 27, column: 23, scope: !32)
+!45 = !DILocation(line: 27, column: 33, scope: !32)
+!46 = !DILocation(line: 27, column: 5, scope: !32)
+!47 = !DILocation(line: 28, column: 1, scope: !32)


### PR DESCRIPTION
This PR improves computations of types sizes, alignments, and offsets.  
Previously, we had wrong computations in many cases, however, it only rarely lead to issues in benchmarks that made use of `offset_of` compiler primitives or similar ways to compute pointer offsets without GEP.
As a result, issue #586 should also be resolved.