### PR TITLE
Fix MemToReg

### DIFF
--- a/benchmarks/miscellaneous/memtoreg_merging_pointers.c
+++ b/benchmarks/miscellaneous/memtoreg_merging_pointers.c
@@ -7,12 +7,12 @@
 int main()
 {
     int a[2];
-    int *i;
+    int *i, *j;
     if (__VERIFIER_nondet_int())
-        i = &a[0];
+        i = &a[0], j = &a[0];
     else
-        i = &a[1];
+        i = &a[1], j = &a[1];
     *i = 1;
-    assert(*i == 1);
+    assert(*j == 1);
     return 0;
 }

--- a/benchmarks/miscellaneous/memtoreg_merging_pointers.c
+++ b/benchmarks/miscellaneous/memtoreg_merging_pointers.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <dat3m.h>
+
+// Issue: If MemToReg does not handle dataflow correctly, it may remove the allocation of an array, while keeping its usages.
+// Expected: PASS
+
+int main()
+{
+    int a[2];
+    int *i;
+    if (__VERIFIER_nondet_int())
+        i = &a[0];
+    else
+        i = &a[1];
+    *i = 1;
+    assert(*i == 1);
+    return 0;
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/InclusionBasedPointerAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/InclusionBasedPointerAnalysis.java
@@ -962,7 +962,7 @@ public class InclusionBasedPointerAnalysis implements AliasAnalysis {
                     k -> derive(newVariable("out" + writer.getGlobalId())));
             addInclude(result, includeEdge(writerVariable));
         }
-        return registerVariables.compute(writers, (k, v) -> derive(result));
+        return writers.isEmpty() ? derive(result) : registerVariables.compute(writers, (k, v) -> derive(result));
     }
 
     private DerivedVariable getOrNewVariable(List<IncludeEdge> edges, String name) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemToReg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemToReg.java
