### PR TITLE
[RA] Fix propagation for negated/flagged axioms 

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/ExecutionGraph.java
@@ -111,7 +111,7 @@ public class ExecutionGraph {
         }
 
         for (Axiom axiom : memoryModel.getAxioms()) {
-            if (axiom instanceof ForceEncodeAxiom || axiom.isFlagged()) {
+            if (axiom instanceof ForceEncodeAxiom || axiom.isFlagged() || axiom.isNegated()) {
                 continue;
             }
             Constraint constraint = getOrCreateConstraintFromAxiom(axiom);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
@@ -351,7 +351,7 @@ public class NativeRelationAnalysis implements RelationAnalysis {
         @Override
         public Map<Relation, ExtendedDelta> visitEmptiness(Emptiness axiom) {
             Relation rel = axiom.getRelation();
-            return axiom.isNegated() ?
+            return axiom.isNegated() || axiom.isFlagged() ?
                 Map.of() :
                 Map.of(rel, new ExtendedDelta(knowledgeMap.get(rel).getMaySet(), new MapEventGraph()));
         }
@@ -361,7 +361,7 @@ public class NativeRelationAnalysis implements RelationAnalysis {
             Relation rel = axiom.getRelation();
             MutableKnowledge k = knowledgeMap.get(rel);
             MutableEventGraph d = k.getMaySet().filter(Tuple::isLoop);
-            return axiom.isNegated() ?
+            return axiom.isNegated() || axiom.isFlagged() ?
                 Map.of() :
                 Map.of(rel, new ExtendedDelta(d, new MapEventGraph()));
         }
@@ -393,7 +393,7 @@ public class NativeRelationAnalysis implements RelationAnalysis {
             } while (!current.isEmpty());
             newDisabled.retainAll(knowledge.getMaySet());
             logger.debug("disabled {} edges in {}ms", newDisabled.size(), System.currentTimeMillis() - t0);
-            return axiom.isNegated() ?
+            return axiom.isNegated() || axiom.isFlagged() ?
                 Map.of() :
                 Map.of(rel, new ExtendedDelta(newDisabled, new MapEventGraph()));
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
@@ -351,7 +351,9 @@ public class NativeRelationAnalysis implements RelationAnalysis {
         @Override
         public Map<Relation, ExtendedDelta> visitEmptiness(Emptiness axiom) {
             Relation rel = axiom.getRelation();
-            return Map.of(rel, new ExtendedDelta(knowledgeMap.get(rel).getMaySet(), new MapEventGraph()));
+            return axiom.isNegated() ?
+                Map.of() :
+                Map.of(rel, new ExtendedDelta(knowledgeMap.get(rel).getMaySet(), new MapEventGraph()));
         }
 
         @Override
@@ -359,7 +361,9 @@ public class NativeRelationAnalysis implements RelationAnalysis {
             Relation rel = axiom.getRelation();
             MutableKnowledge k = knowledgeMap.get(rel);
             MutableEventGraph d = k.getMaySet().filter(Tuple::isLoop);
-            return Map.of(rel, new ExtendedDelta(d, new MapEventGraph()));
+            return axiom.isNegated() ?
+                Map.of() :
+                Map.of(rel, new ExtendedDelta(d, new MapEventGraph()));
         }
 
         @Override
@@ -389,7 +393,9 @@ public class NativeRelationAnalysis implements RelationAnalysis {
             } while (!current.isEmpty());
             newDisabled.retainAll(knowledge.getMaySet());
             logger.debug("disabled {} edges in {}ms", newDisabled.size(), System.currentTimeMillis() - t0);
-            return Map.of(rel, new ExtendedDelta(newDisabled, new MapEventGraph()));
+            return axiom.isNegated() ?
+                Map.of() :
+                Map.of(rel, new ExtendedDelta(newDisabled, new MapEventGraph()));
         }
 
         @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
@@ -350,24 +350,29 @@ public class NativeRelationAnalysis implements RelationAnalysis {
 
         @Override
         public Map<Relation, ExtendedDelta> visitEmptiness(Emptiness axiom) {
+            if (axiom.isNegated() || axiom.isFlagged()) {
+                return Map.of();
+            }
             Relation rel = axiom.getRelation();
-            return axiom.isNegated() || axiom.isFlagged() ?
-                Map.of() :
-                Map.of(rel, new ExtendedDelta(knowledgeMap.get(rel).getMaySet(), new MapEventGraph()));
+            return Map.of(rel, new ExtendedDelta(knowledgeMap.get(rel).getMaySet(), new MapEventGraph()));
         }
 
         @Override
         public Map<Relation, ExtendedDelta> visitIrreflexivity(Irreflexivity axiom) {
+            if (axiom.isNegated() || axiom.isFlagged()) {
+                return Map.of();
+            }
             Relation rel = axiom.getRelation();
             MutableKnowledge k = knowledgeMap.get(rel);
             MutableEventGraph d = k.getMaySet().filter(Tuple::isLoop);
-            return axiom.isNegated() || axiom.isFlagged() ?
-                Map.of() :
-                Map.of(rel, new ExtendedDelta(d, new MapEventGraph()));
+            return Map.of(rel, new ExtendedDelta(d, new MapEventGraph()));
         }
 
         @Override
         public Map<Relation, ExtendedDelta> visitAcyclicity(Acyclicity axiom) {
+            if (axiom.isNegated() || axiom.isFlagged()) {
+                return Map.of();
+            }
             long t0 = System.currentTimeMillis();
             Relation rel = axiom.getRelation();
             ExecutionAnalysis exec = analysisContext.get(ExecutionAnalysis.class);
@@ -393,9 +398,7 @@ public class NativeRelationAnalysis implements RelationAnalysis {
             } while (!current.isEmpty());
             newDisabled.retainAll(knowledge.getMaySet());
             logger.debug("disabled {} edges in {}ms", newDisabled.size(), System.currentTimeMillis() - t0);
-            return axiom.isNegated() || axiom.isFlagged() ?
-                Map.of() :
-                Map.of(rel, new ExtendedDelta(newDisabled, new MapEventGraph()));
+            return Map.of(rel, new ExtendedDelta(newDisabled, new MapEventGraph()));
         }
 
         @Override


### PR DESCRIPTION
For any program with at least two events in a thread, adding the constraint `~empty po` to the memory model should have no effect, however it is not currently the case:
```
> CFLAGS="-DACQ2RX" java -jar dartagnan/target/dartagnan.jar cat/vmm.cat benchmarks/locks/ttas.c
Test: benchmarks/locks/ttas.c
Result: FAIL
Reason: CAT specification violation found
Details:
        Flag w-data-race
        E181 / E181     @ttas.c#18 / @ttas.c#18
        E234 / E234     @ttas.c#18 / @ttas.c#18
Time: 0.980 secs

> echo "" >> cat/vmm.cat 
> echo "~empty po" >> cat/vmm.cat 

> CFLAGS="-DACQ2RX" java -jar dartagnan/target/dartagnan.jar cat/vmm.cat benchmarks/locks/ttas.c
Test: benchmarks/locks/ttas.c
Result: PASS
Time: 0.753 secs
```
