### PR TITLE
Return proper exit code for bounded verification

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -434,6 +434,8 @@ public class Dartagnan extends BaseOptions {
             } catch (IOException e) {
                 logger.warn("Failed to save bounds file: {}", e.getLocalizedMessage());
             }
+            ExitCode code = BOUNDED_RESULT;
+            return new ResultSummary(path, filter, result, condition, reason, details.toString(), time, code);
         }
         // We consider those cases without an explicit return to yield normal termination.
         // This includes verification of litmus code, independent of the verification result.


### PR DESCRIPTION
We are currently returning the wrong exit-code when loops are not unrolled. This was causing problems with vsyncer in which it would return `CheckOK` with the initial (sometimes insufficient) unrolling bound. 