### PR TITLE
AutoCloseable IREvaluator

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -28,6 +28,8 @@ import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 import org.sosy_lab.java_smt.api.FormulaManager;
 import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
+import org.sosy_lab.java_smt.api.ProverEnvironment;
+import org.sosy_lab.java_smt.api.SolverException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -268,6 +270,14 @@ public final class EncodingContext {
 
     public BooleanFormula edge(Relation relation, Event first, Event second) {
         return edge(relation).encode(first, second);
+    }
+
+    // ====================================================================================
+    // Model Evaluation
+
+    // The return value must be closed by the caller, usually with a try-with-resources statement.
+    public IREvaluator newEvaluator(ProverEnvironment prover) throws SolverException {
+        return new IREvaluator(this, prover.getModel());
     }
 
     // ====================================================================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -8,7 +8,6 @@ import com.dat3m.dartagnan.program.analysis.ReachingDefinitionsAnalysis;
 import com.dat3m.dartagnan.program.event.*;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.smt.EncodingUtils;
-import com.dat3m.dartagnan.smt.ModelExt;
 import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.wmm.Constraint;
@@ -146,16 +145,6 @@ public class WmmEncoder implements Encoder {
         ra.getContradictions()
                 .apply((e1, e2) -> enc.add(bmgr.not(context.execution(e1, e2))));
         return bmgr.and(enc);
-    }
-
-    public EventGraph getEventGraph(Relation relation, ModelExt model) {
-        IREvaluator irModel = new IREvaluator(context, model);
-        EncodingContext.EdgeEncoder edge = context.edge(relation);
-        EventGraph encodeSet = encodeSets.getOrDefault(relation, new MapEventGraph())
-                .filter((e1, e2) -> irModel.hasEdge(edge, e1, e2));
-        EventGraph mustEncodeSet = MapEventGraph.from(context.getAnalysisContext().get(RelationAnalysis.class).getKnowledge(relation).getMustSet())
-                .filter((e1, e2) -> irModel.isExecuted(e1) && irModel.isExecuted(e2));
-        return EventGraph.union(encodeSet, mustEncodeSet);
     }
 
     private Map<Relation, EventGraph> initializeEncodeSets() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
@@ -2,7 +2,7 @@ package com.dat3m.dartagnan.solver.caat4wmm;
 
 
 import com.dat3m.dartagnan.encoding.EncodingContext;
-import com.dat3m.dartagnan.smt.ModelExt;
+import com.dat3m.dartagnan.encoding.IREvaluator;
 import com.dat3m.dartagnan.solver.caat.CAATSolver;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreLiteral;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreReasoner;
@@ -47,7 +47,7 @@ public class WMMSolver {
         return executionGraph;
     }
 
-    public Result check(ModelExt model) {
+    public Result check(IREvaluator model) {
         // ============ Extract ExecutionModel ==============
         long curTime = System.currentTimeMillis();
         executionModel.initialize(model);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/DynamicDefaultWMMGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/DynamicDefaultWMMGraph.java
@@ -20,7 +20,7 @@ public class DynamicDefaultWMMGraph extends MaterializedWMMGraph {
         // Careful: The wrapped model <getModel> might get closed/disposed while ExecutionModel as a whole is
         // still in use. The caller should make sure that the underlying model is still alive right now.
         final EncodingContext ctx = model.getContext();
-        final IREvaluator m = new IREvaluator(ctx, model.getModel());
+        final IREvaluator m = model.getEvaluator();
         final EncodingContext.EdgeEncoder edge = ctx.edge(relation);
         final RelationAnalysis.Knowledge k = ctx.getAnalysisContext().get(RelationAnalysis.class).getKnowledge(relation);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/DynamicDefaultWMMSet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/DynamicDefaultWMMSet.java
@@ -21,7 +21,7 @@ public class DynamicDefaultWMMSet extends MaterializedWMMSet {
         // Careful: The wrapped model <getModel> might get closed/disposed while ExecutionModel as a whole is
         // still in use. The caller should make sure that the underlying model is still alive right now.
         final EncodingContext ctx = model.getContext();
-        final IREvaluator m = new IREvaluator(ctx, model.getModel());
+        final IREvaluator m = model.getEvaluator();
         final EncodingContext.EdgeEncoder edge = ctx.edge(relation);
         final RelationAnalysis.Knowledge k = ctx.getAnalysisContext().get(RelationAnalysis.class).getKnowledge(relation);
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -14,7 +14,6 @@ import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.lang.svcomp.BeginAtomic;
 import com.dat3m.dartagnan.program.event.lang.svcomp.EndAtomic;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
-import com.dat3m.dartagnan.smt.ModelExt;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
@@ -42,7 +41,6 @@ public class ExecutionModel {
     private final EncodingContext ctx;
 
     // ============= Model specific  =============
-    private ModelExt model;
     private IREvaluator irModel;
 
     private final EventMap eventMap;
@@ -128,8 +126,8 @@ public class ExecutionModel {
     }
 
     // Model specific data
-    public ModelExt getModel() {
-        return model;
+    public IREvaluator getEvaluator() {
+        return irModel;
     }
     public EncodingContext getContext() {
         return ctx;
@@ -173,13 +171,12 @@ public class ExecutionModel {
 
     //========================== Initialization =========================
 
-    public void initialize(ModelExt model) {
+    public void initialize(IREvaluator model) {
         // We populate here, instead of on construction,
         // to reuse allocated data structures (since these data structures already adapted
         // their capacity in previous iterations, and thus we should have less overhead in future populations)
         // However, for all intents and purposes, this serves as a constructor.
-        this.model = model;
-        this.irModel = new IREvaluator(ctx, model);
+        irModel = model;
         extractEventsFromModel();
         extractMemoryLayout();
         extractReadsFrom();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModelManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModelManager.java
@@ -8,7 +8,6 @@ import com.dat3m.dartagnan.program.event.MemoryEvent;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.filter.Filter;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
-import com.dat3m.dartagnan.smt.ModelExt;
 import com.dat3m.dartagnan.solver.caat.predicates.CAATPredicate;
 import com.dat3m.dartagnan.solver.caat.predicates.Derivable;
 import com.dat3m.dartagnan.solver.caat.predicates.PredicateHierarchy;
@@ -63,12 +62,12 @@ public class ExecutionModelManager {
         edgeModelCache = new HashMap<>();
     }
 
-    public ExecutionModelNext buildExecutionModel(EncodingContext context, ModelExt model) {
+    public ExecutionModelNext buildExecutionModel(IREvaluator evaluator) {
         executionModel = new ExecutionModelNext();
 
-        this.context = context;
-        this.model = new IREvaluator(context, model);
-        this.wmm = context.getTask().getMemoryModel();
+        this.context = evaluator.getEncodingContext();
+        this.model = evaluator;
+        this.wmm = evaluator.getEncodingContext().getTask().getMemoryModel();
         this.domain = new EventDomainNext(executionModel);
 
         extractEvents();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/AssumeSolver.java
@@ -84,7 +84,7 @@ public class AssumeSolver extends ModelChecker {
             res = prover.isUnsat() ? PASS : Result.UNKNOWN;
         } else {
             res = FAIL;
-            saveFlaggedPairsOutput(memoryModel, wmmEncoder, prover, context, task.getProgram());
+            saveFlaggedPairsOutput(memoryModel, prover, context, task.getProgram());
         }
 
         if (logger.isDebugEnabled()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -15,7 +15,6 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.metadata.OriginalId;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
-import com.dat3m.dartagnan.smt.ModelExt;
 import com.dat3m.dartagnan.solver.caat.CAATSolver;
 import com.dat3m.dartagnan.solver.caat4wmm.RefinementModel;
 import com.dat3m.dartagnan.solver.caat4wmm.Refiner;
@@ -311,7 +310,7 @@ public class RefinementSolver extends ModelChecker {
             }
         } else {
             res = FAIL;
-            saveFlaggedPairsOutput(baselineModel, baselineEncoder, prover, context, task.getProgram());
+            saveFlaggedPairsOutput(baselineModel, prover, context, task.getProgram());
         }
 
         // -------------------------- Report statistics summary --------------------------
@@ -410,10 +409,11 @@ public class RefinementSolver extends ModelChecker {
             isFinalIteration = !checkProgress(trace) || iteration.isConclusive();
 
             // ------------------------- Debugging/Logging -------------------------
-            if (generateGraphvizDebugFiles) {
-                final ExecutionModelNext model = new ExecutionModelManager().buildExecutionModel(contextWithFullWmm,
-                        new ModelExt(prover.getModel()));
-                generateGraphvizFiles(task, model, trace.size(), iteration.inconsistencyReasons);
+            if (generateGraphvizDebugFiles && iteration.smtStatus == SMTStatus.SAT) {
+                try (IREvaluator evaluator = contextWithFullWmm.newEvaluator(prover)) {
+                    final ExecutionModelNext model = new ExecutionModelManager().buildExecutionModel(evaluator);
+                    generateGraphvizFiles(task, model, trace.size(), iteration.inconsistencyReasons);
+                }
             }
             if (logger.isDebugEnabled()) {
                 // ---- Internal SMT stats after the first iteration ----
@@ -481,7 +481,7 @@ public class RefinementSolver extends ModelChecker {
             // ------------ CAAT solving ------------
             lastTime = System.currentTimeMillis();
             final WMMSolver.Result solverResult;
-            try (ModelExt model = new ModelExt(prover.getModel())) {
+            try (IREvaluator model = context.newEvaluator(prover)) {
                 solverResult = solver.check(model);
             } catch (SolverException e) {
                 logger.error(e);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
@@ -13,7 +13,6 @@ import com.dat3m.dartagnan.program.event.core.Store;
 import com.dat3m.dartagnan.program.event.lang.svcomp.EndAtomic;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.dat3m.dartagnan.program.event.metadata.UnrollingBound;
-import com.dat3m.dartagnan.smt.ModelExt;
 import com.dat3m.dartagnan.utils.Result;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
@@ -152,8 +151,8 @@ public class WitnessBuilder {
             }
         }
 
-        try (ModelExt model = new ModelExt(prover.getModel())) {
-            List<Event> execution = reOrderBasedOnAtomicity(program, getSCExecutionOrder(new IREvaluator(context, model)));
+        try (IREvaluator evaluator = context.newEvaluator(prover)) {
+            List<Event> execution = reOrderBasedOnAtomicity(program, getSCExecutionOrder(evaluator));
 
             for (int i = 0; i < execution.size(); i++) {
                 Event e = execution.get(i);


### PR DESCRIPTION
Transforms the following:
```java
// before
try (ModelExt model = new ModelExt(prover.getModel())) {
    IREvaluator evaluator = new IREvaluator(context, model);
    // ...
}
// after
try (IREvaluator evaluator = context.newEvaluator(prover)) {
    // ...
}
```
This also removes all current direct usages of `ModelExt` outside of the `com.dat3m.dartagnan.encoding` package.