@@ -307,7 +307,7 @@ public class MemToReg implements FunctionProcessor {
             if (address == null || !isDeletable) {
                 publishRegisters(load.getAddress().getRegs());
             }
-            final AddressOffset value = address == null ? null : stateIfUnique(address);
+            final AddressOffsets value = address == null ? null : state.get(address);
             update(accesses, load, address);
             update(state, register, value);
             return null;
@@ -323,7 +323,8 @@ public class MemToReg implements FunctionProcessor {
             final AddressOffset address = toAddressOffset(addressExpression);
             final RegisterOffset valueExpression = matchGEP(store.getMemValue());
             assert valueExpression == null || valueExpression.register != null;
-            final AddressOffset value = valueExpression == null ? null : stateIfUnique(valueExpression.register);
+            final AddressOffset valueBase = valueExpression == null ? null : stateIfUnique(valueExpression.register);
+            final AddressOffset value = valueBase == null ? null : valueBase.increase(valueExpression.offset);
             final boolean isDeletable = store.getUsers().isEmpty();
             // On complex address expression, give up on any address that could contribute here.
             if (address == null || !isDeletable) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemToReg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemToReg.java
@@ -210,17 +210,17 @@ public class MemToReg implements FunctionProcessor {
         }
     }
 
-    private sealed interface StateElement {}
+    private sealed interface AddressOffsets {}
 
     // Invariant: base != null
-    private record AddressOffset(RegWriter base, long offset) implements StateElement {
+    private record AddressOffset(RegWriter base, long offset) implements AddressOffsets {
         private AddressOffset increase(long o) {
             return o == 0 ? this : new AddressOffset(base, offset + o);
         }
     }
 
     // Invariant: hint != null && !hint.isEmpty()
-    private record PropagationHint(Set<RegWriter> hint) implements StateElement {}
+    private record AddressOffsetSet(Set<RegWriter> hint) implements AddressOffsets {}
 
     // Invariant: register != null
     private record RegisterOffset(Register register, long offset) {}
@@ -243,9 +243,9 @@ public class MemToReg implements FunctionProcessor {
     private static final class Matcher implements EventVisitor<Label> {
 
         // Current local symbolic state.  Missing values mean irreplaceable contents.
-        private final Map<Object, StateElement> state = new HashMap<>();
+        private final Map<Object, AddressOffsets> state = new HashMap<>();
         // Maps labels and jumps to symbolic state information.
-        private final Map<Label, Map<Object, StateElement>> jumps = new HashMap<>();
+        private final Map<Label, Map<Object, AddressOffsets>> jumps = new HashMap<>();
         // Join over all memory information.  Initialized to all empty.  Missing entries mean not promotable.
         private final Map<RegWriter, Set<RegWriter>> reachabilityGraph = new HashMap<>();
         // Collects candidates to be replaced.
@@ -346,7 +346,7 @@ public class MemToReg implements FunctionProcessor {
         public Label visitLabel(Label label) {
             final int localId = label.getLocalId();
             final boolean looping = label.getJumpSet().stream().anyMatch(jump -> localId < jump.getLocalId());
-            final Map<Object, StateElement> restoredState = looping ? jumps.get(label) : jumps.remove(label);
+            final Map<Object, AddressOffsets> restoredState = looping ? jumps.get(label) : jumps.remove(label);
             if (restoredState != null && dead) {
                 assert state.isEmpty();
                 state.putAll(restoredState);
@@ -372,7 +372,7 @@ public class MemToReg implements FunctionProcessor {
             final boolean isGoto = jump.isGoto();
             assert !looping || jumps.containsKey(label);
             // Prepare the current state for continuing from the label.
-            final Map<Object, StateElement> labelState = jumps.get(label);
+            final Map<Object, AddressOffsets> labelState = jumps.get(label);
             if (labelState != null) {
                 // NOTE no short-circuiting.
                 final boolean change = mergeInto(labelState, state);
@@ -399,11 +399,11 @@ public class MemToReg implements FunctionProcessor {
         private void publishRegisters(Set<Register> registers) {
             final var queue = new ArrayDeque<RegWriter>();
             for (final Register register : registers) {
-                final StateElement element = state.remove(register);
+                final AddressOffsets element = state.remove(register);
                 if (element instanceof AddressOffset value) {
                     queue.add(value.base);
                 }
-                if (element instanceof PropagationHint hint) {
+                if (element instanceof AddressOffsetSet hint) {
                     queue.addAll(hint.hint);
                 }
             }
@@ -418,7 +418,7 @@ public class MemToReg implements FunctionProcessor {
 
         private AddressOffset toAddressOffset(RegisterOffset gep) {
             assert gep == null || gep.register != null;
-            final StateElement element = gep == null ? null : state.get(gep.register);
+            final AddressOffsets element = gep == null ? null : state.get(gep.register);
             return element instanceof AddressOffset base ? base.increase(gep.offset) : null;
         }
 
@@ -436,20 +436,40 @@ public class MemToReg implements FunctionProcessor {
             return new RegisterOffset(register, sum);
         }
 
-        private static boolean mergeInto(Map<Object, StateElement> target, Map<Object, StateElement> other) {
+        private static boolean mergeInto(Map<Object, AddressOffsets> target, Map<Object, AddressOffsets> other) {
             boolean changed = false;
             // Keep links between registers and objects to properly propagate publishing.
-            for (Map.Entry<Object, StateElement> entry : target.entrySet()) {
-                final StateElement otherElement = other.get(entry.getKey());
-                final PropagationHint myHint = entry.getValue() instanceof PropagationHint h ? h : null;
-                final boolean reuseOrEqual = myHint != null || entry.getValue().equals(otherElement);
-                final PropagationHint hint = reuseOrEqual ? myHint : new PropagationHint(new HashSet<>());
-                if (hint != null) {
-                    changed |= entry.getValue() instanceof AddressOffset o && hint.hint.add(o.base);
-                    changed |= otherElement instanceof AddressOffset o && hint.hint.add(o.base);
-                    changed |= otherElement instanceof PropagationHint h && hint.hint.addAll(h.hint);
-                    entry.setValue(hint);
+            for (Map.Entry<Object, AddressOffsets> entry : target.entrySet()) {
+                final AddressOffsets otherElement = other.get(entry.getKey());
+                final AddressOffset otherAddress = otherElement instanceof AddressOffset a ? a : null;
+                final AddressOffsetSet otherHint = otherElement instanceof AddressOffsetSet h ? h : null;
+                final AddressOffset targetAddress = entry.getValue() instanceof AddressOffset a ? a : null;
+                final AddressOffsetSet targetHint = entry.getValue() instanceof AddressOffsetSet h ? h : null;
+                assert targetAddress != null || targetHint != null;
+                if (otherElement == null ||
+                        targetAddress != null && targetAddress.equals(otherAddress) ||
+                        targetHint != null && otherAddress != null && targetHint.hint.contains(otherAddress.base) ||
+                        targetHint != null && otherHint != null && targetHint.hint.containsAll(otherHint.hint)) {
+                    continue;
                 }
+                final Set<RegWriter> hint = new HashSet<>();
+                if (targetAddress != null) {
+                    hint.add(targetAddress.base);
+                }
+                if (otherAddress != null) {
+                    hint.add(otherAddress.base);
+                }
+                if (targetHint != null) {
+                    hint.addAll(targetHint.hint);
+                }
+                if (otherHint != null) {
+                    hint.addAll(otherHint.hint);
+                }
+                entry.setValue(new AddressOffsetSet(hint));
+                changed = true;
+            }
+            for (Map.Entry<Object, AddressOffsets> entry : other.entrySet()) {
+                changed |= target.putIfAbsent(entry.getKey(), entry.getValue()) == null;
             }
             return changed;
         }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/MiscellaneousTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/MiscellaneousTest.java
@@ -72,6 +72,7 @@ public class MiscellaneousTest extends AbstractCTest {
                 {"SB-asm-syncs", POWER, PASS, 1},
                 {"MP_atomic_bool", IMM, PASS, 1},
                 {"MP_atomic_bool_weak", IMM, FAIL, 1},
+                {"memtoreg_merging_pointers", IMM, PASS, 1},
                 {"nondet_loop", IMM, FAIL, 1},
                 {"pthread", IMM, PASS, 1},
                 {"recursion", IMM, UNKNOWN, 1},

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/ProcessingTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/ProcessingTest.java
@@ -1,0 +1,180 @@
+package com.dat3m.dartagnan.others.miscellaneous;
+
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.type.TypeFactory;
+import com.dat3m.dartagnan.program.Function;
+import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.EventFactory;
+import com.dat3m.dartagnan.program.event.core.Label;
+import com.dat3m.dartagnan.program.event.core.Local;
+import com.dat3m.dartagnan.program.memory.Memory;
+import com.dat3m.dartagnan.program.processing.MemToReg;
+import org.junit.Test;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ProcessingTest {
+
+    private static final TypeFactory types = TypeFactory.getInstance();
+    private static final ExpressionFactory expressions = ExpressionFactory.getInstance();
+
+    @Test
+    public void memToReg0() throws InvalidConfigurationException {
+        final Program program = new Program(new Memory(), Program.SourceLanguage.LLVM);
+        final Function f = new Function("f", types.getFunctionType(types.getVoidType(), List.of()), List.of(), 0, null);
+        program.addFunction(f);
+        final Register r0 = f.newRegister("r0", types.getArchType());
+        final Register r1 = f.newRegister("r1", types.getBooleanType());
+        final Event alloc = newAlloc(r0, types.getBooleanType(), 1);
+        final Event storeFalse = EventFactory.newStore(r0, expressions.makeFalse());
+        final Event loadFalse = EventFactory.newLoad(r1, r0);
+        final Event storeTrue = EventFactory.newStore(r0, expressions.makeNot(r1));
+        final Event loadTrue = EventFactory.newLoad(r1, r0);
+        final Event assertTrue = EventFactory.newAssert(r1, "assert true");
+        f.append(List.of(alloc, storeFalse, loadFalse, storeTrue, loadTrue, assertTrue));
+        final Configuration config = Configuration.builder().build();
+        MemToReg.fromConfig(config).run(f);
+        final List<Event> events = f.getEvents();
+        assertEquals(5, events.size());
+        assertLocal(events.get(0));
+        assertLocal(events.get(1));
+        assertLocal(events.get(2));
+        assertLocal(events.get(3));
+        assertComparable(assertTrue, events.get(4));
+    }
+
+    @Test
+    public void memToReg1() throws InvalidConfigurationException {
+        final Program program = new Program(new Memory(), Program.SourceLanguage.LLVM);
+        final Function f = new Function("f", types.getFunctionType(types.getVoidType(), List.of()), List.of(), 0, null);
+        program.addFunction(f);
+        final Register r0 = f.newRegister("r0", types.getArchType());
+        final Register r1 = f.newRegister("r1", types.getArchType());
+        final Register r2 = f.newRegister("r2", types.getArchType());
+        final Register r3 = f.newRegister("r3", types.getBooleanType());
+        final Event allocX = newAlloc(r0, types.getBooleanType(), 2);
+        final Event allocY = newAlloc(r1, types.getArchType(), 1);
+        final Event storeIndex = EventFactory.newStore(r1,
+                expressions.makeITE(
+                        program.newConstant(types.getBooleanType()),
+                        expressions.makeValue(1, types.getArchType()),
+                        expressions.makeValue(0, types.getArchType())));
+        final Event loadIndex = EventFactory.newLoad(r2, r1);
+        final Event storeTrue = EventFactory.newStore(expressions.makeAdd(r0, r2), expressions.makeTrue());
+        final Event loadTrue = EventFactory.newLoad(r3, expressions.makeAdd(r0, r2));
+        final Event assertTrue = EventFactory.newAssert(r3, "assert true");
+        f.append(List.of(allocX, allocY, storeIndex, loadIndex, storeTrue, loadTrue, assertTrue));
+        final Configuration config = Configuration.builder().build();
+        MemToReg.fromConfig(config).run(f);
+        final List<Event> events = f.getEvents();
+        assertEquals(6, events.size());
+        assertComparable(allocX, events.get(0));
+        assertLocal(events.get(1));
+        assertLocal(events.get(2));
+        assertComparable(storeTrue, events.get(3));
+        assertComparable(loadTrue, events.get(4));
+        assertComparable(assertTrue, events.get(5));
+    }
+
+    @Test
+    public void memToReg2() throws InvalidConfigurationException {
+        final Program program = new Program(new Memory(), Program.SourceLanguage.LLVM);
+        final Function f = new Function("f", types.getFunctionType(types.getVoidType(), List.of()), List.of(), 0, null);
+        program.addFunction(f);
+        final Register r0 = f.newRegister("r0", types.getArchType());
+        final Register r1 = f.newRegister("r1", types.getArchType());
+        final Register r2 = f.newRegister("r2", types.getArchType());
+        final Register r3 = f.newRegister("r3", types.getBooleanType());
+        final Event allocX = newAlloc(r0, types.getBooleanType(), 2);
+        final Event allocY = newAlloc(r1, types.getArchType(), 1);
+        final Label labelThen = EventFactory.newLabel("then");
+        final Label labelEndIf = EventFactory.newLabel("endIf");
+        final Event jumpNondet = EventFactory.newJump(program.newConstant(types.getBooleanType()), labelThen);
+        final Event gotoEndIf = EventFactory.newGoto(labelEndIf);
+        final Event store0 = EventFactory.newStore(r1, expressions.makeValue(0, types.getArchType()));
+        final Event store1 = EventFactory.newStore(r1, expressions.makeValue(1, types.getArchType()));
+        final Event loadIndex = EventFactory.newLoad(r2, r1);
+        final Event storeTrue = EventFactory.newStore(expressions.makeAdd(r0, r2), expressions.makeTrue());
+        final Event loadTrue = EventFactory.newLoad(r3, expressions.makeAdd(r0, r2));
+        final Event assertTrue = EventFactory.newAssert(r3, "assert true");
+        f.append(List.of(allocX, allocY,
+                jumpNondet, store0, gotoEndIf, labelThen, store1, labelEndIf,
+                loadIndex, storeTrue, loadTrue, assertTrue));
+        final Configuration config = Configuration.builder().build();
+        MemToReg.fromConfig(config).run(f);
+        final List<Event> events = f.getEvents();
+        assertEquals(11, events.size());
+        assertComparable(allocX, events.get(0));
+        assertComparable(jumpNondet, events.get(1));
+        assertLocal(events.get(2));
+        assertComparable(gotoEndIf, events.get(3));
+        assertComparable(labelThen, events.get(4));
+        assertLocal(events.get(5));
+        assertComparable(labelEndIf, events.get(6));
+        assertLocal(events.get(7));
+        assertComparable(storeTrue, events.get(8));
+        assertComparable(loadTrue, events.get(9));
+        assertComparable(assertTrue, events.get(10));
+    }
+
+    @Test
+    public void memToReg3() throws InvalidConfigurationException {
+        final Program program = new Program(new Memory(), Program.SourceLanguage.LLVM);
+        final Function f = new Function("f", types.getFunctionType(types.getVoidType(), List.of()), List.of(), 0, null);
+        program.addFunction(f);
+        final Register r0 = f.newRegister("r0", types.getArchType());
+        final Register r1 = f.newRegister("r1", types.getArchType());
+        final Register r2 = f.newRegister("r2", types.getArchType());
+        final Register r3 = f.newRegister("r3", types.getBooleanType());
+        final Event allocX = newAlloc(r0, types.getBooleanType(), 2);
+        final Event allocY = newAlloc(r1, types.getArchType(), 1);
+        final Label labelThen = EventFactory.newLabel("then");
+        final Label labelEndIf = EventFactory.newLabel("endIf");
+        final Event jumpNondet = EventFactory.newJump(program.newConstant(types.getBooleanType()), labelThen);
+        final Event gotoEndIf = EventFactory.newGoto(labelEndIf);
+        final Event store0 = EventFactory.newStore(r1, r0);
+        final Event store1 = EventFactory.newStore(r1, expressions.makeAdd(r0, expressions.makeValue(1, types.getArchType())));
+        final Event loadIndex = EventFactory.newLoad(r2, r1);
+        final Event storeTrue = EventFactory.newStore(r2, expressions.makeTrue());
+        final Event loadTrue = EventFactory.newLoad(r3, r2);
+        final Event assertTrue = EventFactory.newAssert(r3, "assert true");
+        f.append(List.of(allocX, allocY,
+                jumpNondet, store0, gotoEndIf, labelThen, store1, labelEndIf,
+                loadIndex, storeTrue, loadTrue, assertTrue));
+        final Configuration config = Configuration.builder().build();
+        MemToReg.fromConfig(config).run(f);
+        final List<Event> events = f.getEvents();
+        assertEquals(11, events.size());
+        assertComparable(allocX, events.get(0));
+        assertComparable(jumpNondet, events.get(1));
+        assertLocal(events.get(2));
+        assertComparable(gotoEndIf, events.get(3));
+        assertComparable(labelThen, events.get(4));
+        assertLocal(events.get(5));
+        assertComparable(labelEndIf, events.get(6));
+        assertLocal(events.get(7));
+        assertComparable(storeTrue, events.get(8));
+        assertComparable(loadTrue, events.get(9));
+        assertComparable(assertTrue, events.get(10));
+    }
+
+    private Event newAlloc(Register address, Type type, int count) {
+        return EventFactory.newAlloc(address, type, expressions.makeValue(count, types.getArchType()), false, true);
+    }
+
+    private void assertLocal(Event event) {
+        assertTrue(event instanceof Local);
+    }
+
+    private void assertComparable(Event expected, Event actual) {
+        assertEquals(expected, actual);
+    }
+}

--- a/dartagnan/src/test/resources/miscellaneous/memtoreg_merging_pointers.ll
+++ b/dartagnan/src/test/resources/miscellaneous/memtoreg_merging_pointers.ll
@@ -1,0 +1,124 @@
+; ModuleID = 'benchmarks/miscellaneous/memtoreg_merging_pointers.c'
+source_filename = "benchmarks/miscellaneous/memtoreg_merging_pointers.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@__func__.main = private unnamed_addr constant [5 x i8] c"main\00", align 1, !dbg !0
+@.str = private unnamed_addr constant [28 x i8] c"memtoreg_merging_pointers.c\00", align 1, !dbg !8
+@.str.1 = private unnamed_addr constant [8 x i8] c"*i == 1\00", align 1, !dbg !13
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local i32 @main() #0 !dbg !28 {
+  %1 = alloca i32, align 4
+  %2 = alloca [2 x i32], align 4
+  %3 = alloca ptr, align 8
+  store i32 0, ptr %1, align 4
+    #dbg_declare(ptr %2, !33, !DIExpression(), !37)
+    #dbg_declare(ptr %3, !38, !DIExpression(), !40)
+  %4 = call i32 @__VERIFIER_nondet_int(), !dbg !41
+  %5 = icmp ne i32 %4, 0, !dbg !41
+  br i1 %5, label %6, label %8, !dbg !43
+
+6:                                                ; preds = %0
+  %7 = getelementptr inbounds [2 x i32], ptr %2, i64 0, i64 0, !dbg !44
+  store ptr %7, ptr %3, align 8, !dbg !45
+  br label %10, !dbg !46
+
+8:                                                ; preds = %0
+  %9 = getelementptr inbounds [2 x i32], ptr %2, i64 0, i64 1, !dbg !47
+  store ptr %9, ptr %3, align 8, !dbg !48
+  br label %10
+
+10:                                               ; preds = %8, %6
+  %11 = load ptr, ptr %3, align 8, !dbg !49
+  store i32 1, ptr %11, align 4, !dbg !50
+  %12 = load ptr, ptr %3, align 8, !dbg !51
+  %13 = load i32, ptr %12, align 4, !dbg !51
+  %14 = icmp eq i32 %13, 1, !dbg !51
+  %15 = xor i1 %14, true, !dbg !51
+  %16 = zext i1 %15 to i32, !dbg !51
+  %17 = sext i32 %16 to i64, !dbg !51
+  %18 = icmp ne i64 %17, 0, !dbg !51
+  br i1 %18, label %19, label %21, !dbg !51
+
+19:                                               ; preds = %10
+  call void @__assert_rtn(ptr noundef @__func__.main, ptr noundef @.str, i32 noundef 16, ptr noundef @.str.1) #3, !dbg !51
+  unreachable, !dbg !51
+
+20:                                               ; No predecessors!
+  br label %22, !dbg !51
+
+21:                                               ; preds = %10
+  br label %22, !dbg !51
+
+22:                                               ; preds = %21, %20
+  ret i32 0, !dbg !52
+}
+
+declare i32 @__VERIFIER_nondet_int() #1
+
+; Function Attrs: cold noreturn
+declare void @__assert_rtn(ptr noundef, ptr noundef, i32 noundef, ptr noundef) #2
+
+attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #2 = { cold noreturn "disable-tail-calls"="true" "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #3 = { cold noreturn }
+
+!llvm.dbg.cu = !{!18}
+!llvm.module.flags = !{!20, !21, !22, !23, !24, !25, !26}
+!llvm.ident = !{!27}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(scope: null, file: !2, line: 16, type: !3, isLocal: true, isDefinition: true)
+!2 = !DIFile(filename: "benchmarks/miscellaneous/memtoreg_merging_pointers.c", directory: "/Users/r/git/dat3m", checksumkind: CSK_MD5, checksum: "0906b8cb3847999c8715ea2e910ca5d2")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 40, elements: !6)
+!4 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !5)
+!5 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!6 = !{!7}
+!7 = !DISubrange(count: 5)
+!8 = !DIGlobalVariableExpression(var: !9, expr: !DIExpression())
+!9 = distinct !DIGlobalVariable(scope: null, file: !2, line: 16, type: !10, isLocal: true, isDefinition: true)
+!10 = !DICompositeType(tag: DW_TAG_array_type, baseType: !5, size: 224, elements: !11)
+!11 = !{!12}
+!12 = !DISubrange(count: 28)
+!13 = !DIGlobalVariableExpression(var: !14, expr: !DIExpression())
+!14 = distinct !DIGlobalVariable(scope: null, file: !2, line: 16, type: !15, isLocal: true, isDefinition: true)
+!15 = !DICompositeType(tag: DW_TAG_array_type, baseType: !5, size: 64, elements: !16)
+!16 = !{!17}
+!17 = !DISubrange(count: 8)
+!18 = distinct !DICompileUnit(language: DW_LANG_C11, file: !2, producer: "Homebrew clang version 19.1.7", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !19, splitDebugInlining: false, nameTableKind: None)
+!19 = !{!0, !8, !13}
+!20 = !{i32 7, !"Dwarf Version", i32 5}
+!21 = !{i32 2, !"Debug Info Version", i32 3}
+!22 = !{i32 1, !"wchar_size", i32 4}
+!23 = !{i32 8, !"PIC Level", i32 2}
+!24 = !{i32 7, !"PIE Level", i32 2}
+!25 = !{i32 7, !"uwtable", i32 2}
+!26 = !{i32 7, !"frame-pointer", i32 2}
+!27 = !{!"Homebrew clang version 19.1.7"}
+!28 = distinct !DISubprogram(name: "main", scope: !2, file: !2, line: 7, type: !29, scopeLine: 8, spFlags: DISPFlagDefinition, unit: !18, retainedNodes: !32)
+!29 = !DISubroutineType(types: !30)
+!30 = !{!31}
+!31 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!32 = !{}
+!33 = !DILocalVariable(name: "a", scope: !28, file: !2, line: 9, type: !34)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !31, size: 64, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 2)
+!37 = !DILocation(line: 9, column: 9, scope: !28)
+!38 = !DILocalVariable(name: "i", scope: !28, file: !2, line: 10, type: !39)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!40 = !DILocation(line: 10, column: 10, scope: !28)
+!41 = !DILocation(line: 11, column: 9, scope: !42)
+!42 = distinct !DILexicalBlock(scope: !28, file: !2, line: 11, column: 9)
+!43 = !DILocation(line: 11, column: 9, scope: !28)
+!44 = !DILocation(line: 12, column: 14, scope: !42)
+!45 = !DILocation(line: 12, column: 11, scope: !42)
+!46 = !DILocation(line: 12, column: 9, scope: !42)
+!47 = !DILocation(line: 14, column: 14, scope: !42)
+!48 = !DILocation(line: 14, column: 11, scope: !42)
+!49 = !DILocation(line: 15, column: 6, scope: !28)
+!50 = !DILocation(line: 15, column: 8, scope: !28)
+!51 = !DILocation(line: 16, column: 5, scope: !28)
+!52 = !DILocation(line: 17, column: 5, scope: !28)

--- a/dartagnan/src/test/resources/miscellaneous/memtoreg_merging_pointers.ll
+++ b/dartagnan/src/test/resources/miscellaneous/memtoreg_merging_pointers.ll
@@ -5,54 +5,60 @@ target triple = "x86_64-pc-linux-gnu"
 
 @__func__.main = private unnamed_addr constant [5 x i8] c"main\00", align 1, !dbg !0
 @.str = private unnamed_addr constant [28 x i8] c"memtoreg_merging_pointers.c\00", align 1, !dbg !8
-@.str.1 = private unnamed_addr constant [8 x i8] c"*i == 1\00", align 1, !dbg !13
+@.str.1 = private unnamed_addr constant [8 x i8] c"*j == 1\00", align 1, !dbg !13
 
 ; Function Attrs: noinline nounwind uwtable
 define dso_local i32 @main() #0 !dbg !28 {
   %1 = alloca i32, align 4
   %2 = alloca [2 x i32], align 4
   %3 = alloca ptr, align 8
+  %4 = alloca ptr, align 8
   store i32 0, ptr %1, align 4
     #dbg_declare(ptr %2, !33, !DIExpression(), !37)
     #dbg_declare(ptr %3, !38, !DIExpression(), !40)
-  %4 = call i32 @__VERIFIER_nondet_int(), !dbg !41
-  %5 = icmp ne i32 %4, 0, !dbg !41
-  br i1 %5, label %6, label %8, !dbg !43
+    #dbg_declare(ptr %4, !41, !DIExpression(), !42)
+  %5 = call i32 @__VERIFIER_nondet_int(), !dbg !43
+  %6 = icmp ne i32 %5, 0, !dbg !43
+  br i1 %6, label %7, label %10, !dbg !45
 
-6:                                                ; preds = %0
-  %7 = getelementptr inbounds [2 x i32], ptr %2, i64 0, i64 0, !dbg !44
-  store ptr %7, ptr %3, align 8, !dbg !45
-  br label %10, !dbg !46
+7:                                                ; preds = %0
+  %8 = getelementptr inbounds [2 x i32], ptr %2, i64 0, i64 0, !dbg !46
+  store ptr %8, ptr %3, align 8, !dbg !47
+  %9 = getelementptr inbounds [2 x i32], ptr %2, i64 0, i64 0, !dbg !48
+  store ptr %9, ptr %4, align 8, !dbg !49
+  br label %13, !dbg !50
 
-8:                                                ; preds = %0
-  %9 = getelementptr inbounds [2 x i32], ptr %2, i64 0, i64 1, !dbg !47
-  store ptr %9, ptr %3, align 8, !dbg !48
-  br label %10
+10:                                               ; preds = %0
+  %11 = getelementptr inbounds [2 x i32], ptr %2, i64 0, i64 1, !dbg !51
+  store ptr %11, ptr %3, align 8, !dbg !52
+  %12 = getelementptr inbounds [2 x i32], ptr %2, i64 0, i64 1, !dbg !53
+  store ptr %12, ptr %4, align 8, !dbg !54
+  br label %13
 
-10:                                               ; preds = %8, %6
-  %11 = load ptr, ptr %3, align 8, !dbg !49
-  store i32 1, ptr %11, align 4, !dbg !50
-  %12 = load ptr, ptr %3, align 8, !dbg !51
-  %13 = load i32, ptr %12, align 4, !dbg !51
-  %14 = icmp eq i32 %13, 1, !dbg !51
-  %15 = xor i1 %14, true, !dbg !51
-  %16 = zext i1 %15 to i32, !dbg !51
-  %17 = sext i32 %16 to i64, !dbg !51
-  %18 = icmp ne i64 %17, 0, !dbg !51
-  br i1 %18, label %19, label %21, !dbg !51
+13:                                               ; preds = %10, %7
+  %14 = load ptr, ptr %3, align 8, !dbg !55
+  store i32 1, ptr %14, align 4, !dbg !56
+  %15 = load ptr, ptr %4, align 8, !dbg !57
+  %16 = load i32, ptr %15, align 4, !dbg !57
+  %17 = icmp eq i32 %16, 1, !dbg !57
+  %18 = xor i1 %17, true, !dbg !57
+  %19 = zext i1 %18 to i32, !dbg !57
+  %20 = sext i32 %19 to i64, !dbg !57
+  %21 = icmp ne i64 %20, 0, !dbg !57
+  br i1 %21, label %22, label %24, !dbg !57
 
-19:                                               ; preds = %10
-  call void @__assert_rtn(ptr noundef @__func__.main, ptr noundef @.str, i32 noundef 16, ptr noundef @.str.1) #3, !dbg !51
-  unreachable, !dbg !51
+22:                                               ; preds = %13
+  call void @__assert_rtn(ptr noundef @__func__.main, ptr noundef @.str, i32 noundef 16, ptr noundef @.str.1) #3, !dbg !57
+  unreachable, !dbg !57
 
-20:                                               ; No predecessors!
-  br label %22, !dbg !51
+23:                                               ; No predecessors!
+  br label %25, !dbg !57
 
-21:                                               ; preds = %10
-  br label %22, !dbg !51
+24:                                               ; preds = %13
+  br label %25, !dbg !57
 
-22:                                               ; preds = %21, %20
-  ret i32 0, !dbg !52
+25:                                               ; preds = %24, %23
+  ret i32 0, !dbg !58
 }
 
 declare i32 @__VERIFIER_nondet_int() #1
@@ -71,7 +77,7 @@ attributes #3 = { cold noreturn }
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(scope: null, file: !2, line: 16, type: !3, isLocal: true, isDefinition: true)
-!2 = !DIFile(filename: "benchmarks/miscellaneous/memtoreg_merging_pointers.c", directory: "/Users/r/git/dat3m", checksumkind: CSK_MD5, checksum: "0906b8cb3847999c8715ea2e910ca5d2")
+!2 = !DIFile(filename: "benchmarks/miscellaneous/memtoreg_merging_pointers.c", directory: "/Users/r/git/dat3m", checksumkind: CSK_MD5, checksum: "ed9f2213d07dabf381d78b7196f4a1ac")
 !3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 40, elements: !6)
 !4 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !5)
 !5 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
@@ -110,15 +116,21 @@ attributes #3 = { cold noreturn }
 !38 = !DILocalVariable(name: "i", scope: !28, file: !2, line: 10, type: !39)
 !39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
 !40 = !DILocation(line: 10, column: 10, scope: !28)
-!41 = !DILocation(line: 11, column: 9, scope: !42)
-!42 = distinct !DILexicalBlock(scope: !28, file: !2, line: 11, column: 9)
-!43 = !DILocation(line: 11, column: 9, scope: !28)
-!44 = !DILocation(line: 12, column: 14, scope: !42)
-!45 = !DILocation(line: 12, column: 11, scope: !42)
-!46 = !DILocation(line: 12, column: 9, scope: !42)
-!47 = !DILocation(line: 14, column: 14, scope: !42)
-!48 = !DILocation(line: 14, column: 11, scope: !42)
-!49 = !DILocation(line: 15, column: 6, scope: !28)
-!50 = !DILocation(line: 15, column: 8, scope: !28)
-!51 = !DILocation(line: 16, column: 5, scope: !28)
-!52 = !DILocation(line: 17, column: 5, scope: !28)
+!41 = !DILocalVariable(name: "j", scope: !28, file: !2, line: 10, type: !39)
+!42 = !DILocation(line: 10, column: 14, scope: !28)
+!43 = !DILocation(line: 11, column: 9, scope: !44)
+!44 = distinct !DILexicalBlock(scope: !28, file: !2, line: 11, column: 9)
+!45 = !DILocation(line: 11, column: 9, scope: !28)
+!46 = !DILocation(line: 12, column: 14, scope: !44)
+!47 = !DILocation(line: 12, column: 11, scope: !44)
+!48 = !DILocation(line: 12, column: 25, scope: !44)
+!49 = !DILocation(line: 12, column: 22, scope: !44)
+!50 = !DILocation(line: 12, column: 9, scope: !44)
+!51 = !DILocation(line: 14, column: 14, scope: !44)
+!52 = !DILocation(line: 14, column: 11, scope: !44)
+!53 = !DILocation(line: 14, column: 25, scope: !44)
+!54 = !DILocation(line: 14, column: 22, scope: !44)
+!55 = !DILocation(line: 15, column: 6, scope: !28)
+!56 = !DILocation(line: 15, column: 8, scope: !28)
+!57 = !DILocation(line: 16, column: 5, scope: !28)
+!58 = !DILocation(line: 17, column: 5, scope: !28)


### PR DESCRIPTION
Fixes a bug, where thread-local allocations were *partially* promoted to registers, while some usages were kept unchanged.

Consider the following minimal example.  The buggy `MemToReg` removed the allocation of `a`, but kept the store.  Expected behavior is to keep the allocation.
```c
int a[2];        // r1 := alloc(2 * sizeof(int))
int *i;
if(*) i = &a[0]; // r2 := r1
else i = &a[1];  // r2 := r1 + sizeof(int)
*i = 1;          // store(*r2, 1)
```
In comparison, the following two programs were already handled as expected before this fix.
```c
int a[2];    // r1 := alloc(2 * sizeof(int))
int i;
if(*) i = 0; // r2 := 0
else i = 1;  // r2 := 1
a[i] = 1;    // store(*(r1 + r2), 1)

int a[2];                     // r1 := alloc(2 * sizeof(int))
int *i = (*) ? &a[0] : &a[1]; // r2 := ite(*, r1, r1 + sizeof(int))
*i = 1;                       // store(*r2, 1)
```