### PR TITLE
Add leading zeros when formatting milliseconds

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
@@ -16,7 +16,7 @@ public class Utils {
         milliseconds -= TimeUnit.SECONDS.toMillis(seconds);
 
         if (hours == 0 && minutes == 0) {
-            return String.format("%d.%d secs", seconds, milliseconds);
+            return String.format("%d.%03d secs", seconds, milliseconds);
         } else if (hours == 0) {
             return String.format("%d:%02d mins", minutes, seconds);
         } else {


### PR DESCRIPTION
Formatting only seconds and milliseconds would produce an incorrect string due to missing leading zeros.

Example:  The line `return String.format("%d.%d secs", seconds, milliseconds);` would return the string `"0.18 secs"`  with the call `toTimeString(18)`  .

Fix: Force milliseconds to be at least 3 digits, padding with leading zeros when necessary.