### PR TITLE
Fixes to cat grammar

### DIFF
--- a/dartagnan/src/main/antlr4/Cat.g4
+++ b/dartagnan/src/main/antlr4/Cat.g4
@@ -5,7 +5,7 @@ import com.dat3m.dartagnan.wmm.axiom.*;
 }
 
 mcm
-    :   (NAME)? (QUOTED_STRING)? (definition | include | show)+ EOF
+    :   (NAME)* (QUOTED_STRING)? (definition | include | show)+ EOF
     ;
 
 definition
@@ -16,9 +16,9 @@ definition
     ;
 
 axiomDefinition locals [Class<?> cls]
-    :   (flag = FLAG)? (negate = NOT)? ACYCLIC { $cls = Acyclicity.class; } e = expression (AS NAME)?
-    |   (flag = FLAG)? (negate = NOT)? IRREFLEXIVE { $cls = Irreflexivity.class; } e = expression (AS NAME)?
-    |   (flag = FLAG)? (negate = NOT)? EMPTY { $cls = Emptiness.class; } e = expression (AS NAME)?
+    :   (flag = FLAG | undef = UNDEFINED)? (negate = NOT)? ACYCLIC { $cls = Acyclicity.class; } e = expression (AS NAME)?
+    |   (flag = FLAG | undef = UNDEFINED)? (negate = NOT)? IRREFLEXIVE { $cls = Irreflexivity.class; } e = expression (AS NAME)?
+    |   (flag = FLAG | undef = UNDEFINED)? (negate = NOT)? EMPTY { $cls = Emptiness.class; } e = expression (AS NAME)?
     ;
 
 letFuncDefinition
@@ -62,7 +62,7 @@ include
     ;
 
 show
-    :   SHOW expression (AS NAME)?
+    :   SHOW expression (AS NAME)? (COMMA expression (AS NAME)?)*
     ;
 
 parameterList
@@ -108,6 +108,7 @@ RANGE       :   'range';
 NEW         :   'new';
 
 FLAG       :   'flag';
+UNDEFINED  :   'undefined_unless';
 
 QUOTED_STRING : '"' .*? '"';
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
@@ -116,8 +116,12 @@ class VisitorCat extends CatBaseVisitor<Object> {
         try {
             Relation r = parseAsRelation(ctx.e);
             Constructor<?> constructor = ctx.cls.getConstructor(Relation.class, boolean.class, boolean.class);
-            Axiom axiom = (Axiom) constructor.newInstance(r, ctx.negate != null, ctx.flag != null);
-            if (ctx.NAME() != null) {
+            boolean negate = ctx.negate != null ^ ctx.undef != null;
+            boolean flag = ctx.flag != null || ctx.undef != null;
+            Axiom axiom = (Axiom) constructor.newInstance(r, negate, flag);
+            if (ctx.undef != null) {
+                axiom.setName("*undef*");
+            } else if (ctx.NAME() != null) {
                 axiom.setName(ctx.NAME().toString());
             }
             wmm.addConstraint(axiom);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
@@ -120,7 +120,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
             boolean flag = ctx.flag != null || ctx.undef != null;
             Axiom axiom = (Axiom) constructor.newInstance(r, negate, flag);
             if (ctx.undef != null) {
-                axiom.setName("*undef*");
+                axiom.setName(String.format("%s*undef*", ctx.NAME() != null ? ctx.NAME().toString() + " as " : ""));
             } else if (ctx.NAME() != null) {
                 axiom.setName(ctx.NAME().toString());
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
@@ -119,10 +119,10 @@ class VisitorCat extends CatBaseVisitor<Object> {
             boolean negate = ctx.negate != null ^ ctx.undef != null;
             boolean flag = ctx.flag != null || ctx.undef != null;
             Axiom axiom = (Axiom) constructor.newInstance(r, negate, flag);
-            if (ctx.undef != null) {
-                axiom.setName(String.format("%s*undef*", ctx.NAME() != null ? ctx.NAME().toString() + " as " : ""));
-            } else if (ctx.NAME() != null) {
-                axiom.setName(ctx.NAME().toString());
+            String name = ctx.NAME() != null ? ctx.NAME().toString() : "";
+            name += ctx.undef != null ? " (*undef*)" : "";
+            if (!name.isEmpty()) {
+                axiom.setName(name);
             }
             wmm.addConstraint(axiom);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |


### PR DESCRIPTION
Currently we cannot parse [this](https://github.com/herd/herdtools7/blob/55d31bd75001fbcaf720253ad3504b658b95cd7d/herd/libdir/rc11.cat#L4) memory model.

`herd7` reports `*undef*` independent of the name given to the axiom, thus I copy the same output.