### PR TITLE
Some improvements to aarch64 pseudo-assembly

### DIFF
--- a/dartagnan/src/main/antlr4/LitmusAArch64.g4
+++ b/dartagnan/src/main/antlr4/LitmusAArch64.g4
@@ -76,6 +76,8 @@ instruction
     |   branchRegister
     |   branchLabel
     |   fence
+    |   return
+    |   nop
     ;
 
 mov locals [String rD, int size]
@@ -129,6 +131,14 @@ branchRegister locals [String rV, int size]
 
 branchLabel
     :   label Colon
+    ;
+
+return
+    :   Ret
+    ;
+
+nop
+    :   Nop
     ;
 
 loadInstruction locals [String mo]
@@ -252,7 +262,7 @@ location
     ;
 
 immediate
-    :   Num constant
+    :   Num Hexa? constant
     ;
 
 label
@@ -263,6 +273,18 @@ assertionValue
     :   location
     |   threadId Colon register64
     |   constant
+    ;
+
+Hexa
+    :   '0x'
+    ;
+
+Ret
+    :   'ret'
+    ;
+
+Nop
+    :   'nop'
     ;
 
 Locations
@@ -371,10 +393,12 @@ BitfieldOperator
 
 Register64
     :   'X' DigitSequence
+    |   'XZR' // zero register
     ;
 
 Register32
     :   'W' DigitSequence
+    |   'WZR' // zero register
     ;
 
 LitmusLanguage

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -96,7 +96,7 @@ public class ProcessingManager implements ProgramProcessor {
                                 ComplexBlockSplitting.newInstance(),
                                 BranchReordering.fromConfig(config),
                                 Simplifier.fromConfig(config)
-                        ), Target.FUNCTIONS, true
+                        ), Target.ALL, true
                 ),
                 ProgramProcessor.fromFunctionProcessor(NormalizeLoops.newInstance(), Target.ALL, true),
                 RegisterDecomposition.newInstance(),

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
@@ -40,7 +40,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.dat3m.dartagnan.configuration.Arch.RISCV;
 import static com.dat3m.dartagnan.program.Register.UsageType.*;
 import static com.dat3m.dartagnan.program.event.Tag.*;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -915,16 +914,6 @@ public class NativeRelationAnalysis implements RelationAnalysis {
                         continue;
                     }
                     final Register register = regRead.register();
-                    // TODO: Update after this is merged
-                    //  https://github.com/hernanponcedeleon/Dat3M/pull/741
-                    // Register x0 is hardwired to the constant 0 in RISCV
-                    // https://en.wikichip.org/wiki/risc-v/registers,
-                    // and thus it generates no dependency, see
-                    // https://github.com/herd/herdtools7/issues/408
-                    // TODO: Can't we just replace all reads of "x0" by 0 in RISC-specific preprocessing?
-                    if (program.getArch().equals(RISCV) && register.getName().equals("x0")) {
-                        continue;
-                    }
                     final List<? extends Event> writers = state.ofRegister(register).getMayWriters();
                     for (Event regWriter : writers) {
                         may.add(regWriter, regReader);


### PR DESCRIPTION
This PR adds support for
- return instructions
- nop instructions
- hexa constant
- registers name using underscored names
- special handling for zero registers (similar to RISCV)

It also enables some more passes for litmus code.

TODO
- [x] Fix special treatment of zero registers in `LazyRelationAnalysis` and `NativeRelationAnalysis` #743 