### PR TITLE
Refactor/Rename Location to align with its actual semantics

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -11,7 +11,7 @@ import com.dat3m.dartagnan.expression.misc.ITEExpr;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.misc.NonDetValue;
 import org.sosy_lab.java_smt.api.*;
@@ -298,9 +298,9 @@ class ExpressionEncoder implements ExpressionVisitor<Formula> {
     }
 
     @Override
-    public Formula visitLocation(Location location) {
-        checkState(event == null, "Cannot evaluate %s at event %s.", location, event);
-        int size = types.getMemorySizeInBits(location.getType());
-        return context.lastValue(location.getMemoryObject(), location.getOffset(), size);
+    public Formula visitFinalMemoryValue(FinalMemoryValue val) {
+        checkState(event == null, "Cannot evaluate final memory value of %s at event %s.", val, event);
+        int size = types.getMemorySizeInBits(val.getType());
+        return context.lastValue(val.getMemoryObject(), val.getOffset(), size);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Expression.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/Expression.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.expression;
 
 import com.dat3m.dartagnan.expression.processing.ExpressionInspector;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.collect.ImmutableSet;
 
@@ -40,9 +40,9 @@ public interface Expression {
             }
 
             @Override
-            public Expression visitLocation(Location location) {
-                objects.add(location.getMemoryObject());
-                return location;
+            public Expression visitFinalMemoryValue(FinalMemoryValue val) {
+                objects.add(val.getMemoryObject());
+                return val;
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionKind.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionKind.java
@@ -16,6 +16,7 @@ public interface ExpressionKind {
         NONDET,
         FUNCTION_ADDR,
         MEMORY_ADDR,
+        FINAL_MEM_VAL,
         REGISTER,
         GEP,
         CONSTRUCT,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionVisitor.java
@@ -11,7 +11,7 @@ import com.dat3m.dartagnan.expression.misc.GEPExpr;
 import com.dat3m.dartagnan.expression.misc.ITEExpr;
 import com.dat3m.dartagnan.program.Function;
 import com.dat3m.dartagnan.program.Register;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.misc.NonDetValue;
 
@@ -59,7 +59,7 @@ public interface ExpressionVisitor<TRet> {
     default TRet visitRegister(Register reg) { return visitLeafExpression(reg); }
     default TRet visitFunction(Function function) { return visitLeafExpression(function); }
     default TRet visitMemoryObject(MemoryObject memObj) { return visitLeafExpression(memObj); }
-    default TRet visitLocation(Location loc) { return visitLeafExpression(loc); }
+    default TRet visitFinalMemoryValue(FinalMemoryValue val) { return visitLeafExpression(val); }
     default TRet visitNonDetValue(NonDetValue nonDet) { return visitLeafExpression(nonDet); }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAssertions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAssertions.java
@@ -8,7 +8,7 @@ import com.dat3m.dartagnan.parsers.LitmusAssertionsBaseVisitor;
 import com.dat3m.dartagnan.parsers.LitmusAssertionsLexer;
 import com.dat3m.dartagnan.parsers.LitmusAssertionsParser;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -115,6 +115,6 @@ class VisitorLitmusAssertions extends LitmusAssertionsBaseVisitor<Expression> {
         checkState(base != null, "uninitialized location %s", name);
         TerminalNode offset = ctx.DigitSequence();
         int o = offset == null ? 0 : Integer.parseInt(offset.getText());
-        return right && offset == null ? base : new Location(name, archType, base, o);
+        return right && offset == null ? base : new FinalMemoryValue(name, archType, base, o);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/FinalMemoryValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/memory/FinalMemoryValue.java
@@ -5,15 +5,17 @@ import com.dat3m.dartagnan.expression.ExpressionVisitor;
 import com.dat3m.dartagnan.expression.Type;
 import com.dat3m.dartagnan.expression.base.LeafExpressionBase;
 
-// TODO: Should be replaced with a Pointer class
-public class Location extends LeafExpressionBase<Type> {
+// TODO: Should work with an arbitrary pointer rather than "base + offset"
+// Represents the final (co-maximal) value at a memory address as if read by a load instruction
+// that observed the final store.
+public class FinalMemoryValue extends LeafExpressionBase<Type> {
 
     private final String name;
     private final MemoryObject base;
     private final int offset;
 
-    public Location(String name, Type type, MemoryObject base, int offset) {
-        super(type);
+    public FinalMemoryValue(String name, Type loadType, MemoryObject base, int offset) {
+        super(loadType);
         this.name = name;
         this.base = base;
         this.offset = offset;
@@ -33,12 +35,12 @@ public class Location extends LeafExpressionBase<Type> {
 
     @Override
     public ExpressionKind getKind() {
-        return ExpressionKind.Other.MEMORY_ADDR;
+        return ExpressionKind.Other.FINAL_MEM_VAL;
     }
 
     @Override
     public <T> T accept(ExpressionVisitor<T> visitor) {
-        return visitor.visitLocation(this);
+        return visitor.visitFinalMemoryValue(this);
     }
 
     @Override
@@ -48,17 +50,12 @@ public class Location extends LeafExpressionBase<Type> {
 
     @Override
     public int hashCode() {
-        return base.hashCode() + offset;
+        return base.hashCode() + 31 * offset;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        Location o = (Location) obj;
-        return base.equals(o.base) && offset == o.offset;
+        return (obj instanceof FinalMemoryValue o) &&
+                base.equals(o.base) && offset == o.offset;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveUnusedMemory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveUnusedMemory.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.processing.ExpressionInspector;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.event.RegReader;
-import com.dat3m.dartagnan.program.memory.Location;
+import com.dat3m.dartagnan.program.memory.FinalMemoryValue;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.collect.Sets;
@@ -52,9 +52,9 @@ public class RemoveUnusedMemory implements ProgramProcessor {
         }
 
         @Override
-        public Expression visitLocation(Location location) {
-            memoryObjects.add(location.getMemoryObject());
-            return location;
+        public Expression visitFinalMemoryValue(FinalMemoryValue val) {
+            memoryObjects.add(val.getMemoryObject());
+            return val;
         }
     }
 }


### PR DESCRIPTION
During the discussions in #703 I realized why the `Location` class always felt off: its name suggested it represents an address, but it never did; it always represented the final value in memory.
This PR fixes this long-standing mistake.