### PR TITLE
Fix PTX models

### DIFF
--- a/cat/ptx-v6.0.cat
+++ b/cat/ptx-v6.0.cat
@@ -39,14 +39,14 @@ let morally-strong = (ms1 & ms2) \ id
 
 // The ASPLOS'19 paper uses the definition below
 // let rec observation = (morally-strong & rf) | (observation; rmw; observation)
-// but the ISCA'22 paper claims the one below is equivalent, thus we avoid the recursion
+// but the ISCA'22 paper claims we can use the one below if we use observation+ in sync
 let observation = (morally-strong & rf) | rmw
 
 let release-pattern = ([W & REL]; po-loc?; [strong-write]) | ([F & ACQ_REL]; po; [strong-write])
 
 let acquire-pattern = ([strong-read]; po-loc?; [R & ACQ]) | ([strong-read]; po; [F & ACQ_REL])
 
-let sync = morally-strong & (release-pattern; observation; acquire-pattern)
+let sync = morally-strong & (release-pattern; observation+; acquire-pattern)
 let cause-base = po?; ((sync | sync_fence | sync_barrier); po?)+
 let cause = cause-base | (observation; (cause-base | po-loc))
 

--- a/cat/ptx-v7.5.cat
+++ b/cat/ptx-v7.5.cat
@@ -57,16 +57,16 @@ let ms2 = same-proxy
 let ms3 = ((M * M) & vloc) | ((_ * _) \ (M * M))
 let morally-strong = (ms1 & ms2 & ms3) \ id
 
-// This is probably equivalent to 
+// The ASPLOS'19 paper uses the definition below
 // let rec observation = (morally-strong & rf) | (observation; rmw; observation)
-// We opt to avoid the recursion
+// but the ISCA'22 paper claims we can use the one below if we use observation+ in sync
 let observation = (morally-strong & rf) | rmw
 
 let release-pattern = ([W & REL]; po-vloc?; [strong-write]) | ([F & ACQ_REL]; po; [strong-write])
 
 let acquire-pattern = ([strong-read]; po-vloc?; [R & ACQ]) | ([strong-read]; po; [F & ACQ_REL])
 
-let sync = morally-strong & (release-pattern; observation; acquire-pattern)
+let sync = morally-strong & (release-pattern; observation+; acquire-pattern)
 let cause-base = (po?; ((sync | sync_fence | sync_barrier); po?)+) | po
 
 (*******************)

--- a/dartagnan/src/test/resources/PTXv6_0-expected.csv
+++ b/dartagnan/src/test/resources/PTXv6_0-expected.csv
@@ -129,3 +129,7 @@ litmus/PTX/Manual/counter-plain-store-plain-load.litmus,1
 litmus/PTX/Manual/MICRO24-Fig4a.litmus,1
 litmus/PTX/Manual/MICRO24-Fig4a-correct.litmus,0
 litmus/PTX/Manual/MICRO24-Fig4b.litmus,1
+litmus/PTX/Manual/rmw-chain-1.litmus,0
+litmus/PTX/Manual/rmw-chain-2a.litmus,1
+litmus/PTX/Manual/rmw-chain-2b.litmus,0
+litmus/PTX/Manual/rmw-chain-2c.litmus,0

--- a/dartagnan/src/test/resources/PTXv7_5-expected.csv
+++ b/dartagnan/src/test/resources/PTXv7_5-expected.csv
@@ -258,3 +258,7 @@ litmus/PTX/Manual/counter-plain-store-plain-load.litmus,1
 litmus/PTX/Manual/MICRO24-Fig4a.litmus,1
 litmus/PTX/Manual/MICRO24-Fig4a-correct.litmus,0
 litmus/PTX/Manual/MICRO24-Fig4b.litmus,1
+litmus/PTX/Manual/rmw-chain-1.litmus,0
+litmus/PTX/Manual/rmw-chain-2a.litmus,1
+litmus/PTX/Manual/rmw-chain-2b.litmus,0
+litmus/PTX/Manual/rmw-chain-2c.litmus,0

--- a/litmus/PTX/Manual/rmw-chain-1.litmus
+++ b/litmus/PTX/Manual/rmw-chain-1.litmus
@@ -1,0 +1,11 @@
+PTX RMW-chain-1
+{
+P1:r0=0;
+P2:r1=0; P2:r2=0;
+x=0; y=0;
+}
+ P0@cta 0,gpu 0       | P1@cta 0,gpu 0                | P2@cta 0,gpu 0       ;
+ st.relaxed.gpu x, 1  | atom.relaxed.gpu.add r0, y, 1 | ld.acquire.gpu r1, y ;
+ st.release.gpu y, 1  |                               | ld.relaxed.gpu r2, x ;
+
+exists (1:r0 = 1 /\ 2:r1 = 2 /\ 2:r2 = 0)

--- a/litmus/PTX/Manual/rmw-chain-2a.litmus
+++ b/litmus/PTX/Manual/rmw-chain-2a.litmus
@@ -1,0 +1,12 @@
+PTX RMW-chain-2a
+{
+P0:r0=0;
+P1:r1=0;
+P2:r2=0;
+x=0; y=0;
+}
+ P0@cta 0,gpu 0       | P1@cta 0,gpu 0                | P2@cta 0,gpu 0       ;
+ ld.acquire.gpu r0, y | atom.relaxed.gpu.add r1, x, 0 | ld.relaxed.gpu r2, x ;
+ st.weak x, 1         |                               | st.release.gpu y, 1  ;
+
+exists (0:r0 = 1 /\ 1:r1 = 1 /\ 2:r2 = 1)

--- a/litmus/PTX/Manual/rmw-chain-2b.litmus
+++ b/litmus/PTX/Manual/rmw-chain-2b.litmus
@@ -1,0 +1,12 @@
+PTX RMW-chain-2b
+{
+P0:r0=0;
+P1:r1=0;
+P2:r2=0;
+x=0; y=0;
+}
+ P0@cta 0,gpu 0       | P1@cta 0,gpu 0                | P2@cta 0,gpu 0       ;
+ ld.acquire.gpu r0, y | ld.relaxed.gpu r1, x          | ld.relaxed.gpu r2, x ;
+ st.weak x, 1         |                               | st.release.gpu y, 1  ;
+
+exists (0:r0 = 1 /\ 1:r1 = 1 /\ 2:r2 = 1)

--- a/litmus/PTX/Manual/rmw-chain-2c.litmus
+++ b/litmus/PTX/Manual/rmw-chain-2c.litmus
@@ -1,0 +1,12 @@
+PTX RMW-chain-2c
+{
+P0:r0=0;
+P1:r1=0;
+P2:r2=0;
+x=0; y=0;
+}
+ P0@cta 0,gpu 0       | P1@cta 0,gpu 0                | P2@cta 0,gpu 0       ;
+ ld.acquire.gpu r0, y | atom.relaxed.gpu.add r1, x, 2 | ld.relaxed.gpu r2, x ;
+ st.relaxed.gpu x, 1  |                               | st.release.gpu y, 1  ;
+
+exists (0:r0 = 1 /\ 1:r1 = 1 /\ 2:r2 = 1)


### PR DESCRIPTION
We made a mistake in the definition of `observation / sync` when we ported the alloy model to cat. The test `rmw-chain-1` shows that our current model is wrong.

I came up with the other tests when I was trying to figure it out if the other usage of `observation` should also be transitively closed. I got confirmation from the NVIDIA folks that the current behavior is the intended one.