### PR TITLE
Fix direct data and addr dependency extraction for witness

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModelManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModelManager.java
@@ -455,56 +455,6 @@ public class ExecutionModelManager {
         }
 
         @Override
-        public Void visitAddressDependency(DirectAddressDependency addrDirect) {
-            SimpleGraph rg = (SimpleGraph) relGraphCache.get(addrDirect.getDefinedRelation());
-            for (ThreadModel tm : executionModel.getThreadModels()) {
-                Set<RegWriterModel> writes = new HashSet<>();
-                for (EventModel em : tm.getEventModels()) {
-                    if (em instanceof RegWriterModel rwm) {
-                        writes.add(rwm);
-                        continue;
-                    }
-                    if (em instanceof RegReaderModel rrm) {
-                        for (RegWriterModel write : writes) {
-                            for (Register.Read read : rrm.getRegisterReads()) {
-                                if (read.register() == write.getResultRegister()
-                                    && read.usageType() == Register.UsageType.ADDR) {
-                                    rg.add(new Edge(write.getId(), rrm.getId()));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            return null;
-        }
-
-        @Override
-        public Void visitInternalDataDependency(DirectDataDependency idd) {
-            SimpleGraph rg = (SimpleGraph) relGraphCache.get(idd.getDefinedRelation());
-            for (ThreadModel tm : executionModel.getThreadModels()) {
-                Set<RegWriterModel> writes = new HashSet<>();
-                for (EventModel em : tm.getEventModels()) {
-                    if (em instanceof RegWriterModel rwm) {
-                        writes.add(rwm);
-                        continue;
-                    }
-                    if (em instanceof RegReaderModel rrm) {
-                        for (RegWriterModel write : writes) {
-                            for (Register.Read read : rrm.getRegisterReads()) {
-                                if (read.register() == write.getResultRegister()
-                                    && read.usageType() == Register.UsageType.DATA) {
-                                    rg.add(new Edge(write.getId(), rrm.getId()));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            return null;
-        }
-
-        @Override
         public Void visitEmpty(Empty empty) {
             return null;
         }


### PR DESCRIPTION
The methods for direct data and addr dependency extraction in `ExecutionModelManager` is problematic since in some cases it lacks of edges of these two relations and the derived ones based on them in the witness graph. The easiest fix is to delete these two methods and let them extracted by the fallback method. Now the graph shows identical relation information as what the solver has.