### PR TITLE
Add memory effects to LLVM grammar and better error message

### DIFF
--- a/dartagnan/src/main/antlr4/LLVMIR.g4
+++ b/dartagnan/src/main/antlr4/LLVMIR.g4
@@ -740,7 +740,17 @@ funcAttr:
 	| 'sspstrong'
 	| 'strictfp'
 	| 'willreturn'
-	| 'writeonly';
+	| 'writeonly'
+	| 'memory(' memoryEffect+ ')';
+memoryEffect
+	: accessKind
+	| 'argmem:' accessKind
+	| 'inaccessiblemem:' accessKind;
+accessKind
+	: 'none'
+	| 'readwrite'
+	| 'read'
+	| 'write';
 distinct: 'distinct';
 inBounds: 'inbounds';
 returnAttr:

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
@@ -240,13 +240,17 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
         final String name = globalIdent(ctx.GlobalIdent());
         check(!constantMap.containsKey(name), "Redeclared constant in %s.", ctx);
         final int size = types.getMemorySizeInBytes(parseType(ctx.type()));
-        final MemoryObject globalObject = program.getMemory().allocate(size);
-        globalObject.setName(name);
-        if (ctx.threadLocal() != null) {
-            globalObject.setIsThreadLocal(true);
+        if (size > 0) {
+            final MemoryObject globalObject = program.getMemory().allocate(size);
+            globalObject.setName(name);
+            if (ctx.threadLocal() != null) {
+                globalObject.setIsThreadLocal(true);
+            }
+            // TODO: mark the global as constant, if possible.
+            constantMap.put(name, globalObject);
+            return;
         }
-        // TODO: mark the global as constant, if possible.
-        constantMap.put(name, globalObject);
+        throw new ParsingException(String.format("Cannot compute memory size for '%s'", name));
     }
 
     @Override


### PR DESCRIPTION
Added memory effects to function attributes, according to https://github.com/llvm/llvm-project/blob/main/llvm/docs/LangRef.rst to avoid parsing errors for different clang versions.

More informative error messages text when LLVM Visitor cannot allocate memory.