### PR TITLE
Fix execution encoding of control barriers

### DIFF
--- a/benchmarks/opencl/NonUniformBarrier.cl
+++ b/benchmarks/opencl/NonUniformBarrier.cl
@@ -1,0 +1,7 @@
+__kernel void non_uniform_barrier() {
+
+    if(get_global_id(0) == 0) {
+        barrier(CLK_GLOBAL_MEM_FENCE);
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
@@ -264,7 +264,8 @@ public class ProgramEncoder implements Encoder {
                     if (!e1.getThread().equals(e2.getThread())) {
                         Expression id2 = e2.getId();
                         BooleanFormula sameId = context.equal(context.encodeExpressionAt(id1, e1), context.encodeExpressionAt(id2, e2));
-                        BooleanFormula cf = bmgr.or(context.controlFlow(e2), bmgr.not(sameId));
+                        BooleanFormula cfImplExec = bmgr.implication(context.controlFlow(e2), context.execution(e2));
+                        BooleanFormula cf = bmgr.or(cfImplExec, bmgr.not(sameId));
                         allCF = bmgr.and(allCF, cf);
                     }
                 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvLivenessTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/basic/SpirvLivenessTest.java
@@ -1,0 +1,87 @@
+package com.dat3m.dartagnan.spirv.basic;
+
+import com.dat3m.dartagnan.configuration.Arch;
+import com.dat3m.dartagnan.encoding.ProverWithTracker;
+import com.dat3m.dartagnan.parsers.cat.ParserCat;
+import com.dat3m.dartagnan.parsers.program.ProgramParser;
+import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.verification.VerificationTask;
+import com.dat3m.dartagnan.verification.solving.AssumeSolver;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
+import com.dat3m.dartagnan.wmm.Wmm;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.log.BasicLogManager;
+import org.sosy_lab.java_smt.SolverContextFactory;
+import org.sosy_lab.java_smt.api.SolverContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import static com.dat3m.dartagnan.configuration.Property.LIVENESS;
+import static com.dat3m.dartagnan.utils.ResourceHelper.getRootPath;
+import static com.dat3m.dartagnan.utils.ResourceHelper.getTestResourcePath;
+import static com.dat3m.dartagnan.utils.Result.*;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class SpirvLivenessTest {
+
+    private final String modelPath = getRootPath("cat/spirv.cat");
+    private final String programPath;
+    private final int bound;
+    private final Result expected;
+
+    public SpirvLivenessTest(String file, int bound, Result expected) {
+        this.programPath = getTestResourcePath("spirv/basic/" + file);
+        this.bound = bound;
+        this.expected = expected;
+    }
+
+    @Parameterized.Parameters(name = "{index}: {0}, {1}, {2}")
+    public static Iterable<Object[]> data() throws IOException {
+        return Arrays.asList(new Object[][]{
+                {"NonUniformBarrier.spv.dis", 1, PASS},
+        });
+    }
+
+    @Test
+    public void testAllSolvers() throws Exception {
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
+             assertEquals(expected, RefinementSolver.run(ctx, prover, mkTask()).getResult());
+        }
+        try (SolverContext ctx = mkCtx(); ProverWithTracker prover = mkProver(ctx)) {
+            assertEquals(expected, AssumeSolver.run(ctx, prover, mkTask()).getResult());
+        }
+    }
+
+    private SolverContext mkCtx() throws InvalidConfigurationException {
+        Configuration cfg = Configuration.builder().build();
+        return SolverContextFactory.createSolverContext(
+                cfg,
+                BasicLogManager.create(cfg),
+                ShutdownManager.create().getNotifier(),
+                SolverContextFactory.Solvers.Z3);
+    }
+
+    private ProverWithTracker mkProver(SolverContext ctx) {
+        return new ProverWithTracker(ctx, "", SolverContext.ProverOptions.GENERATE_MODELS);
+    }
+
+    private VerificationTask mkTask() throws Exception {
+        VerificationTask.VerificationTaskBuilder builder = VerificationTask.builder()
+                .withConfig(Configuration.builder().build())
+                .withBound(bound)
+                .withTarget(Arch.VULKAN);
+        Program program = new ProgramParser().parse(new File(programPath));
+        Wmm mcm = new ParserCat().parse(new File(modelPath));
+        return builder.build(program, mcm, EnumSet.of(LIVENESS));
+    }
+}

--- a/dartagnan/src/test/resources/spirv/basic/NonUniformBarrier.spv.dis
+++ b/dartagnan/src/test/resources/spirv/basic/NonUniformBarrier.spv.dis
@@ -1,0 +1,62 @@
+; @Config: 2, 1, 1
+; SPIR-V
+; Version: 1.6
+; Generator: Google Clspv; 0
+; Bound: 43
+; Schema: 0
+               OpCapability Shader
+         %35 = OpExtInstImport "NonSemantic.ClspvReflection.5"
+               OpMemoryModel Logical Vulkan
+               OpEntryPoint GLCompute %16 "non_uniform_barrier" %gl_GlobalInvocationID %13 %5
+               OpSource OpenCL_C 300
+         %36 = OpString "non_uniform_barrier"
+         %37 = OpString "__kernel"
+               OpMemberDecorate %_struct_3 0 Offset 0
+               OpDecorate %_struct_3 Block
+               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+               OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+               OpDecorate %8 SpecId 0
+               OpDecorate %9 SpecId 1
+               OpDecorate %10 SpecId 2
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+  %_struct_3 = OpTypeStruct %v3uint
+%_ptr_PushConstant__struct_3 = OpTypePointer PushConstant %_struct_3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+          %8 = OpSpecConstant %uint 1
+          %9 = OpSpecConstant %uint 1
+         %10 = OpSpecConstant %uint 1
+%gl_WorkGroupSize = OpSpecConstantComposite %v3uint %8 %9 %10
+%_ptr_Private_v3uint = OpTypePointer Private %v3uint
+       %void = OpTypeVoid
+         %15 = OpTypeFunction %void
+%_ptr_Input_uint = OpTypePointer Input %uint
+     %uint_0 = OpConstant %uint 0
+%_ptr_PushConstant_uint = OpTypePointer PushConstant %uint
+       %bool = OpTypeBool
+     %uint_2 = OpConstant %uint 2
+    %uint_72 = OpConstant %uint 72
+    %uint_12 = OpConstant %uint 12
+     %uint_1 = OpConstant %uint 1
+          %5 = OpVariable %_ptr_PushConstant__struct_3 PushConstant
+%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
+         %13 = OpVariable %_ptr_Private_v3uint Private %gl_WorkGroupSize
+         %16 = OpFunction %void None %15
+         %17 = OpLabel
+         %20 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
+         %21 = OpLoad %uint %20 Aligned 16
+         %23 = OpAccessChain %_ptr_PushConstant_uint %5 %uint_0 %uint_0
+         %24 = OpLoad %uint %23 Aligned 16
+         %25 = OpISub %uint %uint_0 %24
+         %27 = OpIEqual %bool %21 %25
+               OpSelectionMerge %34 None
+               OpBranchConditional %27 %30 %34
+         %30 = OpLabel
+               OpControlBarrier %uint_2 %uint_2 %uint_72
+               OpBranch %34
+         %34 = OpLabel
+               OpReturn
+               OpFunctionEnd
+         %40 = OpExtInst %void %35 PushConstantRegionOffset %uint_0 %uint_12
+         %38 = OpExtInst %void %35 Kernel %16 %36 %uint_0 %uint_0 %37
+         %42 = OpExtInst %void %35 SpecConstantWorkgroupSize %uint_0 %uint_1 %uint_2


### PR DESCRIPTION
The added test (which should not hang) shows that our current encoding of execution barriers is wrong.
The current encoding is 
```
exec(e) = cf(e) /\ forall e' in group-barriers (cf(e') \/ id(e) != id(e'))
```
which allows the barrier in thread 0 not to be executed (since the other barrier id is the same and its control flow is false) even if its control flow is true, thus getting stuck and leading to a liveness violation.

The correct encoding should be
```
exec(e) = cf(e) /\ forall e' in group-barriers ((cf(e') => exec(e')) \/ id(e) != id(e'))
```
