### PR TITLE
Fix handling of empty type

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
@@ -5,7 +5,10 @@ import com.dat3m.dartagnan.utils.Normalizer;
 import com.google.common.math.IntMath;
 
 import java.math.RoundingMode;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -170,7 +173,7 @@ public final class TypeFactory {
             return getMemorySizeInBytes(arrayType.getElementType());
         }
         if (type instanceof AggregateType aType) {
-            return aType.getTypeOffsets().stream().map(o -> getAlignment(o.type())).max(Integer::compare).orElseThrow();
+            return aType.getTypeOffsets().stream().map(o -> getAlignment(o.type())).max(Integer::compare).orElse(1);
         }
         throw new UnsupportedOperationException("Cannot compute memory layout of type " + type);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/type/TypeFactory.java
@@ -147,7 +147,7 @@ public final class TypeFactory {
         }
         if (type instanceof AggregateType aType) {
             List<TypeOffset> typeOffsets = aType.getTypeOffsets();
-            if (aType.getTypeOffsets().stream().anyMatch(o -> !hasKnownSize(type))) {
+            if (aType.getTypeOffsets().stream().anyMatch(o -> !hasKnownSize(o.type()))) {
                 return -1;
             }
             if (typeOffsets.isEmpty()) {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/expression/type/AggregateTypeTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/expression/type/AggregateTypeTest.java
@@ -85,6 +85,20 @@ public class AggregateTypeTest {
         testIllegalOffsets(List.of(arr, i32), List.of(0, 8), "Non-last element with unknown size");
     }
 
+    @Test
+    public void testEmptyType() {
+        Type empty = types.getAggregateType(List.of());
+        Type emptyAlt = types.getAggregateType(List.of(), List.of());
+
+        assertEquals(empty, emptyAlt);
+
+        Type i32 = types.getIntegerType(32);
+        List<Type> structMembers = List.of(empty, i32, empty, empty, i32, empty);
+
+        testDefaultOffsets(structMembers, List.of(0, 0, 4, 4, 4, 8), 8);
+        testExplicitOffsets(structMembers, List.of(0, 0, 4, 5, 8, 13), 16);
+    }
+
     private void testStandardOffsets(List<Type> fields, List<Integer> offsets, int size) {
         testDefaultOffsets(fields, offsets, size);
         testExplicitOffsets(fields, offsets, size);


### PR DESCRIPTION
This fixes a bug introduced in #770. 

EDIT: I renamed the PR and added more fixes, mostly related to handling the empty type (+ one fix for alignments computation of arrays).