### PR TITLE
Remove unnecessary includes in cat models

### DIFF
--- a/cat/aarch64.cat
+++ b/cat/aarch64.cat
@@ -39,19 +39,6 @@
 "ARMv8 AArch64"
 
 (*
- * Include the cos.cat file shipped with herd.
- * This builds the co relation as a total order over writes to the same
- * location and then consequently defines the fr relation using co and
- * rf.
- *)
-include "cos.cat"
-
-(*
- * Include aarch64fences.cat so that barriers show up in generated diagrams.
- *)
-include "aarch64fences.cat"
-
-(*
  * As a restriction of the model, all observers are limited to the same
  * inner-shareable domain. Consequently, the ISH, OSH and SY barrier
  * options are all equivalent to each other.

--- a/cat/arm.cat
+++ b/cat/arm.cat
@@ -1,8 +1,5 @@
 ARM
 
-(* Model for ARM, ie with po-loc omitted from ppo *)
-include "cos.cat"
-
 (* Uniproc *)
 acyclic po-loc | rf | fr | co as uniproc
 

--- a/cat/c11-orig.cat
+++ b/cat/c11-orig.cat
@@ -9,9 +9,6 @@ Rewritten by Luc Maranget for herd7
 
 *)
 
-include "c11_cos.cat"
-include "c11_los.cat"
-
 let asw = IW * (M \ IW)
 let sb = po
 let mo = co

--- a/cat/c11-partialsc.cat
+++ b/cat/c11-partialsc.cat
@@ -12,9 +12,6 @@ C "C++11"
 * https://multicore.doc.ic.ac.uk/overhauling/c11_partialSC.cat
 *)
 
-include "c11_cos.cat"
-include "c11_los.cat"
-
 // dynamic_tag relates events to itself that access an address whose init event is marked X
 let dynamic_tag(X) = [range([IW & X]; loc)]
 

--- a/cat/c11.cat
+++ b/cat/c11.cat
@@ -12,9 +12,6 @@ C "C++11"
 * https://multicore.doc.ic.ac.uk/overhauling/c11_simp.cat
 *)
 
-include "c11_cos.cat"
-include "c11_los.cat"
-
 // dynamic_tag relates events to itself that access an address whose init event is marked X
 let dynamic_tag(X) = [range([IW & X]; loc)]
 

--- a/cat/lock.cat
+++ b/cat/lock.cat
@@ -1,9 +1,9 @@
-// // SPDX-License-Identifier: GPL-2.0+
-// (*
-//  * Copyright (C) 2016 Luc Maranget <luc.maranget@inria.fr> for Inria
-//  * Copyright (C) 2017 Alan Stern <stern@rowland.harvard.edu>
-//  *)
-//
+// SPDX-License-Identifier: GPL-2.0+
+(*
+ * Copyright (C) 2016 Luc Maranget <luc.maranget@inria.fr> for Inria
+ * Copyright (C) 2017 Alan Stern <stern@rowland.harvard.edu>
+ *)
+
 // (*
 //  * Generate coherence orders and handle lock operations
 //  *
@@ -143,6 +143,4 @@
 // let fre = fr & ext
 // let fri = fr & int
 //
-// show co,rf,fr
-
-include "basic.cat"
+show co,rf,fr

--- a/cat/opencl-herd.cat
+++ b/cat/opencl-herd.cat
@@ -25,8 +25,6 @@ OpenCL
 // dynamic_tag relates events to itself that access an address whose init event is marked X or Fence tagged with X
 let dynamic_tag(X) = [range([IW & X]; loc)] | [X & F]
 
-include "basic.cat"
-
 let symm(r) = r | r^-1
 let wi = int
 

--- a/cat/power.cat
+++ b/cat/power.cat
@@ -1,6 +1,5 @@
 Power
 
-include "cos.cat"
 include "ppcfences.cat"
 
 (* Uniproc *)

--- a/cat/rc11.cat
+++ b/cat/rc11.cat
@@ -7,9 +7,6 @@ RC11
  * Cat coding by Sicon Colin.
  *)
 
-(* Define co (and fr) *)
-include "cos.cat"
-
 // This is needed for herd which can create a single event for rmw instructions
 let myrmw = [RMW] | rmw
 

--- a/cat/riscv-orig.cat
+++ b/cat/riscv-orig.cat
@@ -56,9 +56,6 @@ let ppo =
 | r12
 | r13
 
-(* Compute coherence relation *)
-include "cos-opt.cat"
-
 (**********)
 (* Axioms *)
 (**********)

--- a/cat/riscv.cat
+++ b/cat/riscv.cat
@@ -6,9 +6,6 @@ Partial
 (* Definitions *)
 (***************)
 
-(* Define co (and fr) *)
-include "cos.cat"
-
 (*************)
 (* Utilities *)
 (*************)
@@ -58,9 +55,6 @@ let ppo =
 | r11
 | r12
 | r13
-
-(* Compute coherence relation *)
-include "cos-opt.cat"
 
 (**********)
 (* Axioms *)

--- a/cat/sc.cat
+++ b/cat/sc.cat
@@ -1,8 +1,5 @@
 SC
 
-(* Define co (and fr) *)
-include "cos.cat"
-
 (* All communication relations *)
 let com = (rf | fr | co)
 

--- a/cat/svcomp.cat
+++ b/cat/svcomp.cat
@@ -1,8 +1,5 @@
 SVCOMP
 
-(* Define co (and fr) *)
-include "cos.cat"
-
 (* All communication relations *)
 let com = (rf | fr | co)
 

--- a/cat/tso.cat
+++ b/cat/tso.cat
@@ -1,8 +1,6 @@
 "X86 TSO"
 
-include "cos.cat"
 include "x86fences.cat"
-include "filters.cat"
 
 (* All communication relations *)
 let com = (co | fr | rf)


### PR DESCRIPTION
This PR removes many inexistent and unnecessary includes which populate the output with useless warnings.