### PR TITLE
Sound detection of non-terminating loops containing control barriers

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/NonTerminationEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/NonTerminationEncoder.java
@@ -696,15 +696,17 @@ public class NonTerminationEncoder {
 
         // (5) If a control barrier is in the suffix, then all its syncing control barriers must also be in the suffix
         final Relation syncBar = memoryModel.getRelation(RelationNameRepository.SYNCBAR);
-        final EventGraph syncBarMay = ra.getKnowledge(syncBar).getMaySet();
-        syncBarMay.apply((x, y) -> {
-            if (isPossiblySuffix(x)) {
-                enc.add(bmgr.implication(
-                        bmgr.and(isInSuffix(x), context.edge(syncBar, x, y)),
-                        isInSuffix(y)
-                ));
-            }
-        });
+        if (syncBar != null) {
+            final EventGraph syncBarMay = ra.getKnowledge(syncBar).getMaySet();
+            syncBarMay.apply((x, y) -> {
+                if (isPossiblySuffix(x)) {
+                    enc.add(bmgr.implication(
+                            bmgr.and(isInSuffix(x), context.edge(syncBar, x, y)),
+                            isInSuffix(y)
+                    ));
+                }
+            });
+        }
 
         return bmgr.and(enc);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/NonTerminationEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/NonTerminationEncoder.java
@@ -13,16 +13,18 @@ import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.core.special.StateSnapshot;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Relation;
+import com.dat3m.dartagnan.wmm.RelationNameRepository;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.utils.graph.EventGraph;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import org.sosy_lab.java_smt.api.BooleanFormula;
-import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.sosy_lab.java_smt.api.BooleanFormula;
+import org.sosy_lab.java_smt.api.BooleanFormulaManager;
+
 import java.util.*;
 
 import static com.dat3m.dartagnan.wmm.RelationNameRepository.CO;
@@ -691,6 +693,18 @@ public class NonTerminationEncoder {
                 enc.add(bmgr.implication(isCfInSuffix(exclStore), context.execution(exclStore)));
             }
         }
+
+        // (5) If a control barrier is in the suffix, then all its syncing control barriers must also be in the suffix
+        final Relation syncBar = memoryModel.getRelation(RelationNameRepository.SYNCBAR);
+        final EventGraph syncBarMay = ra.getKnowledge(syncBar).getMaySet();
+        syncBarMay.apply((x, y) -> {
+            if (isPossiblySuffix(x)) {
+                enc.add(bmgr.implication(
+                        bmgr.and(isInSuffix(x), context.edge(syncBar, x, y)),
+                        isInSuffix(y)
+                ));
+            }
+        });
 
         return bmgr.and(enc);
     }


### PR DESCRIPTION
We require that whenever a `ControlBarrier` is inside a non-terminating loop, then all CBs it synchronizes with must also be inside a non-terminating loop.