### PR TITLE
Slightly better memory encoding

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -161,16 +161,6 @@ public final class EncodingContext {
         return (event.cfImpliesExec() ? controlFlowVariables : executionVariables).get(event);
     }
 
-    /**
-     * Simple formula proposing the execution of two events.
-     * Does not test for mutual exclusion.
-     * @param first
-     * Some event of a program to be encoded.
-     * @param second
-     * Another event of the same program.
-     * @return
-     * Proposition that both {@code first} and {@code second} are included in the modelled execution.
-     */
     public BooleanFormula execution(Event first, Event second) {
         boolean b = first.getGlobalId() < second.getGlobalId();
         Event x = b ? first : second;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ProgramEncoder.java
@@ -6,8 +6,8 @@ import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.integers.IntLiteral;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
-import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.*;
+import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.BranchEquivalence;
 import com.dat3m.dartagnan.program.analysis.ExecutionAnalysis;
 import com.dat3m.dartagnan.program.analysis.ReachingDefinitionsAnalysis;
@@ -440,7 +440,10 @@ public class ProgramEncoder implements Encoder {
                 final Expression zero = exprs.makeValue(BigInteger.ZERO, archType);
                 final Expression one = exprs.makeValue(BigInteger.ONE, archType);
 
-                size = exprs.makeITE(exec, cur.size(), zero);
+                // NOTE: If we know the size/alignment of the allocation, we can pre-reserve memory space.
+                // This improves performance.
+                // We could also do this if the size is unknown but has a known upper bound.
+                size = cur.hasKnownSize() ? cur.size() : exprs.makeITE(exec, cur.size(), zero);
                 alignment = cur.hasKnownAlignment() ? cur.alignment() : exprs.makeITE(exec, cur.alignment(), one);
             }
 


### PR DESCRIPTION
This PR assigns a fixed memory range to dynamic allocations with known size and alignment irrespective of whether the allocation happens or not. As a result, in any program with only known-sized allocations, the memory encoding results in a statically fixed memory layout (the memory layout is identical for all program executions).

Some preliminary evaluations show that this encoding is roughly 10% faster on various benchmarks (e.g. LFDS).

NOTE: We could do the same for memory allocations that are of unknown size but have a known upper bound (e.g., computed by a value range analysis).