### PR TITLE
Fixed copying of event tags

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
@@ -16,7 +16,7 @@ import java.util.*;
 public abstract class AbstractEvent implements Event {
 
     private final MetadataMap metadataMap = new MetadataMap();
-    private final Set<String> tags;
+    private final TagSet tags;
     private final Set<EventUser> currentUsers = new HashSet<>();
     // These ids are dynamically changing during processing.
     private transient int globalId = -1; // (Global) ID within a program
@@ -27,12 +27,12 @@ public abstract class AbstractEvent implements Event {
     private transient AbstractEvent predecessor;
 
     protected AbstractEvent() {
-        tags = new HashSet<>();
+        tags = new TagSet();
     }
 
     protected AbstractEvent(AbstractEvent other) {
         copyAllMetadataFrom(other);
-        this.tags = other.tags; // TODO: Dangerous code! A Copy-on-Write Set should be used (e.g. PersistentSet/Map)
+        this.tags = other.tags.copy();
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/TagSet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/TagSet.java
@@ -1,0 +1,56 @@
+package com.dat3m.dartagnan.program.event;
+
+import java.util.*;
+
+public final class TagSet extends AbstractSet<String> {
+
+    private final List<String> sortedTags = new ArrayList<>();
+
+    @Override
+    public boolean add(String tag) {
+        final int index = Collections.binarySearch(sortedTags, tag);
+        if (index < 0) {
+            sortedTags.add(~index, tag);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        if (o instanceof String tag) {
+            return Collections.binarySearch(sortedTags, tag) >= 0;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (!(o instanceof String tag)) {
+            return false;
+        }
+
+        final int index = Collections.binarySearch(sortedTags, tag);
+        if (index >= 0) {
+            sortedTags.remove(index);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return sortedTags.listIterator();
+    }
+
+    @Override
+    public int size() {
+        return sortedTags.size();
+    }
+
+    public TagSet copy() {
+        final TagSet copy = new TagSet();
+        copy.sortedTags.addAll(this.sortedTags);
+        return copy;
+    }
+}


### PR DESCRIPTION
This PR fixes a problem we had for a very long: when copying events, we did not copy the set of tags but instead shared the same set instance. This could lead to very subtle and hard-to-debug bugs, so we now make proper copies instead.

Memory-wise, the copies can be wasteful if they all end up storing the exact same set of tags (which is common), so copy-on-write sets or persistent sets might offer a more memory-efficient solution.
I don't use them yet, but I added a `TagSet` class to abstract away from the underlying implementation and use sorted lists for now (they are more efficient than hash sets).