### PR TITLE
using record class for CmpInstruction in litmusAArch64 and LitmusPPC visitors

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -25,16 +25,7 @@ import com.dat3m.dartagnan.program.event.core.Load;
 
 public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
 
-    private static class CmpInstruction {
-        private final Expression left;
-        private final Expression right;
-
-        public CmpInstruction(Expression left, Expression right) {
-            this.left = left;
-            this.right = right;
-        }
-    }
-
+    private record CmpInstruction(Expression left, Expression right) {};
     private final ProgramBuilder programBuilder = ProgramBuilder.forArch(Program.SourceLanguage.LITMUS, Arch.ARM8);
     private final TypeFactory types = programBuilder.getTypeFactory();
     private final IntegerType archType = types.getArchType();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -1,5 +1,8 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.exception.ParsingException;
 import com.dat3m.dartagnan.expression.Expression;
@@ -13,26 +16,15 @@ import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventFactory;
+import static com.dat3m.dartagnan.program.event.FenceNameRepository.ISYNC;
+import static com.dat3m.dartagnan.program.event.FenceNameRepository.LWSYNC;
+import static com.dat3m.dartagnan.program.event.FenceNameRepository.SYNC;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.dat3m.dartagnan.program.event.FenceNameRepository.*;
-
 public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
 
-    private static class CmpInstruction {
-        private final Expression left;
-        private final Expression right;
-
-        public CmpInstruction(Register left, Expression comparand) {
-            this.left = left;
-            this.right = comparand;
-        }
-    }
-
+    private record CmpInstruction(Expression left, Expression right) {};
     private final static ImmutableSet<String> fences = ImmutableSet.of(SYNC, LWSYNC, ISYNC);
 
     private final ProgramBuilder programBuilder = ProgramBuilder.forArch(Program.SourceLanguage.LITMUS, Arch.POWER);


### PR DESCRIPTION
Following from the comment that Thomas gave me in  #802, I noticed that the LitmusAArch64 and LitmusPPC visitors (for which I was basing my visitors on) were still using a private static class for CmpInstruction instead of a record, so I thought about modifying it