### PR TITLE
Smtlib2

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -43,7 +43,6 @@ import org.sosy_lab.common.configuration.Options;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
 import org.sosy_lab.java_smt.api.Model;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan;
 import com.dat3m.dartagnan.configuration.OptionNames;
 import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.expression.ExpressionPrinter;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
@@ -163,7 +164,10 @@ public class Dartagnan extends BaseOptions {
                     BasicLogManager.create(solverConfig),
                     sdm.getNotifier(),
                     o.getSolver());
-                    ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+                    ProverWithTracker prover = new ProverWithTracker(ctx,
+                        o.getDumpSmtLib() ? 
+                            System.getenv("DAT3M_OUTPUT") + String.format("/%s.smt2", p.getName()) : "",
+                        ProverOptions.GENERATE_MODELS)) {
                 ModelChecker modelChecker;
                 if (properties.contains(DATARACEFREEDOM)) {
                     if (properties.size() > 1) {
@@ -207,7 +211,7 @@ public class Dartagnan extends BaseOptions {
         }
     }
 
-    public static File generateExecutionGraphFile(VerificationTask task, ProverEnvironment prover, ModelChecker modelChecker,
+    public static File generateExecutionGraphFile(VerificationTask task, ProverWithTracker prover, ModelChecker modelChecker,
                                                   WitnessType witnessType)
             throws InvalidConfigurationException, SolverException, IOException {
         Preconditions.checkArgument(modelChecker.hasModel(), "No execution graph to generate.");
@@ -228,7 +232,7 @@ public class Dartagnan extends BaseOptions {
                 synContext, witnessType.convertToPng());
     }
 
-    private static void generateWitnessIfAble(VerificationTask task, ProverEnvironment prover,
+    private static void generateWitnessIfAble(VerificationTask task, ProverWithTracker prover,
             ModelChecker modelChecker, String summary) {
         // ------------------ Generate Witness, if possible ------------------
         final EnumSet<Property> properties = task.getProperty();
@@ -247,7 +251,7 @@ public class Dartagnan extends BaseOptions {
         }
     }
 
-    public static String generateResultSummary(VerificationTask task, ProverEnvironment prover,
+    public static String generateResultSummary(VerificationTask task, ProverWithTracker prover,
             ModelChecker modelChecker) throws SolverException {
         // ----------------- Generate output of verification result -----------------
         final Program p = task.getProgram();
@@ -385,7 +389,7 @@ public class Dartagnan extends BaseOptions {
         return summary.toString();
     }
 
-    private static void printWarningIfThreadStartFailed(Program p, EncodingContext encoder, ProverEnvironment prover)
+    private static void printWarningIfThreadStartFailed(Program p, EncodingContext encoder, ProverWithTracker prover)
             throws SolverException {
         for (Event e : p.getThreadEvents()) {
             if (e.hasTag(Tag.STARTLOAD)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -43,6 +43,7 @@ import org.sosy_lab.common.configuration.Options;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
 import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 import org.sosy_lab.java_smt.api.SolverException;
@@ -210,7 +211,7 @@ public class Dartagnan extends BaseOptions {
         }
     }
 
-    public static File generateExecutionGraphFile(VerificationTask task, ProverWithTracker prover, ModelChecker modelChecker,
+    public static File generateExecutionGraphFile(VerificationTask task, ProverEnvironment prover, ModelChecker modelChecker,
                                                   WitnessType witnessType)
             throws InvalidConfigurationException, SolverException, IOException {
         Preconditions.checkArgument(modelChecker.hasModel(), "No execution graph to generate.");
@@ -231,7 +232,7 @@ public class Dartagnan extends BaseOptions {
                 synContext, witnessType.convertToPng());
     }
 
-    private static void generateWitnessIfAble(VerificationTask task, ProverWithTracker prover,
+    private static void generateWitnessIfAble(VerificationTask task, ProverEnvironment prover,
             ModelChecker modelChecker, String summary) {
         // ------------------ Generate Witness, if possible ------------------
         final EnumSet<Property> properties = task.getProperty();
@@ -250,7 +251,7 @@ public class Dartagnan extends BaseOptions {
         }
     }
 
-    public static String generateResultSummary(VerificationTask task, ProverWithTracker prover,
+    public static String generateResultSummary(VerificationTask task, ProverEnvironment prover,
             ModelChecker modelChecker) throws SolverException {
         // ----------------- Generate output of verification result -----------------
         final Program p = task.getProgram();
@@ -388,7 +389,7 @@ public class Dartagnan extends BaseOptions {
         return summary.toString();
     }
 
-    private static void printWarningIfThreadStartFailed(Program p, EncodingContext encoder, ProverWithTracker prover)
+    private static void printWarningIfThreadStartFailed(Program p, EncodingContext encoder, ProverEnvironment prover)
             throws SolverException {
         for (Event e : p.getThreadEvents()) {
             if (e.hasTag(Tag.STARTLOAD)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -164,7 +164,7 @@ public class Dartagnan extends BaseOptions {
                     sdm.getNotifier(),
                     o.getSolver());
                     ProverWithTracker prover = new ProverWithTracker(ctx,
-                        o.getDumpSmtLib() ? 
+                        o.getDumpSmtLib() ?
                             System.getenv("DAT3M_OUTPUT") + String.format("/%s.smt2", p.getName()) : "",
                         ProverOptions.GENERATE_MODELS)) {
                 ModelChecker modelChecker;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -12,6 +12,7 @@ public class OptionNames {
     public static final String VALIDATE = "validate";
     public static final String COVERAGE = "coverage";
     public static final String WITNESS = "witness";
+    public static final String SMTLIB2 = "smtlib2";
 
     // Modeling Options
     public static final String THREAD_CREATE_ALWAYS_SUCCEEDS = "modeling.threadCreateAlwaysSucceeds";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -11,7 +11,7 @@ import com.dat3m.dartagnan.expression.misc.ITEExpr;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.misc.NonDetValue;
 import org.sosy_lab.java_smt.api.*;
@@ -298,9 +298,9 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
     }
 
     @Override
-    public Formula visitLocation(Location location) {
-        checkState(event == null, "Cannot evaluate %s at event %s.", location, event);
-        int size = types.getMemorySizeInBits(location.getType());
-        return context.lastValue(location.getMemoryObject(), location.getOffset(), size);
+    public Formula visitFinalMemoryValue(FinalMemoryValue val) {
+        checkState(event == null, "Cannot evaluate final memory value of %s at event %s.", val, event);
+        int size = types.getMemorySizeInBits(val.getType());
+        return context.lastValue(val.getMemoryObject(), val.getOffset(), size);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/PropertyEncoder.java
@@ -21,7 +21,6 @@ import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.dat3m.dartagnan.wmm.utils.EventGraph;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
@@ -36,8 +35,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.dat3m.dartagnan.configuration.Property.*;
-import static com.dat3m.dartagnan.wmm.RelationNameRepository.CO;
 import static com.dat3m.dartagnan.program.Program.SourceLanguage.LLVM;
+import static com.dat3m.dartagnan.wmm.RelationNameRepository.CO;
 
 public class PropertyEncoder implements Encoder {
 
@@ -66,7 +65,7 @@ public class PropertyEncoder implements Encoder {
        Since we encode a lot of potential violations, and we want to trace back which one lead to
        our query being SAT, we use trackable formulas.
      */
-    private static class TrackableFormula {
+    public static class TrackableFormula {
         private final BooleanFormula trackingLiteral;
         private final BooleanFormula trackedFormula;
 
@@ -304,7 +303,7 @@ public class PropertyEncoder implements Encoder {
         final EncodingContext ctx = this.context;
         final Wmm memoryModel = this.memoryModel;
         final List<Axiom> flaggedAxioms = memoryModel.getAxioms().stream()
-                .filter(Axiom::isFlagged).collect(Collectors.toList());
+                .filter(Axiom::isFlagged).toList();
 
         if (flaggedAxioms.isEmpty()) {
             logger.info("No CAT specification in the WMM. Skipping encoding.");
@@ -402,22 +401,30 @@ public class PropertyEncoder implements Encoder {
 
     private TrackableFormula encodeDeadlocks() {
         logger.info("Encoding dead locks");
-        return new LivenessEncoder().encodeDeadlocks();
+        return new LivenessEncoder().encodeLivenessBugs();
     }
 
     /*
         Encoder for the liveness property.
 
         We have a liveness violation in some execution if
-            - At least one thread is stuck inside a loop (*)
+            - At least one thread is stuck (*)
             - All other threads are either stuck or terminated normally (**)
 
-        (*) A thread is stuck if it finishes a loop iteration
-            - without causing side-effects (e.g., visible stores)
-            - while reading only from co-maximal stores
-        => Without external help, a stuck thread will never be able to exit the loop.
+        (*) A thread is stuck if
+            (1) it performs a loop iteration without causing side-effects (e.g., visible stores)
+                while satisfying fairness conditions
+                => Without external help, a stuck thread will never be able to exit the loop.
+         OR (2) the thread is blocked by a control barrier.
 
-        (**) A thread terminates normally IFF it does not terminate early (denoted by EARLYTERMINATION-tagged jumps)
+        Fairness conditions for loops:
+            - Memory fairness: the loop iteration reads only co-maximal values
+            - Excl-Store progress: all exclusive stores in the iteration succeed (infinite spurious failures are unfair)
+              NOTE: Here we assume strong progress. Under weak fairness, a loop with two exclusive stores that need
+              to succeed in the same iteration could fail liveness if they succeed in alternation.
+
+        (**) A thread terminates normally IFF it does terminate (no NONTERMINATION-tagged jumps) non-exceptionally
+             (no EXCEPTIONAL_TERMINATION-tagged jumps)
              due to e.g.,
             - violating an assertion
             - reaching the loop unrolling bound
@@ -429,36 +436,19 @@ public class PropertyEncoder implements Encoder {
     */
     private class LivenessEncoder {
 
-        private static class SpinIteration {
-            public final List<Load> containedLoads = new ArrayList<>();
-            // Execution of the <boundJump> means the loop performed a side-effect-free
-            // iteration without exiting. If such a jump is executed + all loads inside the loop
-            // were co-maximal, then we have a deadlock condition.
-            public final List<CondJump> spinningJumps = new ArrayList<>();
-        }
-
-        public TrackableFormula encodeDeadlocks() {
+        public TrackableFormula encodeLivenessBugs() {
             final Program program = PropertyEncoder.this.program;
             final EncodingContext context = PropertyEncoder.this.context;
             final BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
-            final LoopAnalysis loopAnalysis = LoopAnalysis.newInstance(program);
-
-            // Find spin loops of all threads
-            final Map<Thread, List<SpinIteration>> spinloopsMap =
-                    Maps.toMap(program.getThreads(), t -> this.findSpinLoopsInThread(t, loopAnalysis));
-            // Compute "stuckness" encoding for all threads
-            final Map<Thread, BooleanFormula> isStuckMap = Maps.toMap(program.getThreads(), t ->
-                    bmgr.or(generateBarrierStucknessEncoding(t, context),
-                            this.generateSpinloopStucknessEncoding(spinloopsMap.get(t), context)));
 
             // Deadlock <=> allStuckOrDone /\ atLeastOneStuck
             BooleanFormula allStuckOrDone = bmgr.makeTrue();
             BooleanFormula atLeastOneStuck = bmgr.makeFalse();
             for (Thread thread : program.getThreads()) {
-                final BooleanFormula isStuck = isStuckMap.get(thread);
+                final BooleanFormula isStuck = isStuckEncoding(thread, context);
                 final BooleanFormula isTerminatingNormally = thread
                         .getEvents().stream()
-                        .filter(e -> e.hasTag(Tag.EARLYTERMINATION))
+                        .filter(e -> e.hasTag(Tag.EXCEPTIONAL_TERMINATION) || e.hasTag(Tag.NONTERMINATION))
                         .map(CondJump.class::cast)
                         .map(j -> bmgr.not(bmgr.and(context.execution(j), context.jumpCondition(j))))
                         .reduce(bmgr.makeTrue(), bmgr::and);
@@ -471,6 +461,16 @@ public class PropertyEncoder implements Encoder {
             return new TrackableFormula(bmgr.not(LIVENESS.getSMTVariable(context)), hasDeadlock);
         }
 
+        private BooleanFormula isStuckEncoding(Thread thread, EncodingContext context) {
+            return context.getBooleanFormulaManager().or(
+                    generateSpinloopStucknessEncoding(thread, context),
+                    generateBarrierStucknessEncoding(thread, context)
+            );
+        }
+
+        // ------------------------------------------------------------------------------
+        // Liveness issue due to blocked execution (due to ControlBarrier)
+
         private BooleanFormula generateBarrierStucknessEncoding(Thread thread, EncodingContext context) {
             final BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
             return bmgr.or(thread.getEvents().stream()
@@ -479,37 +479,85 @@ public class PropertyEncoder implements Encoder {
                     .toList());
         }
 
-        // Compute "stuckness": A thread is stuck if it reaches a spin loop bound event
-        // while only reading from co-maximal stores.
-        private BooleanFormula generateSpinloopStucknessEncoding(List<SpinIteration> loops, EncodingContext context) {
+        // ------------------------------------------------------------------------------
+        // Liveness issue due to non-terminating loops (~ deadlocks)
+
+        private record SpinIteration(List<Event> body, List<CondJump> spinningJumps) {
+            // Execution of the <spinningJumps> means the loop performed a side-effect-free
+            // iteration without exiting. If such a jump is executed + all loads inside the loop
+            // were co-maximal, then we have a deadlock condition.
+        }
+
+        private BooleanFormula generateSpinloopStucknessEncoding(Thread thread, EncodingContext context) {
+            final LoopAnalysis loopAnalysis = LoopAnalysis.onFunction(thread);
+            final BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
+
+            return this.findSpinLoopsInThread(thread, loopAnalysis).stream()
+                    .map(loop -> generateSpinloopStucknessEncoding(loop, context))
+                    .reduce(bmgr.makeFalse(), bmgr::or);
+        }
+
+        private BooleanFormula generateSpinloopStucknessEncoding(SpinIteration loop, EncodingContext context) {
+            return context.getBooleanFormulaManager().and(
+                    isSideEffectFreeEncoding(loop, context),
+                    fairnessEncoding(loop, context)
+            );
+        }
+
+        private BooleanFormula isSideEffectFreeEncoding(SpinIteration loop, EncodingContext context) {
+            // Note that we assume (for now) that a SPINLOOP-tagged jump is executed only if the loop iteration
+            // was side-effect free.
+            final BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
+            final BooleanFormula isSideEffectFree = loop.spinningJumps.stream()
+                    .map(j -> bmgr.and(context.execution(j), context.jumpCondition(j)))
+                    .reduce(bmgr.makeFalse(), bmgr::or);
+            return isSideEffectFree;
+        }
+
+        private BooleanFormula fairnessEncoding(SpinIteration loop, EncodingContext context) {
+            return context.getBooleanFormulaManager().and(
+                    memoryFairnessEncoding(loop, context),
+                    exclStoreFairnessEncoding(loop, context)
+            );
+        }
+
+        private BooleanFormula memoryFairnessEncoding(SpinIteration loop, EncodingContext context) {
             final BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
             final RelationAnalysis ra = PropertyEncoder.this.ra;
             final Relation rf = memoryModel.getRelation(RelationNameRepository.RF);
             final EncodingContext.EdgeEncoder rfEncoder = context.edge(rf);
             final Map<Event, Set<Event>> rfMayIn = ra.getKnowledge(rf).getMaySet().getInMap();
 
-            if (loops.isEmpty()) {
-                return bmgr.makeFalse();
+            final List<Load> loads = loop.body.stream()
+                    .filter(Load.class::isInstance)
+                    .map(Load.class::cast)
+                    .toList();
+
+            BooleanFormula allLoadsAreCoMaximal = bmgr.makeTrue();
+            for (Load load : loads) {
+                final BooleanFormula readsCoMaximalStore = rfMayIn.getOrDefault(load, Set.of()).stream()
+                        .map(store -> bmgr.and(rfEncoder.encode(store, load), lastCoVar(store)))
+                        .reduce(bmgr.makeFalse(), bmgr::or);
+                final BooleanFormula isCoMaximalLoad = bmgr.implication(context.execution(load), readsCoMaximalStore);
+                allLoadsAreCoMaximal = bmgr.and(allLoadsAreCoMaximal, isCoMaximalLoad);
             }
 
-            BooleanFormula isStuck = bmgr.makeFalse();
-            for (SpinIteration loop : loops) {
-                BooleanFormula allLoadsAreCoMaximal = bmgr.makeTrue();
-                for (Load load : loop.containedLoads) {
-                    final BooleanFormula readsCoMaximalStore = rfMayIn.getOrDefault(load, Set.of()).stream()
-                            .map(store -> bmgr.and(rfEncoder.encode(store, load), lastCoVar(store)))
-                            .reduce(bmgr.makeFalse(), bmgr::or);
-                    final BooleanFormula isCoMaximalLoad = bmgr.implication(context.execution(load), readsCoMaximalStore);
-                    allLoadsAreCoMaximal = bmgr.and(allLoadsAreCoMaximal, isCoMaximalLoad);
-                }
-                // Note that we assume (for now) that a SPINLOOP-tagged jump is executed only if the loop iteration
-                // was side-effect free.
-                final BooleanFormula isSideEffectFree = loop.spinningJumps.stream()
-                        .map(j -> bmgr.and(context.execution(j), context.jumpCondition(j)))
-                        .reduce(bmgr.makeFalse(), bmgr::or);
-                isStuck = bmgr.or(isStuck, bmgr.and(isSideEffectFree, allLoadsAreCoMaximal));
+            return allLoadsAreCoMaximal;
+        }
+
+        private BooleanFormula exclStoreFairnessEncoding(SpinIteration loop, EncodingContext context) {
+            final BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
+            final List<RMWStoreExclusive> exclStores = loop.body.stream()
+                    .filter(RMWStoreExclusive.class::isInstance)
+                    .map(RMWStoreExclusive.class::cast)
+                    .toList();
+            BooleanFormula allExclStoresExecuted = bmgr.makeTrue();
+            for (RMWStoreExclusive exclStore : exclStores) {
+                final BooleanFormula executedIfPossible = bmgr.implication(context.controlFlow(exclStore), context.execution(exclStore));
+                allExclStoresExecuted = bmgr.and(allExclStoresExecuted, executedIfPossible);
             }
-            return isStuck;
+
+            return allExclStoresExecuted;
         }
 
         private List<SpinIteration> findSpinLoopsInThread(Thread thread, LoopAnalysis loopAnalysis) {
@@ -525,14 +573,7 @@ public class PropertyEncoder implements Encoder {
                             .toList();
 
                     if (!spinningJumps.isEmpty()) {
-                        final List<Load> loads = iterBody.stream()
-                                .filter(Load.class::isInstance)
-                                .map(Load.class::cast)
-                                .toList();
-
-                        final SpinIteration spinIter = new SpinIteration();
-                        spinIter.spinningJumps.addAll(spinningJumps);
-                        spinIter.containedLoads.addAll(loads);
+                        final SpinIteration spinIter = new SpinIteration(iterBody, spinningJumps);
                         spinIterations.add(spinIter);
                     }
                 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
@@ -111,14 +111,14 @@ public class ProverWithTracker implements AutoCloseable {
         }
     }
 
-    private String removeDuplicatedDeclarations(String content) {
-        String output = "";
+    private StringBuilder removeDuplicatedDeclarations(String content) {
+        StringBuilder builder = new StringBuilder();
         for(String line : content.split("\n")) {
             if(line.contains("declare-fun") && !declarations.add(line)) {
                 continue;
             }
-            output += line + "\n";
+            builder.append(line + "\n");
         }
-        return output;
+        return builder;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
@@ -1,0 +1,82 @@
+package com.dat3m.dartagnan.encoding;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collection;
+
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.FormulaManager;
+import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
+import org.sosy_lab.java_smt.api.SolverContext;
+import org.sosy_lab.java_smt.api.SolverException;
+import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
+
+import com.google.common.collect.ImmutableMap;
+
+public class ProverWithTracker implements AutoCloseable {
+    
+    private final FormulaManager fmgr;
+    private final ProverEnvironment prover;
+    private final String fileName;
+    private BooleanFormula enc;
+
+    public ProverWithTracker(SolverContext ctx, String filename, ProverOptions... options) {
+        this.fmgr = ctx.getFormulaManager();
+        this.prover = ctx.newProverEnvironment(options);
+        this.enc = ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
+        this.fileName = filename;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if(!fileName.isEmpty()) {
+            File file = new File(fileName);
+            FileWriter writer;
+            try {
+                writer = new FileWriter(file, true);
+                PrintWriter printer = new PrintWriter(writer);
+                printer.append("(set-logic ALL)\n");
+                printer.append(fmgr.dumpFormula(enc).toString());
+                printer.append("(check-sat)");
+                printer.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }    
+        }
+        prover.close();
+    }
+
+    public void addConstraint(BooleanFormula f) throws InterruptedException {
+        if(!fileName.isEmpty()) {
+            enc = fmgr.getBooleanFormulaManager().and(f, enc);
+        }
+        prover.addConstraint(f);
+    }
+
+    public boolean isUnsatWithAssumptions(Collection<BooleanFormula> f) throws SolverException, InterruptedException {
+        return prover.isUnsatWithAssumptions(f);
+    }
+
+    public boolean isUnsat() throws SolverException, InterruptedException {
+        return prover.isUnsat();
+    }
+
+    public ImmutableMap<String, String> getStatistics() {
+        return prover.getStatistics();
+    }
+
+    public Model getModel() throws SolverException {
+        return prover.getModel();
+    }
+
+    public void push() throws InterruptedException {
+        prover.push();
+    }
+
+    public void pop() {
+        prover.pop();
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
@@ -78,7 +78,9 @@ public class ProverWithTracker implements AutoCloseable {
     }
 
     public boolean isUnsatWithAssumptions(Collection<BooleanFormula> fs) throws SolverException, InterruptedException {
+        long start = System.currentTimeMillis();
         boolean result = prover.isUnsatWithAssumptions(fs);
+        long end = System.currentTimeMillis();
         String resultString = result ? "unsat" : "sat";
         if(dump()) {
             write("(push)\n");
@@ -87,17 +89,21 @@ public class ProverWithTracker implements AutoCloseable {
             }
             write("(set-info :status " + resultString + ")\n");
             write("(check-sat)\n");
+            write("; Original solving time: " + (end - start) + " ms");
             write("(pop)\n");
         }
         return result;
     }
 
     public boolean isUnsat() throws SolverException, InterruptedException {
+        long start = System.currentTimeMillis();
         boolean result = prover.isUnsat();
+        long end = System.currentTimeMillis();
         String resultString = result ? "unsat" : "sat";
         if(dump()) {
             write("(set-info :status " + resultString + ")\n");
             write("(check-sat)\n");
+            write("; Original solving time: " + (end - start) + " ms");
         }
         return result;
     }
@@ -124,7 +130,7 @@ public class ProverWithTracker implements AutoCloseable {
         prover.pop();
     }
 
-    private void write(String content) {
+    public void write(String content) {
         File file = new File(fileName);
         FileWriter writer;
         try {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
@@ -1,18 +1,13 @@
 package com.dat3m.dartagnan.encoding;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.sosy_lab.java_smt.api.*;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
@@ -1,17 +1,18 @@
 package com.dat3m.dartagnan.encoding;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
-
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.FormulaManager;
-import org.sosy_lab.java_smt.api.Model;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
-import org.sosy_lab.java_smt.api.SolverContext;
-import org.sosy_lab.java_smt.api.SolverException;
+import java.util.List;
+import org.sosy_lab.java_smt.api.*;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
 import com.google.common.collect.ImmutableMap;
@@ -21,46 +22,76 @@ public class ProverWithTracker implements AutoCloseable {
     private final FormulaManager fmgr;
     private final ProverEnvironment prover;
     private final String fileName;
-    private BooleanFormula enc;
 
-    public ProverWithTracker(SolverContext ctx, String filename, ProverOptions... options) {
+    public ProverWithTracker(SolverContext ctx, String fileName, ProverOptions... options) {
         this.fmgr = ctx.getFormulaManager();
         this.prover = ctx.newProverEnvironment(options);
-        this.enc = ctx.getFormulaManager().getBooleanFormulaManager().makeTrue();
-        this.fileName = filename;
+        this.fileName = fileName;
+        init();
+    }
+
+    private void init() {
+        try {
+            Files.deleteIfExists(Paths.get(fileName));
+            write("(set-logic ALL)\n");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     public void close() throws Exception {
-        if(!fileName.isEmpty()) {
-            File file = new File(fileName);
-            FileWriter writer;
-            try {
-                writer = new FileWriter(file, true);
-                PrintWriter printer = new PrintWriter(writer);
-                printer.append("(set-logic ALL)\n");
-                printer.append(fmgr.dumpFormula(enc).toString());
-                printer.append("(check-sat)");
-                printer.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }    
-        }
+        removeDuplicatedDeclarations(fileName);
         prover.close();
+    }
+
+    private void removeDuplicatedDeclarations(String fileName) {
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(fileName));
+            List<String> newLines = new ArrayList<>();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // We only skip repeated declarations
+                if (!line.contains("declare-fun") || !newLines.contains(line)) {
+                    newLines.add(line);
+                }
+            }
+            reader.close();
+
+            BufferedWriter writer = new BufferedWriter(new FileWriter(fileName));
+            for (String newLine : newLines) {
+                writer.write(newLine);
+                writer.newLine();
+            }
+            writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     public void addConstraint(BooleanFormula f) throws InterruptedException {
         if(!fileName.isEmpty()) {
-            enc = fmgr.getBooleanFormulaManager().and(f, enc);
+            write(fmgr.dumpFormula(f).toString());
         }
         prover.addConstraint(f);
     }
 
-    public boolean isUnsatWithAssumptions(Collection<BooleanFormula> f) throws SolverException, InterruptedException {
-        return prover.isUnsatWithAssumptions(f);
+    public boolean isUnsatWithAssumptions(Collection<BooleanFormula> fs) throws SolverException, InterruptedException {
+        if(!fileName.isEmpty()) {
+            write("(push)\n");
+            for(BooleanFormula f : fs) {
+                write(fmgr.dumpFormula(f).toString());
+            }
+            write("(check-sat)\n");
+            write("(pop)\n");
+        }
+        return prover.isUnsatWithAssumptions(fs);
     }
 
     public boolean isUnsat() throws SolverException, InterruptedException {
+        if(!fileName.isEmpty()) {
+            write("(check-sat)\n");
+        }
         return prover.isUnsat();
     }
 
@@ -73,10 +104,29 @@ public class ProverWithTracker implements AutoCloseable {
     }
 
     public void push() throws InterruptedException {
+        if(!fileName.isEmpty()) {
+            write("(push)\n");
+        }
         prover.push();
     }
 
     public void pop() {
+        if(!fileName.isEmpty()) {
+            write("(pop)\n");
+        }
         prover.pop();
+    }
+
+    private void write(String content) {
+        File file = new File(fileName);
+        FileWriter writer;
+        try {
+            writer = new FileWriter(file, true);
+            PrintWriter printer = new PrintWriter(writer);
+            printer.append(content);
+            printer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
@@ -55,8 +55,9 @@ public class ProverWithTracker implements AutoCloseable {
             Files.deleteIfExists(Paths.get(fileName));
             write("(set-info :smt-lib-version 2.6)\n");
             write("(set-logic ALL)\n");
-            write("(set-info :category industrial)\n");
+            write("(set-info :category \"industrial\")\n");
             write("(set-info :source |\n" + description + "\n|)\n");
+            write("(set-info :license \"https://creativecommons.org/licenses/by/4.0/\")\n");
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProverWithTracker.java
@@ -38,7 +38,7 @@ public class ProverWithTracker implements ProverEnvironment {
     private boolean dump() {
         return !fileName.isEmpty();
     }
-    
+
     private void init() {
         if(dump()) {
             try {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Expression.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Expression.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.processing.ExpressionInspector;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.collect.ImmutableSet;
 
@@ -40,9 +40,9 @@ public interface Expression {
             }
 
             @Override
-            public Expression visitLocation(Location location) {
-                objects.add(location.getMemoryObject());
-                return location;
+            public Expression visitFinalMemoryValue(FinalMemoryValue val) {
+                objects.add(val.getMemoryObject());
+                return val;
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionKind.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionKind.java
@@ -16,6 +16,7 @@ public interface ExpressionKind {
         NONDET,
         FUNCTION_ADDR,
         MEMORY_ADDR,
+        FINAL_MEM_VAL,
         REGISTER,
         GEP,
         CONSTRUCT,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionVisitor.java
@@ -11,7 +11,7 @@ import com.dat3m.dartagnan.expression.misc.GEPExpr;
 import com.dat3m.dartagnan.expression.misc.ITEExpr;
 import com.dat3m.dartagnan.program.Function;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.misc.NonDetValue;
 
@@ -59,7 +59,7 @@ public interface ExpressionVisitor<TRet> {
     default TRet visitRegister(Register reg) { return visitLeafExpression(reg); }
     default TRet visitFunction(Function function) { return visitLeafExpression(function); }
     default TRet visitMemoryObject(MemoryObject memObj) { return visitLeafExpression(memObj); }
-    default TRet visitLocation(Location loc) { return visitLeafExpression(loc); }
+    default TRet visitFinalMemoryValue(FinalMemoryValue val) { return visitLeafExpression(val); }
     default TRet visitNonDetValue(NonDetValue nonDet) { return visitLeafExpression(nonDet); }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAssertions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAssertions.java
@@ -8,7 +8,7 @@ import com.dat3m.dartagnan.parsers.LitmusAssertionsBaseVisitor;
 import com.dat3m.dartagnan.parsers.LitmusAssertionsLexer;
 import com.dat3m.dartagnan.parsers.LitmusAssertionsParser;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -115,6 +115,6 @@ class VisitorLitmusAssertions extends LitmusAssertionsBaseVisitor<Expression> {
         checkState(base != null, "uninitialized location %s", name);
         TerminalNode offset = ctx.DigitSequence();
         int o = offset == null ? 0 : Integer.parseInt(offset.getText());
-        return right && offset == null ? base : new Location(name, archType, base, o);
+        return right && offset == null ? base : new FinalMemoryValue(name, archType, base, o);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
@@ -27,9 +27,11 @@ public final class Tag {
     public static final String EXCL             = "__EXCL";
     // Marks the event that is reachable IFF a loop has not been fully unrolled.
     public static final String BOUND            = "__BOUND";
-    // Marks jumps that somehow terminate a thread earlier than "normally"
-    // This can be bound events, spinning events, assertion violations, etc.
-    public static final String EARLYTERMINATION = "__EARLYTERMINATION";
+    // Marks jumps that designate an exceptional termination, typically due to assertion failures
+    public static final String EXCEPTIONAL_TERMINATION = "__EXCEPTIONAL_TERMINATION";
+    // Marks jumps that designate non-termination, typically spinloops and bound events
+    // (and control barriers in the future)
+    public static final String NONTERMINATION    = "__NONTERMINATION";
     // Marks jumps that terminate a thread due to spinning behaviour, i.e. side-effect-free loop iterations
     public static final String SPINLOOP         = "__SPINLOOP";
     // Some events should not be optimized (e.g. fake dependencies) or deleted (e.g. bounds)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/FinalMemoryValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/FinalMemoryValue.java
@@ -5,15 +5,17 @@ import com.dat3m.dartagnan.expression.ExpressionVisitor;
 import com.dat3m.dartagnan.expression.Type;
 import com.dat3m.dartagnan.expression.base.LeafExpressionBase;
 
-// TODO: Should be replaced with a Pointer class
-public class Location extends LeafExpressionBase<Type> {
+// TODO: Should work with an arbitrary pointer rather than "base + offset"
+// Represents the final (co-maximal) value at a memory address as if read by a load instruction
+// that observed the final store.
+public class FinalMemoryValue extends LeafExpressionBase<Type> {
 
     private final String name;
     private final MemoryObject base;
     private final int offset;
 
-    public Location(String name, Type type, MemoryObject base, int offset) {
-        super(type);
+    public FinalMemoryValue(String name, Type loadType, MemoryObject base, int offset) {
+        super(loadType);
         this.name = name;
         this.base = base;
         this.offset = offset;
@@ -33,12 +35,12 @@ public class Location extends LeafExpressionBase<Type> {
 
     @Override
     public ExpressionKind getKind() {
-        return ExpressionKind.Other.MEMORY_ADDR;
+        return ExpressionKind.Other.FINAL_MEM_VAL;
     }
 
     @Override
     public <T> T accept(ExpressionVisitor<T> visitor) {
-        return visitor.visitLocation(this);
+        return visitor.visitFinalMemoryValue(this);
     }
 
     @Override
@@ -48,17 +50,12 @@ public class Location extends LeafExpressionBase<Type> {
 
     @Override
     public int hashCode() {
-        return base.hashCode() + offset;
+        return base.hashCode() + 31 * offset;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        Location o = (Location) obj;
-        return base.equals(o.base) && offset == o.offset;
+        return (obj instanceof FinalMemoryValue o) &&
+                base.equals(o.base) && offset == o.offset;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Inlining.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Inlining.java
@@ -88,7 +88,7 @@ public class Inlining implements ProgramProcessor {
             if (depth > bound) {
                 final AbortIf boundEvent = newAbortIf(ExpressionFactory.getInstance().makeTrue());
                 boundEvent.copyAllMetadataFrom(call);
-                boundEvent.addTags(Tag.BOUND, Tag.EARLYTERMINATION, Tag.NOOPT);
+                boundEvent.addTags(Tag.BOUND, Tag.NONTERMINATION, Tag.NOOPT);
                 call.replaceBy(boundEvent);
                 event = boundEvent;
             } else {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Intrinsics.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Intrinsics.java
@@ -901,7 +901,7 @@ public class Intrinsics {
         final Expression condition = expressions.makeFalse();
         final Event assertion = EventFactory.newAssert(condition, errorMsg);
         final Event abort = EventFactory.newAbortIf(expressions.makeTrue());
-        abort.addTags(Tag.EARLYTERMINATION);
+        abort.addTags(Tag.EXCEPTIONAL_TERMINATION);
         return List.of(assertion, abort);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -191,7 +191,7 @@ public class LoopUnrolling implements ProgramProcessor {
         final Event boundEvent = func instanceof Thread thread ?
                 EventFactory.newGoto((Label) thread.getExit()) :
                 EventFactory.newAbortIf(ExpressionFactory.getInstance().makeTrue());
-        boundEvent.addTags(Tag.BOUND, Tag.EARLYTERMINATION, Tag.NOOPT);
+        boundEvent.addTags(Tag.BOUND, Tag.NONTERMINATION, Tag.NOOPT);
         return boundEvent;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveUnusedMemory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveUnusedMemory.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.processing.ExpressionInspector;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.RegReader;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.collect.Sets;
@@ -52,9 +52,9 @@ public class RemoveUnusedMemory implements ProgramProcessor {
         }
 
         @Override
-        public Expression visitLocation(Location location) {
-            memoryObjects.add(location.getMemoryObject());
-            return location;
+        public Expression visitFinalMemoryValue(FinalMemoryValue val) {
+            memoryObjects.add(val.getMemoryObject());
+            return val;
         }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorLKMM.java
@@ -2,10 +2,8 @@ package com.dat3m.dartagnan.program.processing.compilation;
 
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
-import com.dat3m.dartagnan.expression.Type;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.Tag;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/options/BaseOptions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/options/BaseOptions.java
@@ -68,4 +68,11 @@ public abstract class BaseOptions {
     private WitnessType witnessType=WitnessType.getDefault();
 
     public WitnessType getWitnessType() { return witnessType; }
+
+    @Option(
+        name=SMTLIB2,
+        description="Dump encoding to an SMTLIB2 file.")
+    private boolean smtlib=false;
+
+    public boolean getDumpSmtLib() { return smtlib; }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -21,16 +21,16 @@ public class AssumeSolver extends ModelChecker {
     private static final Logger logger = LogManager.getLogger(AssumeSolver.class);
 
     private final SolverContext ctx;
-    private final ProverEnvironment prover;
+    private final ProverWithTracker prover;
     private final VerificationTask task;
 
-    private AssumeSolver(SolverContext c, ProverEnvironment p, VerificationTask t) {
+    private AssumeSolver(SolverContext c, ProverWithTracker p, VerificationTask t) {
         ctx = c;
         prover = p;
         task = t;
     }
 
-    public static AssumeSolver run(SolverContext ctx, ProverEnvironment prover, VerificationTask task)
+    public static AssumeSolver run(SolverContext ctx, ProverWithTracker prover, VerificationTask task)
             throws InterruptedException, SolverException, InvalidConfigurationException {
         AssumeSolver s = new AssumeSolver(ctx, prover, task);
         s.run();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -55,27 +55,27 @@ public class AssumeSolver extends ModelChecker {
         SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context);
 
         logger.info("Starting encoding using " + ctx.getVersion());
-        prover.write("; Program encoding");
+        prover.writeComment("Program encoding");
         prover.addConstraint(programEncoder.encodeFullProgram());
-        prover.write("; Memory model encoding");
+        prover.writeComment("Memory model encoding");
         prover.addConstraint(wmmEncoder.encodeFullMemoryModel());
         // For validation this contains information.
         // For verification graph.encode() just returns ctx.mkTrue()
-        prover.write("; Witness encoding");
+        prover.writeComment("Witness encoding");
         prover.addConstraint(task.getWitness().encode(context));
-        prover.write("; Symmetry breaking encoding");
+        prover.writeComment("Symmetry breaking encoding");
         prover.addConstraint(symmetryEncoder.encodeFullSymmetryBreaking());
 
         BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
         BooleanFormula assumptionLiteral = bmgr.makeVariable("DAT3M_spec_assumption");
         BooleanFormula propertyEncoding = propertyEncoder.encodeProperties(task.getProperty());
         BooleanFormula assumedSpec = bmgr.implication(assumptionLiteral, propertyEncoding);
-        prover.write("; Property encoding");
+        prover.writeComment("Property encoding");
         prover.addConstraint(assumedSpec);
         
         logger.info("Starting first solver.check()");
         if(prover.isUnsatWithAssumptions(singletonList(assumptionLiteral))) {
-            prover.write("; Bound encoding");
+            prover.writeComment("Bound encoding");
 			prover.addConstraint(propertyEncoder.encodeBoundEventExec());
             logger.info("Starting second solver.check()");
             res = prover.isUnsat()? PASS : Result.UNKNOWN;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
@@ -9,7 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverException;
 
@@ -25,16 +25,16 @@ public class DataRaceSolver extends ModelChecker {
     private static final Logger logger = LogManager.getLogger(DataRaceSolver.class);
 
 	private final SolverContext ctx;
-	private final ProverEnvironment prover;
+	private final ProverWithTracker prover;
 	private final VerificationTask task;
 
-	private DataRaceSolver(SolverContext c, ProverEnvironment p, VerificationTask t) {
+	private DataRaceSolver(SolverContext c, ProverWithTracker p, VerificationTask t) {
 		ctx = c;
 		prover = p;
 		task = t;
 	}
 
-	public static DataRaceSolver run(SolverContext ctx, ProverEnvironment prover, VerificationTask task)
+	public static DataRaceSolver run(SolverContext ctx, ProverWithTracker prover, VerificationTask task)
 			throws InterruptedException, SolverException, InvalidConfigurationException {
 		DataRaceSolver s = new DataRaceSolver(ctx, prover, task);
 		s.run();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
@@ -59,16 +59,20 @@ public class DataRaceSolver extends ModelChecker {
 		SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context);
 
         logger.info("Starting encoding using " + ctx.getVersion());
+        prover.write("; Program encoding");
 		prover.addConstraint(programEncoder.encodeFullProgram());
+        prover.write("; Memory model encoding");
 		prover.addConstraint(wmmEncoder.encodeFullMemoryModel());
+        prover.write("; Symmetry breaking encoding");
 		prover.addConstraint(symmetryEncoder.encodeFullSymmetryBreaking());
 		prover.push();
-
+        prover.write("; Property encoding");
 		prover.addConstraint(propertyEncoder.encodeProperties(EnumSet.of(Property.DATARACEFREEDOM)));
 
 		logger.info("Starting first solver.check()");
 		if(prover.isUnsat()) {
 			prover.pop();
+            prover.write("; Bound encoding");
 			prover.addConstraint(propertyEncoder.encodeBoundEventExec());
 			logger.info("Starting second solver.check()");
 			res = prover.isUnsat() ? PASS : UNKNOWN;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/DataRaceSolver.java
@@ -18,67 +18,67 @@ import java.util.EnumSet;
 import static com.dat3m.dartagnan.utils.Result.*;
 
 public class DataRaceSolver extends ModelChecker {
-	
-	// This analysis assumes that CAT file defining the memory model has a happens-before 
-	// relation named hb: it should contain the following axiom "acyclic hb"
+
+    // This analysis assumes that CAT file defining the memory model has a happens-before
+    // relation named hb: it should contain the following axiom "acyclic hb"
 
     private static final Logger logger = LogManager.getLogger(DataRaceSolver.class);
 
-	private final SolverContext ctx;
-	private final ProverWithTracker prover;
-	private final VerificationTask task;
+    private final SolverContext ctx;
+    private final ProverWithTracker prover;
+    private final VerificationTask task;
 
-	private DataRaceSolver(SolverContext c, ProverWithTracker p, VerificationTask t) {
-		ctx = c;
-		prover = p;
-		task = t;
-	}
+    private DataRaceSolver(SolverContext c, ProverWithTracker p, VerificationTask t) {
+        ctx = c;
+        prover = p;
+        task = t;
+    }
 
-	public static DataRaceSolver run(SolverContext ctx, ProverWithTracker prover, VerificationTask task)
-			throws InterruptedException, SolverException, InvalidConfigurationException {
-		DataRaceSolver s = new DataRaceSolver(ctx, prover, task);
-		s.run();
-		return s;
-	}
+    public static DataRaceSolver run(SolverContext ctx, ProverWithTracker prover, VerificationTask task)
+            throws InterruptedException, SolverException, InvalidConfigurationException {
+        DataRaceSolver s = new DataRaceSolver(ctx, prover, task);
+        s.run();
+        return s;
+    }
 
-	private void run() throws InterruptedException, SolverException, InvalidConfigurationException {
-		Wmm memoryModel = task.getMemoryModel();
-		Context analysisContext = Context.create();
-		Configuration config = task.getConfig();
+    private void run() throws InterruptedException, SolverException, InvalidConfigurationException {
+        Wmm memoryModel = task.getMemoryModel();
+        Context analysisContext = Context.create();
+        Configuration config = task.getConfig();
 
-		memoryModel.configureAll(config);
-		preprocessProgram(task, config);
-		preprocessMemoryModel(task, config);
-		performStaticProgramAnalyses(task, analysisContext, config);
-		performStaticWmmAnalyses(task, analysisContext, config);
+        memoryModel.configureAll(config);
+        preprocessProgram(task, config);
+        preprocessMemoryModel(task, config);
+        performStaticProgramAnalyses(task, analysisContext, config);
+        performStaticWmmAnalyses(task, analysisContext, config);
 
-		context = EncodingContext.of(task, analysisContext, ctx.getFormulaManager());
-		ProgramEncoder programEncoder = ProgramEncoder.withContext(context);
-		PropertyEncoder propertyEncoder = PropertyEncoder.withContext(context);
-		WmmEncoder wmmEncoder = WmmEncoder.withContext(context);
-		SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context);
+        context = EncodingContext.of(task, analysisContext, ctx.getFormulaManager());
+        ProgramEncoder programEncoder = ProgramEncoder.withContext(context);
+        PropertyEncoder propertyEncoder = PropertyEncoder.withContext(context);
+        WmmEncoder wmmEncoder = WmmEncoder.withContext(context);
+        SymmetryEncoder symmetryEncoder = SymmetryEncoder.withContext(context);
 
         logger.info("Starting encoding using " + ctx.getVersion());
-        prover.write("; Program encoding");
-		prover.addConstraint(programEncoder.encodeFullProgram());
-        prover.write("; Memory model encoding");
-		prover.addConstraint(wmmEncoder.encodeFullMemoryModel());
-        prover.write("; Symmetry breaking encoding");
-		prover.addConstraint(symmetryEncoder.encodeFullSymmetryBreaking());
-		prover.push();
-        prover.write("; Property encoding");
-		prover.addConstraint(propertyEncoder.encodeProperties(EnumSet.of(Property.DATARACEFREEDOM)));
+        prover.writeComment("Program encoding");
+        prover.addConstraint(programEncoder.encodeFullProgram());
+        prover.writeComment("Memory model encoding");
+        prover.addConstraint(wmmEncoder.encodeFullMemoryModel());
+        prover.writeComment("Symmetry breaking encoding");
+        prover.addConstraint(symmetryEncoder.encodeFullSymmetryBreaking());
+        prover.push();
+        prover.writeComment("Property encoding");
+        prover.addConstraint(propertyEncoder.encodeProperties(EnumSet.of(Property.DATARACEFREEDOM)));
 
-		logger.info("Starting first solver.check()");
-		if(prover.isUnsat()) {
-			prover.pop();
-            prover.write("; Bound encoding");
-			prover.addConstraint(propertyEncoder.encodeBoundEventExec());
-			logger.info("Starting second solver.check()");
-			res = prover.isUnsat() ? PASS : UNKNOWN;
-		} else {
-			res = FAIL;
-		}
+        logger.info("Starting first solver.check()");
+        if (prover.isUnsat()) {
+            prover.pop();
+            prover.writeComment("Bound encoding");
+            prover.addConstraint(propertyEncoder.encodeBoundEventExec());
+            logger.info("Starting second solver.check()");
+            res = prover.isUnsat() ? PASS : UNKNOWN;
+        } else {
+            res = FAIL;
+        }
 
         logger.info("Verification finished with result " + res);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.verification.solving;
 
 import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.encoding.WmmEncoder;
 import com.dat3m.dartagnan.exception.UnsatisfiedRequirementException;
 import com.dat3m.dartagnan.program.Program;
@@ -21,7 +22,6 @@ import com.dat3m.dartagnan.wmm.processing.WmmProcessingManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.api.Model;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverException;
 
 import java.util.Optional;
@@ -109,7 +109,7 @@ public abstract class ModelChecker {
         analysisContext.register(RelationAnalysis.class, RelationAnalysis.fromConfig(task, analysisContext, config));
     }
 
-    protected void saveFlaggedPairsOutput(Wmm wmm, WmmEncoder encoder, ProverEnvironment prover, EncodingContext ctx, Program program) throws SolverException {
+    protected void saveFlaggedPairsOutput(Wmm wmm, WmmEncoder encoder, ProverWithTracker prover, EncodingContext ctx, Program program) throws SolverException {
         if (!ctx.getTask().getProperty().contains(CAT_SPEC)) {
             return;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.verification.solving;
 
 import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.encoding.WmmEncoder;
 import com.dat3m.dartagnan.exception.UnsatisfiedRequirementException;
 import com.dat3m.dartagnan.program.Program;
@@ -22,6 +21,7 @@ import com.dat3m.dartagnan.wmm.processing.WmmProcessingManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverException;
 
 import java.util.Optional;
@@ -109,7 +109,7 @@ public abstract class ModelChecker {
         analysisContext.register(RelationAnalysis.class, RelationAnalysis.fromConfig(task, analysisContext, config));
     }
 
-    protected void saveFlaggedPairsOutput(Wmm wmm, WmmEncoder encoder, ProverWithTracker prover, EncodingContext ctx, Program program) throws SolverException {
+    protected void saveFlaggedPairsOutput(Wmm wmm, WmmEncoder encoder, ProverEnvironment prover, EncodingContext ctx, Program program) throws SolverException {
         if (!ctx.getTask().getProperty().contains(CAT_SPEC)) {
             return;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -224,8 +224,11 @@ public class RefinementSolver extends ModelChecker {
         final Property.Type propertyType = Property.getCombinedType(task.getProperty(), task);
 
         logger.info("Starting encoding using " + ctx.getVersion());
+        prover.write("; Program encoding");
         prover.addConstraint(programEncoder.encodeFullProgram());
+        prover.write("; Memory model (baseline) encoding");
         prover.addConstraint(baselineEncoder.encodeFullMemoryModel());
+        prover.write("; Symmetry breaking encoding");
         prover.addConstraint(symmetryEncoder.encodeFullSymmetryBreaking());
 
         // ------------------------ Solving ------------------------
@@ -233,6 +236,7 @@ public class RefinementSolver extends ModelChecker {
 
         logger.info("Checking target property.");
         prover.push();
+        prover.write("; Property encoding");
         prover.addConstraint(propertyEncoder.encodeProperties(task.getProperty()));
 
         final RefinementTrace propertyTrace = runRefinement(task, prover, solver, refiner);
@@ -265,8 +269,10 @@ public class RefinementSolver extends ModelChecker {
             logger.info("Checking unrolling bounds.");
             final long lastTime = System.currentTimeMillis();
             prover.pop();
+            prover.write("; Bound encoding");
             prover.addConstraint(propertyEncoder.encodeBoundEventExec());
             // Add back the refinement clauses we already found, hoping that this improves the performance.
+            prover.write("; Refinement encoding");
             prover.addConstraint(bmgr.and(propertyTrace.getRefinementFormulas()));
             final RefinementTrace boundTrace = runRefinement(task, prover, solver, refiner);
             boundCheckTime = System.currentTimeMillis() - lastTime;
@@ -455,6 +461,7 @@ public class RefinementSolver extends ModelChecker {
                 inconsistencyReasons = solverResult.getCoreReasons();
                 lastTime = System.currentTimeMillis();
                 refinementFormula = refiner.refine(inconsistencyReasons, context);
+                prover.write("; Refinement encoding");
                 prover.addConstraint(refinementFormula);
                 refineTime = (System.currentTimeMillis() - lastTime);
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -162,7 +162,7 @@ public class RefinementSolver extends ModelChecker {
     //TODO: We do not yet use Witness information. The problem is that WitnessGraph.encode() generates
     // constraints on hb, which is not encoded in Refinement.
     //TODO (2): Add possibility for Refinement to handle CAT-properties (it ignores them for now).
-    public static RefinementSolver run(SolverContext ctx, ProverEnvironment prover, VerificationTask task)
+    public static RefinementSolver run(SolverContext ctx, ProverWithTracker prover, VerificationTask task)
             throws InterruptedException, SolverException, InvalidConfigurationException {
         RefinementSolver solver = new RefinementSolver();
         task.getConfig().inject(solver);
@@ -171,7 +171,7 @@ public class RefinementSolver extends ModelChecker {
         return solver;
     }
 
-    private void runInternal(SolverContext ctx, ProverEnvironment prover, VerificationTask task)
+    private void runInternal(SolverContext ctx, ProverWithTracker prover, VerificationTask task)
             throws InterruptedException, SolverException, InvalidConfigurationException {
         final Program program = task.getProgram();
         final Wmm memoryModel = task.getMemoryModel();
@@ -358,7 +358,7 @@ public class RefinementSolver extends ModelChecker {
     // Refinement core algorithm
 
     // TODO: We could expose the following method(s) to allow for more general application of refinement.
-    private RefinementTrace runRefinement(VerificationTask task, ProverEnvironment prover, WMMSolver solver, Refiner refiner)
+    private RefinementTrace runRefinement(VerificationTask task, ProverWithTracker prover, WMMSolver solver, Refiner refiner)
             throws SolverException, InterruptedException {
 
         final List<RefinementIteration> trace = new ArrayList<>();
@@ -418,7 +418,7 @@ public class RefinementSolver extends ModelChecker {
         return !last.inconsistencyReasons.equals(prev.inconsistencyReasons);
     }
 
-    private RefinementIteration doRefinementIteration(ProverEnvironment prover, WMMSolver solver, Refiner refiner)
+    private RefinementIteration doRefinementIteration(ProverWithTracker prover, WMMSolver solver, Refiner refiner)
             throws SolverException, InterruptedException {
 
         long nativeTime = 0;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -469,6 +469,13 @@ public class RefinementSolver extends ModelChecker {
     // ================================================================================================================
     // Special memory model processing
 
+    private static boolean isUnknownDefinitionForCAAT(Definition def) {
+        // TODO: We should probably automatically cut all "unknown relation",
+        //  i.e., use a white-list of known relations instead of a blacklist of unknown one's.
+        return def instanceof LinuxCriticalSections // LKMM
+                || def instanceof SyncFence || def instanceof SyncBar || def instanceof SameVirtualLocation; // GPUs
+    }
+
     private static RefinementModel generateRefinementModel(Wmm original) {
         // We cut (i) negated axioms, (ii) negated relations (if derived),
         // and (iii) some special relations because they are derived from internal relations (like data/addr/ctrl)
@@ -492,7 +499,7 @@ public class RefinementSolver extends ModelChecker {
             } else if (c instanceof Definition def && def.getDefinedRelation().hasName()) {
                 // (iii) Special relations
                 final String name = def.getDefinedRelation().getName().get();
-                if (name.equals(DATA) || name.equals(CTRL) || name.equals(ADDR) || name.equals(CRIT)) {
+                if (name.equals(DATA) || name.equals(CTRL) || name.equals(ADDR) || isUnknownDefinitionForCAAT(def)) {
                     constraintsToCut.add(c);
                 }
             } else if (c instanceof Definition def && def instanceof Fences) {
@@ -516,7 +523,8 @@ public class RefinementSolver extends ModelChecker {
                     memoryModel.getOrCreatePredefinedRelation(POLOC),
                     rf,
                     memoryModel.getOrCreatePredefinedRelation(CO),
-                    memoryModel.getOrCreatePredefinedRelation(FR)))));
+                    memoryModel.getOrCreatePredefinedRelation(FR)
+            ))));
         }
         if (biases.contains(Baseline.NO_OOTA)) {
             // ---- acyclic (dep | rf) ----
@@ -524,7 +532,8 @@ public class RefinementSolver extends ModelChecker {
                     memoryModel.getOrCreatePredefinedRelation(CTRL),
                     memoryModel.getOrCreatePredefinedRelation(DATA),
                     memoryModel.getOrCreatePredefinedRelation(ADDR),
-                    rf))));
+                    rf)
+            )));
         }
         if (biases.contains(Baseline.ATOMIC_RMW)) {
             // ---- empty (rmw & fre;coe) ----

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -224,11 +224,11 @@ public class RefinementSolver extends ModelChecker {
         final Property.Type propertyType = Property.getCombinedType(task.getProperty(), task);
 
         logger.info("Starting encoding using " + ctx.getVersion());
-        prover.write("; Program encoding");
+        prover.writeComment("Program encoding");
         prover.addConstraint(programEncoder.encodeFullProgram());
-        prover.write("; Memory model (baseline) encoding");
+        prover.writeComment("Memory model (baseline) encoding");
         prover.addConstraint(baselineEncoder.encodeFullMemoryModel());
-        prover.write("; Symmetry breaking encoding");
+        prover.writeComment("Symmetry breaking encoding");
         prover.addConstraint(symmetryEncoder.encodeFullSymmetryBreaking());
 
         // ------------------------ Solving ------------------------
@@ -236,7 +236,7 @@ public class RefinementSolver extends ModelChecker {
 
         logger.info("Checking target property.");
         prover.push();
-        prover.write("; Property encoding");
+        prover.writeComment("Property encoding");
         prover.addConstraint(propertyEncoder.encodeProperties(task.getProperty()));
 
         final RefinementTrace propertyTrace = runRefinement(task, prover, solver, refiner);
@@ -269,10 +269,10 @@ public class RefinementSolver extends ModelChecker {
             logger.info("Checking unrolling bounds.");
             final long lastTime = System.currentTimeMillis();
             prover.pop();
-            prover.write("; Bound encoding");
+            prover.writeComment("Bound encoding");
             prover.addConstraint(propertyEncoder.encodeBoundEventExec());
             // Add back the refinement clauses we already found, hoping that this improves the performance.
-            prover.write("; Refinement encoding");
+            prover.writeComment("Refinement encoding");
             prover.addConstraint(bmgr.and(propertyTrace.getRefinementFormulas()));
             final RefinementTrace boundTrace = runRefinement(task, prover, solver, refiner);
             boundCheckTime = System.currentTimeMillis() - lastTime;
@@ -461,7 +461,7 @@ public class RefinementSolver extends ModelChecker {
                 inconsistencyReasons = solverResult.getCoreReasons();
                 lastTime = System.currentTimeMillis();
                 refinementFormula = refiner.refine(inconsistencyReasons, context);
-                prover.write("; Refinement encoding");
+                prover.writeComment("Refinement encoding");
                 prover.addConstraint(refinementFormula);
                 refineTime = (System.currentTimeMillis() - lastTime);
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.witness.graphml;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.expression.booleans.BoolLiteral;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
@@ -17,6 +16,7 @@ import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverException;
 
 import java.io.File;
@@ -40,7 +40,7 @@ import static java.lang.String.valueOf;
 public class WitnessBuilder {
 
     private final EncodingContext context;
-    private final ProverWithTracker prover;
+    private final ProverEnvironment prover;
     private final String type;
     private final String ltlProperty;
 
@@ -60,14 +60,14 @@ public class WitnessBuilder {
 
     private final Map<Event, Integer> eventThreadMap = new HashMap<>();
 
-    private WitnessBuilder(EncodingContext c, ProverWithTracker p, Result r, String summary) {
+    private WitnessBuilder(EncodingContext c, ProverEnvironment p, Result r, String summary) {
         context = checkNotNull(c);
         prover = checkNotNull(p);
         type = r.equals(FAIL) ? "violation" : "correctness";
         ltlProperty = getLtlPropertyFromSummary(summary);
     }
 
-    public static WitnessBuilder of(EncodingContext context, ProverWithTracker prover, Result result,
+    public static WitnessBuilder of(EncodingContext context, ProverEnvironment prover, Result result,
             String ltlProperty) throws InvalidConfigurationException {
         WitnessBuilder b = new WitnessBuilder(context, prover, result, ltlProperty);
         context.getTask().getConfig().inject(b);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.witness.graphml;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.expression.booleans.BoolLiteral;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
@@ -16,7 +17,6 @@ import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 import org.sosy_lab.java_smt.api.Model;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverException;
 
 import java.io.File;
@@ -40,7 +40,7 @@ import static java.lang.String.valueOf;
 public class WitnessBuilder {
 
     private final EncodingContext context;
-    private final ProverEnvironment prover;
+    private final ProverWithTracker prover;
     private final String type;
     private final String ltlProperty;
 
@@ -60,14 +60,14 @@ public class WitnessBuilder {
 
     private final Map<Event, Integer> eventThreadMap = new HashMap<>();
 
-    private WitnessBuilder(EncodingContext c, ProverEnvironment p, Result r, String summary) {
+    private WitnessBuilder(EncodingContext c, ProverWithTracker p, Result r, String summary) {
         context = checkNotNull(c);
         prover = checkNotNull(p);
         type = r.equals(FAIL) ? "violation" : "correctness";
         ltlProperty = getLtlPropertyFromSummary(summary);
     }
 
-    public static WitnessBuilder of(EncodingContext context, ProverEnvironment prover, Result result,
+    public static WitnessBuilder of(EncodingContext context, ProverWithTracker prover, Result result,
             String ltlProperty) throws InvalidConfigurationException {
         WitnessBuilder b = new WitnessBuilder(context, prover, result, ltlProperty);
         context.getTask().getConfig().inject(b);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Assumption.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Assumption.java
@@ -1,20 +1,14 @@
 package com.dat3m.dartagnan.wmm;
 
-import com.dat3m.dartagnan.verification.Context;
-import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.utils.EventGraph;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Map;
 import java.util.Set;
 
-import static com.dat3m.dartagnan.wmm.utils.EventGraph.difference;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class Assumption implements Constraint {
-
-    private static final Logger logger = LogManager.getLogger(Assumption.class);
 
     private final Relation rel;
     private final EventGraph may;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Constraint.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Constraint.java
@@ -3,7 +3,6 @@ package com.dat3m.dartagnan.wmm;
 import com.dat3m.dartagnan.encoding.EncodingContext;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
-import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.axiom.*;
 import com.dat3m.dartagnan.wmm.definition.*;
 import com.dat3m.dartagnan.wmm.utils.EventGraph;

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/c/AbstractCTest.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan.c;
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.OptionNames;
 import com.dat3m.dartagnan.configuration.Property;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.rules.Provider;
@@ -17,7 +18,6 @@ import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.util.EnumSet;
@@ -84,7 +84,7 @@ public abstract class AbstractCTest {
     protected final Provider<Configuration> configurationProvider = getConfigurationProvider();
     protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, configurationProvider);
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider, solverProvider);
-    protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);
+    protected final Provider<ProverWithTracker> proverProvider = Providers.createProverWithFixedOptions(contextProvider, SolverContext.ProverOptions.GENERATE_MODELS);
 
     // Special rules
     protected final Timeout timeout = Timeout.millis(getTimeout());

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -20,7 +20,6 @@ import org.junit.rules.Timeout;
 import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/compilation/AbstractCompilationTest.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.compilation;
 
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.Property;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -99,8 +100,8 @@ public abstract class AbstractCompilationTest {
     protected final Provider<VerificationTask> task2Provider = Providers.createTask(program2Provider, wmm2Provider, propertyProvider, targetProvider,  () -> 1, configProvider);
     protected final Provider<SolverContext> context1Provider = Providers.createSolverContextFromManager(shutdownManagerProvider, () -> Solvers.Z3);
     protected final Provider<SolverContext> context2Provider = Providers.createSolverContextFromManager(shutdownManagerProvider, () -> Solvers.Z3);
-    protected final Provider<ProverEnvironment> prover1Provider = Providers.createProverWithFixedOptions(context1Provider, ProverOptions.GENERATE_MODELS);
-    protected final Provider<ProverEnvironment> prover2Provider = Providers.createProverWithFixedOptions(context2Provider, ProverOptions.GENERATE_MODELS);
+    protected final Provider<ProverWithTracker> prover1Provider = Providers.createProverWithFixedOptions(context1Provider, ProverOptions.GENERATE_MODELS);
+    protected final Provider<ProverWithTracker> prover2Provider = Providers.createProverWithFixedOptions(context2Provider, ProverOptions.GENERATE_MODELS);
     
     private final Timeout timeout = Timeout.millis(getTimeout());
     private final RequestShutdownOnError shutdownOnError = RequestShutdownOnError.create(shutdownManagerProvider);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.litmus;
 
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.Property;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.ResourceHelper;
 import com.dat3m.dartagnan.utils.Result;
@@ -19,7 +20,6 @@ import org.junit.rules.Timeout;
 import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
@@ -110,8 +110,8 @@ public abstract class AbstractLitmusTest {
     protected final Provider<Configuration> configProvider = getConfigurationProvider();
     protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, targetProvider, boundProvider, configProvider);
     protected final Provider<SolverContext> contextProvider = Providers.createSolverContextFromManager(shutdownManagerProvider, () -> Solvers.Z3);
-    protected final Provider<ProverEnvironment> proverProvider = Providers.createProverWithFixedOptions(contextProvider, ProverOptions.GENERATE_MODELS);
-    protected final Provider<ProverEnvironment> prover2Provider = Providers.createProverWithFixedOptions(contextProvider, ProverOptions.GENERATE_MODELS);
+    protected final Provider<ProverWithTracker> proverProvider = Providers.createProverWithFixedOptions(contextProvider, ProverOptions.GENERATE_MODELS);
+    protected final Provider<ProverWithTracker> prover2Provider = Providers.createProverWithFixedOptions(contextProvider, ProverOptions.GENERATE_MODELS);
 
     private final Timeout timeout = Timeout.millis(getTimeout());
     private final RequestShutdownOnError shutdownOnError = RequestShutdownOnError.create(shutdownManagerProvider);

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/ArrayValidTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/ArrayValidTest.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.miscellaneous;
 
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.Property;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
@@ -12,7 +13,6 @@ import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
@@ -56,7 +56,7 @@ public class ArrayValidTest {
     @Test
     public void test() {
         try (SolverContext ctx = TestHelper.createContext();
-             ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+             ProverWithTracker prover = new ProverWithTracker(ctx, "", ProverOptions.GENERATE_MODELS)) {
             Program program = new ProgramParser().parse(new File(path));
             VerificationTask task = VerificationTask.builder()
                     .withSolverTimeout(60)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/BranchTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/BranchTest.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.miscellaneous;
 
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.Property;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
@@ -14,7 +15,6 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
@@ -95,7 +95,7 @@ public class BranchTest {
     @Test
     public void test() {
         try (SolverContext ctx = TestHelper.createContext();
-             ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+              ProverWithTracker prover = new ProverWithTracker(ctx, "", ProverOptions.GENERATE_MODELS)) {
             Program program = new ProgramParser().parse(new File(path));
             VerificationTask task = VerificationTask.builder()
                     .withSolverTimeout(60)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvAssertionsTest.java
@@ -28,8 +28,7 @@ import java.util.EnumSet;
 import static com.dat3m.dartagnan.configuration.Property.PROGRAM_SPEC;
 import static com.dat3m.dartagnan.utils.ResourceHelper.getRootPath;
 import static com.dat3m.dartagnan.utils.ResourceHelper.getTestResourcePath;
-import static com.dat3m.dartagnan.utils.Result.FAIL;
-import static com.dat3m.dartagnan.utils.Result.PASS;
+import static com.dat3m.dartagnan.utils.Result.*;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
@@ -79,30 +78,23 @@ public class SpirvAssertionsTest {
                 {"builtin-all-321.spv.dis", 1, PASS},
                 {"branch-cond-ff.spv.dis", 1, PASS},
                 {"branch-cond-ff-inverted.spv.dis", 1, PASS},
-                {"branch-cond-bf.spv.dis", 1, FAIL},
+                {"branch-cond-bf.spv.dis", 1, UNKNOWN},
                 {"branch-cond-bf.spv.dis", 2, PASS},
-                {"branch-cond-bf.spv.dis", 3, PASS},
-                {"branch-cond-fb.spv.dis", 1, FAIL},
+                {"branch-cond-fb.spv.dis", 1, UNKNOWN},
                 {"branch-cond-fb.spv.dis", 2, PASS},
-                {"branch-cond-fb.spv.dis", 3, PASS},
                 {"branch-cond-struct.spv.dis", 1, PASS},
                 {"branch-cond-struct-read-write.spv.dis", 1, PASS},
                 {"branch-race.spv.dis", 1, PASS},
-                {"branch-loop.spv.dis", 2, FAIL},
+                {"branch-loop.spv.dis", 2, UNKNOWN},
                 {"branch-loop.spv.dis", 3, PASS},
-                {"branch-loop.spv.dis", 4, PASS},
-                {"loop-struct-cond.spv.dis", 1, FAIL},
+                {"loop-struct-cond.spv.dis", 1, UNKNOWN},
                 {"loop-struct-cond.spv.dis", 2, PASS},
-                {"loop-struct-cond.spv.dis", 3, PASS},
-                {"loop-struct-cond-suffix.spv.dis", 1, FAIL},
+                {"loop-struct-cond-suffix.spv.dis", 1, UNKNOWN},
                 {"loop-struct-cond-suffix.spv.dis", 2, PASS},
-                {"loop-struct-cond-suffix.spv.dis", 3, PASS},
-                {"loop-struct-cond-sequence.spv.dis", 2, FAIL},
+                {"loop-struct-cond-sequence.spv.dis", 2, UNKNOWN},
                 {"loop-struct-cond-sequence.spv.dis", 3, PASS},
-                {"loop-struct-cond-sequence.spv.dis", 4, PASS},
-                {"loop-struct-cond-nested.spv.dis", 2, FAIL},
+                {"loop-struct-cond-nested.spv.dis", 2, UNKNOWN},
                 {"loop-struct-cond-nested.spv.dis", 3, PASS},
-                {"loop-struct-cond-nested.spv.dis", 4, PASS},
                 {"phi.spv.dis", 1, PASS},
                 {"phi-unstruct-true.spv.dis", 1, PASS},
                 {"phi-unstruct-false.spv.dis", 1, PASS},

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvAssertionsTest.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.spirv.basic;
 
 import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
@@ -17,7 +18,6 @@ import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.io.File;
@@ -113,13 +113,14 @@ public class SpirvAssertionsTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
-            assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
+             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
         }
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }
     }
+
 
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
@@ -130,8 +131,8 @@ public class SpirvAssertionsTest {
                 SolverContextFactory.Solvers.Z3);
     }
 
-    private ProverEnvironment mkProver(SolverContext ctx) {
-        return ctx.newProverEnvironment(SolverContext.ProverOptions.GENERATE_MODELS);
+    private ProverWithTracker mkProver(SolverContext ctx) {
+        return new ProverWithTracker(ctx, "", SolverContext.ProverOptions.GENERATE_MODELS);
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvAssertionsTest.java
@@ -121,8 +121,6 @@ public class SpirvAssertionsTest {
         }
     }
 
-
-
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
         return SolverContextFactory.createSolverContext(

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvAssertionsTest.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.AssumeSolver;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -120,10 +121,9 @@ public class SpirvAssertionsTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        /* TODO: Implementation
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
-        }*/
+        }
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvAssertionsTest.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.AssumeSolver;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -113,10 +114,9 @@ public class SpirvAssertionsTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        /* TODO: Implementation
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
              assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
-        }*/
+        }
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvAssertionsTest.java
@@ -122,8 +122,6 @@ public class SpirvAssertionsTest {
         }
     }
 
-
-
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
         return SolverContextFactory.createSolverContext(

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvAssertionsTest.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.spirv.benchmarks;
 
 import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
@@ -17,7 +18,6 @@ import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.io.File;
@@ -114,13 +114,14 @@ public class SpirvAssertionsTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
              assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
         }
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }
     }
+
 
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
@@ -131,8 +132,8 @@ public class SpirvAssertionsTest {
                 SolverContextFactory.Solvers.Z3);
     }
 
-    private ProverEnvironment mkProver(SolverContext ctx) {
-        return ctx.newProverEnvironment(SolverContext.ProverOptions.GENERATE_MODELS);
+    private ProverWithTracker mkProver(SolverContext ctx) {
+        return new ProverWithTracker(ctx, "", SolverContext.ProverOptions.GENERATE_MODELS);
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvChecksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvChecksTest.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.AssumeSolver;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -117,10 +118,9 @@ public class SpirvChecksTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        /* TODO: Implementation
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
-        }*/
+        }
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvChecksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvChecksTest.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.spirv.benchmarks;
 
 import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
@@ -17,7 +18,6 @@ import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.io.File;
@@ -118,13 +118,14 @@ public class SpirvChecksTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
-            assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
+             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
         }
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }
     }
+
 
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
@@ -135,8 +136,8 @@ public class SpirvChecksTest {
                 SolverContextFactory.Solvers.Z3);
     }
 
-    private ProverEnvironment mkProver(SolverContext ctx) {
-        return ctx.newProverEnvironment(SolverContext.ProverOptions.GENERATE_MODELS);
+    private ProverWithTracker mkProver(SolverContext ctx) {
+        return new ProverWithTracker(ctx, "", SolverContext.ProverOptions.GENERATE_MODELS);
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvChecksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvChecksTest.java
@@ -126,8 +126,6 @@ public class SpirvChecksTest {
         }
     }
 
-
-
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
         return SolverContextFactory.createSolverContext(

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvRacesTest.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.AssumeSolver;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -118,10 +119,9 @@ public class SpirvRacesTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        /* TODO: Implementation
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
-        }*/
+        }
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvRacesTest.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.spirv.benchmarks;
 
 import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
@@ -17,7 +18,6 @@ import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.io.File;
@@ -119,13 +119,14 @@ public class SpirvRacesTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
-            assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
+             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
         }
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }
     }
+
 
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
@@ -136,8 +137,8 @@ public class SpirvRacesTest {
                 SolverContextFactory.Solvers.Z3);
     }
 
-    private ProverEnvironment mkProver(SolverContext ctx) {
-        return ctx.newProverEnvironment(SolverContext.ProverOptions.GENERATE_MODELS);
+    private ProverWithTracker mkProver(SolverContext ctx) {
+        return new ProverWithTracker(ctx, "", SolverContext.ProverOptions.GENERATE_MODELS);
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/benchmarks/SpirvRacesTest.java
@@ -127,8 +127,6 @@ public class SpirvRacesTest {
         }
     }
 
-
-
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
         return SolverContextFactory.createSolverContext(

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvChecksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvChecksTest.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.AssumeSolver;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -345,10 +346,9 @@ public class SpirvChecksTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        /* TODO: Implementation
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
-        }*/
+        }
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvChecksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvChecksTest.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.spirv.gpuverify;
 
 import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
@@ -17,7 +18,6 @@ import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.io.File;
@@ -346,13 +346,14 @@ public class SpirvChecksTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
-            assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
+             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
         }
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }
     }
+
 
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
@@ -363,8 +364,8 @@ public class SpirvChecksTest {
                 SolverContextFactory.Solvers.Z3);
     }
 
-    private ProverEnvironment mkProver(SolverContext ctx) {
-        return ctx.newProverEnvironment(SolverContext.ProverOptions.GENERATE_MODELS);
+    private ProverWithTracker mkProver(SolverContext ctx) {
+        return new ProverWithTracker(ctx, "", SolverContext.ProverOptions.GENERATE_MODELS);
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvChecksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvChecksTest.java
@@ -354,8 +354,6 @@ public class SpirvChecksTest {
         }
     }
 
-
-
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
         return SolverContextFactory.createSolverContext(

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvRacesTest.java
@@ -354,8 +354,6 @@ public class SpirvRacesTest {
         }
     }
 
-
-
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
         return SolverContextFactory.createSolverContext(

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvRacesTest.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.spirv.gpuverify;
 
 import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
@@ -17,7 +18,6 @@ import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.io.File;
@@ -346,13 +346,14 @@ public class SpirvRacesTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
-            assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
+             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
         }
-        try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }
     }
+
 
     private SolverContext mkCtx() throws InvalidConfigurationException {
         Configuration cfg = Configuration.builder().build();
@@ -363,8 +364,8 @@ public class SpirvRacesTest {
                 SolverContextFactory.Solvers.Z3);
     }
 
-    private ProverEnvironment mkProver(SolverContext ctx) {
-        return ctx.newProverEnvironment(SolverContext.ProverOptions.GENERATE_MODELS);
+    private ProverWithTracker mkProver(SolverContext ctx) {
+        return new ProverWithTracker(ctx, "", SolverContext.ProverOptions.GENERATE_MODELS);
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/gpuverify/SpirvRacesTest.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.AssumeSolver;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -345,10 +346,9 @@ public class SpirvRacesTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        /* TODO: Implementation
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
-        }*/
+        }
         try (SolverContext ctx = mkCtx(); ProverEnvironment prover = mkProver(ctx)) {
             assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
         }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
@@ -8,12 +8,12 @@ import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.Property;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 
 import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.ShutdownNotifier;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 
 import java.io.File;
@@ -81,11 +81,11 @@ public class Providers {
         return Provider.fromSupplier(() -> TestHelper.createContextWithShutdownNotifier(shutdownManagerSupplier.get().getNotifier(), solverSupplier.get()));
     }
 
-    public static Provider<ProverEnvironment> createProver(Supplier<SolverContext> contextSupplier, Supplier<SolverContext.ProverOptions[]> optionsSupplier) {
-        return Provider.fromSupplier(() -> contextSupplier.get().newProverEnvironment(optionsSupplier.get()));
+    public static Provider<ProverWithTracker> createProver(Supplier<SolverContext> contextSupplier, Supplier<SolverContext.ProverOptions[]> optionsSupplier) {
+        return Provider.fromSupplier(() -> new ProverWithTracker(contextSupplier.get(), "", optionsSupplier.get()));
     }
 
-    public static Provider<ProverEnvironment> createProverWithFixedOptions(Supplier<SolverContext> contextSupplier, SolverContext.ProverOptions... options) {
+    public static Provider<ProverWithTracker> createProverWithFixedOptions(Supplier<SolverContext> contextSupplier, SolverContext.ProverOptions... options) {
         return createProver(contextSupplier, () -> options);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/witness/BuildWitnessTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/witness/BuildWitnessTest.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.witness;
 
 import com.dat3m.dartagnan.configuration.Property;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
@@ -15,7 +16,6 @@ import org.junit.Test;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
@@ -43,7 +43,7 @@ public class BuildWitnessTest {
         Wmm wmm = new ParserCat().parse(new File(getRootPath("cat/svcomp.cat")));
         VerificationTask task = VerificationTask.builder().withConfig(config).build(p, wmm, Property.getDefault());
         try (SolverContext ctx = TestHelper.createContext();
-             ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+              ProverWithTracker prover = new ProverWithTracker(ctx, "", ProverOptions.GENERATE_MODELS)) {
             AssumeSolver modelChecker = AssumeSolver.run(ctx, prover, task);
             Result res = modelChecker.getResult();
             WitnessBuilder witnessBuilder = WitnessBuilder.of(modelChecker.getEncodingContext(), prover, res, "user assertion");

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -10,13 +10,13 @@ import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.witness.WitnessType;
 import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
 import com.dat3m.ui.utils.UiOptions;
 import com.dat3m.ui.utils.Utils;
 import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.log.BasicLogManager;
 import org.sosy_lab.java_smt.SolverContextFactory;
-import org.sosy_lab.java_smt.api.ProverEnvironment;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
@@ -92,7 +92,7 @@ public class ReachabilityResult {
                     BasicLogManager.create(solverConfig),
                     sdm.getNotifier(),
                     options.solver());
-                 ProverEnvironment prover = ctx.newProverEnvironment(ProverOptions.GENERATE_MODELS)) {
+                    ProverWithTracker prover = new ProverWithTracker(ctx, "", ProverOptions.GENERATE_MODELS)) {
 
                 final ModelChecker modelChecker; modelChecker = switch (options.method()) {
                     case EAGER -> AssumeSolver.run(ctx, prover, task);


### PR DESCRIPTION
This PR creates a wrapper around the `ProverEnvironment` which allows to dump the encoding to an smtlib2 file.
Attached are the encodings of ticketlock both with eager and lazy methods, and this is the output of z3
```
> z3 output/ticketlock-eager.smt2 
unsat
unsat
> z3 output/ticketlock-lazy.smt2 
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
sat
unsat
unsat
```
[output.zip](https://github.com/user-attachments/files/16785768/output.zip)
