### PR TITLE
Add Entrypoint class to describe the entry point of a Program

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -51,7 +51,7 @@ public class ProgramBuilder {
     // ----------------------------------------------------------------------------------------------------------------
     // Construction
     private ProgramBuilder(SourceLanguage format) {
-        this.program = new Program(new Memory(), format, null);
+        this.program = new Program(new Memory(), format);
     }
 
     public static ProgramBuilder forArch(SourceLanguage format, Arch arch) {
@@ -76,6 +76,7 @@ public class ProgramBuilder {
             thread.append(endOfThread);
         }
         processAfterParsing(program);
+        program.setEntrypoint(new Entrypoint.Resolved());
         return program;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
@@ -1,17 +1,15 @@
 package com.dat3m.dartagnan.parsers.program.visitors;
 
 import com.dat3m.dartagnan.exception.ParsingException;
+import com.dat3m.dartagnan.exception.ProgramProcessingException;
 import com.dat3m.dartagnan.expression.*;
 import com.dat3m.dartagnan.expression.integers.IntBinaryOp;
 import com.dat3m.dartagnan.expression.type.*;
 import com.dat3m.dartagnan.parsers.LLVMIRBaseVisitor;
 import com.dat3m.dartagnan.parsers.LLVMIRParser.*;
-import com.dat3m.dartagnan.parsers.program.ParserAsm;
-import com.dat3m.dartagnan.parsers.program.ParserAsmPPC;
-import com.dat3m.dartagnan.parsers.program.ParserAsmRISCV;
-import com.dat3m.dartagnan.parsers.program.ParserAsmX86;
-import com.dat3m.dartagnan.parsers.program.ParserAsmArm;
+import com.dat3m.dartagnan.parsers.program.*;
 import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
+import com.dat3m.dartagnan.program.Entrypoint;
 import com.dat3m.dartagnan.program.Function;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
@@ -27,7 +25,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -39,9 +36,7 @@ import java.math.BigInteger;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import com.dat3m.dartagnan.exception.ProgramProcessingException;
 import static com.dat3m.dartagnan.expression.utils.ExpressionHelper.isAggregateLike;
-
 import static com.dat3m.dartagnan.program.event.EventFactory.*;
 import static com.dat3m.dartagnan.program.event.EventFactory.Llvm.newCompareExchange;
 import static com.google.common.base.Preconditions.checkState;
@@ -53,7 +48,7 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
     private static final String DEFAULT_ENTRY_FUNCTION = "main";
 
     // Global context
-    private final Program program = new Program(new Memory(), Program.SourceLanguage.LLVM, null);
+    private final Program program = new Program(new Memory(), Program.SourceLanguage.LLVM);
     private final TypeFactory types = TypeFactory.getInstance();
     private final ExpressionFactory expressions = ExpressionFactory.getInstance();
     private final Type pointerType = types.getPointerType();
@@ -141,9 +136,6 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
     @Override
     public Expression visitFuncHeader(FuncHeaderContext ctx) {
         final String name = globalIdent(ctx.GlobalIdent());
-        if (name.equals(DEFAULT_ENTRY_FUNCTION)) {
-            program.setEntryPoint(name);
-        }
         final Type returnType = parseType(ctx.type());
         final List<Type> parameterTypes = new ArrayList<>();
         final List<String> parameterNames = new ArrayList<>();
@@ -166,6 +158,10 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
 
         program.addFunction(declaredFunction);
         constantMap.put(name, declaredFunction);
+
+        if (name.equals(DEFAULT_ENTRY_FUNCTION)) {
+            program.setEntrypoint(new Entrypoint.Simple(declaredFunction));
+        }
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Entrypoint.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Entrypoint.java
@@ -1,0 +1,63 @@
+package com.dat3m.dartagnan.program;
+
+import com.dat3m.dartagnan.program.processing.transformers.MemoryTransformer;
+
+import java.util.List;
+
+public sealed interface Entrypoint {
+
+    Function getEntryFunction();
+
+    // In case the parser already spawns the threads, e.g., like we do in Litmus code.
+    final class Resolved implements Entrypoint {
+        @Override
+        public Function getEntryFunction() {
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "Resolved";
+        }
+    }
+
+    // Standard entry point
+    final class Simple implements Entrypoint {
+        private final Function function;
+        public Simple(Function function) {
+            this.function = function;
+        }
+        @Override
+        public Function getEntryFunction() { return function; }
+
+        @Override
+        public String toString() {
+            return "Entry@" + function.getName();
+        }
+    }
+
+    // GPU entry point
+    final class Grid implements Entrypoint {
+        private final Function function;
+        private final ThreadGrid threadGrid;
+        private final List<MemoryTransformer> memoryTransformers;
+
+        public Grid(Function function, ThreadGrid grid, List<MemoryTransformer> transformers) {
+            this.function = function;
+            this.threadGrid = grid;
+            this.memoryTransformers = transformers;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Entry@%s with %s", function.getName(), threadGrid);
+        }
+
+        @Override
+        public Function getEntryFunction() { return function; }
+        public ThreadGrid getThreadGrid() { return threadGrid; }
+        public List<MemoryTransformer> getMemoryTransformers() { return memoryTransformers; }
+    }
+
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
@@ -4,7 +4,6 @@ import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.Type;
-import com.dat3m.dartagnan.expression.processing.ExprTransformer;
 import com.dat3m.dartagnan.expression.type.AggregateType;
 import com.dat3m.dartagnan.expression.type.ArrayType;
 import com.dat3m.dartagnan.expression.type.TypeOffset;
@@ -30,27 +29,26 @@ public class Program {
     private final List<Function> functions;
     private final List<NonDetValue> constants = new ArrayList<>();
     private final Memory memory;
+    private Entrypoint entrypoint;
     private Arch arch;
     private int unrollingBound = 0;
     private boolean isCompiled;
     private final SourceLanguage format;
-    private final ThreadGrid grid;
-    private String entryPoint;
-    private final List<ExprTransformer> transformers = new ArrayList<>();
 
     private int nextConstantId = 0;
 
-    public Program(Memory memory, SourceLanguage format, ThreadGrid grid) {
-        this("", memory, format, grid);
+    // ------------------------
+
+    public Program(Memory memory, SourceLanguage format) {
+        this("", memory, format);
     }
 
-    public Program(String name, Memory memory, SourceLanguage format, ThreadGrid grid) {
+    public Program(String name, Memory memory, SourceLanguage format) {
         this.name = name;
         this.memory = memory;
         this.threads = new ArrayList<>();
         this.functions = new ArrayList<>();
         this.format = format;
-        this.grid = grid;
     }
 
     public SourceLanguage getFormat() {
@@ -87,6 +85,14 @@ public class Program {
 
     public Memory getMemory() {
         return this.memory;
+    }
+
+    public void setEntrypoint(Entrypoint entrypoint) {
+        this.entrypoint = entrypoint;
+    }
+
+    public Entrypoint getEntrypoint() {
+        return entrypoint;
     }
 
     public SpecificationType getSpecificationType() {
@@ -138,26 +144,6 @@ public class Program {
     // Looks up a declared function by name.
     public Optional<Function> getFunctionByName(String name) {
         return functions.stream().filter(f -> f.getName().equals(name)).findFirst();
-    }
-
-    public void setEntryPoint(String entryPoint) {
-        this.entryPoint = entryPoint;
-    }
-
-    public String getEntryPoint() {
-        return entryPoint;
-    }
-
-    public ThreadGrid getGrid() {
-        return grid;
-    }
-
-    public void addTransformer(ExprTransformer transformer) {
-        transformers.add(transformer);
-    }
-
-    public List<ExprTransformer> getTransformers() {
-        return transformers;
     }
 
     public Expression newConstant(Type type) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/ThreadGrid.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/ThreadGrid.java
@@ -24,6 +24,13 @@ public class ThreadGrid {
         this.dvCount = dvCount;
     }
 
+    @Override
+    public String toString() {
+        return String.format("Grid(th=%d,sg=%d,wg=%d,qf=%d,dv=%d)",
+                thCount, sgCount, wgCount, qfCount, dvCount
+        );
+    }
+
     public int sgSize() {
         return thCount;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadFunctions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/RemoveDeadFunctions.java
@@ -55,8 +55,8 @@ public class RemoveDeadFunctions implements ProgramProcessor {
         final Set<Function> reachableFunctions = new HashSet<>();
         reachableFunctions.addAll(functionCollector.collectedFunctions);
         reachableFunctions.addAll(program.getThreads()); // threads are reachable
-        if (program.getEntryPoint() != null) {
-            program.getFunctionByName(program.getEntryPoint()).ifPresent(reachableFunctions::add); // entry point is reachable
+        if (program.getEntrypoint().getEntryFunction() != null) {
+            reachableFunctions.add(program.getEntrypoint().getEntryFunction()); // entry point is reachable
         }
         program.getFunctions().stream().filter(Function::isIntrinsic).forEach(reachableFunctions::add); // intrinsics
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/header/ConfigTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/header/ConfigTest.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.spirv.header;
 
 import com.dat3m.dartagnan.exception.ParsingException;
+import com.dat3m.dartagnan.program.Entrypoint;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.ScopeHierarchy;
 import com.dat3m.dartagnan.program.ThreadGrid;
@@ -28,7 +29,7 @@ public class ConfigTest extends AbstractTest {
 
         // then
         int size = scopes.stream().reduce(1, (a, b) -> a * b);
-        ThreadGrid grid = program.getGrid();
+        ThreadGrid grid = ((Entrypoint.Grid) program.getEntrypoint()).getThreadGrid();
         assertEquals(size, grid.dvSize());
 
         int sg_size = scopes.get(0);


### PR DESCRIPTION
This PR adds a simple `Entrypoint` class with subclasses `Simple/Grid/Resolved` which describe how `ThreadCreation` should create threads. 
- `Simple` is given by a single function (usually "main" for C/LLVM).
- `Resolved` describes that the parser has already created the threads (Litmus)
- `Grid` is given by a single function, a thread grid, and a list of memory transformer (or GPU code).