### PR TITLE
Add SVCOMP support for nontermination

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/NonterminationDetection.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/NonterminationDetection.java
@@ -17,6 +17,8 @@ import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
@@ -41,6 +43,8 @@ import static com.dat3m.dartagnan.configuration.OptionNames.NONTERMINATION_INSTR
 @Options
 public class NonterminationDetection implements ProgramProcessor {
     
+    private static final Logger logger = LogManager.getLogger(NonterminationDetection.class);
+
     public enum Mode {
         ONLY_SPINLOOPS,
         SIMPLE,
@@ -66,6 +70,7 @@ public class NonterminationDetection implements ProgramProcessor {
 
     @Override
     public void run(Program program) {
+        logger.info("Non-termination detection mode {}", mode);
         if (mode == Mode.ONLY_SPINLOOPS) {
             // Done by DynamicSpinLoopDetection
             return;
@@ -91,7 +96,7 @@ public class NonterminationDetection implements ProgramProcessor {
             iters = loop.iterations();
         } else if (mode == Mode.SIMPLE) {
             final int last = loop.iterations().size() - 1;
-            iters = List.of(loop.iterations().get(last - 1));
+            iters = List.of(loop.iterations().get(last));
         } else {
             throw new IllegalStateException("Unexpected mode: " + mode);
         }

--- a/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
@@ -42,6 +42,8 @@ public class SVCOMPRunner extends BaseOptions {
         //TODO process the property file instead of assuming its contents based of its name
         if(p.contains("no-data-race")) {
             property = Property.DATARACEFREEDOM;
+        } else if(p.contains("termination")) {
+            property = Property.TERMINATION;
         } else if(p.contains("unreach-call") || p.contains("no-overflow") || p.contains("valid-memsafety")) {
             property = Property.PROGRAM_SPEC;
         } else {


### PR DESCRIPTION
I added support for the termination category in the SVCOMP wrapper and used the new category proposal from [here](https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/merge_requests/1363) to evaluate the new termination encoding from #772.

The new encoding allows us to detect some non-termination cases that the old encoding did not

![termination-1](https://github.com/user-attachments/assets/5fdf1e9c-9344-4861-991c-4faafe26a887)

but it is also slower for proving some cases of termination (which is expected)

![termination-2](https://github.com/user-attachments/assets/4fef0f75-2c18-427e-95bb-c8ff9b84f04d)

I also fixed a bug related to an index in the code related to the `SIMPLE` instrumentation variant.