### PR TITLE
Fix InclusionBasedPointerAnalysis.Top

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/InclusionBasedPointerAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/InclusionBasedPointerAnalysis.java
@@ -448,7 +448,7 @@ public class InclusionBasedPointerAnalysis implements AliasAnalysis {
         return modifier.offset == 0 && isConstant(modifier);
     }
 
-    private static final List<Integer> TOP = List.of(1);
+    private static final List<Integer> TOP = List.of(-1);
 
     private static final Modifier RELAXED_MODIFIER = new Modifier(0, TOP);
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/miscellaneous/AnalysisTest.java
@@ -112,7 +112,7 @@ public class AnalysisTest {
 
     @Test
     public void full0() throws InvalidConfigurationException {
-        program0(FULL, MAY, MAY, NONE, NONE, NONE, NONE);
+        program0(FULL, NONE, MAY, NONE, NONE, NONE, NONE);
     }
 
     private void program0(Alias method, Result... expect) throws InvalidConfigurationException {


### PR DESCRIPTION
Sets `TOP` to its theoretical definition. This should make `IBPA` sound for programs with negative dynamic indexing.