### PR TITLE
General BlockingEvent interface

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -11,11 +11,11 @@ import com.dat3m.dartagnan.parsers.witness.ParserWitness;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
+import com.dat3m.dartagnan.program.event.BlockingEvent;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.Assert;
 import com.dat3m.dartagnan.program.event.core.CondJump;
-import com.dat3m.dartagnan.program.event.core.ControlBarrier;
 import com.dat3m.dartagnan.program.event.core.Load;
 import com.dat3m.dartagnan.program.processing.LoopUnrolling;
 import com.dat3m.dartagnan.utils.Result;
@@ -313,7 +313,7 @@ public class Dartagnan extends BaseOptions {
                         final boolean isStuckLoop = e instanceof CondJump jump
                                 && e.hasTag(Tag.NONTERMINATION) && !e.hasTag(Tag.BOUND)
                                 && TRUE.equals(model.evaluate(encCtx.jumpTaken(jump)));
-                        final boolean isStuckBarrier = e instanceof ControlBarrier barrier
+                        final boolean isStuckBarrier = e instanceof BlockingEvent barrier
                                 && TRUE.equals(model.evaluate(encCtx.blocked(barrier)));
 
                         if (isStuckLoop || isStuckBarrier) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -11,6 +11,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.analysis.BranchEquivalence;
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis;
+import com.dat3m.dartagnan.program.event.BlockingEvent;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.MemoryEvent;
 import com.dat3m.dartagnan.program.event.RegWriter;
@@ -196,11 +197,11 @@ public final class EncodingContext {
         return booleanFormulaManager.and(execution(jump), jumpCondition(jump));
     }
 
-    public BooleanFormula blocked(ControlBarrier barrier) {
+    public BooleanFormula blocked(BlockingEvent barrier) {
         return booleanFormulaManager.and(controlFlow(barrier), booleanFormulaManager.not(execution(barrier)));
     }
 
-    public BooleanFormula unblocked(ControlBarrier barrier) {
+    public BooleanFormula unblocked(BlockingEvent barrier) {
         return execution(barrier);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/NonTerminationEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/NonTerminationEncoder.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.program.Function;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.LoopAnalysis;
+import com.dat3m.dartagnan.program.event.BlockingEvent;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.RegWriter;
 import com.dat3m.dartagnan.program.event.Tag;
@@ -229,7 +230,7 @@ public class NonTerminationEncoder {
     //  to avoid such wrong results.
     private BooleanFormula encodeBarriersAreStuck() {
         final BooleanFormulaManager bmgr = context.getBooleanFormulaManager();
-        return task.getProgram().getThreadEvents(ControlBarrier.class).stream()
+        return task.getProgram().getThreadEvents(BlockingEvent.class).stream()
                 .map(context::blocked)
                 .reduce(bmgr.makeFalse(), bmgr::or); // TODO: Change to AND?
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
@@ -3,9 +3,9 @@ package com.dat3m.dartagnan.program.analysis;
 import com.dat3m.dartagnan.exception.MalformedProgramException;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
+import com.dat3m.dartagnan.program.event.BlockingEvent;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.core.CondJump;
-import com.dat3m.dartagnan.program.event.core.ControlBarrier;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
@@ -147,7 +147,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
                     b2.parents.add(branch);
                     return branch;
                 }
-            } else if (succ instanceof ControlBarrier barrier) {
+            } else if (succ instanceof BlockingEvent barrier) {
                 final Branch succBranch = computeBranchDecomposition(barrier.getSuccessor(), event2BranchMap, branches);
                 branch.children.add(succBranch);
                 succBranch.parents.add(branch);
@@ -274,7 +274,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
         Set<Branch> commonSucc = null;
         for (Branch br : b.children) {
             computeMustSuccSet(br);
-            if (!isEndingWithControlBarrier(b)) {
+            if (!isEndingWithBlockingEvent(b)) {
                 if (commonSucc == null) {
                     commonSucc = new HashSet<>(br.mustSucc);
                 } else {
@@ -288,10 +288,10 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
         b.mustSuccComputed = true;
     }
 
-    private boolean isEndingWithControlBarrier(Branch branch) {
+    private boolean isEndingWithBlockingEvent(Branch branch) {
         if (!branch.events.isEmpty()) {
             int last = branch.events.size() - 1;
-            return branch.events.get(last) instanceof ControlBarrier;
+            return branch.events.get(last) instanceof BlockingEvent;
         }
         return false;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
@@ -312,7 +312,9 @@ public abstract class AbstractEvent implements Event {
 
     // This method needs to get overwritten for conditional events.
     @Override
-    public boolean cfImpliesExec() { return true; }
+    public boolean cfImpliesExec() {
+        return !(this instanceof BlockingEvent);
+    }
 
     @Override
     public BooleanFormula encodeExec(EncodingContext ctx) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/BlockingEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/BlockingEvent.java
@@ -2,6 +2,10 @@ package com.dat3m.dartagnan.program.event;
 
 /*
     Base interface for all events that can block, i.e., stop the control-flow.
+
+    IMPLEMENTATION NOTE:
+        A BlockingEvent is considered blocking if it is part of the control-flow but does not get executed,
+        i.e., the execution condition is precisely the unblocking condition.
  */
 public interface BlockingEvent extends Event {
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/BlockingEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/BlockingEvent.java
@@ -1,0 +1,7 @@
+package com.dat3m.dartagnan.program.event;
+
+/*
+    Base interface for all events that can block, i.e., stop the control-flow.
+ */
+public interface BlockingEvent extends Event {
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventVisitor.java
@@ -19,20 +19,22 @@ import com.dat3m.dartagnan.program.event.lang.llvm.*;
 import com.dat3m.dartagnan.program.event.lang.pthread.InitLock;
 import com.dat3m.dartagnan.program.event.lang.pthread.Lock;
 import com.dat3m.dartagnan.program.event.lang.pthread.Unlock;
+import com.dat3m.dartagnan.program.event.lang.spirv.*;
 import com.dat3m.dartagnan.program.event.lang.svcomp.BeginAtomic;
 import com.dat3m.dartagnan.program.event.lang.svcomp.EndAtomic;
-import com.dat3m.dartagnan.program.event.lang.spirv.*;
 
 public interface EventVisitor<T> {
 
     // ============================== General events ==============================
     T visitEvent(Event e);
     default T visitMemEvent(MemoryEvent e) { return visitEvent(e); }
+    default T visitBlockingEvent(BlockingEvent e) { return visitEvent(e); }
 
     // ============================== Core-level events ==============================
     default T visitAssume(Assume e) { return visitEvent(e); }
     default T visitAssert(Assert e) { return visitEvent(e); }
     default T visitCondJump(CondJump e) { return visitEvent(e); }
+    default T visitControlBarrier(ControlBarrier e) { return visitBlockingEvent(e); }
     default T visitExecutionStatus(ExecutionStatus e) { return visitEvent(e); }
     default T visitIfAsJump(IfAsJump e) { return visitCondJump(e); }
     default T visitLabel(Label e) { return visitEvent(e); }
@@ -101,7 +103,6 @@ public interface EventVisitor<T> {
     default T visitEndAtomic(EndAtomic e) { return visitEvent(e); }
 
     // ------------------ GPU Events ------------------
-    default T visitControlBarrier(ControlBarrier e) { return visitEvent(e); }
     default T visitPtxRedOp(PTXRedOp e) { return visitMemEvent(e); }
     default T visitPtxAtomOp(PTXAtomOp e) { return visitMemEvent(e); }
     default T visitPtxAtomCAS(PTXAtomCAS e) { return visitMemEvent(e); }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/ControlBarrier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/ControlBarrier.java
@@ -1,11 +1,12 @@
 package com.dat3m.dartagnan.program.event.core;
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.program.event.BlockingEvent;
 import com.dat3m.dartagnan.program.event.EventVisitor;
 import com.dat3m.dartagnan.program.event.Tag;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 
-public class ControlBarrier extends GenericVisibleEvent {
+public class ControlBarrier extends GenericVisibleEvent implements BlockingEvent {
 
     // Identifier of a control barrier instance. Only barriers with the
     // same instanceId can synchronize with each other.
@@ -51,10 +52,5 @@ public class ControlBarrier extends GenericVisibleEvent {
     @Override
     public BooleanFormula encodeExec(EncodingContext ctx) {
         return ctx.getBooleanFormulaManager().implication(ctx.execution(this), ctx.controlFlow(this));
-    }
-
-    @Override
-    public boolean cfImpliesExec() {
-        return false;
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/NamedBarrier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/NamedBarrier.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.RegReader;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class NamedBarrier extends ControlBarrier implements RegReader {
@@ -67,11 +68,7 @@ public class NamedBarrier extends ControlBarrier implements RegReader {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        Set<Register.Read> result = new HashSet<>();
-        resourceId.getRegs().forEach(r -> result.add(new Register.Read(r, Register.UsageType.OTHER)));
-        if (quorum != null) {
-            quorum.getRegs().forEach(r -> result.add(new Register.Read(r, Register.UsageType.OTHER)));
-        }
-        return result;
+        final List<Expression> exprs = quorum != null ? List.of(resourceId, quorum) : List.of(resourceId);
+        return Register.collectRegisterReads(exprs, Register.UsageType.OTHER, new HashSet<>());
     }
 }


### PR DESCRIPTION
This PR is a pure refactoring: it adds a new `BlockingEvent` interface and changes many explicit checks for `ControlBarrier` to checks for `BlockingEvent`.

The idea is to make it easier to add new blocking instructions besides control barriers. For example, `pthread_join` could be modeled by a blocking event instead of a spin loop.