### PR TITLE
Better program printing

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -70,7 +70,7 @@ public class OptionNames {
 
     // Refinement Options
     public static final String BASELINE = "refinement.baseline";
-    public static final String GRAPHVIZ_DEBUG_FILES = "refinement.generageGraphvizDebugFiles";
+    public static final String GRAPHVIZ_DEBUG_FILES = "refinement.generateGraphvizDebugFiles";
     public static final String SYMMETRIC_LEARNING = "refinement.symmetricLearning";
 
     // SMT solver Options
@@ -89,4 +89,10 @@ public class OptionNames {
     public static final String PRINT_PROGRAM_AFTER_UNROLLING = "printer.afterUnrolling";
     public static final String PRINT_PROGRAM_AFTER_COMPILATION = "printer.afterCompilation";
     public static final String PRINT_PROGRAM_AFTER_PROCESSING = "printer.afterProcessing";
+
+    public static final String PRINTER_SHOW_INIT_THREADS = "printer.showInitThreads";
+    public static final String PRINTER_SHOW_ANNOTATIONS = "printer.showAnnotations";
+    public static final String PRINTER_SHOW_DYNAMIC_ALLOCATIONS = "printer.showDynamicAllocations";
+    public static final String PRINTER_SHOW_PROGRAM_CONSTANTS = "printer.showProgramConstants";
+    public static final String PRINTER_SHOW_SPECIFICATION = "printer.showSpecification";
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/StoreExclusive.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/StoreExclusive.java
@@ -36,7 +36,7 @@ public class StoreExclusive extends StoreBase implements RegWriter {
 
     @Override
     public String defaultString() {
-        return register + " <- store(*" + address + ", " + value + (!mo.isEmpty() ? ", " + mo : "") + ")";
+        return String.format("%s = store excl(%s, %s%s)", register, address, value, mo.isEmpty() ? "" : ", " + mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/Xchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/Xchg.java
@@ -17,7 +17,7 @@ public class Xchg extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s <- xchg(*%s, %s)", resultRegister, address, storeValue);
+        return String.format("%s = xchg(%s, %s)", resultRegister, address, storeValue);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/opencl/OpenCLRMWExtremum.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/opencl/OpenCLRMWExtremum.java
@@ -20,7 +20,7 @@ public class OpenCLRMWExtremum extends RMWExtremumBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = rmw_ext[%s](%s, %s, %s)\t###OPENCL", resultRegister, mo, storeValue, address, operator.getName());
+        return String.format("%s = rmw_ext[%s](%s, %s, %s)", resultRegister, mo, storeValue, address, operator.getName());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/opencl/OpenCLRMWExtremum.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/opencl/OpenCLRMWExtremum.java
@@ -20,7 +20,7 @@ public class OpenCLRMWExtremum extends RMWExtremumBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := rmw_ext[%s](%s, %s, %s)\t###OPENCL", resultRegister, mo, storeValue, address, operator.getName());
+        return String.format("%s = rmw_ext[%s](%s, %s, %s)\t###OPENCL", resultRegister, mo, storeValue, address, operator.getName());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/ptx/PTXAtomCAS.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/ptx/PTXAtomCAS.java
@@ -17,7 +17,7 @@ public class PTXAtomCAS extends RMWCmpXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atom_cas_%s(%s, %s, %s)", resultRegister, mo, address, expectedValue, storeValue);
+        return String.format("%s = atom_cas_%s(%s, %s, %s)", resultRegister, mo, address, expectedValue, storeValue);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/ptx/PTXAtomExch.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/ptx/PTXAtomExch.java
@@ -17,7 +17,7 @@ public class PTXAtomExch extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atom_exch_%s(%s, %s)", resultRegister, mo, storeValue, address);
+        return String.format("%s = atom_exch_%s(%s, %s)", resultRegister, mo, storeValue, address);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/ptx/PTXAtomOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/ptx/PTXAtomOp.java
@@ -18,7 +18,7 @@ public class PTXAtomOp extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atom_%s_%s(%s, %s)", resultRegister, operator.getName(), mo, operand, address);
+        return String.format("%s = atom_%s_%s(%s, %s)", resultRegister, operator.getName(), mo, operand, address);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/TSOXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/tso/TSOXchg.java
@@ -21,7 +21,7 @@ public class TSOXchg extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("xchg(*%s, %s)", address, resultRegister);
+        return String.format("xchg(%s, %s)", address, resultRegister);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/vulkan/VulkanCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/vulkan/VulkanCmpXchg.java
@@ -20,7 +20,7 @@ public class VulkanCmpXchg extends RMWCmpXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := cmp_xchg[%s](%s, %s, %s)", resultRegister, mo, storeValue, expectedValue, address);
+        return String.format("%s = cmp_xchg[%s](%s, %s, %s)", resultRegister, mo, storeValue, expectedValue, address);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/vulkan/VulkanRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/vulkan/VulkanRMW.java
@@ -19,7 +19,7 @@ public class VulkanRMW extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := rmw[%s](%s, %s)", resultRegister, mo, storeValue, address);
+        return String.format("%s = rmw[%s](%s, %s)", resultRegister, mo, storeValue, address);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/vulkan/VulkanRMWExtremum.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/vulkan/VulkanRMWExtremum.java
@@ -20,7 +20,7 @@ public class VulkanRMWExtremum extends RMWExtremumBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := rmw_ext[%s](%s, %s, %s)", resultRegister, mo, storeValue, address, operator.getName());
+        return String.format("%s = rmw_ext[%s](%s, %s, %s)", resultRegister, mo, storeValue, address, operator.getName());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/vulkan/VulkanRMWOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/arch/vulkan/VulkanRMWOp.java
@@ -20,7 +20,7 @@ public class VulkanRMWOp extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := rmw_%s[%s](%s, %s)", resultRegister, operator.getName(), mo, operand, address);
+        return String.format("%s = rmw_%s[%s](%s, %s)", resultRegister, operator.getName(), mo, operand, address);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/LoadBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/LoadBase.java
@@ -36,7 +36,7 @@ public abstract class LoadBase extends SingleAccessMemoryEvent implements RegWri
     @Override
     public String defaultString() {
         final MemoryOrder mo = getMetadata(MemoryOrder.class);
-        return String.format("%s <- load(*%s%s)", resultRegister, address, mo != null ? ", " + mo.value() : "");
+        return String.format("%s = load(%s%s)", resultRegister, address, mo != null ? ", " + mo.value() : "");
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/RMWCmpXchgBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/RMWCmpXchgBase.java
@@ -67,7 +67,7 @@ public abstract class RMWCmpXchgBase extends SingleAccessMemoryEvent implements 
     @Override
     protected String defaultString() {
         final String strongSuffix = isStrong ?  "strong" : "weak";
-        return String.format("%s := rmw compare_exchange_%s(%s, %s, %s)",
+        return String.format("%s = rmw compare_exchange_%s(%s, %s, %s)",
                 resultRegister, strongSuffix, address, expectedValue, storeValue);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/RMWExtremumBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/RMWExtremumBase.java
@@ -25,7 +25,7 @@ public class RMWExtremumBase extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := rmw ext_%s(%s, %s, %s)", resultRegister, mo, storeValue, address, operator.getName());
+        return String.format("%s = rmw ext_%s(%s, %s, %s)", resultRegister, mo, storeValue, address, operator.getName());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/RMWOpResultBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/RMWOpResultBase.java
@@ -36,7 +36,7 @@ public abstract class RMWOpResultBase extends RMWOpBase implements RegWriter {
 
     @Override
     protected String defaultString() {
-        return String.format("%s := rmw %s_result(%s, %s)", resultRegister, operator.getName(), address, operand);
+        return String.format("%s = rmw %s_result(%s, %s)", resultRegister, operator.getName(), address, operand);
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/RMWXchgBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/RMWXchgBase.java
@@ -50,7 +50,7 @@ public abstract class RMWXchgBase extends SingleAccessMemoryEvent implements Reg
 
     @Override
     protected String defaultString() {
-        return String.format("%s := rmw exchange(%s, %s)", resultRegister, address, storeValue);
+        return String.format("%s = rmw exchange(%s, %s)", resultRegister, address, storeValue);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/StoreBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/StoreBase.java
@@ -43,7 +43,7 @@ public abstract class StoreBase extends SingleAccessMemoryEvent {
 
     @Override
     public String defaultString() {
-        return String.format("store(*%s, %s%s)", address, value, !mo.isEmpty() ? ", " + mo : "");
+        return String.format("store(%s, %s%s)", address, value, !mo.isEmpty() ? ", " + mo : "");
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Alloc.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Alloc.java
@@ -117,7 +117,7 @@ public final class Alloc extends AbstractEvent implements RegReader, RegWriter {
 
     @Override
     protected String defaultString() {
-        return String.format("%s <- %salloc(type=%s, size=%s, align=%s)",
+        return String.format("%s = %salloc(type=%s, size=%s, align=%s)",
                 resultRegister, isHeapAllocation ? "heap" : "stack", allocationType, arraySize, alignment);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/ExecutionStatus.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/ExecutionStatus.java
@@ -56,7 +56,7 @@ public class ExecutionStatus extends AbstractEvent implements RegWriter, EventUs
 
     @Override
     public String defaultString() {
-        return register + " <- not_exec(" + event + ")";
+        return register + " = not_exec(" + event + ")";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Init.java
@@ -51,7 +51,7 @@ public class Init extends Store {
 
     @Override
     public String defaultString() {
-        return String.format("%s[%d] := %s", base, offset, getValue());
+        return String.format("%s[%d] = %s", base, offset, getValue());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Load.java
@@ -38,7 +38,7 @@ public class Load extends AbstractMemoryCoreEvent implements RegWriter {
     @Override
     public String defaultString() {
         final MemoryOrder mo = getMetadata(MemoryOrder.class);
-        return String.format("%s = load(*%s%s)", resultRegister, address, mo != null ? ", " + mo.value() : "");
+        return String.format("%s = load(%s%s)", resultRegister, address, mo != null ? ", " + mo.value() : "");
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
@@ -56,7 +56,7 @@ public class Local extends AbstractEvent implements RegWriter, RegReader {
 
     @Override
     public String defaultString() {
-        return String.format("%s <- %s", register, expr);
+        return String.format("%s = %s", register, expr);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/RMWStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/RMWStore.java
@@ -32,7 +32,7 @@ public class RMWStore extends Store implements EventUser {
 
     @Override
     public String defaultString() {
-        return "rmw " + super.defaultString();
+        return String.format("rmw %s \t #Linked to E%s", super.defaultString(), loadEvent.getGlobalId());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Store.java
@@ -46,7 +46,7 @@ public class Store extends AbstractMemoryCoreEvent {
 
     public String defaultString() {
         final MemoryOrder mo = getMetadata(MemoryOrder.class);
-        return String.format("store(*%s, %s%s)", address, value, mo != null ? ", " + mo.value() : "");
+        return String.format("store(%s, %s%s)", address, value, mo != null ? ", " + mo.value() : "");
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadArgument.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadArgument.java
@@ -52,7 +52,7 @@ public class ThreadArgument extends AbstractEvent implements RegWriter, EventUse
 
     @Override
     public String defaultString() {
-        return String.format("%s := Argument(%s) from %s", register, argIndex, creator);
+        return String.format("%s = Argument(%s) from %s", register, argIndex, creator);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadJoin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadJoin.java
@@ -33,7 +33,7 @@ public class ThreadJoin extends AbstractEvent implements RegWriter, BlockingEven
 
     @Override
     protected String defaultString() {
-        return String.format("%s <- ThreadJoin(%s)", resultRegister, joinThread);
+        return String.format("%s = ThreadJoin(%s)", resultRegister, joinThread);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/functions/ValueFunctionCall.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/functions/ValueFunctionCall.java
@@ -37,7 +37,7 @@ public class ValueFunctionCall extends FunctionCall implements RegWriter {
     @Override
     protected String defaultString() {
         final Object target = isDirectCall() ? ((Function)callTarget).getName() : callTarget;
-        return String.format("%s <- call %s(%s)", resultRegister, target, super.argumentsToString());
+        return String.format("%s = call %s(%s)", resultRegister, target, super.argumentsToString());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
@@ -83,7 +83,7 @@ public class AtomicCmpXchg extends SingleAccessMemoryEvent implements RegWriter 
     @Override
     public String defaultString() {
         final String strongSuffix = isStrong ? "strong" : "weak";
-        return String.format("%s := atomic_compare_exchange_%s(*%s, %s, %s, %s)\t### C11",
+        return String.format("%s = atomic_compare_exchange_%s(%s, %s, %s, %s)\t### C11",
                 resultRegister, strongSuffix, address, expectedAddr, storeValue, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicCmpXchg.java
@@ -83,7 +83,7 @@ public class AtomicCmpXchg extends SingleAccessMemoryEvent implements RegWriter 
     @Override
     public String defaultString() {
         final String strongSuffix = isStrong ? "strong" : "weak";
-        return String.format("%s = atomic_compare_exchange_%s(%s, %s, %s, %s)\t### C11",
+        return String.format("%s = atomic_compare_exchange_%s(%s, %s, %s, %s)",
                 resultRegister, strongSuffix, address, expectedAddr, storeValue, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
@@ -20,7 +20,7 @@ public class AtomicFetchOp extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = atomic_fetch_%s(%s, %s, %s)\t### C11",
+        return String.format("%s = atomic_fetch_%s(%s, %s, %s)",
                 resultRegister, operator.getName(), address, operand, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicFetchOp.java
@@ -20,7 +20,7 @@ public class AtomicFetchOp extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atomic_fetch_%s(*%s, %s, %s)\t### C11",
+        return String.format("%s = atomic_fetch_%s(%s, %s, %s)\t### C11",
                 resultRegister, operator.getName(), address, operand, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -25,7 +25,7 @@ public class AtomicLoad extends LoadBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = atomic_load(%s, %s)\t### C11", resultRegister, address, mo);
+        return String.format("%s = atomic_load(%s, %s)", resultRegister, address, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicLoad.java
@@ -25,7 +25,7 @@ public class AtomicLoad extends LoadBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atomic_load(*%s, %s)\t### C11", resultRegister, address, mo);
+        return String.format("%s = atomic_load(%s, %s)\t### C11", resultRegister, address, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -23,7 +23,7 @@ public class AtomicStore extends StoreBase {
 
     @Override
     public String defaultString() {
-        return String.format("atomic_store(%s, %s, %s)\t### C11", address, value, mo);
+        return String.format("atomic_store(%s, %s, %s)", address, value, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicStore.java
@@ -23,7 +23,7 @@ public class AtomicStore extends StoreBase {
 
     @Override
     public String defaultString() {
-        return String.format("atomic_store(*%s, %s, %s)\t### C11", address, value, mo);
+        return String.format("atomic_store(%s, %s, %s)\t### C11", address, value, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicThreadFence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicThreadFence.java
@@ -17,7 +17,7 @@ public class AtomicThreadFence extends FenceBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s(%s)\t### C11", name, mo);
+        return String.format("%s(%s)", name, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
@@ -19,7 +19,7 @@ public class AtomicXchg extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atomic_exchange(*%s, %s, %s)\t###C11", resultRegister, address, storeValue, mo);
+        return String.format("%s = atomic_exchange(%s, %s, %s)\t###C11", resultRegister, address, storeValue, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicXchg.java
@@ -19,7 +19,7 @@ public class AtomicXchg extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = atomic_exchange(%s, %s, %s)\t###C11", resultRegister, address, storeValue, mo);
+        return String.format("%s = atomic_exchange(%s, %s, %s)", resultRegister, address, storeValue, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadCreate.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadCreate.java
@@ -44,7 +44,7 @@ public class DynamicThreadCreate extends CallBase implements RegWriter {
     @Override
     protected String defaultString() {
         final String func = isDirectCall() ? getDirectCallTarget().getName() : getCallTarget().toString();
-        return String.format("%s <- DynamicThreadCreate(func=%s, args={ %s })", getResultRegister(), func, argumentsToString());
+        return String.format("%s = DynamicThreadCreate(func=%s, args={ %s })", getResultRegister(), func, argumentsToString());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadJoin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadJoin.java
@@ -74,7 +74,7 @@ public class DynamicThreadJoin extends AbstractEvent implements RegWriter, RegRe
 
     @Override
     protected String defaultString() {
-        return String.format("%s <- DynamicThreadJoin(%s)", resultRegister, tid);
+        return String.format("%s = DynamicThreadJoin(%s)", resultRegister, tid);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMAddUnless.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMAddUnless.java
@@ -36,7 +36,7 @@ public class LKMMAddUnless extends SingleAccessMemoryEvent implements RegWriter 
 
     @Override
     public String defaultString() {
-        return String.format("%s := atomic_add_unless(%s, %s, %s)\t### LKMM",
+        return String.format("%s = atomic_add_unless(%s, %s, %s)\t### LKMM",
                 resultRegister, address, operand, cmp);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMAddUnless.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMAddUnless.java
@@ -36,7 +36,7 @@ public class LKMMAddUnless extends SingleAccessMemoryEvent implements RegWriter 
 
     @Override
     public String defaultString() {
-        return String.format("%s = atomic_add_unless(%s, %s, %s)\t### LKMM",
+        return String.format("%s = atomic_add_unless(%s, %s, %s)",
                 resultRegister, address, operand, cmp);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMCmpXchg.java
@@ -18,7 +18,7 @@ public class LKMMCmpXchg extends RMWCmpXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atomic_cmpxchg%s(%s, %s, %s)\t### LKMM",
+        return String.format("%s = atomic_cmpxchg%s(%s, %s, %s)\t### LKMM",
                 resultRegister, Tag.Linux.toText(mo), address, expectedValue, storeValue);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMCmpXchg.java
@@ -18,7 +18,7 @@ public class LKMMCmpXchg extends RMWCmpXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = atomic_cmpxchg%s(%s, %s, %s)\t### LKMM",
+        return String.format("%s = atomic_cmpxchg%s(%s, %s, %s)",
                 resultRegister, Tag.Linux.toText(mo), address, expectedValue, storeValue);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMFetchOp.java
@@ -19,7 +19,7 @@ public class LKMMFetchOp extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = atomic_fetch_%s%s(%s, %s)\t### LKMM",
+        return String.format("%s = atomic_fetch_%s%s(%s, %s)",
                 resultRegister, operator.getName(), Tag.Linux.toText(mo), operand, address);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMFetchOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMFetchOp.java
@@ -19,7 +19,7 @@ public class LKMMFetchOp extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atomic_fetch_%s%s(%s, %s)\t### LKMM",
+        return String.format("%s = atomic_fetch_%s%s(%s, %s)\t### LKMM",
                 resultRegister, operator.getName(), Tag.Linux.toText(mo), operand, address);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
@@ -5,24 +5,8 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventVisitor;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.common.LoadBase;
-import com.dat3m.dartagnan.program.event.core.Load;
-import com.dat3m.dartagnan.program.event.metadata.CustomPrinting;
-import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
-
-import java.util.Optional;
 
 public class LKMMLoad extends LoadBase {
-
-    // A custom printer to make core loads appear like LKMMLoads
-    public static final CustomPrinting CUSTOM_CORE_PRINTING = (e -> {
-        assert e instanceof Load;
-        Load load = (Load)e;
-        MemoryOrder memoryOrder = load.getMetadata(MemoryOrder.class);
-        if (memoryOrder != null && memoryOrder.value().equals(Tag.Linux.MO_ONCE)) {
-            return Optional.of(load.getResultRegister() + " := READ_ONCE(" + load.getAddress() + ")\t### LKMM");
-        }
-        return Optional.empty(); // Use default printing
-    });
 
     public LKMMLoad(Register register, Expression address, String mo) {
         super(register, address, mo);
@@ -35,7 +19,7 @@ public class LKMMLoad extends LoadBase {
     @Override
     public String defaultString() {
         if (mo.equals(Tag.Linux.MO_ONCE)) {
-            return resultRegister + " = READ_ONCE(" + address + ")\t### LKMM";
+            return resultRegister + " = READ_ONCE(" + address + ")";
         }
         return super.defaultString();
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLoad.java
@@ -35,7 +35,7 @@ public class LKMMLoad extends LoadBase {
     @Override
     public String defaultString() {
         if (mo.equals(Tag.Linux.MO_ONCE)) {
-            return resultRegister + " := READ_ONCE(" + address + ")\t### LKMM";
+            return resultRegister + " = READ_ONCE(" + address + ")\t### LKMM";
         }
         return super.defaultString();
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMLock.java
@@ -24,7 +24,7 @@ public class LKMMLock extends SingleAccessMemoryEvent {
 
     @Override
     public String defaultString() {
-        return String.format("spin_lock(*%s)", address);
+        return String.format("spin_lock(%s)", address);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpAndTest.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpAndTest.java
@@ -19,7 +19,7 @@ public class LKMMOpAndTest extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = atomic_%s_and_test(%s, %s)\t### LKMM",
+        return String.format("%s = atomic_%s_and_test(%s, %s)",
                 resultRegister, operator.getName(), operand, address);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpAndTest.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpAndTest.java
@@ -19,7 +19,7 @@ public class LKMMOpAndTest extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atomic_%s_and_test(%s, %s)\t### LKMM",
+        return String.format("%s = atomic_%s_and_test(%s, %s)\t### LKMM",
                 resultRegister, operator.getName(), operand, address);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpNoReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpNoReturn.java
@@ -19,7 +19,7 @@ public class LKMMOpNoReturn extends RMWOpBase {
 
     @Override
     public String defaultString() {
-        return String.format("atomic_%s(%s, %s)\t### LKMM", operator.getName(), operand, address);
+        return String.format("atomic_%s(%s, %s)", operator.getName(), operand, address);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpReturn.java
@@ -19,7 +19,7 @@ public class LKMMOpReturn extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = atomic_%s_return%s(%s, %s)\t### LKMM",
+        return String.format("%s = atomic_%s_return%s(%s, %s)",
                 resultRegister, operator.getName(), Tag.Linux.toText(mo), operand, address);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMOpReturn.java
@@ -19,7 +19,7 @@ public class LKMMOpReturn extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atomic_%s_return%s(%s, %s)\t### LKMM",
+        return String.format("%s = atomic_%s_return%s(%s, %s)\t### LKMM",
                 resultRegister, operator.getName(), Tag.Linux.toText(mo), operand, address);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
@@ -4,24 +4,8 @@ import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.program.event.EventVisitor;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.common.StoreBase;
-import com.dat3m.dartagnan.program.event.core.Store;
-import com.dat3m.dartagnan.program.event.metadata.CustomPrinting;
-import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
-
-import java.util.Optional;
 
 public class LKMMStore extends StoreBase {
-
-    // A custom printer to make core stores appear like LKMMStore
-    public static final CustomPrinting CUSTOM_CORE_PRINTING = (e -> {
-        assert e instanceof Store;
-        Store store = (Store)e;
-        MemoryOrder memoryOrder = store.getMetadata(MemoryOrder.class);
-        if (memoryOrder != null && memoryOrder.value().equals(Tag.Linux.MO_ONCE)) {
-            return Optional.of( "STORE_ONCE(" + store.getAddress() + ", " + store.getMemValue() + ")\t### LKMM");
-        }
-        return Optional.empty(); // Use default printing
-    });
 
     public LKMMStore(Expression address, Expression value, String mo) {
         super(address, value, mo);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMStore.java
@@ -18,7 +18,7 @@ public class LKMMStore extends StoreBase {
     @Override
     public String defaultString() {
         if (mo.equals(Tag.Linux.MO_ONCE)) {
-            return "STORE_ONCE(" + address + ", " + value + ")\t### LKMM";
+            return "STORE_ONCE(" + address + ", " + value + ")";
         }
         return super.defaultString();
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMUnlock.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMUnlock.java
@@ -6,21 +6,10 @@ import com.dat3m.dartagnan.expression.type.TypeFactory;
 import com.dat3m.dartagnan.program.event.EventVisitor;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.common.StoreBase;
-import com.dat3m.dartagnan.program.event.core.Store;
-import com.dat3m.dartagnan.program.event.metadata.CustomPrinting;
-
-import java.util.Optional;
 
 import static com.dat3m.dartagnan.program.event.Tag.Linux.MO_RELEASE;
 
 public class LKMMUnlock extends StoreBase {
-
-    // A custom printer to make core stores appear like LKMMUnlock
-    public static final CustomPrinting CUSTOM_CORE_PRINTING = (e -> {
-        assert e instanceof Store;
-        Store store = (Store)e;
-        return Optional.of(String.format("spin_unlock(*%s)", store.getAddress()));
-    });
 
     public LKMMUnlock(Expression lock) {
         super(lock, ExpressionFactory.getInstance().makeZero(TypeFactory.getInstance().getIntegerType(32)), MO_RELEASE);
@@ -33,7 +22,7 @@ public class LKMMUnlock extends StoreBase {
 
     @Override
     public String defaultString() {
-        return String.format("spin_unlock(*%s)", address);
+        return String.format("spin_unlock(%s)", address);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMXchg.java
@@ -18,7 +18,7 @@ public class LKMMXchg extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = atomic_xchg%s(%s, %s)\t### LKMM",
+        return String.format("%s = atomic_xchg%s(%s, %s)",
                 resultRegister, Tag.Linux.toText(mo), address, storeValue);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/linux/LKMMXchg.java
@@ -18,7 +18,7 @@ public class LKMMXchg extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := atomic_xchg%s(%s, %s)\t### LKMM",
+        return String.format("%s = atomic_xchg%s(%s, %s)\t### LKMM",
                 resultRegister, Tag.Linux.toText(mo), address, storeValue);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
@@ -57,7 +57,7 @@ public class LlvmCmpXchg extends RMWCmpXchgBase {
     @Override
     public String defaultString() {
         final String strongSuffix = isStrong ? "strong" : "weak";
-        return String.format("(%s, %s) := llvm_cmpxchg_%s(*%s, %s, %s, %s)\t### LLVM",
+        return String.format("(%s, %s) = llvm_cmpxchg_%s(%s, %s, %s, %s)\t### LLVM",
                 resultRegister, cmpRegister, strongSuffix, address, expectedValue, storeValue, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmCmpXchg.java
@@ -57,7 +57,7 @@ public class LlvmCmpXchg extends RMWCmpXchgBase {
     @Override
     public String defaultString() {
         final String strongSuffix = isStrong ? "strong" : "weak";
-        return String.format("(%s, %s) = llvm_cmpxchg_%s(%s, %s, %s, %s)\t### LLVM",
+        return String.format("(%s, %s) = llvm_cmpxchg_%s(%s, %s, %s, %s)",
                 resultRegister, cmpRegister, strongSuffix, address, expectedValue, storeValue, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmFence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmFence.java
@@ -17,7 +17,7 @@ public class LlvmFence extends FenceBase {
 
     @Override
     public String defaultString() {
-        return name + "(" + mo + ")\t### LLVM";
+        return String.format("%s(%s)", name, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -25,7 +25,7 @@ public class LlvmLoad extends LoadBase {
 
     @Override
     public String defaultString() {
-        return resultRegister + " = llvm_load(" + address + ", " + mo + ")\t### LLVM";
+        return String.format("%s = llvm_load(%s, %s)", resultRegister, address, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmLoad.java
@@ -25,7 +25,7 @@ public class LlvmLoad extends LoadBase {
 
     @Override
     public String defaultString() {
-        return resultRegister + " = llvm_load(*" + address + ", " + mo + ")\t### LLVM";
+        return resultRegister + " = llvm_load(" + address + ", " + mo + ")\t### LLVM";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
@@ -20,7 +20,7 @@ public class LlvmRMW extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := llvm_rmw_%s(*%s, %s, %s)\t### LLVM",
+        return String.format("%s = llvm_rmw_%s(%s, %s, %s)\t### LLVM",
                 resultRegister, operator.getName(), address, operand, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
@@ -21,7 +21,7 @@ public class LlvmRMW extends RMWOpResultBase {
     @Override
     public String defaultString() {
         return String.format("%s = llvm_rmw_%s(%s, %s, %s)\t### LLVM",
-                resultRegister, operator.getName(), address, operand, mo);
+                resultRegister, operator.getName().toLowerCase(), address, operand, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmRMW.java
@@ -20,7 +20,7 @@ public class LlvmRMW extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = llvm_rmw_%s(%s, %s, %s)\t### LLVM",
+        return String.format("%s = llvm_rmw_%s(%s, %s, %s)",
                 resultRegister, operator.getName().toLowerCase(), address, operand, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -23,7 +23,7 @@ public class LlvmStore extends StoreBase {
 
     @Override
     public String defaultString() {
-        return "llvm_store(" + address + ", " + value + ", " + mo + ")\t### LLVM";
+        return String.format("llvm_store(%s, %s, %s)", address, value, mo);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmStore.java
@@ -23,7 +23,7 @@ public class LlvmStore extends StoreBase {
 
     @Override
     public String defaultString() {
-        return "llvm_store(*" + address + ", " + value + ", " + mo + ")\t### LLVM";
+        return "llvm_store(" + address + ", " + value + ", " + mo + ")\t### LLVM";
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
@@ -19,7 +19,7 @@ public class LlvmXchg extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := llvm_xchg(*%s, %s, %s)\t### LLVM",
+        return String.format("%s = llvm_xchg(%s, %s, %s)\t### LLVM",
                 resultRegister, address, storeValue, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/llvm/LlvmXchg.java
@@ -19,7 +19,7 @@ public class LlvmXchg extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s = llvm_xchg(%s, %s, %s)\t### LLVM",
+        return String.format("%s = llvm_xchg(%s, %s, %s)",
                 resultRegister, address, storeValue, mo);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/spirv/SpirvCmpXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/spirv/SpirvCmpXchg.java
@@ -42,7 +42,7 @@ public class SpirvCmpXchg extends RMWCmpXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := spirv_cmpxchg[%s, %s, %s](%s, %s, %s)",
+        return String.format("%s = spirv_cmpxchg[%s, %s, %s](%s, %s, %s)",
                 resultRegister, eqMo, mo, scope, address, expectedValue, storeValue);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/spirv/SpirvRmw.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/spirv/SpirvRmw.java
@@ -28,7 +28,7 @@ public class SpirvRmw extends RMWOpResultBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := spirv_rmw_%s[%s, %s](%s, %s)",
+        return String.format("%s = spirv_rmw_%s[%s, %s](%s, %s)",
                 resultRegister, operator.getName(), mo, scope, address, operand);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/spirv/SpirvRmwExtremum.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/spirv/SpirvRmwExtremum.java
@@ -35,7 +35,7 @@ public class SpirvRmwExtremum extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := spirv_rmw_ext%s[%s, %s](%s, %s, %s)",
+        return String.format("%s = spirv_rmw_ext%s[%s, %s](%s, %s, %s)",
                 resultRegister, operator.getName(), mo, scope, address, storeValue, operator.getName());
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/spirv/SpirvXchg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/spirv/SpirvXchg.java
@@ -27,7 +27,7 @@ public class SpirvXchg extends RMWXchgBase {
 
     @Override
     public String defaultString() {
-        return String.format("%s := spirv_xchg[%s, %s](%s, %s)",
+        return String.format("%s = spirv_xchg[%s, %s](%s, %s)",
                 resultRegister, mo, scope, address, storeValue);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/svcomp/NonDetChoice.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/svcomp/NonDetChoice.java
@@ -26,7 +26,7 @@ public class NonDetChoice extends AbstractEvent implements RegWriter {
 
     @Override
     protected String defaultString() {
-        return String.format("%s <- *", register);
+        return String.format("%s = *", register);
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/misc/NonDetValue.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/misc/NonDetValue.java
@@ -46,6 +46,6 @@ public class NonDetValue extends LeafExpressionBase<Type> {
 
     @Override
     public String toString() {
-        return String.format("nondet_%s#%d", type, id);
+        return String.format("%s nondet#%d", type, id);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DebugPrint.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DebugPrint.java
@@ -2,24 +2,32 @@ package com.dat3m.dartagnan.program.processing;
 
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.printer.Printer;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
 
 public class DebugPrint implements ProgramProcessor {
 
     private final String printHeader;
-    private final Printer.Mode printerMode;
+    private final Printer printer;
 
-    private DebugPrint(String printHeader, Printer.Mode mode) {
+    private DebugPrint(String printHeader, Printer.Mode mode, Configuration configuration)
+            throws InvalidConfigurationException {
         this.printHeader = printHeader;
-        this.printerMode = mode;
+        printer = Printer.fromConfig(configuration).setMode(mode);
     }
 
-    public static DebugPrint withHeader(String header, Printer.Mode mode) { return new DebugPrint(header, mode);}
-    public static DebugPrint newInstance(Printer.Mode mode) { return withHeader("DebugPrint", mode); }
+    public static DebugPrint withHeader(String header, Printer.Mode mode, Configuration configuration) throws InvalidConfigurationException {
+        return new DebugPrint(header, mode, configuration);
+    }
+
+    public static DebugPrint fromConfig(Printer.Mode mode, Configuration configuration) throws InvalidConfigurationException {
+        return withHeader("DebugPrint", mode, configuration);
+    }
 
     @Override
     public void run(Program program) {
         System.out.println("======== " + printHeader +  " ========");
-        System.out.println(new Printer().setMode(printerMode).print(program));
+        System.out.println(printer.print(program));
         System.out.println("======================================");
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -98,7 +98,7 @@ public class ProcessingManager implements ProgramProcessor {
                 simplifyFunction, Target.THREADS, true
         );
         programProcessors.addAll(Arrays.asList(
-                printBeforeProcessing ? DebugPrint.withHeader("Before processing", Printer.Mode.ALL) : null,
+                printBeforeProcessing ? DebugPrint.withHeader("Before processing", Printer.Mode.ALL, config) : null,
                 intrinsics.markIntrinsicsPass(),
                 ProgramProcessor.fromFunctionProcessor(intrinsics.earlyInliningPass(), Target.ALL, true),
                 GEPToAddition.newInstance(),
@@ -114,16 +114,16 @@ public class ProcessingManager implements ProgramProcessor {
                 ),
                 ProgramProcessor.fromFunctionProcessor(NormalizeLoops.newInstance(), Target.ALL, true),
                 RemoveDeadFunctions.newInstance(),
-                printAfterSimplification ? DebugPrint.withHeader("After simplification", Printer.Mode.ALL) : null,
+                printAfterSimplification ? DebugPrint.withHeader("After simplification", Printer.Mode.ALL, config) : null,
                 Compilation.fromConfig(config), // We keep compilation global for now
                 LoopFormVerification.fromConfig(config),
-                printAfterCompilation ? DebugPrint.withHeader("After compilation", Printer.Mode.ALL) : null,
+                printAfterCompilation ? DebugPrint.withHeader("After compilation", Printer.Mode.ALL, config) : null,
                 ProgramProcessor.fromFunctionProcessor(MemToReg.fromConfig(config), Target.FUNCTIONS, true),
                 ProgramProcessor.fromFunctionProcessor(sccp, Target.FUNCTIONS, false),
                 dynamicSpinLoopDetection ? DynamicSpinLoopDetection.fromConfig(config) : null,
                 ProgramProcessor.fromFunctionProcessor(NaiveLoopBoundAnnotation.fromConfig(config), Target.FUNCTIONS, true),
                 LoopUnrolling.fromConfig(config), // We keep unrolling global for now
-                printAfterUnrolling ? DebugPrint.withHeader("After loop unrolling", Printer.Mode.ALL) : null,
+                printAfterUnrolling ? DebugPrint.withHeader("After loop unrolling", Printer.Mode.ALL, config) : null,
                 ProgramProcessor.fromFunctionProcessor(
                         FunctionProcessor.chain(
                                 ResolveLLVMObjectSizeCalls.fromConfig(config),
@@ -148,7 +148,7 @@ public class ProcessingManager implements ProgramProcessor {
                 NonterminationDetection.fromConfig(config),
                 // --- Statistics + verification ---
                 IdReassignment.newInstance(), // Normalize used Ids (remove any gaps)
-                printAfterProcessing ? DebugPrint.withHeader("After processing", Printer.Mode.THREADS) : null,
+                printAfterProcessing ? DebugPrint.withHeader("After processing", Printer.Mode.THREADS, config) : null,
                 ProgramProcessor.fromFunctionProcessor(
                         CoreCodeVerification.fromConfig(config),
                         Target.THREADS, false

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/printer/Printer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/printer/Printer.java
@@ -1,61 +1,150 @@
 package com.dat3m.dartagnan.utils.printer;
 
-import com.dat3m.dartagnan.program.Entrypoint;
-import com.dat3m.dartagnan.program.Function;
-import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.*;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.core.Init;
 import com.dat3m.dartagnan.program.event.core.Label;
-import com.dat3m.dartagnan.program.event.core.Skip;
+import com.dat3m.dartagnan.program.event.core.annotations.CodeAnnotation;
+import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
+import com.dat3m.dartagnan.program.misc.NonDetValue;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class Printer {
 
+    // =========================== Configurables ===========================
+    // TODO: Maybe use Configuration with proper @Option tags
+
     public enum Mode {
         THREADS,
         FUNCTIONS,
-        ALL
+        ALL;
+
+        private boolean includesThreads() {
+            return this == THREADS || this == ALL;
+        }
+
+        private boolean includesFunctions() {
+            return this == FUNCTIONS || this == ALL;
+        }
     }
 
-    private StringBuilder result;
-    private StringBuilder padding;
-
-    private boolean showAuxiliaryEvents = true;
-    private boolean showInitThreads = false;
     private Mode mode = Mode.ALL;
+    private boolean showInitThreads = false;
+    private boolean showAnnotationEvents = true;
+    private boolean showDynamicMemoryAllocations = true;
+    private boolean showProgramConstants = false;
 
-    private final String paddingBase = "      ";
+    public Printer setShowInitThreads(boolean flag) {
+        this.showInitThreads = flag;
+        return this;
+    }
+
+    public Printer setMode(Mode mode) {
+        this.mode = mode;
+        return this;
+    }
+
+    // =================================================================================
 
     public String print(Program program) {
-        result = new StringBuilder();
-        padding = new StringBuilder(paddingBase);
+        final StringBuilder result = new StringBuilder();
 
-        String name = program.getName();
-        if(name == null){
-            name = "program";
+        // ----- Program header -----
+        appendHeader(program, result);
+        result.append("\n\n");
+
+        // ----- Program constants -----
+        if (showProgramConstants) {
+            appendProgramConstants(program, result);
+            result.append("\n\n");
         }
+
+        // ----- Memory -----
+        appendMemory(program.getMemory(), result);
+        result.append("\n\n");
+
+        // ----- Program body -----
+        appendMainBody(program, result);
+
+        return result.toString();
+    }
+
+    private void appendHeader(Program program, StringBuilder result) {
+        final String name = program.getName() != null ?  program.getName() : "program";
         result.append(name);
         if (!(program.getEntrypoint() instanceof Entrypoint.Resolved)) {
             result.append(" ").append(program.getEntrypoint());
         }
-        result.append("\n");
+    }
 
-        for (MemoryObject obj : program.getMemory().getObjects()) {
-            if (obj.isStaticallyAllocated()) {
-                appendMemoryObject(obj);
+    // -------------------------------------------------------------------------------------------
+    // Program constants
+
+    private void appendProgramConstants(Program program, StringBuilder result) {
+        result.append("Constants:");
+
+        for (NonDetValue constant : program.getConstants()) {
+            result.append("\n").append(constant);
+        }
+    }
+
+
+    // -------------------------------------------------------------------------------------------
+    // Memory
+
+    private void appendMemory(Memory memory, StringBuilder result) {
+        result.append("Memory:");
+
+        int omitted = 0;
+        for (MemoryObject obj : memory.getObjects()) {
+            if (showMemoryObject(obj)) {
+                result.append("\n");
+                appendMemoryObject(obj, result);
+            } else {
+                omitted++;
             }
         }
 
-        result.append("\n");
+        if (omitted > 0) {
+            result.append("\n... omitted ").append(omitted).append(" memory objects ...");
+        }
+    }
 
-        if (mode == Mode.THREADS || mode == Mode.ALL) {
+    private void appendMemoryObject(MemoryObject obj, StringBuilder result) {
+        final String size = obj.hasKnownSize() ? Integer.toString(obj.getKnownSize()) : "unknown";
+        final String align = obj.hasKnownAlignment() ? Integer.toString(obj.getKnownAlignment()) : "unknown";
+        final String modifier = obj.isStaticallyAllocated() ? "static" : "dynamic";
+        final String name = obj.isStaticallyAllocated()
+                ? obj.getName()
+                : "@E" + obj.getAllocationSite().getGlobalId();
+
+        result.append(modifier).append(" ")
+                .append(String.format("[size=%s, align=%s]\t", size, align))
+                .append(name).append("\t");
+
+        final int displayLimit = 5;
+        var fieldStrings = obj.getInitializedFields().stream().sorted().limit(displayLimit)
+                        .map(field -> String.format("%s: %s", field, obj.getInitialValue(field)));
+        fieldStrings = obj.getInitializedFields().size() > displayLimit ? Stream.concat(fieldStrings, Stream.of("...")) : fieldStrings;
+        result.append(fieldStrings.collect(Collectors.joining(", ", "{ ", " }")));
+    }
+
+
+    private boolean showMemoryObject(MemoryObject obj){
+        return showDynamicMemoryAllocations || obj.isStaticallyAllocated();
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Functions & Threads
+
+    private void appendMainBody(Program program, StringBuilder result) {
+        if (mode.includesThreads()) {
             for (Thread thread : program.getThreads()) {
-                if (shouldPrintThread(thread)) {
-                    appendFunction(thread);
+                if (showThread(thread)) {
+                    appendFunction(thread, result);
                 }
             }
 
@@ -68,54 +157,17 @@ public class Printer {
             }
         }
 
-        if (mode == Mode.FUNCTIONS || mode == Mode.ALL) {
+        if (mode.includesFunctions()) {
             for (Function function : program.getFunctions()) {
                 if (function instanceof Thread) {
                     continue;
                 }
-                appendFunction(function);
+                appendFunction(function, result);
             }
         }
-
-        return result.toString();
     }
 
-    private void appendMemoryObject(MemoryObject obj) {
-        result.append("\nstatic ").append(obj.getName())
-                .append(String.format(" [size=%s, align=%s] ", obj.getKnownSize(), obj.getKnownAlignment()));
-
-        final int displayLimit = 10;
-        var fieldStrings = obj.getInitializedFields().stream().sorted().limit(displayLimit)
-                        .map(field -> String.format("%s: %s", field, obj.getInitialValue(field)));
-        fieldStrings = obj.getInitializedFields().size() > displayLimit ? Stream.concat(fieldStrings, Stream.of("...")) : fieldStrings;
-        result.append(fieldStrings.collect(Collectors.joining(", ", "{ ", " }")));
-    }
-
-    public Printer setShowAuxiliaryEvents(boolean flag) {
-        this.showAuxiliaryEvents = flag;
-        return this;
-    }
-
-    public Printer setShowInitThreads(boolean flag) {
-        this.showInitThreads = flag;
-        return this;
-    }
-
-    public Printer setMode(Mode mode) {
-        this.mode = mode;
-        return this;
-    }
-
-    private boolean shouldPrintThread(Thread thread){
-        if(showInitThreads){
-            return true;
-        }
-        Event firstEvent = thread.getEntry().getSuccessor();
-        // Thread always have at least two events, Skip and end Label
-        return firstEvent.getSuccessor() != null && !(firstEvent instanceof Init);
-    }
-
-    private void appendFunction(Function func) {
+    private void appendFunction(Function func, StringBuilder result) {
         result.append("\n[").append(func.getId()).append("]");
         result.append(func instanceof Thread ? " thread " : " function ");
         result.append(functionSignatureToString(func));
@@ -127,33 +179,42 @@ public class Printer {
         }
         result.append("\n");
         for (Event e : func.getEvents()) {
-            appendEvent(e);
+            if (showEvent(e)) {
+                appendEvent(e, result);
+            }
         }
     }
 
-    public String functionSignatureToString(Function func) {
+    private boolean showThread(Thread thread){
+        return showInitThreads || !IRHelper.isInitThread(thread);
+    }
+
+    private void appendEvent(Event event, StringBuilder result){
+        final StringBuilder idSb = new StringBuilder()
+                .append(event.getGlobalId()).append(":");
+        result.append(idSb);
+        if(!(event instanceof Label)) {
+            result.append("   ");
+        }
+
+        final String paddingBase = "      ";
+        if (idSb.length() < paddingBase.length()) {
+            result.append(paddingBase, idSb.length(), paddingBase.length());
+        }
+        result.append(event).append("\n");
+    }
+
+    private boolean showEvent(Event event) {
+        return (showAnnotationEvents || !(event instanceof CodeAnnotation));
+    }
+
+    // ------------------------------------------------------------------------
+
+    private String functionSignatureToString(Function func) {
         final String prefix = func.getFunctionType().getReturnType() + " " + func.getName() + "(";
         final String suffix = func.getFunctionType().isVarArgs() ? ", ...)": ")";
         return func.getParameterRegisters().stream().map(r -> r.getType() + " " + r.getName())
                 .collect(Collectors.joining(", ", prefix, suffix));
     }
 
-    private void appendEvent(Event event){
-        if(showAuxiliaryEvents || !isAuxiliary(event)){
-            StringBuilder idSb = new StringBuilder();
-            idSb.append(event.getGlobalId()).append(":");
-            result.append(idSb);
-            if(!(event instanceof Label)) {
-                result.append("   ");
-            }
-            if (idSb.length() < padding.length()) {
-                result.append(padding, idSb.length(), padding.length());
-            }
-            result.append(event).append("\n");
-        }
-    }
-
-    private boolean isAuxiliary(Event event){
-        return event instanceof Skip;
-    }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LFDSTest.java
@@ -77,8 +77,8 @@ public class LFDSTest extends AbstractCTest {
                 // These are simplified from the actual C-code in benchmarks/lfds
                 // and contain fewer calls to push to improve verification time
                 // We only have two instances to make the CI faster
-                //{"safe_stack", TSO, FAIL},
-                //{"safe_stack", ARM8, FAIL},
+                {"safe_stack", TSO, FAIL},
+                {"safe_stack", ARM8, FAIL},
                 {"hash_table", TSO, PASS},
                 {"hash_table", ARM8, PASS},
                 {"hash_table", POWER, PASS},

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LFDSTest.java
@@ -77,8 +77,8 @@ public class LFDSTest extends AbstractCTest {
                 // These are simplified from the actual C-code in benchmarks/lfds
                 // and contain fewer calls to push to improve verification time
                 // We only have two instances to make the CI faster
-                {"safe_stack", TSO, FAIL},
-                {"safe_stack", ARM8, FAIL},
+                //{"safe_stack", TSO, FAIL},
+                //{"safe_stack", ARM8, FAIL},
                 {"hash_table", TSO, PASS},
                 {"hash_table", ARM8, PASS},
                 {"hash_table", POWER, PASS},

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/PrinterTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/PrinterTest.java
@@ -22,51 +22,51 @@ public class PrinterTest {
     @Test()
     public void Printll() throws Exception {
         Program p = new ProgramParser().parse(new File(getTestResourcePath("locks/linuxrwlock.ll")));
-        assertNotNull(new Printer().print(p));
+        assertNotNull(Printer.newInstance().print(p));
         Compilation.newInstance().run(p);
         LoopUnrolling.newInstance().run(p);
-        assertNotNull(new Printer().print(p));
+        assertNotNull(Printer.newInstance().print(p));
     }
 
     @Test()
     public void PrintX86() throws Exception {
         Program p = new ProgramParser().parse(new File(getTestResourcePath("litmus/MP+mfence-rmw+rmw-mfence.litmus")));
-        assertNotNull(new Printer().print(p));
+        assertNotNull(Printer.newInstance().print(p));
         assertNotNull(p.getSpecification().toString());
     }
 
     @Test()
     public void PrintPPC() throws Exception {
         Program p = new ProgramParser().parse(new File(getTestResourcePath("litmus/MP+lwsync+data-wsi-rfi-ctrlisync.litmus")));
-        assertNotNull(new Printer().print(p));
+        assertNotNull(Printer.newInstance().print(p));
         assertNotNull(p.getSpecification().toString());
     }
 
     @Test()
     public void PrintAARCH64() throws Exception {
         Program p = new ProgramParser().parse(new File(getTestResourcePath("litmus/MP+popl+poap.litmus")));
-        assertNotNull(new Printer().print(p));
+        assertNotNull(Printer.newInstance().print(p));
         assertNotNull(p.getSpecification().toString());
     }
 
     @Test()
     public void PrintLinux() throws Exception {
         Program p = new ProgramParser().parse(new File(getTestResourcePath("litmus/C-rcu-link-after.litmus")));
-        assertNotNull(new Printer().print(p));
+        assertNotNull(Printer.newInstance().print(p));
         assertNotNull(p.getSpecification().toString());
     }
 
     @Test()
     public void PrintLinux2() throws Exception {
         Program p = new ProgramParser().parse(new File(getRootPath("litmus/LKMM/dart/C-atomic-fetch-simple-01.litmus")));
-        assertNotNull(new Printer().print(p));
+        assertNotNull(Printer.newInstance().print(p));
         assertNotNull(p.getSpecification().toString());
     }
 
     @Test()
     public void PrintLinux3() throws Exception {
         Program p = new ProgramParser().parse(new File(getRootPath("litmus/LKMM/manual/atomic/C-atomic-01.litmus")));
-        assertNotNull(new Printer().print(p));
+        assertNotNull(Printer.newInstance().print(p));
         assertNotNull(p.getSpecification().toString());
     }
 


### PR DESCRIPTION
- Streamlined IR printing to always use `=` when doing assignments (before we used `<-`, `:=` and `=`).
- `Printer` has more features now, the most important being that it now prints the memory and the entry point of the program. It has some configuration options, but they have to be set in the code right now (we could use a `Configuration` object instead so that the user can configure the printer).