### PR TITLE
Fix mathsat5 in native mode

### DIFF
--- a/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/jni-config.json
+++ b/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/jni-config.json
@@ -1,14 +1,27 @@
 [
     {
       "name": "com.microsoft.z3.Native$IntPtr",
-      "fields": [
+      "fields":
+      [
         { "name": "value", "allowWrite": true }
       ]
     },
     {
       "name": "com.microsoft.z3.Native$LongPtr",
-      "fields": [
+      "fields":
+      [
         { "name": "value", "allowWrite": true }
       ]
+    },
+    {
+      "name": "org.sosy_lab.java_smt.solvers.mathsat5.Mathsat5NativeApi$TerminationCallback",
+      "methods":
+      [
+        {
+          "name": "shouldTerminate",
+          "parameterTypes": [],
+          "returnType": "boolean"
+        }
+      ]
     }
-  ]
+]


### PR DESCRIPTION
I also checked the other solvers in native mode: bitwuzla currently complains about JNI stuff, but even if I fix that, I eventually get an `Attempted to invoke pure virtual method` error. I do not think this is something we can fix on our side, so for that solver we would need to use JVM mode. For the other solvers there are no more problems related to reflection/JNI (at least for the few benchmarks I tried).