### PR TITLE
Relation Model Implementation

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -22,6 +22,7 @@ import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.VerificationTask.VerificationTaskBuilder;
 import com.dat3m.dartagnan.verification.model.ExecutionModel;
+import com.dat3m.dartagnan.verification.model.ExecutionModelManager;
 import com.dat3m.dartagnan.verification.solving.AssumeSolver;
 import com.dat3m.dartagnan.verification.solving.DataRaceSolver;
 import com.dat3m.dartagnan.verification.solving.ModelChecker;
@@ -225,8 +226,11 @@ public class Dartagnan extends BaseOptions {
             throws InvalidConfigurationException, SolverException, IOException {
         Preconditions.checkArgument(modelChecker.hasModel(), "No execution graph to generate.");
 
-        final ExecutionModel m = ExecutionModel.withContext(modelChecker.getEncodingContext());
-        m.initialize(prover.getModel());
+        final ExecutionModel m = ExecutionModelManager.newManager(modelChecker.getEncodingContext())
+                                                      .setEncodingContextForWitness(modelChecker.getEncodingContextForWitness())
+                                                      .initializeModel(prover.getModel());
+        // final ExecutionModel m = ExecutionModel.withContext(modelChecker.getEncodingContext());
+        // m.initialize(prover.getModel());
         final SyntacticContextAnalysis synContext = newInstance(task.getProgram());
         final String progName = task.getProgram().getName();
         final int fileSuffixIndex = progName.lastIndexOf('.');

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -229,8 +229,6 @@ public class Dartagnan extends BaseOptions {
         final ExecutionModel m = ExecutionModelManager.newManager(modelChecker.getEncodingContext())
                                                       .setEncodingContextForWitness(modelChecker.getEncodingContextForWitness())
                                                       .initializeModel(prover.getModel());
-        // final ExecutionModel m = ExecutionModel.withContext(modelChecker.getEncodingContext());
-        // m.initialize(prover.getModel());
         final SyntacticContextAnalysis synContext = newInstance(task.getProgram());
         final String progName = task.getProgram().getName();
         final int fileSuffixIndex = progName.lastIndexOf('.');

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -73,6 +73,7 @@ public class OptionNames {
 
     // Witness Options
     public static final String WITNESS_ORIGINAL_PROGRAM_PATH = "witness.originalProgramFilePath";
+    public static final String WITNESS_RELATIONS_TO_SHOW = "witness.relationsToShow";
 
     // SVCOMP Options
     public static final String PROPERTYPATH = "svcomp.property";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/EventData.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/EventData.java
@@ -3,6 +3,8 @@ package com.dat3m.dartagnan.verification.model;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.core.CondJump;
+import com.dat3m.dartagnan.program.event.core.Local;
+import com.dat3m.dartagnan.program.event.core.Assert;
 
 import java.math.BigInteger;
 
@@ -74,7 +76,7 @@ public class EventData implements Comparable<EventData> {
     }
 
     public int getCoherenceIndex() { return coIndex; }
-    void setCoherenceIndex(int index) { coIndex = index; }
+    public void setCoherenceIndex(int index) { coIndex = index; }
 
     public boolean isMemoryEvent() { return event.hasTag(MEMORY); }
     public boolean isInit() {
@@ -91,6 +93,12 @@ public class EventData implements Comparable<EventData> {
     }
     public boolean isRMW() {
     	return event.hasTag(RMW);
+    }
+    public boolean isLocal() {
+        return event instanceof Local;
+    }
+    public boolean isAssert() {
+        return event instanceof Assert;
     }
 
     public boolean hasTag(String tag) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -221,10 +221,7 @@ public class ExecutionModel {
     }
 
     public EdgeModel getEdge(String identifier) {
-        if (edges.containsKey(identifier)) {
-            return edges.get(identifier);
-        }
-        return null;
+        return edges.get(identifier);
     }
 
     public void addEdge(EdgeModel edge) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -222,7 +222,7 @@ public class ExecutionModel {
         rmManager.extractRelations(names);
     }
 
-    public Map<MemoryObject, BigInteger> getMemoryLayoutMap() { return memoryLayoutMapView; }
+    public Map<MemoryObject, MemoryObjectModel> getMemoryLayoutMap() { return memoryLayoutMapView; }
     public Map<Thread, List<EventData>> getThreadEventsMap() {
         return threadEventsMapView;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModelManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModelManager.java
@@ -1,0 +1,48 @@
+package com.dat3m.dartagnan.verification.model;
+
+import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.verification.model.ExecutionModel;
+import com.dat3m.dartagnan.verification.model.relation.RelationModelManager;
+
+import org.sosy_lab.java_smt.api.Model;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+
+import java.util.*;
+
+import static com.dat3m.dartagnan.wmm.RelationNameRepository.*;
+
+
+public class ExecutionModelManager {
+    private final ExecutionModel model;
+    private final RelationModelManager rmManager;
+    private final Set<String> necessaryRelations;
+
+    private ExecutionModelManager(ExecutionModel model) {
+        this.model = model;
+        rmManager = RelationModelManager.newRMManager(model);
+        necessaryRelations = new HashSet<>(Set.of(PO, RF, CO));
+    }
+
+    public static ExecutionModelManager newManager(EncodingContext context)
+            throws InvalidConfigurationException{
+        ExecutionModel m = ExecutionModel.withContext(context);
+        return new ExecutionModelManager(m);
+    }
+
+    public ExecutionModel getExecutionModel() { return model; }
+
+    public ExecutionModelManager setEncodingContextForWitness(EncodingContext c) {
+        model.setEncodingContextForWitness(c);
+        return this;
+    }
+
+    public ExecutionModel initializeModel(Model m) {
+        model.initialize(m, this);
+        extractRelations(new ArrayList<>(necessaryRelations));
+        return model;
+    }
+
+    public void extractRelations(List<String> relNames) {
+        rmManager.extractRelations(relNames);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModel.java
@@ -1,0 +1,78 @@
+package com.dat3m.dartagnan.verification.model.relation;
+
+import com.dat3m.dartagnan.wmm.Relation;
+import com.dat3m.dartagnan.verification.model.EventData;
+
+import java.util.Set;
+import java.util.HashSet;
+
+
+public class RelationModel {
+    private String name;
+    private final Relation relation;
+    private final Set<EdgeModel> edges;
+
+    RelationModel(Relation r) {
+        relation = r;
+        edges = new HashSet<>();
+    }
+
+    public Relation getRelation() {
+        return relation;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isDefined() {
+        return name != null;
+    }
+
+    public Set<EdgeModel> getEdges() {
+        return Set.copyOf(edges);
+    }
+
+    public void addEdge(EdgeModel edge) {
+        edges.add(edge);
+    }
+
+    public void addEdges(Set<EdgeModel> edgeModels) {
+        edges.addAll(edgeModels);
+    }
+
+    public EdgeModel newEdge(EventData p, EventData s) {
+        EdgeModel edge = new EdgeModel(p, s);
+        addEdge(edge);
+        return edge;
+    }
+
+    
+    public static class EdgeModel {
+        private final EventData predecessor;
+        private final EventData successor;
+        private final String identifier;
+
+        EdgeModel(EventData p, EventData s) {
+            predecessor = p;
+            successor = s;
+            identifier = p.getId() + " -> " + s.getId();
+        }
+
+        public EventData getPredecessor() {
+            return predecessor;
+        }
+
+        public EventData getSuccessor() {
+            return successor;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModel.java
@@ -97,7 +97,7 @@ public class RelationModel {
             if (this == other) {
                 return true;
             }
-            return getIdentifier().equals(((EdgeModel) other).getIdentifier());
+            return identifier.equals(((EdgeModel) other).getIdentifier());
         }
 
         @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModel.java
@@ -10,11 +10,11 @@ import java.util.HashSet;
 public class RelationModel {
     private String name;
     private final Relation relation;
-    private final Set<EdgeModel> edges;
+    private final Set<EdgeModel> edges = new HashSet<>();
+    private final Set<EdgeModel> edgesToShow = new HashSet<>();
 
     RelationModel(Relation r) {
         relation = r;
-        edges = new HashSet<>();
     }
 
     public Relation getRelation() {
@@ -33,16 +33,30 @@ public class RelationModel {
         return name != null;
     }
 
+    public boolean containsEdge(EdgeModel edge) {
+        return edges.contains(edge);
+    }
+
+    public void removeEdgeToShow(EdgeModel edge) {
+        edgesToShow.remove(edge);
+    }
+
     public Set<EdgeModel> getEdges() {
         return Set.copyOf(edges);
     }
 
+    public Set<EdgeModel> getEdgesToShow() {
+        return Set.copyOf(edgesToShow);
+    }
+
     public void addEdge(EdgeModel edge) {
         edges.add(edge);
+        edgesToShow.add(edge);
     }
 
     public void addEdges(Set<EdgeModel> edgeModels) {
         edges.addAll(edgeModels);
+        edgesToShow.addAll(edgeModels);
     }
 
     public EdgeModel newEdge(EventData p, EventData s) {
@@ -73,6 +87,22 @@ public class RelationModel {
 
         public String getIdentifier() {
             return identifier;
+        }
+
+        @Override
+        public String toString() { return identifier; }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            return getIdentifier().equals(((EdgeModel) other).getIdentifier());
+        }
+
+        @Override
+        public int hashCode() {
+            return predecessor.getId() * 31 + successor.getId() * 23;
         }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModelManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModelManager.java
@@ -1,0 +1,526 @@
+package com.dat3m.dartagnan.verification.model.relation;
+
+import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.event.Tag;
+import com.dat3m.dartagnan.verification.model.ExecutionModel;
+import com.dat3m.dartagnan.verification.model.EventData;
+import com.dat3m.dartagnan.verification.model.relation.RelationModel;
+import com.dat3m.dartagnan.verification.model.relation.RelationModel.EdgeModel;
+import com.dat3m.dartagnan.wmm.Constraint.Visitor;
+import com.dat3m.dartagnan.wmm.definition.*;
+import com.dat3m.dartagnan.wmm.Relation;
+import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
+
+import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+
+import java.math.BigInteger;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.dat3m.dartagnan.wmm.RelationNameRepository.*;
+
+public class RelationModelManager {
+    private final ExecutionModel executionModel;
+    private final RelationModelBuilder builder;
+
+    private RelationModelManager(ExecutionModel m) {
+        executionModel = m;
+        builder = new RelationModelBuilder(m, this);
+    }
+
+    public static RelationModelManager newRMManager(ExecutionModel m) {
+        return new RelationModelManager(m);
+    }
+
+    public RelationModel newModel(Relation r) {
+        return new RelationModel(r);
+    }
+
+    public RelationModel newModel(Relation r, String relationName) {
+        RelationModel m = newModel(r);
+        m.setName(relationName);
+        return m;
+    }
+
+    public void addEdgeToRelation(RelationModel r, EventData p, EventData s) {
+        String identifier = p.getId() + " -> " + s.getId();
+        EdgeModel edge = executionModel.getEdge(identifier);
+        if (edge == null) {
+            executionModel.addEdge(r.newEdge(p, s));
+        }
+        else {
+            r.addEdge(edge);
+        }
+    }
+
+    public void extractRelations(List<String> relationNames) {
+        for (String name : relationNames) {
+            Relation r = executionModel.getMemoryModel().getRelation(name);
+            extractRelation(r, Optional.of(name));
+        }
+    }
+
+    private void extractRelation(Relation r, Optional<String> name) {
+        if (executionModel.containsRelation(r)) { return; }
+        RelationModel rm;
+        // TODO: Treat DATA, ADDR, CTRL as derived.
+        if (name.isPresent() && name.get().equals(DATA)) {
+            rm = builder.buildDataDependency(r);
+        } else if (name.isPresent() && name.get().equals(ADDR)) {
+            rm = builder.buildAddressDependency(r);
+        } else if (name.isPresent() && name.get().equals(CTRL)) {
+            rm = builder.buildControlDependency(r);
+        } else {
+            List<Relation> deps = r.getDependencies();
+            for (Relation dep : deps) {
+                extractRelation(dep, dep.getName());
+            }
+            rm = r.getDefinition().accept(builder);
+            if (name.isPresent()) {
+                rm.setName(name.get());
+            }
+        }
+        executionModel.addRelation(r, rm);
+    }
+
+    private RelationModel computeInverse(Relation r, RelationModel rm) {
+        RelationModel result = newModel(r);
+        for(EdgeModel edge : rm.getEdges()) {
+            addEdgeToRelation(result, edge.getSuccessor(), edge.getPredecessor());
+        }
+        return result;
+    }
+
+    private RelationModel computeComposition(Relation r, RelationModel first, RelationModel second) {
+        RelationModel result = newModel(r);
+        for (EdgeModel f : first.getEdges()) {
+            for (EdgeModel s : second.getEdges()) {
+                if (f.getSuccessor() == s.getPredecessor()) {
+                    addEdgeToRelation(result, f.getPredecessor(), s.getSuccessor());
+                }
+            }
+        }
+        return result;
+    }
+
+    private RelationModel computeDifference(Relation r, RelationModel minuend, RelationModel subtrahend) {
+        RelationModel result = newModel(r);
+        for (EdgeModel m : minuend.getEdges()) {
+            boolean found = false;
+            for (EdgeModel s : subtrahend.getEdges()) {
+                if (m == s) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                result.addEdge(m);
+            }
+        }
+        return result;
+    }
+
+    private RelationModel computeUnion(Relation r, List<RelationModel> relations) {
+        RelationModel result = newModel(r);
+        for (RelationModel rm : relations) {
+            result.addEdges(rm.getEdges());
+        }
+        return result;
+    }
+
+    private RelationModel computeIntersection(Relation r, List<RelationModel> relations) {
+        RelationModel result = newModel(r);
+        if (relations.size() == 1) {
+            result.addEdges(relations.get(0).getEdges());
+        } else {
+            if (relations.size() == 2) {
+                Set<EdgeModel> edges = Sets.intersection(relations.get(0).getEdges(), relations.get(1).getEdges());
+                if (relations.size() > 2) {
+                    for (int i = 2; i < relations.size(); i++) {
+                        edges = Sets.intersection(edges, relations.get(i).getEdges());
+                    }
+                }
+                result.addEdges(edges);
+            }
+        }
+        return result;
+    }
+
+    private RelationModel computeTransitiveClosure(Relation r, RelationModel rm) {
+        RelationModel result = newModel(r);
+        final Map<EventData, Set<EventData>> reachMap = new HashMap<>();
+        for (EdgeModel edge : rm.getEdges()) {
+            reachMap.putIfAbsent(edge.getPredecessor(), new HashSet<>());
+            reachMap.get(edge.getPredecessor()).add(edge.getSuccessor());
+        }
+        for (EventData p : reachMap.keySet()) {
+            final Set<EventData> reachables = new HashSet<>();
+            depthFirstSearch(p, reachMap, reachables);
+            for (EventData s : reachables) {
+                if (p != s) { addEdgeToRelation(result, p, s); }
+            }
+        }
+        return result;
+    }
+
+    private void depthFirstSearch(EventData p, Map<EventData, Set<EventData>> reachMap, Set<EventData> visited) {
+        if (visited.contains(p)) { return; }
+        visited.add(p);
+        if (reachMap.containsKey(p)) {
+            for (EventData s : reachMap.get(p)) {
+                depthFirstSearch(s, reachMap, visited);
+            }
+        }
+    }
+
+
+    private final class RelationModelBuilder implements Visitor<RelationModel> {
+        private final ExecutionModel executionModel;
+        private final RelationModelManager manager;
+
+        public RelationModelBuilder(ExecutionModel model, RelationModelManager manager) {
+            executionModel = model;
+            this.manager = manager;
+        }
+
+        @Override
+        public RelationModel visitInverse(Inverse invs) {
+            Relation inversed = invs.getDefinedRelation();
+            RelationModel toInverse = executionModel.getRelationModel(invs.getOperand());
+            return manager.computeInverse(inversed, toInverse);
+        }
+
+        @Override
+        public RelationModel visitComposition(Composition comp) {
+            Relation compR = comp.getDefinedRelation();
+            RelationModel left = executionModel.getRelationModel(comp.getLeftOperand());
+            RelationModel right = executionModel.getRelationModel(comp.getRightOperand());
+            return manager.computeComposition(compR, left, right);
+        }
+
+        @Override
+        public RelationModel visitDifference(Difference diff) {
+            Relation diffR = diff.getDefinedRelation();
+            RelationModel minuend = executionModel.getRelationModel(diff.getMinuend());
+            RelationModel subtrahend = executionModel.getRelationModel(diff.getSubtrahend());
+            return manager.computeDifference(diffR, minuend, subtrahend);
+        }
+
+        @Override
+        public RelationModel visitUnion(Union u) {
+            Relation uR = u.getDefinedRelation();
+            List<RelationModel> operandModels = u.getOperands().stream().map(r -> executionModel.getRelationModel(r)).collect(Collectors.toList());
+            return manager.computeUnion(uR, operandModels);
+        }
+
+        @Override
+        public RelationModel visitIntersection(Intersection intsc) {
+            Relation intscR = intsc.getDefinedRelation();
+            List<RelationModel> operandModels = intsc.getOperands().stream().map(r -> executionModel.getRelationModel(r)).collect(Collectors.toList());
+            return manager.computeIntersection(intscR, operandModels);
+        }
+
+        @Override
+        public RelationModel visitTransitiveClosure(TransitiveClosure tscl) {
+            Relation tsclR = tscl.getDefinedRelation();
+            RelationModel operand = executionModel.getRelationModel(tscl.getOperand());
+            return manager.computeTransitiveClosure(tsclR, operand);
+        }
+
+        @Override
+        public RelationModel visitProgramOrder(ProgramOrder po) {
+            Relation r = po.getDefinedRelation();
+            RelationModel rm = manager.newModel(r, PO);
+            for (Thread t : executionModel.getThreads()) {
+                List<EventData> events = executionModel.getThreadEventsMap().get(t).stream()
+                                                       .filter(e -> e.hasTag(Tag.VISIBLE)
+                                                               || e.isLocal()
+                                                               || e.isAssert())
+                                                       .toList();
+                if (events.size() <= 1) { continue; }
+                for (int i = 1; i < events.size(); i++) {
+                    EventData e1 = events.get(i - 1);
+                    EventData e2 = events.get(i);
+                    manager.addEdgeToRelation(rm, e1, e2);
+                }
+            }
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitReadFrom(ReadFrom rf) {
+            Relation r = rf.getDefinedRelation();
+            RelationModel rm = manager.newModel(r, RF);
+            EncodingContext.EdgeEncoder rfEncoder = executionModel.getContext().edge(r);
+            for (Map.Entry<BigInteger, Set<EventData>> reads : executionModel.getAddressReadsMap().entrySet()) {
+                BigInteger address = reads.getKey();
+                for (EventData read : reads.getValue()) {
+                    for (EventData write : executionModel.getAddressWritesMap().get(address)) {
+                        BooleanFormula rfExpr = rfEncoder.encode(write.getEvent(), read.getEvent());
+                        if (isTrue(rfExpr)) {
+                            manager.addEdgeToRelation(rm, write, read);
+                            break;
+                        }
+                    }
+                }
+            }
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitCoherence(Coherence co) {
+            Relation r = co.getDefinedRelation();
+            RelationModel rm = manager.newModel(r, CO);
+            EncodingContext.EdgeEncoder coEncoder = executionModel.getContext().edge(r);
+            for (Map.Entry<BigInteger, Set<EventData>> writes : executionModel.getAddressWritesMap().entrySet()) {
+                BigInteger address = writes.getKey();
+                Set<EventData> writeEvents = writes.getValue();
+                List<EventData> sortedWrites;
+                if (executionModel.getContext().usesSATEncoding()) {
+                    Map<EventData, List<EventData>> edges = new HashMap<>();
+                    for (EventData w1 : writeEvents) {
+                        edges.put(w1, new ArrayList<>());
+                        for (EventData w2 : writeEvents) {
+                            if (isTrue(coEncoder.encode(w1.getEvent(), w2.getEvent()))) {
+                                edges.get(w1).add(w2);
+                            }
+                        }
+                    }
+                    DependencyGraph<EventData> depGraph = DependencyGraph.from(writeEvents, edges);
+                    sortedWrites = new ArrayList<>(Lists.reverse(depGraph.getNodeContents()));
+                } else {
+                    Map<EventData, BigInteger> writeClockMap = new HashMap<>(writeEvents.size() * 4 / 3, 0.75f);
+                    for (EventData w : writeEvents) {
+                        writeClockMap.put(w, executionModel.getModel().evaluate(executionModel.getContext().memoryOrderClock(w.getEvent())));
+                    }
+                    sortedWrites = writeEvents.stream().sorted(Comparator.comparing(writeClockMap::get)).collect(Collectors.toList());
+                }
+
+                int index = 0;
+                for (EventData w : sortedWrites) {
+                    w.setCoherenceIndex(index++);
+                }
+                for (int i = 2; i < sortedWrites.size(); i ++) {
+                    EventData w1 = sortedWrites.get(i - 1);
+                    EventData w2 = sortedWrites.get(i);
+                    manager.addEdgeToRelation(rm, w1, w2);
+                }
+            }
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitSameLocation(SameLocation loc) {
+            Relation r = loc.getDefinedRelation();
+            RelationModel rm = manager.newModel(r, LOC);
+            EncodingContext.EdgeEncoder locEncoder = executionModel.getContext().edge(r);
+            Map<BigInteger, Set<EventData>> memoryAccesses = Stream.concat(executionModel.getAddressReadsMap().entrySet().stream(),
+                                                                           executionModel.getAddressWritesMap().entrySet().stream())
+                                                                   .collect(Collectors.toMap(
+                                                                            Map.Entry::getKey,
+                                                                            Map.Entry::getValue,
+                                                                            (set1, set2) -> {
+                                                                                Set<EventData> merged = new HashSet<>(set1);
+                                                                                merged.addAll(set2);
+                                                                                return merged;
+                                                                            }
+                                                             ));
+            for (Map.Entry<BigInteger, Set<EventData>> sameLocAccesses : memoryAccesses.entrySet()) {
+                BigInteger addr = sameLocAccesses.getKey();
+                List<EventData> asList = new ArrayList<>(sameLocAccesses.getValue());
+                for (int i = 0; i < asList.size(); i++) {
+                    for (int j = i + 1; j < asList.size(); j++) {
+                        EventData e1 = asList.get(i);
+                        EventData e2 = asList.get(j);
+                        BooleanFormula locExpr1 = locEncoder.encode(e1.getEvent(), e2.getEvent());
+                        if (isTrue(locExpr1)) {
+                            manager.addEdgeToRelation(rm, e1, e2);
+                        }
+                        BooleanFormula locExpr2 = locEncoder.encode(e2.getEvent(), e1.getEvent());
+                        if (isTrue(locExpr2)) {
+                            manager.addEdgeToRelation(rm, e2, e1);
+                        }
+                    }
+                }
+            }
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitInternal(Internal in) {
+            Relation r = in.getDefinedRelation();
+            RelationModel rm = manager.newModel(r, INT);
+            EncodingContext.EdgeEncoder intEncoder = executionModel.getContext().edge(r);
+            for (Thread t : executionModel.getThreads()) {
+                List<EventData> events = getVisibleEvents(t);
+                if (events.size() <= 1) { continue; }
+                for (int i = 0; i < events.size(); i++) {
+                    for (int j = i + 1; j < events.size(); j++) {
+                        EventData e1 = events.get(i);
+                        EventData e2 = events.get(j);
+                        BooleanFormula intExpr1 = intEncoder.encode(e1.getEvent(), e2.getEvent());
+                        if (isTrue(intExpr1)) {
+                            manager.addEdgeToRelation(rm, e1, e2);
+                        }
+                        BooleanFormula intExpr2 = intEncoder.encode(e2.getEvent(), e1.getEvent());
+                        if (isTrue(intExpr2)) {
+                            manager.addEdgeToRelation(rm, e2, e1);
+                        }
+                    }
+                }
+            }
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitExternal(External ext) {
+            Relation r = ext.getDefinedRelation();
+            RelationModel rm = manager.newModel(r, EXT);
+            EncodingContext.EdgeEncoder extEncoder = executionModel.getContext().edge(r);
+            List<Thread> threads = executionModel.getThreads();
+            for (int i = 0; i < threads.size(); i++) {
+                List<EventData> eventList1 = getVisibleEvents(threads.get(i));
+                if (eventList1.size() <= 1) { continue; }
+                for (int j = i + 1; j < threads.size(); j++) {
+                    List<EventData> eventList2 = getVisibleEvents(threads.get(j));
+                    if (eventList2.size() <= 1) { continue; }
+                    for (EventData e1 : eventList1) {
+                        for (EventData e2 : eventList2) {
+                            BooleanFormula extExpr1 = extEncoder.encode(e1.getEvent(), e2.getEvent());
+                            if (isTrue(extExpr1)) {
+                                manager.addEdgeToRelation(rm, e1, e2);
+                            }
+                            BooleanFormula extExpr2 = extEncoder.encode(e2.getEvent(), e1.getEvent());
+                            if (isTrue(extExpr2)) {
+                                manager.addEdgeToRelation(rm, e2, e1);
+                            }
+                        }
+                    }
+                }
+            }
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitReadModifyWrites(ReadModifyWrites rmw) {
+            Relation r = rmw.getDefinedRelation();
+            RelationModel rm = manager.newModel(r, RMW);
+            EncodingContext.EdgeEncoder rmwEncoder = executionModel.getContext().edge(r);
+            for (Map.Entry<BigInteger, Set<EventData>> addressReads : executionModel.getAddressReadsMap().entrySet()) {
+                BigInteger addr = addressReads.getKey();
+                for (EventData read : addressReads.getValue()) {
+                    for (EventData write : executionModel.getAddressWritesMap().get(addr)) {
+                        if (read.getThread() == write.getThread()
+                            && read.isRMW() && write.isRMW()) {
+                            BooleanFormula rmwExpr = rmwEncoder.encode(read.getEvent(), write.getEvent());
+                            if (isTrue(rmwExpr)) {
+                                manager.addEdgeToRelation(rm, read, write);
+                            }
+                        }
+                    }
+                }
+            }
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitProduct(CartesianProduct prod) {
+            Relation r = prod.getDefinedRelation();
+            RelationModel rm = manager.newModel(r);
+            List<EventData> eList1 = executionModel.getEventList().stream()
+                                                   .filter(e -> prod.getFirstFilter().apply(e.getEvent()))
+                                                   .toList();
+            List<EventData> eList2 = executionModel.getEventList().stream()
+                                                   .filter(e -> prod.getSecondFilter().apply(e.getEvent()))
+                                                   .toList();
+            for (EventData p : eList1) {
+                for (EventData s : eList2) {
+                    if (p != s) {
+                        manager.addEdgeToRelation(rm, p, s);
+                    }
+                }
+            }
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitSetIdentity(SetIdentity set) {
+            Relation r = set.getDefinedRelation();
+            RelationModel rm = manager.newModel(r);
+            List<EventData> eList = executionModel.getEventList().stream()
+                                                  .filter(e -> set.getFilter().apply(e.getEvent()))
+                                                  .toList();
+            eList.stream().forEach(e -> manager.addEdgeToRelation(rm, e, e));
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitRangeIdentity(RangeIdentity range) {
+            Relation r = range.getDefinedRelation();
+            RelationModel rm = manager.newModel(r);
+            Set<EventData> successors = new HashSet<>();
+            executionModel.getRelationModel(range.getOperand()).getEdges()
+                          .stream().forEach(e -> successors.add(e.getSuccessor()));
+            successors.stream().forEach(s -> manager.addEdgeToRelation(rm, s, s));
+            return rm;
+        }
+
+        @Override
+        public RelationModel visitDomainIdentity(DomainIdentity domain) {
+            Relation r = domain.getDefinedRelation();
+            RelationModel rm = manager.newModel(r);
+            Set<EventData> predecessors = new HashSet<>();
+            executionModel.getRelationModel(domain.getOperand()).getEdges()
+                          .stream().forEach(e -> predecessors.add(e.getPredecessor()));
+            predecessors.stream().forEach(p -> manager.addEdgeToRelation(rm, p, p));
+            return rm;
+        }
+
+        public RelationModel buildDataDependency(Relation dataDep) {
+            RelationModel rm = manager.newModel(dataDep, DATA);
+            for (Map.Entry<EventData, Set<EventData>> deps : executionModel.getDataDepMap().entrySet()) {
+                EventData e = deps.getKey();
+                for (EventData dep : deps.getValue()) {
+                    manager.addEdgeToRelation(rm, e, dep);
+                }
+            }
+            return rm;
+        }
+
+        public RelationModel buildAddressDependency(Relation addrDep) {
+            RelationModel rm = manager.newModel(addrDep, ADDR);
+            for (Map.Entry<EventData, Set<EventData>> deps : executionModel.getAddrDepMap().entrySet()) {
+                EventData e = deps.getKey();
+                for (EventData dep : deps.getValue()) {
+                    manager.addEdgeToRelation(rm, e, dep);
+                }
+            }
+            return rm;
+        }
+        
+        public RelationModel buildControlDependency(Relation ctrlDep) {
+            RelationModel rm = manager.newModel(ctrlDep, CTRL);
+            for (Map.Entry<EventData, Set<EventData>> deps : executionModel.getCtrlDepMap().entrySet()) {
+                EventData e = deps.getKey();
+                for (EventData dep : deps.getValue()) {
+                    manager.addEdgeToRelation(rm, e, dep);
+                }
+            }
+            return rm;
+        }
+
+        private boolean isTrue(BooleanFormula formula) {
+            return Boolean.TRUE.equals(executionModel.getModel().evaluate(formula));
+        }
+
+        private List<EventData> getVisibleEvents(Thread t) {
+            return executionModel.getThreadEventsMap().get(t).stream()
+                                 .filter(e -> e.hasTag(Tag.VISIBLE))
+                                 .toList();
+        }
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModelManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/relation/RelationModelManager.java
@@ -14,6 +14,8 @@ import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Lists;
 import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.math.BigInteger;
 import java.util.*;
@@ -24,6 +26,9 @@ import static com.dat3m.dartagnan.wmm.RelationNameRepository.*;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class RelationModelManager {
+
+    private static final Logger logger = LogManager.getLogger(RelationModelManager.class);
+
     private final ExecutionModel executionModel;
     private final RelationModelBuilder builder;
 
@@ -38,8 +43,11 @@ public class RelationModelManager {
 
     public void extractRelations(List<String> relationNames) {
         for (String name : relationNames) {
-            Relation r = checkNotNull(executionModel.getMemoryModelForWitness().getRelation(name),
-                                      String.format("Relation with the name %s does not exist", name));
+            Relation r = executionModel.getMemoryModelForWitness().getRelation(name);
+            if (r == null) {
+                logger.warn("Relation with the name {} does not exist", name);
+                continue;
+            }
             extractRelation(r, Optional.of(name));
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -35,6 +35,7 @@ public abstract class ModelChecker {
 
     protected Result res = Result.UNKNOWN;
     protected EncodingContext context;
+    protected EncodingContext contextForWitness;
     private String flaggedPairsOutput = "";
 
     public final Result getResult() {
@@ -42,6 +43,12 @@ public abstract class ModelChecker {
     }
     public EncodingContext getEncodingContext() {
         return context;
+    }
+    public EncodingContext getEncodingContextForWitness() {
+        return contextForWitness;
+    }
+    protected void setEncodingContextForWitness(EncodingContext c) {
+        contextForWitness = c;
     }
     public final String getFlaggedPairsOutput() {
         return flaggedPairsOutput;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -206,7 +206,8 @@ public class RefinementSolver extends ModelChecker {
         performStaticWmmAnalyses(task, analysisContext, config);
 
         // Encoding for witness generation only
-        setEncodingContextForWitness(EncodingContext.of(task, analysisContext, ctx.getFormulaManager()));
+        EncodingContext contextForWitness = EncodingContext.of(task, analysisContext, ctx.getFormulaManager());
+        setEncodingContextForWitness(contextForWitness);
 
         //  ------- Generate refinement model -------
         final RefinementModel refinementModel = generateRefinementModel(memoryModel);
@@ -233,7 +234,7 @@ public class RefinementSolver extends ModelChecker {
         final WmmEncoder baselineEncoder = WmmEncoder.withContext(context);
 
         final BooleanFormulaManager bmgr = ctx.getFormulaManager().getBooleanFormulaManager();
-        final WMMSolver solver = WMMSolver.withContext(refinementModel, context, analysisContext, config);
+        final WMMSolver solver = WMMSolver.withContext(refinementModel, context, contextForWitness, config);
         final Refiner refiner = new Refiner(refinementModel);
         final Property.Type propertyType = Property.getCombinedType(task.getProperty(), task);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -205,6 +205,9 @@ public class RefinementSolver extends ModelChecker {
         Context baselineContext = Context.createCopyFrom(analysisContext);
         performStaticWmmAnalyses(task, analysisContext, config);
 
+        // Encoding for witness generation only
+        setEncodingContextForWitness(EncodingContext.of(task, analysisContext, ctx.getFormulaManager()));
+
         //  ------- Generate refinement model -------
         final RefinementModel refinementModel = generateRefinementModel(memoryModel);
         final Wmm baselineModel = refinementModel.getBaseModel();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ColorMap.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ColorMap.java
@@ -1,0 +1,67 @@
+package com.dat3m.dartagnan.witness.graphviz;
+
+import java.awt.Color;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
+
+import static com.dat3m.dartagnan.wmm.RelationNameRepository.PO;
+import static com.dat3m.dartagnan.wmm.RelationNameRepository.RF;
+import static com.dat3m.dartagnan.wmm.RelationNameRepository.CO;
+
+
+class ColorMap {
+    private final Map<String, String> fixedColorMap = new HashMap<>();
+    private final Set<String> usedColors = new HashSet<>();
+    private int currentHue = 0;
+    private int step = 72;
+    private float saturation = 1.0f;
+    private float brightness = 1.0f;
+
+    ColorMap() {
+        // Black for PO
+        fixedColorMap.put(PO, colorToHex(Color.getHSBColor(0.0f, 0.0f, 0.0f)));
+        // Green for RF
+        fixedColorMap.put(RF, colorToHex(Color.getHSBColor(0.33f, 1.0f, 1.0f)));
+        // Red for CO
+        fixedColorMap.put(CO, colorToHex(Color.getHSBColor(0.0f, 1.0f, 1.0f)));
+        // Orange for FR
+        fixedColorMap.put("fr", colorToHex(Color.getHSBColor(0.08f, 1.0f, 1.0f)));
+
+        usedColors.addAll(fixedColorMap.values());
+    }
+
+    String getColor(String relName) {
+        if (fixedColorMap.containsKey(relName)) {
+            return fixedColorMap.get(relName);
+        }
+        return generateColor();
+    }
+
+    private String generateColor() {
+        updateHue();
+        float hue = currentHue / 360.0f;
+        String c = colorToHex(Color.getHSBColor(hue, saturation, brightness));
+        if (usedColors.contains(c)) {
+            c = generateColor();
+        }
+        usedColors.add(c);
+        return c;
+    }
+
+    private String colorToHex(Color c) {
+        return String.format("\"#%02x%02x%02x\"", c.getRed(), c.getGreen(), c.getBlue());
+    }
+
+    private void updateHue() {
+        currentHue += step;
+        if (currentHue >= 360) {
+            currentHue -= 360;
+            step /= 2;
+            if (currentHue == 0) {
+                updateHue();
+            }
+        }
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -91,7 +91,7 @@ public class ExecutionGraphVisualizer {
             throws InvalidConfigurationException {
         model.getContext().getTask().getConfig().inject(this);
         if (relToShowStr.equals("default")) {
-            relToShow = new HashSet<>(Set.of(PO, RF, CO, "fr"));
+            relToShow = new HashSet<>(Set.of(PO, RF, CO));
         }
         else {
             relToShow = new HashSet<>(Arrays.asList(relToShowStr.split(",\\s*")));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -37,13 +37,13 @@ public class ExecutionGraphVisualizer {
     private static final Logger logger = LogManager.getLogger(ExecutionGraphVisualizer.class);
 
     private final Graphviz graphviz;
+    private final ColorMap colorMap;
     private SyntacticContextAnalysis synContext = getEmptyInstance();
     // By default, we do not filter anything
     private BiPredicate<EventData, EventData> rfFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> frFilter = (x, y) -> true;
     private BiPredicate<EventData, EventData> coFilter = (x, y) -> true;
     private final List<MemoryObjectModel> sortedMemoryObjects = new ArrayList<>();
-    private Map<String, String> colors;
     private Set<String> relToShow;
 
     @Option(name=WITNESS_RELATIONS_TO_SHOW,
@@ -53,8 +53,7 @@ public class ExecutionGraphVisualizer {
 
     public ExecutionGraphVisualizer() {
         this.graphviz = new Graphviz();
-
-        initializeColors();
+        this.colorMap = new ColorMap();
     }
 
 
@@ -100,23 +99,8 @@ public class ExecutionGraphVisualizer {
         return this;
     }
 
-    private void initializeColors() {
-        colors = new HashMap<>();
-        colors.put(PO, "black");
-        colors.put(RF, "green");
-        colors.put("fr", "orange");
-        colors.put(CO, "red");
-    }
-
     private BiPredicate<EventData, EventData> getFilter(String relationName) {
         return (x, y) -> true;
-    }
-
-    private String getColor(String relationName) {
-        if (colors.containsKey(relationName)) {
-            return colors.get(relationName);
-        }
-        return "aqua";
     }
 
     private void computeAddressMap(ExecutionModel model) {
@@ -139,7 +123,7 @@ public class ExecutionGraphVisualizer {
 
     private ExecutionGraphVisualizer addRelation(ExecutionModel model, String relationName) {
         graphviz.beginSubgraph(relationName);
-        String attributes = String.format("color=%s", getColor(relationName));
+        String attributes = String.format("color=%s", colorMap.getColor(relationName));
         if (relationName.equals(PO)) {
             attributes += ", weight=100";
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -128,10 +128,10 @@ public class ExecutionGraphVisualizer {
             attributes += ", weight=100";
         }
         graphviz.setEdgeAttributes(attributes);
-        String label = "label=" + relationName.replace("-", "");
+        String label = String.format("label=\"%s\"", relationName);
         BiPredicate<EventData, EventData> filter = getFilter(relationName);
         RelationModel rm = model.getRelationModel(relationName);
-        for (RelationModel.EdgeModel edge : rm.getEdges()) {
+        for (RelationModel.EdgeModel edge : rm.getEdgesToShow()) {
             EventData predecessor = edge.getPredecessor();
             EventData successor = edge.getSuccessor();
 
@@ -162,18 +162,6 @@ public class ExecutionGraphVisualizer {
 
         // --- Subgraph start ---
         graphviz.beginSubgraph("T" + thread.getId());
-        // graphviz.setEdgeAttributes("weight=100");
-        // // --- Node list ---
-        // for (int i = 1; i < threadEvents.size(); i++) {
-        //     EventData e1 = threadEvents.get(i - 1);
-        //     EventData e2 = threadEvents.get(i);
-
-        //     if (ignore(e1) || ignore(e2)) {
-        //         continue;
-        //     }
-
-        //     appendEdge(e1, e2, (String[]) null);
-        // }
 
         for (EventData e : threadEvents) {
             appendNode(e, (String[]) null);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -122,6 +122,11 @@ public class ExecutionGraphVisualizer {
     }
 
     private ExecutionGraphVisualizer addRelation(ExecutionModel model, String relationName) {
+        RelationModel rm = model.getRelationModel(relationName);
+        if (rm == null) {
+            logger.warn("Relation with the name {} does not exist", relationName);
+            return this;
+        }
         graphviz.beginSubgraph(relationName);
         String attributes = String.format("color=%s", colorMap.getColor(relationName));
         if (relationName.equals(PO)) {
@@ -130,7 +135,6 @@ public class ExecutionGraphVisualizer {
         graphviz.setEdgeAttributes(attributes);
         String label = String.format("label=\"%s\"", relationName);
         BiPredicate<EventData, EventData> filter = getFilter(relationName);
-        RelationModel rm = model.getRelationModel(relationName);
         for (RelationModel.EdgeModel edge : rm.getEdgesToShow()) {
             EventData predecessor = edge.getPredecessor();
             EventData successor = edge.getSuccessor();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/Graphviz.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/Graphviz.java
@@ -61,7 +61,11 @@ public class Graphviz {
     }
 
     public Graphviz addNode(String name, String... attributes) {
-        text.append(String.format("%s [%s]\n", name, String.join(", ", attributes)));
+        if (attributes == null) {
+            text.append(String.format("%s\n", name));
+        } else {
+            text.append(String.format("%s [%s]\n", name, String.join(", ", attributes)));
+        }
         return this;
     }
 


### PR DESCRIPTION
This PR is related to #732 and contains the following:

1) Implementation of `RelationModel`, a representation of relations in `Dartagnan` dedicated for better witness generation, and the corresponding "RelationModelManager" that is responsible for construction of `RelationModel` and computation of derived relations.
2) Support of witness generation for showing relations defined in the model `vmm.cat`. Users may pass `--witness.relationsToShow=r1,r2,r3...` into the command to have witness for corresponding relations.
3) Add `Local` and `Assert` events to witness graph. But note code of this part is temporary and needs to be refined, which will be done in the next step: implementation of `EventModel`...