### PR TITLE
Improved automatic data type conversion along rf-edges (+ related improvements)

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -257,8 +257,9 @@ public final class EncodingContext {
     public BooleanFormula equal(Formula left, Formula right, ConversionMode cMode) {
         if (cMode == ConversionMode.LEFT_TO_RIGHT) {
             return equal(right, left, ConversionMode.RIGHT_TO_LEFT);
-        } else if (cMode == ConversionMode.NO) {
-            new EncodingHelper(formulaManager).checkEqualTypes(left, right);
+        } else if (cMode == ConversionMode.NO && !new EncodingHelper(formulaManager).hasSameType(left, right)) {
+            final String error = String.format("Mismatching formula types: %s and %s", left, right);
+            throw new IllegalArgumentException(error);
         }
 
         if (left instanceof IntegerFormula l) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -269,8 +269,8 @@ public final class EncodingContext {
             BitvectorFormulaManager bvmgr = formulaManager.getBitvectorFormulaManager();
             return bvmgr.equal(l, toBitvector(right, bvmgr.getLength(l)));
         }
-        if (left instanceof BooleanFormula l && right instanceof BooleanFormula r) {
-            return booleanFormulaManager.equivalence(l, r);
+        if (left instanceof BooleanFormula l) {
+            return booleanFormulaManager.equivalence(l, toBoolean(right));
         }
         if (left instanceof TupleFormula l && right instanceof TupleFormula r) {
             return tupleFormulaManager.equal(l, r);
@@ -296,6 +296,13 @@ public final class EncodingContext {
             return formulaManager.getBitvectorFormulaManager().toIntegerFormula(f, false);
         }
         throw new UnsupportedOperationException(String.format("Unknown type for toInteger(%s).", formula));
+    }
+
+    private BooleanFormula toBoolean(Formula formula) {
+        if (formula instanceof BooleanFormula f) {
+            return f;
+        }
+        return booleanFormulaManager.not(equalZero(formula));
     }
 
     private BitvectorFormula toBitvector(Formula formula, int length) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingHelper.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingHelper.java
@@ -7,6 +7,7 @@ import com.google.common.base.Preconditions;
 import org.sosy_lab.java_smt.api.*;
 
 import java.math.BigInteger;
+import java.util.stream.IntStream;
 
 public class EncodingHelper {
 
@@ -126,7 +127,7 @@ public class EncodingHelper {
         return fmgr.getFormulaType(formula);
     }
 
-    public boolean checkEqualTypes(Formula left, Formula right) {
+    public boolean hasSameType(Formula left, Formula right) {
         if (left instanceof IntegerType && right instanceof IntegerType) {
             return true;
         } else if (left instanceof BooleanFormula && right instanceof BooleanFormula) {
@@ -135,13 +136,12 @@ public class EncodingHelper {
             final BitvectorFormulaManager bvmgr = fmgr.getBitvectorFormulaManager();
             return bvmgr.getLength(x) == bvmgr.getLength(y);
         } else if (left instanceof TupleFormula x && right instanceof TupleFormula y) {
-            boolean same = (x.getElements().size() == y.getElements().size());
-            if (same) {
-                for (int i = 0; i < x.getElements().size(); i++) {
-                    same &= checkEqualTypes(x.getElements().get(i), y.getElements().get(i));
-                }
+            if (x.getElements().size() != y.getElements().size()) {
+                return false;
             }
-            return same;
+            return IntStream.range(0, x.getElements().size()).allMatch(
+                    i -> hasSameType(x.getElements().get(i), y.getElements().get(i))
+            );
         }
 
         return false;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingHelper.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingHelper.java
@@ -2,9 +2,9 @@ package com.dat3m.dartagnan.encoding;
 
 import com.dat3m.dartagnan.encoding.formulas.TupleFormula;
 import com.dat3m.dartagnan.encoding.formulas.TupleValue;
-import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.google.common.base.Preconditions;
 import org.sosy_lab.java_smt.api.*;
+import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 
 import java.math.BigInteger;
 import java.util.stream.IntStream;
@@ -18,7 +18,7 @@ public class EncodingHelper {
     }
 
     public BooleanFormula equals(Formula left, Formula right) {
-        if (left instanceof NumeralFormula.IntegerFormula iLeft && right instanceof NumeralFormula.IntegerFormula iRight) {
+        if (left instanceof IntegerFormula iLeft && right instanceof IntegerFormula iRight) {
             return fmgr.getIntegerFormulaManager().equal(iLeft, iRight);
         }
 
@@ -32,7 +32,7 @@ public class EncodingHelper {
     }
 
     public BooleanFormula greaterThan(Formula left, Formula right, boolean signed) {
-        if (left instanceof NumeralFormula.IntegerFormula iLeft && right instanceof NumeralFormula.IntegerFormula iRight) {
+        if (left instanceof IntegerFormula iLeft && right instanceof IntegerFormula iRight) {
             return fmgr.getIntegerFormulaManager().greaterThan(iLeft, iRight);
         }
 
@@ -46,7 +46,7 @@ public class EncodingHelper {
     }
 
     public BooleanFormula greaterOrEquals(Formula left, Formula right, boolean signed) {
-        if (left instanceof NumeralFormula.IntegerFormula iLeft && right instanceof NumeralFormula.IntegerFormula iRight) {
+        if (left instanceof IntegerFormula iLeft && right instanceof IntegerFormula iRight) {
             return fmgr.getIntegerFormulaManager().greaterOrEquals(iLeft, iRight);
         }
 
@@ -60,7 +60,7 @@ public class EncodingHelper {
     }
 
     public Formula add(Formula left, Formula right) {
-        if (left instanceof NumeralFormula.IntegerFormula iLeft && right instanceof NumeralFormula.IntegerFormula iRight) {
+        if (left instanceof IntegerFormula iLeft && right instanceof IntegerFormula iRight) {
             return fmgr.getIntegerFormulaManager().add(iLeft, iRight);
         }
 
@@ -74,7 +74,7 @@ public class EncodingHelper {
     }
 
     public Formula subtract(Formula left, Formula right) {
-        if (left instanceof NumeralFormula.IntegerFormula iLeft && right instanceof NumeralFormula.IntegerFormula iRight) {
+        if (left instanceof IntegerFormula iLeft && right instanceof IntegerFormula iRight) {
             return fmgr.getIntegerFormulaManager().subtract(iLeft, iRight);
         }
 
@@ -91,7 +91,7 @@ public class EncodingHelper {
         //FIXME: integer modulo and BV modulo have different semantics, the former is always positive, the latter
         // returns a value whose sign depends on one of the two BVs.
         // The results in this implementation will match if the denominator <right> is positive which is the most usual case.
-        if (left instanceof NumeralFormula.IntegerFormula iLeft && right instanceof NumeralFormula.IntegerFormula iRight) {
+        if (left instanceof IntegerFormula iLeft && right instanceof IntegerFormula iRight) {
             return fmgr.getIntegerFormulaManager().modulo(iLeft, iRight);
         }
 
@@ -128,7 +128,7 @@ public class EncodingHelper {
     }
 
     public boolean hasSameType(Formula left, Formula right) {
-        if (left instanceof IntegerType && right instanceof IntegerType) {
+        if (left instanceof IntegerFormula && right instanceof IntegerFormula) {
             return true;
         } else if (left instanceof BooleanFormula && right instanceof BooleanFormula) {
             return true;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -5,7 +5,10 @@ import com.dat3m.dartagnan.expression.integers.IntLiteral;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.analysis.ReachingDefinitionsAnalysis;
 import com.dat3m.dartagnan.program.event.*;
-import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.core.Load;
+import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
+import com.dat3m.dartagnan.program.event.core.NamedBarrier;
+import com.dat3m.dartagnan.program.event.core.RMWStoreExclusive;
 import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.wmm.Constraint;
@@ -33,6 +36,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.*;
+import static com.dat3m.dartagnan.encoding.EncodingContext.ConversionMode.LEFT_TO_RIGHT;
 import static com.dat3m.dartagnan.program.event.Tag.*;
 import static com.dat3m.dartagnan.wmm.RelationNameRepository.RF;
 import static com.google.common.base.Verify.verify;
@@ -569,7 +573,7 @@ public class WmmEncoder implements Encoder {
                 MemoryCoreEvent r = (MemoryCoreEvent) e2;
                 BooleanFormula e = edge.encode(w, r);
                 BooleanFormula sameAddress = context.sameAddress(w, r);
-                BooleanFormula sameValue = context.equal(context.value(w), context.value(r));
+                BooleanFormula sameValue = context.equal(context.value(w), context.value(r), LEFT_TO_RIGHT);
                 edgeMap.computeIfAbsent(r, key -> new ArrayList<>()).add(e);
                 enc.add(bmgr.implication(e, bmgr.and(execution(w, r), sameAddress, sameValue)));
             });

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/formulas/TupleFormula.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/formulas/TupleFormula.java
@@ -18,6 +18,11 @@ public class TupleFormula implements Formula {
         this.elements = elements;
     }
 
+    // WARNING: Avoid using this method if possible.
+    public List<Formula> getElements() {
+        return elements;
+    }
+
     @Override
     public String toString() {
         return elements.stream()

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/formulas/TupleValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/formulas/TupleValue.java
@@ -1,0 +1,14 @@
+package com.dat3m.dartagnan.encoding.formulas;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/*
+    Simple representation of values of TupleFormula
+ */
+public record TupleValue(List<?> values) {
+    @Override
+    public String toString() {
+        return values.stream().map(Object::toString).collect(Collectors.joining(", ", "( ", " )"));
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/EventData.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/EventData.java
@@ -15,7 +15,7 @@ public class EventData implements Comparable<EventData> {
     private EventData readFrom;
     private int id = -1;
     private int localId = -1;
-    private BigInteger value;
+    private Object value;
     private BigInteger accessedAddress;
     private int coIndex = Integer.MIN_VALUE;
     private boolean wasExecuted;
@@ -52,10 +52,10 @@ public class EventData implements Comparable<EventData> {
     	accessedAddress = address;
     }
 
-    public BigInteger getValue() {
+    public Object getValue() {
     	return value;
     }
-    void setValue(BigInteger val) {
+    void setValue(Object val) {
     	value = val;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModelManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModelManager.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.verification.model;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.encoding.EncodingHelper;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Event;
@@ -269,7 +270,7 @@ public class ExecutionModelManager {
     }
 
     private Object evaluateByModel(Formula formula) {
-        return model.evaluate(formula);
+        return EncodingHelper.evaluate(formula, model);
     }
 
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ValueModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ValueModel.java
@@ -1,5 +1,7 @@
 package com.dat3m.dartagnan.verification.model;
 
+import com.dat3m.dartagnan.encoding.formulas.TupleValue;
+
 import java.math.BigInteger;
 
 
@@ -11,7 +13,7 @@ public class ValueModel {
     public ValueModel(Object literal) {
         if (literal == null) {
             value = null;
-        } else if (literal instanceof BigInteger || literal instanceof Boolean) {
+        } else if (literal instanceof BigInteger || literal instanceof Boolean || literal instanceof TupleValue) {
             value = literal;
         } else {
             throw new IllegalArgumentException("Unsupported value type: " + literal.getClass());


### PR DESCRIPTION
`EncodingContext.equal(Formula f, Formula g)` encodes equality modulo type conversions, e.g., if `f` and `g` have different are BV formulas of different bit-width, then one of them is truncated or extended to the other.
Which parameter was type-converted to the other was totally unclear from the callers perspective and caused ugly issues when encoding value equality induced by rf-edges.

I added a third parameter that let's the caller how the type conversion should be done (or if it should be done at all).

I also added the ability to evaluate `TupleFormulas` over a model. This requires using the helper method `EncodingHelper.evaluate(Formula, Model)` rather than invoking `Model.evaluate(Formula)`

@hernan-poncedeleon This will fix the strange values in the witness of the benchmark in #817 
