### PR TITLE
Allow bounds to be saved to and loaded from files 

### DIFF
--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -45,7 +45,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.3.9</version>
+            <version>${maven-model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>${commons-csv.version}</version>
         </dependency>
 
         <!-- Z3 dependency (OS independent) -->

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -413,9 +413,10 @@ public class Dartagnan extends BaseOptions {
     }
 
     private static void increaseBoundAndDump(List<Event> boundEvents, Configuration config) throws IOException {
-        final File boundsFile = new File(config.hasProperty(BOUNDS_SAVE_PATH) ?
-                config.getProperty(BOUNDS_SAVE_PATH) :
-                GlobalSettings.getBoundsFile());
+        if(!config.hasProperty(BOUNDS_SAVE_PATH)) {
+            return;
+        }
+        final File boundsFile = new File(config.getProperty(BOUNDS_SAVE_PATH));
 
         // Parse old entries
         final List<CSVRecord> entries;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -16,8 +16,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Assert;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Load;
-import com.dat3m.dartagnan.program.event.metadata.UnrollingBound;
-import com.dat3m.dartagnan.program.event.metadata.UnrollingId;
+import com.dat3m.dartagnan.program.processing.LoopUnrolling;
 import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
@@ -36,8 +35,8 @@ import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharSource;
-
 import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.logging.log4j.LogManager;
@@ -59,17 +58,13 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
 import java.math.BigInteger;
 import java.nio.file.Path;
 import java.util.*;
 
 import static com.dat3m.dartagnan.GlobalSettings.getOrCreateOutputDirectory;
 import static com.dat3m.dartagnan.configuration.OptionInfo.collectOptions;
-import static com.dat3m.dartagnan.configuration.OptionNames.BOUNDS_SAVE_PATH;
-import static com.dat3m.dartagnan.configuration.OptionNames.PHANTOM_REFERENCES;
-import static com.dat3m.dartagnan.configuration.OptionNames.TARGET;
+import static com.dat3m.dartagnan.configuration.OptionNames.*;
 import static com.dat3m.dartagnan.configuration.Property.*;
 import static com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis.*;
 import static com.dat3m.dartagnan.utils.GitInfo.*;
@@ -343,18 +338,26 @@ public class Dartagnan extends BaseOptions {
                 }
             } else if (result == UNKNOWN && modelChecker.hasModel()) {
                 // We reached unrolling bounds.
-                summary.append("=========== Not fully unrolled loops ============\n");
+                final List<Event> reachedBounds = new ArrayList<>();
                 for (Event ev : p.getThreadEventsWithAllTags(Tag.BOUND)) {
-                    final boolean isReached = TRUE.equals(model.evaluate(encCtx.execution(ev)));
-                    if (isReached) {
-                        summary
-                                .append("\t")
-                                .append(synContext.getSourceLocationWithContext(ev, true))
-                                .append("\n");
-                        increaseBoundAndDump(ev, task.getConfig());
+                    if (TRUE.equals(model.evaluate(encCtx.execution(ev)))) {
+                        reachedBounds.add(ev);
                     }
                 }
+                summary.append("=========== Not fully unrolled loops ============\n");
+                for (Event bound : reachedBounds) {
+                    summary
+                            .append("\t")
+                            .append(synContext.getSourceLocationWithContext(bound, true))
+                            .append("\n");
+                }
                 summary.append("=================================================\n");
+
+                try {
+                    increaseBoundAndDump(reachedBounds, task.getConfig());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
             summary.append(result).append("\n");
         } else {
@@ -409,42 +412,40 @@ public class Dartagnan extends BaseOptions {
         return summary.toString();
     }
 
-    private static void increaseBoundAndDump(Event ev, Configuration config) {
+    private static void increaseBoundAndDump(List<Event> boundEvents, Configuration config) throws IOException {
+        final File boundsFile = new File(config.hasProperty(BOUNDS_SAVE_PATH) ?
+                config.getProperty(BOUNDS_SAVE_PATH) :
+                GlobalSettings.getBoundsFile());
 
-        String evId = String.valueOf(ev.getMetadata(UnrollingId.class).value());
-        String incBound = String.valueOf(ev.getMetadata(UnrollingBound.class).value() + 1);
-
-        // We read from and write to the same CSV file,
-        // thus we need to split this in two loops
-        List<String[]> modifiedRecords = new ArrayList<>();
-        // We read the file written by the LoopUnrolling pass,
-        // thus we use BOUNDS_SAVE_PATH also for the reader
-        try (Reader reader = new FileReader(config.hasProperty(BOUNDS_SAVE_PATH) ?
-                                            config.getProperty(BOUNDS_SAVE_PATH) :
-                                            GlobalSettings.getBoundsFile())) {
-            for (CSVRecord record : CSVFormat.DEFAULT.parse(reader)) {
-                String nextId = record.get(0);
-                String nextBound = record.get(1);
-                String sourceLoc = record.get(2);
-                if (nextId.equals(evId)) {
-                    nextBound = incBound;
-                }
-                modifiedRecords.add(new String[] { nextId, nextBound, sourceLoc });
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
+        // Parse old entries
+        final List<CSVRecord> entries;
+        try (CSVParser parser = CSVParser.parse(new FileReader(boundsFile), CSVFormat.DEFAULT)) {
+            entries = parser.getRecords();
         }
 
-        try (Writer writer = new FileWriter(config.hasProperty(BOUNDS_SAVE_PATH) ?
-                                            config.getProperty(BOUNDS_SAVE_PATH) :
-                                            GlobalSettings.getBoundsFile(), false);
-                CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
-            for (String[] record : modifiedRecords) {
-                csvPrinter.printRecord(record[0], record[1], record[2]);
+        // Compute update for entries
+        final Map<Integer, Integer> loopId2UpdatedBound = new HashMap<>();
+        for (Event e : boundEvents) {
+            assert e instanceof CondJump;
+            final CondJump loopJump = (CondJump) e;
+            final int loopId = LoopUnrolling.getPersistentLoopId(loopJump);
+            final int bound = LoopUnrolling.getUnrollingBoundAnnotation(loopJump);
+            loopId2UpdatedBound.put(loopId, bound + 1);
+        }
+
+        // Write new entries
+        try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(boundsFile, false), CSVFormat.DEFAULT)) {
+            for (CSVRecord entry : entries) {
+                final int entryId = Integer.parseInt(entry.get(0));
+                if (!loopId2UpdatedBound.containsKey(entryId)) {
+                    csvPrinter.printRecord(entry);
+                } else {
+                    final String[] content = entry.values();
+                    content[0] = String.valueOf(loopId2UpdatedBound.get(entryId));
+                    csvPrinter.printRecord(Arrays.asList(content));
+                }
             }
             csvPrinter.flush();
-        } catch (IOException e) {
-            e.printStackTrace();
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -419,7 +419,9 @@ public class Dartagnan extends BaseOptions {
         List<String[]> modifiedRecords = new ArrayList<>();
         // We read the file written by the LoopUnrolling pass,
         // thus we use BOUNDS_SAVE_PATH also for the reader
-        try (Reader reader = new FileReader(config.getProperty(BOUNDS_SAVE_PATH))) {
+        try (Reader reader = new FileReader(config.hasProperty(BOUNDS_SAVE_PATH) ?
+                                            config.getProperty(BOUNDS_SAVE_PATH) :
+                                            GlobalSettings.getBoundsFile())) {
             for (CSVRecord record : CSVFormat.DEFAULT.parse(reader)) {
                 String nextId = record.get(0);
                 String nextBound = record.get(1);
@@ -433,7 +435,9 @@ public class Dartagnan extends BaseOptions {
             e.printStackTrace();
         }
 
-        try (Writer writer = new FileWriter(config.getProperty(BOUNDS_SAVE_PATH), false);
+        try (Writer writer = new FileWriter(config.hasProperty(BOUNDS_SAVE_PATH) ?
+                                            config.getProperty(BOUNDS_SAVE_PATH) :
+                                            GlobalSettings.getBoundsFile(), false);
                 CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
             for (String[] record : modifiedRecords) {
                 csvPrinter.printRecord(record[0], record[1], record[2]);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -441,7 +441,7 @@ public class Dartagnan extends BaseOptions {
                     csvPrinter.printRecord(entry);
                 } else {
                     final String[] content = entry.values();
-                    content[0] = String.valueOf(loopId2UpdatedBound.get(entryId));
+                    content[1] = String.valueOf(loopId2UpdatedBound.get(entryId));
                     csvPrinter.printRecord(Arrays.asList(content));
                 }
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -407,8 +407,10 @@ public class Dartagnan extends BaseOptions {
 
     private static void increaseBoundAndDumpToFile(Event ev) {
         try (FileWriter writer = new FileWriter(GlobalSettings.getBoundsFile(), true)) {
+            final SyntacticContextAnalysis synContext = newInstance(ev.getThread().getProgram());
             writer.append(String.valueOf(ev.getMetadata(UnrollingId.class).value())).append(',')
-                    .append(String.valueOf(ev.getMetadata(UnrollingBound.class).value() + 1)).append('\n');
+                    .append(String.valueOf(ev.getMetadata(UnrollingBound.class).value() + 1)).append(',')
+                    .append(synContext.getSourceLocationWithContext(ev, false)).append('\n');
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -356,7 +356,7 @@ public class Dartagnan extends BaseOptions {
                 try {
                     increaseBoundAndDump(reachedBounds, task.getConfig());
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    logger.warn("Failed to save bounds file: {}", e.getLocalizedMessage());
                 }
             }
             summary.append(result).append("\n");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
@@ -38,10 +38,6 @@ public class GlobalSettings {
         return env + "/cat";
     }
 
-    public static String getBoundsFile() {
-        return getOutputDirectory() + "/bounds.csv";
-    }
-
     public static String getOrCreateOutputDirectory() throws IOException {
         String path = getOutputDirectory();
         Files.createDirectories(Paths.get(path));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
@@ -38,6 +38,10 @@ public class GlobalSettings {
         return env + "/cat";
     }
 
+    public static String getBoundsFile() {
+        return getOutputDirectory() + "/bounds.csv";
+    }
+
     public static String getOrCreateOutputDirectory() throws IOException {
         String path = getOutputDirectory();
         Files.createDirectories(Paths.get(path));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -5,6 +5,7 @@ public class OptionNames {
     // Base Options
     public static final String PROPERTY = "property";
     public static final String BOUND = "bound";
+    public static final String BOUNDS_LOAD_PATH = "bound.load";
     public static final String TARGET = "target";
     public static final String METHOD = "method";
     public static final String SOLVER = "solver";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -6,6 +6,7 @@ public class OptionNames {
     public static final String PROPERTY = "property";
     public static final String BOUND = "bound";
     public static final String BOUNDS_LOAD_PATH = "bound.load";
+    public static final String BOUNDS_SAVE_PATH = "bound.save";
     public static final String TARGET = "target";
     public static final String METHOD = "method";
     public static final String SOLVER = "solver";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/UnrollingBound.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/UnrollingBound.java
@@ -1,0 +1,3 @@
+package com.dat3m.dartagnan.program.event.metadata;
+
+public record UnrollingBound(int value) implements Metadata { }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -68,7 +68,7 @@ public class LoopUnrolling implements ProgramProcessor {
     @Option(name = BOUNDS_SAVE_PATH,
             description = "Path to the CSV file to save loop bounds.",
             secure = true)
-    private String boundsSavePath = GlobalSettings.getBoundsFile();
+    private String boundsSavePath = "";
 
     // =====================================================================
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -289,7 +289,7 @@ public class LoopUnrolling implements ProgramProcessor {
                         .put(loopJump, bound);
             }
         } catch (IOException e) {
-            // Nothing to be done, filePath is guaranteed to exists when the FileReader is called.
+            logger.warn("Failed to read bounds file: {}", e.getLocalizedMessage());
         }
 
         return loopBoundsMapPerFunction;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -301,7 +301,7 @@ public class LoopUnrolling implements ProgramProcessor {
         }
 
         final SyntacticContextAnalysis synContext = SyntacticContextAnalysis.newInstance(program);
-        try (CSVPrinter csvPrinter = new CSVPrinter( new FileWriter(filePath, true), CSVFormat.DEFAULT)) {
+        try (CSVPrinter csvPrinter = new CSVPrinter( new FileWriter(filePath, false), CSVFormat.DEFAULT)) {
             for (Map<CondJump, Integer> loopBoundsMap : loopBounds.values()) {
                 for (Map.Entry<CondJump, Integer> entry : loopBoundsMap.entrySet()) {
                     final CondJump loopJump = entry.getKey();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.program.Function;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.EventFactory;
 import com.dat3m.dartagnan.program.event.EventUser;
@@ -227,9 +228,13 @@ public class LoopUnrolling implements ProgramProcessor {
     }
 
     private void dumpBoundToFile(Event jump, int bound) {
-        System.out.println("Dumping " + jump.getGlobalId() + " with value " + bound);
         try (FileWriter writer = new FileWriter(GlobalSettings.getBoundsFile(), true)) {
-            writer.append(String.valueOf(jump.getGlobalId())).append(',').append(String.valueOf(bound)).append('\n');
+            final SyntacticContextAnalysis synContext = SyntacticContextAnalysis
+                    .newInstance(jump.getFunction().getProgram());
+            writer.append(String.valueOf(jump.getGlobalId())).append(',')
+                    .append(String.valueOf(bound)).append(',')
+                    .append(synContext.getSourceLocationWithContext(jump, false))
+                    .append('\n');
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -63,6 +63,11 @@ public class LoopUnrolling implements ProgramProcessor {
             secure = true)
     private String bounds_load_path = "";
 
+    @Option(name = BOUNDS_SAVE_PATH,
+            description = "Path to the CSV file to save loop bounds.",
+            secure = true)
+    private String bounds_save_path = GlobalSettings.getBoundsFile();
+
     // =====================================================================
 
     private LoopUnrolling() { }
@@ -239,7 +244,7 @@ public class LoopUnrolling implements ProgramProcessor {
     }
 
     private void createBoundsFileIfMissing() {
-        File file = new File(GlobalSettings.getBoundsFile());
+        File file = new File(bounds_save_path);
         if (!file.exists()) {
             try {
                 file.createNewFile();
@@ -253,8 +258,8 @@ public class LoopUnrolling implements ProgramProcessor {
         String evId = String.valueOf(jump.getMetadata(UnrollingId.class).value());
         final SyntacticContextAnalysis synContext = SyntacticContextAnalysis.newInstance(jump.getFunction().getProgram());
         String sourceLoc = synContext.getSourceLocationWithContext(jump, false);
-        try (Reader reader = new FileReader(GlobalSettings.getBoundsFile());
-                Writer writer = new FileWriter(GlobalSettings.getBoundsFile(), true);
+        try (Reader reader = new FileReader(bounds_load_path);
+                Writer writer = new FileWriter(bounds_save_path, true);
                 CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
             boolean found = false;
             for (CSVRecord record : CSVFormat.DEFAULT.parse(reader)) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/LoopUnrolling.java
@@ -289,7 +289,7 @@ public class LoopUnrolling implements ProgramProcessor {
                         .put(loopJump, bound);
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            // Nothing to be done, filePath is guaranteed to exists when the FileReader is called.
         }
 
         return loopBoundsMapPerFunction;
@@ -313,7 +313,7 @@ public class LoopUnrolling implements ProgramProcessor {
             }
             csvPrinter.flush();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.warn("Failed to save bounds file: {}", e.getLocalizedMessage());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
         <guava.version>32.1.2-jre</guava.version>
         <junit.version>4.13.2</junit.version>
         <log4j.version>2.23.0</log4j.version>
+        <maven-model.version>3.3.9</maven-model.version>
+        <commons-csv.version>1.12.0</commons-csv.version>
         <mockito.version>5.11.0</mockito.version>
         <rsyntaxtextarea.version>3.3.4</rsyntaxtextarea.version>
 


### PR DESCRIPTION
This feature needs to be used with caution since the information depends on event ids which may not match if the program is changed. However, if used as intended (just run dartagnan several times in a row and let it automatically adapt the bounds until getting PASS), it can boost performance. I have seen improvements up to 3x. 