### PR TITLE
Fix witnesses excluding the rf edges they enforce.

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
@@ -875,9 +875,8 @@ public class NativeRelationAnalysis implements RelationAnalysis {
                 EventGraph g = witness.getReadFromKnowledge(program, alias);
                 must.addAll(g);
                 for (Event r : g.getRange()) {
-                    may.removeIf((e1, e2) -> e2 == r);
+                    may.removeIf((e1, e2) -> e2 == r && !g.contains(e1, e2));
                 }
-                may.addAll(g);
             }
 
             logger.debug("Initial may set size for read-from: {}", may.size());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
@@ -877,6 +877,7 @@ public class NativeRelationAnalysis implements RelationAnalysis {
                 for (Event r : g.getRange()) {
                     may.removeIf((e1, e2) -> e2 == r);
                 }
+                may.addAll(g);
             }
 
             logger.debug("Initial may set size for read-from: {}", may.size());

--- a/svcomp.properties
+++ b/svcomp.properties
@@ -3,5 +3,3 @@ encoding.integers=true
 svcomp.step=5
 svcomp.umax=27
 witness=graphml
-// We can get rid of the option below once #767 is fixed
-wmm.analysis.extendedRelationAnalysis=false


### PR DESCRIPTION
Should fix issue #767.  When validating a witness, the Relation Analysis extracts `rf` edges, that must occur.  Because `rf` is (usually) functional, any other candidate in-edge for the participating load event is disabled by the witness.  The extraction code disabled even the extracted `rf` edge.  The Extended Relation Analysis then inferred mutual exclusiveness between those events.  Even without XRA, such loads always read 0, because of uninitialized memory.
The bug should affect all violation witnesses with at least one `rf` edge.