### PR TITLE
Fix UI parsing

### DIFF
--- a/ui/src/main/java/com/dat3m/ui/editor/Editor.java
+++ b/ui/src/main/java/com/dat3m/ui/editor/Editor.java
@@ -100,7 +100,7 @@ public class Editor extends RTextScrollPane implements ActionListener {
             if (chooser.showOpenDialog(null) == APPROVE_OPTION) {
                 String path = chooser.getSelectedFile().getPath();
                 loadedPath = path.substring(0, path.lastIndexOf('/') + 1);
-                String format = path.endsWith("spv.dis") ? "spv.dis" : path.substring(path.indexOf('.') + 1).trim();
+                String format = path.endsWith("spv.dis") ? "spv.dis" : path.substring(path.lastIndexOf('.') + 1).trim();
                 if (allowedFormats.contains(format)) {
                     loadedFormat = format;
                     notifyListeners();


### PR DESCRIPTION
The PR that added support for SPIRV to the UI replaced a `lastIndexOf` operation by `indexOf`, which causes the UI to break whenever the path to some file contains multiple `.` symbols, especially `/../`.