### PR TITLE
Fix wrong simplification of ExtractExpr

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
@@ -320,6 +320,9 @@ public class ExprSimplifier extends ExprTransformer {
         }
 
         final ImmutableList<Integer> newIndices = indices.subList(indexCursor, indices.size());
+        if (newIndices.isEmpty()) {
+            return inner;
+        }
         if (inner instanceof ExtractExpr extract) {
             // Merge multiple extracts
             return expressions.makeExtract(inner, Iterables.concat(extract.getIndices(), newIndices));


### PR DESCRIPTION
@hernanponcedeleon This is a fix of the bug we talked about. 