### PR TITLE
Fix addresses in witnesses

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -47,10 +47,10 @@ import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 import org.sosy_lab.java_smt.api.*;
 
+import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.function.BiPredicate;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.dat3m.dartagnan.GlobalSettings.REFINEMENT_GENERATE_GRAPHVIZ_DEBUG_FILES;
@@ -241,7 +241,7 @@ public class RefinementSolver extends ModelChecker {
         if (smtStatus == SMTStatus.UNKNOWN) {
             // Refinement got no result (should not be able to happen), so we cannot proceed further.
             logger.warn("Refinement procedure was inconclusive. Trying to find reason of inconclusiveness.");
-            analyzeInconclusiveness(task, propertyTrace, analysisContext);
+            analyzeInconclusiveness(task, analysisContext, solver.getExecution());
             throw new RuntimeException("Terminated verification due to inconclusiveness (bug?).");
         }
 
@@ -312,7 +312,7 @@ public class RefinementSolver extends ModelChecker {
         logger.info("Verification finished with result " + res);
     }
 
-    private void analyzeInconclusiveness(VerificationTask task, RefinementTrace propertyTrace, Context analysisContext) {
+    private void analyzeInconclusiveness(VerificationTask task, Context analysisContext, ExecutionModel model) {
         final AliasAnalysis alias = analysisContext.get(AliasAnalysis.class);
         if (alias == null) {
             return;
@@ -322,41 +322,35 @@ public class RefinementSolver extends ModelChecker {
             synContext = newInstance(task.getProgram());
         }
 
-        final DNF<CoreLiteral> lastReasons = propertyTrace.getFinalIteration().inconsistencyReasons;
-        for (Conjunction<CoreLiteral> reason : lastReasons.getCubes()) {
-            for (CoreLiteral literal : reason.getLiterals()) {
-                if (literal instanceof RelLiteral relLit && doesViolateAliasingRules(relLit, alias)) {
-                    final Event e1 = relLit.getSource();
-                    final Event e2 = relLit.getTarget();
+        final Map<BigInteger, Set<EventData>> addr2Events = new HashMap<>();
+        model.getAddressReadsMap().forEach((addr, reads) -> addr2Events.computeIfAbsent(addr, key -> new HashSet<>()).addAll(reads));
+        model.getAddressWritesMap().forEach((addr, writes) -> addr2Events.computeIfAbsent(addr, key -> new HashSet<>()).addAll(writes));
+        model.getAddressInitMap().forEach((addr, init) -> addr2Events.computeIfAbsent(addr, key -> new HashSet<>()).add(init));
 
-                    final StringBuilder builder = new StringBuilder();
-                    builder.append("Found unexpected aliasing between:\n");
-                    builder.append("\t")
-                            .append(synContext.getSourceLocationWithContext(e1, true))
-                            .append("\n")
-                            .append("AND\n")
-                            .append("\t")
-                            .append(synContext.getSourceLocationWithContext(e2, true))
-                            .append("\n");
-                    builder.append("Possible out-of-bounds access in source code or error in alias analysis.");
+        for (Set<EventData> sameLocEvents : addr2Events.values()) {
+            final List<EventData> events = sameLocEvents.stream().sorted().toList();
 
-                    logger.warn(builder.toString());
-                    return;
+            for (int i = 0; i < events.size() - 1; i++) {
+                for (int j = 1; j < events.size(); j++) {
+                    final MemoryCoreEvent e1 = (MemoryCoreEvent) events.get(i).getEvent();
+                    final MemoryCoreEvent e2 = (MemoryCoreEvent) events.get(j).getEvent();
+                    if (!alias.mayAlias(e1, e2)) {
+                        final StringBuilder builder = new StringBuilder();
+                        builder.append("Found unexpected aliasing between:\n");
+                        builder.append("\t")
+                                .append(synContext.getSourceLocationWithContext(e1, true))
+                                .append("\n")
+                                .append("AND\n")
+                                .append("\t")
+                                .append(synContext.getSourceLocationWithContext(e2, true))
+                                .append("\n");
+                        builder.append("Possible out-of-bounds access in source code or error in alias analysis.");
+
+                        logger.warn(builder.toString());
+                        return;
+                    }
                 }
             }
-        }
-    }
-
-    private boolean doesViolateAliasingRules(RelLiteral lit, AliasAnalysis alias) {
-        final Predicate<Relation> isMemRel = r -> r.getDefinition() instanceof ReadFrom
-                || r.getDefinition() instanceof Coherence;
-
-        if (lit.isPositive() && isMemRel.test(lit.getRelation())) {
-            final MemoryCoreEvent e1 = (MemoryCoreEvent) lit.getSource();
-            final MemoryCoreEvent e2 = (MemoryCoreEvent) lit.getTarget();
-            return !alias.mayAlias(e1, e2);
-        } else {
-            return false;
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -331,7 +331,7 @@ public class RefinementSolver extends ModelChecker {
             final List<EventData> events = sameLocEvents.stream().sorted().toList();
 
             for (int i = 0; i < events.size() - 1; i++) {
-                for (int j = 1; j < events.size(); j++) {
+                for (int j = i + 1; j < events.size(); j++) {
                     final MemoryCoreEvent e1 = (MemoryCoreEvent) events.get(i).getEvent();
                     final MemoryCoreEvent e2 = (MemoryCoreEvent) events.get(j).getEvent();
                     if (!alias.mayAlias(e1, e2)) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -1,12 +1,10 @@
 package com.dat3m.dartagnan.witness.graphviz;
 
-import com.dat3m.dartagnan.expression.Expression;
-import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
+import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.verification.model.EventData;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
 import org.apache.logging.log4j.LogManager;
@@ -17,9 +15,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.BiPredicate;
 
 import static com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis.*;
@@ -38,7 +34,7 @@ public class ExecutionGraphVisualizer {
     private BiPredicate<EventData, EventData> rfFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> frFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> coFilter = (x, y) -> true;
-    private final Map<BigInteger, Expression> addresses = new HashMap<>();
+    private final LinkedHashMap<MemoryObject, BigInteger> objToAddrMap = new LinkedHashMap<>();
 
     public ExecutionGraphVisualizer() {
         this.graphviz = new Graphviz();
@@ -66,15 +62,7 @@ public class ExecutionGraphVisualizer {
     }
 
     public void generateGraphOfExecutionModel(Writer writer, String graphName, ExecutionModel model) throws IOException {
-        for (EventData data : model.getEventList()) {
-            if (data.isMemoryEvent()) {
-                MemoryCoreEvent m = (MemoryCoreEvent) data.getEvent();
-                Expression addr = m.getAddress();
-                if (!(addr instanceof Register)) {
-                    addresses.putIfAbsent(data.getAccessedAddress(), addr);
-                }
-            }
-        }
+        computeAddressMap(model);
         graphviz.beginDigraph(graphName);
         graphviz.append(String.format("label=\"%s\" \n", graphName));
         addAllThreadPos(model);
@@ -83,6 +71,16 @@ public class ExecutionGraphVisualizer {
         addCoherence(model);
         graphviz.end();
         graphviz.generateOutput(writer);
+    }
+
+    private void computeAddressMap(ExecutionModel model) {
+        final Map<MemoryObject, BigInteger> memLayout = model.getMemoryLayoutMap();
+        final List<MemoryObject> objs = new ArrayList<>(memLayout.keySet());
+        objs.sort(Comparator.comparing(memLayout::get));
+
+        for (MemoryObject obj : objs) {
+            objToAddrMap.put(obj, memLayout.get(obj));
+        }
     }
 
     private boolean ignore(EventData e) {
@@ -188,18 +186,35 @@ public class ExecutionGraphVisualizer {
         return this;
     }
 
+    private String getAddressString(BigInteger address) {
+        MemoryObject obj = null;
+        BigInteger objAddress = null;
+        for (Map.Entry<MemoryObject, BigInteger> entry : objToAddrMap.entrySet()) {
+            final BigInteger nextObjAddr = entry.getValue();
+            if (nextObjAddr.compareTo(address) >= 0) {
+                obj = entry.getKey();
+                objAddress = nextObjAddr;
+                break;
+            }
+        }
+
+        if (obj == null) {
+            return address + "[OOB]";
+        } else if (address.equals(objAddress)) {
+            return obj.toString();
+        } else {
+            return String.format("%s + %s", obj, address.subtract(objAddress));
+        }
+    }
 
     private String eventToNode(EventData e) {
         if (e.isInit()) {
-            return String.format("\"I(%s, %d)\"", addresses.get(e.getAccessedAddress()), e.getValue());
+            return String.format("\"I(%s, %d)\"", getAddressString(e.getAccessedAddress()), e.getValue());
         }
         // We have MemEvent + Fence
         String tag = e.getEvent().toString();
         if (e.isMemoryEvent()) {
-            Object address = addresses.get(e.getAccessedAddress());
-            if (address == null) {
-                address = e.getAccessedAddress();
-            }
+            String address = getAddressString(e.getAccessedAddress());
             BigInteger value = e.getValue();
             MemoryOrder mo = e.getEvent().getMetadata(MemoryOrder.class);
             String moString = mo == null ? "" : ", " + mo.value();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -191,7 +191,7 @@ public class ExecutionGraphVisualizer {
         BigInteger objAddress = null;
         for (Map.Entry<MemoryObject, BigInteger> entry : objToAddrMap.entrySet()) {
             final BigInteger nextObjAddr = entry.getValue();
-            if (nextObjAddr.compareTo(address) >= 0) {
+            if (nextObjAddr.compareTo(address) > 0) {
                 break;
             }
             obj = entry.getKey();
@@ -199,11 +199,12 @@ public class ExecutionGraphVisualizer {
         }
 
         if (obj == null) {
-            return address + "[OOB]";
+            return address + " [OOB]";
         } else if (address.equals(objAddress)) {
             return obj.toString();
         } else {
-            return String.format("%s + %s", obj, address.subtract(objAddress));
+            final boolean isOOB = address.compareTo(objAddress.add(BigInteger.valueOf(obj.size()))) >= 0;
+            return String.format("%s + %s%s", obj, address.subtract(objAddress), isOOB ? " [OOB]" : "");
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -192,10 +192,10 @@ public class ExecutionGraphVisualizer {
         for (Map.Entry<MemoryObject, BigInteger> entry : objToAddrMap.entrySet()) {
             final BigInteger nextObjAddr = entry.getValue();
             if (nextObjAddr.compareTo(address) >= 0) {
-                obj = entry.getKey();
-                objAddress = nextObjAddr;
                 break;
             }
+            obj = entry.getKey();
+            objAddress = nextObjAddr;
         }
 
         if (obj == null) {


### PR DESCRIPTION
This PR fixes the printing of addresses in witnesses.
Furthermore, the witness will now print every address that belongs to an object as `obj + offset`.
Addresses that do not belong to an object get an "[OOB]" tag for "out-of-bounds".

EDIT: I also added a fix for Refinements inconclusiveness analysis to give proper feedback.