### PR TITLE
Easier handling of nondet choices

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -444,6 +444,14 @@ public class EventFactory {
         public static LoopBound newLoopBound(Expression bound) {
             return new LoopBound(bound);
         }
+
+        public static NonDetChoice newNonDetChoice(Register register) {
+            return new NonDetChoice(register, false);
+        }
+
+        public static NonDetChoice newSignedNonDetChoice(Register register, boolean isSigned) {
+            return new NonDetChoice(register, isSigned);
+        }
     }
 
     // =============================================================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/svcomp/NonDetChoice.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/svcomp/NonDetChoice.java
@@ -1,0 +1,46 @@
+package com.dat3m.dartagnan.program.event.lang.svcomp;
+
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.AbstractEvent;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.RegWriter;
+import com.google.common.base.Preconditions;
+
+public class NonDetChoice extends AbstractEvent implements RegWriter {
+
+    protected Register register;
+    protected boolean isSigned;
+
+    public NonDetChoice(Register register, boolean isSigned) {
+        this.register = Preconditions.checkNotNull(register);
+        this.isSigned = isSigned;
+    }
+
+    protected NonDetChoice(NonDetChoice other) {
+        super(other);
+        this.register = other.register;
+        this.isSigned = other.isSigned;
+    }
+
+    public boolean isSigned() { return isSigned; }
+
+    @Override
+    protected String defaultString() {
+        return String.format("%s <- *", register);
+    }
+
+    @Override
+    public Event getCopy() {
+        return new NonDetChoice(this);
+    }
+
+    @Override
+    public Register getResultRegister() {
+        return register;
+    }
+
+    @Override
+    public void setResultRegister(Register reg) {
+        this.register = reg;
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -121,6 +121,7 @@ public class ProcessingManager implements ProgramProcessor {
                         ), Target.FUNCTIONS, true
                 ),
                 ThreadCreation.fromConfig(config),
+                ResolveNonDetChoices.newInstance(),
                 reduceSymmetry ? SymmetryReduction.fromConfig(config) : null,
                 intrinsics.lateInliningPass(),
                 ProgramProcessor.fromFunctionProcessor(

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ResolveNonDetChoices.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ResolveNonDetChoices.java
@@ -1,0 +1,35 @@
+package com.dat3m.dartagnan.program.processing;
+
+import com.dat3m.dartagnan.expression.Expression;
+import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.program.Function;
+import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.event.EventFactory;
+import com.dat3m.dartagnan.program.event.core.Local;
+import com.dat3m.dartagnan.program.event.lang.svcomp.NonDetChoice;
+
+public class ResolveNonDetChoices implements ProgramProcessor {
+
+    private ResolveNonDetChoices() { }
+
+    public static ResolveNonDetChoices newInstance() {
+        return new ResolveNonDetChoices();
+    }
+
+    @Override
+    public void run(Program program) {
+        program.getThreads().forEach(this::resolveNonDetChoices);
+    }
+
+    private void resolveNonDetChoices(Function func) {
+        final Program prog = func.getProgram();
+        for (NonDetChoice choice : func.getEvents(NonDetChoice.class)) {
+            final Type valueType = choice.getResultRegister().getType();
+            final Expression constant = prog.newConstant(valueType);
+
+            final Local assignment = EventFactory.newLocal(choice.getResultRegister(), constant);
+            assignment.copyAllMetadataFrom(choice);
+            choice.replaceBy(assignment);
+        }
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ResolveNonDetChoices.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ResolveNonDetChoices.java
@@ -2,11 +2,13 @@ package com.dat3m.dartagnan.program.processing;
 
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.processing.ExpressionInspector;
 import com.dat3m.dartagnan.program.Function;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.core.Local;
 import com.dat3m.dartagnan.program.event.lang.svcomp.NonDetChoice;
+import com.dat3m.dartagnan.program.misc.NonDetValue;
 
 public class ResolveNonDetChoices implements ProgramProcessor {
 
@@ -26,6 +28,15 @@ public class ResolveNonDetChoices implements ProgramProcessor {
         for (NonDetChoice choice : func.getEvents(NonDetChoice.class)) {
             final Type valueType = choice.getResultRegister().getType();
             final Expression constant = prog.newConstant(valueType);
+
+            final ExpressionInspector signednessMarker = new ExpressionInspector() {
+                @Override
+                public Expression visitNonDetValue(NonDetValue nonDet) {
+                    nonDet.setIsSigned(choice.isSigned());
+                    return nonDet;
+                }
+            };
+            constant.accept(signednessMarker);
 
             final Local assignment = EventFactory.newLocal(choice.getResultRegister(), constant);
             assignment.copyAllMetadataFrom(choice);


### PR DESCRIPTION
This PR adds a new `NonDetChoice` event that essentially plays the role of `__VERIFIER_nondet_XXX` calls.
The difference is that `NonDetChoice` works with arbitrary types and does not rely on intrinsic functions to be declared, which makes it easier to use programatically (e.g., linux CAS compilation can emit this event rather than relying on calling `__VERIFIER_nondet_bool` which must get declared globally beforehand).
`__VERIFIER_nondet_XXX` calls can now be inlined early by translating them all to `NonDetChoice` events.
There is a dedicated pass that finally resolves those choice events by generating program constants.

The major reason why I made this PR is because currently it just sucks to programatically generate non det choices.
While we currently have only a single use-case, namely Linux CAS compilation, I also require this to generate code instrumentation for k-boundedness checks of loops.