### PR TITLE
LLVM Debug Records

### DIFF
--- a/dartagnan/src/main/antlr4/LLVMIR.g4
+++ b/dartagnan/src/main/antlr4/LLVMIR.g4
@@ -115,6 +115,8 @@ instruction: // Instructions producing values.
 	// Instructions not producing values.
 	| storeInst
 	| fenceInst
+	// Debug Records, which are not actually instructions, but appear interleaved.
+	| debugRecord
 	)
 	(',' metadataAttachment)*;
 terminator:
@@ -669,6 +671,8 @@ arg: concreteType paramAttribute* value | metadataType metadata;
 
 exceptionArg: concreteType value | metadataType metadata;
 exceptionPad: noneConst | LocalIdent;
+
+debugRecord: DebugRecord '(' (metadata ',')* mdNode ')';
 
 externalLinkage: 'extern_weak' | 'external';
 internalLinkage:
@@ -1361,6 +1365,7 @@ GlobalIdent: GlobalName | GlobalId;
 LocalIdent: LocalName | LocalId;
 LabelIdent: (Letter | DecimalDigit)+ ':' | QuotedString ':';
 AttrGroupId: '#' Id;
+DebugRecord: '#dbg_' Name;
 ComdatName: '$' (Name | QuotedString);
 MetadataName: '!' EscapeName;
 MetadataId: '!' Id;


### PR DESCRIPTION
This PR modifies the LLVM grammar to recognize files with [Debug Records](https://llvm.org/docs/SourceLevelDebugging.html).  These entities replace the debug intrinsic calls generated by Clang 19+.

An alternative would be to execute `clang` with `--write-experimental-debuginfo=false`[[1]](https://discourse.llvm.org/t/psa-ir-output-changing-from-debug-intrinsics-to-debug-records/79578).