### PR TITLE
Improvements for SVCOMP 2025

### DIFF
--- a/Dartagnan-SVCOMP.sh
+++ b/Dartagnan-SVCOMP.sh
@@ -21,8 +21,6 @@ else
     export DAT3M_HOME=$(pwd)
     export DAT3M_OUTPUT=$DAT3M_HOME/output
 
-    export OPTFLAGS="-mem2reg -sroa -early-cse -indvars -loop-unroll -fix-irreducible -loop-simplify -simplifycfg -gvn"
-
     skip_assertions_of_type="--program.processing.skipAssertionsOfType=USER"
     if [[ $propertypath == *"no-overflow.prp"* ]]; then
         export CFLAGS="-fgnu89-inline -fsanitize=signed-integer-overflow"

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -251,7 +251,7 @@ public class Dartagnan extends BaseOptions {
         // ------------------ Generate Witness, if possible ------------------
         final EnumSet<Property> properties = task.getProperty();
         if (task.getProgram().getFormat().equals(SourceLanguage.LLVM) && modelChecker.hasModel()
-                && properties.contains(PROGRAM_SPEC) && properties.size() == 1
+                && (properties.contains(PROGRAM_SPEC) || properties.contains(DATARACEFREEDOM)) && properties.size() == 1
                 && modelChecker.getResult() != UNKNOWN) {
             try {
                 WitnessBuilder w = WitnessBuilder.of(modelChecker.getEncodingContext(), prover,
@@ -317,6 +317,10 @@ public class Dartagnan extends BaseOptions {
                                     .append("\n");
                         }
                     }
+                    summary.append("=================================================\n");
+                }
+                if (props.contains(DATARACEFREEDOM) && FALSE.equals(model.evaluate(DATARACEFREEDOM.getSMTVariable(encCtx)))) {
+                    summary.append("============= SVCOMP data race found ============\n");
                     summary.append("=================================================\n");
                 }
                 final List<Axiom> violatedCATSpecs = task.getMemoryModel().getAxioms().stream()

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Intrinsics.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/Intrinsics.java
@@ -664,9 +664,9 @@ public class Intrinsics {
         final Expression lockAddress = call.getArguments().get(0);
         final Expression locked = expressions.makeOne(type);
         final Expression unlocked = expressions.makeZero(type);
-        return List.of(
+        return EventFactory.eventSequence(
                 EventFactory.Llvm.newLoad(oldValueRegister, lockAddress, Tag.C11.MO_RELAXED),
-                EventFactory.newAssert(expressions.makeEQ(oldValueRegister, locked), "Unlocking an already unlocked mutex"),
+                notToInline.contains(AssertionType.USER) ? null : EventFactory.newAssert(expressions.makeEQ(oldValueRegister, locked), "Unlocking an already unlocked mutex"),
                 EventFactory.Llvm.newStore(lockAddress, unlocked, Tag.C11.MO_RELEASE),
                 assignSuccess(errorRegister)
         );

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
@@ -84,6 +84,9 @@ public class WitnessBuilder {
         if (summary.contains("user assertion")) {
             return "CHECK( init(main()), LTL(G ! call(reach_error())))";
         }
+        if (summary.contains("SVCOMP data race found")) {
+            return "CHECK( init(main()), LTL(G ! data-race) )";
+        }
         throw new UnsupportedOperationException("Violation found for unsupported property");
     }
 

--- a/svcomp.properties
+++ b/svcomp.properties
@@ -2,3 +2,4 @@ method=eager
 encoding.integers=true
 svcomp.step=5
 svcomp.umax=27
+witness=graphml

--- a/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
@@ -127,7 +127,6 @@ public class SVCOMPRunner extends BaseOptions {
             cmd.add("svcomp.properties");
             cmd.add(String.format("--%s=%s", PROPERTY, r.property.asStringOption()));
             cmd.add(String.format("--%s=%s", BOUND, bound));
-            cmd.add(String.format("--%s=%s", WITNESS, GRAPHML.asStringOption()));
             cmd.add(String.format("--%s=%s", WITNESS_ORIGINAL_PROGRAM_PATH, programPath));
             cmd.addAll(filterOptions(config));
 


### PR DESCRIPTION
This PR makes some improvements for SVCOMP 2025:
- removes the llvm optimizations (I did some dryrun a few weeks ago and it did not seem to help much using them)
- it enables the generation of witnesses for data-race violations (which were not required until the 2024 edition)
- it skips the "trying to release an already released lock" assertion when `AssertionType.USER` is configured to be skipped.
- moves some hardcoded options from the svcomp runner to the option file