### PR TITLE
Update JavaSMT version

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -187,8 +187,8 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
                 case MUL -> bvmgr.multiply(bv1, bv2);
                 case DIV -> bvmgr.divide(bv1, bv2, true);
                 case UDIV -> bvmgr.divide(bv1, bv2, false);
-                case SREM -> bvmgr.modulo(bv1, bv2, true);
-                case UREM -> bvmgr.modulo(bv1, bv2, false);
+                case SREM -> bvmgr.remainder(bv1, bv2, true);
+                case UREM -> bvmgr.remainder(bv1, bv2, false);
                 case AND -> bvmgr.and(bv1, bv2);
                 case OR -> bvmgr.or(bv1, bv2);
                 case XOR -> bvmgr.xor(bv1, bv2);

--- a/pom.xml
+++ b/pom.xml
@@ -598,6 +598,15 @@
                     <classifier>libz3java</classifier>
                 </dependency>
 
+                <!-- Bitwuzla dependencies -->
+                <dependency>
+                    <groupId>org.sosy-lab</groupId>
+                    <artifactId>javasmt-solver-bitwuzla</artifactId>
+                    <version>${bitwuzla.version}</version>
+                    <type>dll</type>
+                    <classifier>libbitwuzlaj</classifier>
+                </dependency>
+
                 <!-- MathSAT5 dependencies -->
                 <dependency>
                     <groupId>org.sosy-lab</groupId>
@@ -652,6 +661,15 @@
                                         <type>dll</type>
                                         <classifier>libz3</classifier>
                                         <destFileName>libz3.dll</destFileName>
+                                    </artifactItem>
+
+                                    <!-- Bitwuzla dependencies -->
+                                    <artifactItem>
+                                        <groupId>org.sosy-lab</groupId>
+                                        <artifactId>javasmt-solver-bitwuzla</artifactId>
+                                        <type>dll</type>
+                                        <classifier>libbitwuzlaj</classifier>
+                                        <destFileName>libbitwuzlaj.dll</destFileName>
                                     </artifactItem>
 
                                     <!-- MathSAT5 dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <cvc4.version>1.8-prerelease-2020-06-24-g7825d8f28</cvc4.version>
         <cvc5.version>1.0.5-g4cb2ab9eb</cvc5.version>
         <opensmt.version>2.6.0-g2f72cc0e</opensmt.version>
-        <yices2-api.version>4.1.0-1-gc58fe5b4</yices2-api.version>
+        <yices2-api.version>4.1.1-734-g3732f7e08</yices2-api.version>
         <yices2.version>2.6.2-396-g194350c1</yices2.version>
         <z3.version>4.12.5</z3.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,13 @@
                     <groupId>org.sosy-lab</groupId>
                     <artifactId>javasmt-solver-bitwuzla</artifactId>
                     <version>${bitwuzla.version}</version>
+                    <type>jar</type>
+                    <classifier>bitwuzla</classifier>
+                </dependency>
+                <dependency>
+                    <groupId>org.sosy-lab</groupId>
+                    <artifactId>javasmt-solver-bitwuzla</artifactId>
+                    <version>${bitwuzla.version}</version>
                     <classifier>libbitwuzlaj</classifier>
                     <type>so</type>
                 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,15 +30,16 @@
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
 
         <!-- 3rd party solver versions -->
-        <java-smt.version>4.1.0</java-smt.version>
+        <java-smt.version>5.0.0</java-smt.version>
+        <bitwuzla.version>0.4.0-g4dbf3b1f</bitwuzla.version>
         <boolector.version>3.2.2-g1a89c229</boolector.version>
         <mathsat.version>5.6.10</mathsat.version>
         <cvc4.version>1.8-prerelease-2020-06-24-g7825d8f28</cvc4.version>
         <cvc5.version>1.0.5-g4cb2ab9eb</cvc5.version>
-        <opensmt.version>2.5.2-g7f502169</opensmt.version>
+        <opensmt.version>2.6.0-g2f72cc0e</opensmt.version>
         <yices2-api.version>4.1.0-1-gc58fe5b4</yices2-api.version>
         <yices2.version>2.6.2-396-g194350c1</yices2.version>
-        <z3.version>4.12.2</z3.version>
+        <z3.version>4.12.5</z3.version>
 
         <!-- 3rd party library versions -->
         <antlr.version>4.13.0</antlr.version>
@@ -160,6 +161,15 @@
                     <version>${z3.version}</version>
                     <type>so</type>
                     <classifier>libz3java</classifier>
+                </dependency>
+
+                <!-- Bitwuzla dependencies -->
+                <dependency>
+                    <groupId>org.sosy-lab</groupId>
+                    <artifactId>javasmt-solver-bitwuzla</artifactId>
+                    <version>${bitwuzla.version}</version>
+                    <classifier>libbitwuzlaj</classifier>
+                    <type>so</type>
                 </dependency>
 
                 <!-- MathSAT5 dependencies -->
@@ -335,6 +345,15 @@
                                         <destFileName>libz3.so</destFileName>
                                     </artifactItem>
 
+                                    <!-- Bitwuzla dependencies -->
+                                    <artifactItem>
+                                        <groupId>org.sosy-lab</groupId>
+                                        <artifactId>javasmt-solver-bitwuzla</artifactId>
+                                        <type>so</type>
+                                        <classifier>libbitwuzlaj</classifier>
+                                        <destFileName>libbitwuzlaj.so</destFileName>
+                                    </artifactItem>
+
                                     <!-- MathSAT5 dependencies -->
                                     <artifactItem>
                                         <groupId>org.sosy-lab</groupId>
@@ -344,7 +363,7 @@
                                         <destFileName>libmathsat5j.so</destFileName>
                                     </artifactItem>
 
-                                    <!-- Boolector dependencies -->
+                                        <!-- Boolector dependencies -->
                                     <artifactItem>
                                         <groupId>org.sosy-lab</groupId>
                                         <artifactId>javasmt-solver-boolector</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
                                         <destFileName>libmathsat5j.so</destFileName>
                                     </artifactItem>
 
-                                        <!-- Boolector dependencies -->
+                                    <!-- Boolector dependencies -->
                                     <artifactItem>
                                         <groupId>org.sosy-lab</groupId>
                                         <artifactId>javasmt-solver-boolector</artifactId>


### PR DESCRIPTION
This PR updates JavaSMT to the latest version and adds support for the new bitwuzla solver.

I did some basic performance testing for bitwuzla and it does not look good (similar to z3 using BVs, i.e. 10x slower than yices2).

EDIT: actually, z3 and yices2 performance is not that different in our usual benchmarks. For those bitwuzla is much worse than both. These are the solving times for ttas with bound 3
```
yices2: 1.426 secs
z3: 2.588 secs
bitwuzla: 6.993 secs
```


@xeren can you check in your Windows machine if adding this to the pom
```
diff --git a/pom.xml b/pom.xml
index 9461ac21b..6cdbd9ed9 100644
--- a/pom.xml
+++ b/pom.xml
@@ -598,6 +598,15 @@
                     <classifier>libz3java</classifier>
                 </dependency>
 
+                <!-- Bitwuzla dependencies -->
+                <dependency>
+                    <groupId>org.sosy-lab</groupId>
+                    <artifactId>javasmt-solver-bitwuzla</artifactId>
+                    <version>${bitwuzla.version}</version>
+                    <type>dll</type>
+                    <classifier>libbitwuzlaj</classifier>
+                </dependency>
+
                 <!-- MathSAT5 dependencies -->
                 <dependency>
                     <groupId>org.sosy-lab</groupId>
```
is enough to have support in windows?