### PR TITLE
Better allocation of thread-local memory & SCCP across threads

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -15,6 +15,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.CondJump;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.Local;
+import com.dat3m.dartagnan.program.event.core.threading.ThreadArgument;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
@@ -133,6 +134,11 @@ public class SparseConditionalConstantPropagation implements FunctionProcessor {
                 final Expression expr = local.getExpr();
                 final Expression valueToPropagate = checkDoPropagate.test(expr) ? expr : null;
                 propagationMap.compute(local.getResultRegister(), (k, v) -> valueToPropagate);
+            } else if (cur instanceof ThreadArgument arg) {
+                // Propagate constant arguments passed across threads
+                final Expression expr = arg.getCreator().getArguments().get(arg.getIndex());
+                final Expression valueToPropagate = expr.getRegs().isEmpty() ? expr : null;
+                propagationMap.compute(arg.getResultRegister(), (k, v) -> valueToPropagate);
             }
 
             if (cur instanceof CondJump jump) {


### PR DESCRIPTION
- Thread-local variables can be replaced by local stack allocations. This allows `Mem2Reg` to replace them, possibly getting rid of all memory accesses of thread-local variables.
- SCCP now propagates constant arguments across thread creations.

For CNA with B=2, this reduces the number of memory accesses by quite a bit:
```
// Old
	#Stores: 69
	#Loads: 106
	#Inits: 21
	#Others: 0
	#must|may rf edges: 3|1147
	#must|may co edges: 36|783

// New
	#Stores: 66
	#Loads: 94
	#Inits: 18
	#Others: 0
	#must|may rf edges: 3|787
	#must|may co edges: 57|660
```
The verification time is not improved by that much.

It should have impact on all code that makes use of thread local variables.