### PR TITLE
Update mockito version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ on:
   pull_request:
     branches: [ master, development ]
   schedule:
-    - cron: '0 0 * * 3'  # Run weekly
+    - cron: '0 0 * * 4'  # Run weekly
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up the Java JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'adopt'
           cache: maven
 
@@ -65,7 +65,7 @@ jobs:
       - name: Set up the Java JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'adopt'
           cache: maven
 
@@ -89,7 +89,7 @@ jobs:
       - name: Set up the Java JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'adopt'
           cache: maven
 
@@ -113,7 +113,7 @@ jobs:
       - name: Set up the Java JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'adopt'
           cache: maven
 
@@ -143,7 +143,7 @@ jobs:
       - name: Set up the Java JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'adopt'
           cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <native-maven-plugin.version>0.11.3</native-maven-plugin.version>
         <maven-model.version>3.3.9</maven-model.version>
         <commons-csv.version>1.12.0</commons-csv.version>
-        <mockito.version>5.11.0</mockito.version>
+        <mockito.version>5.21.0</mockito.version>
         <rsyntaxtextarea.version>3.3.4</rsyntaxtextarea.version>
 
         <!-- 3rd party plugin versions -->


### PR DESCRIPTION
Our unit tests using mockito fail on `development` when using java 25
```
[ERROR]   VisitorSpirvOpenCLTest.testStore:76->doTestStore:97 Mockito 
Mockito cannot mock this class: class com.dat3m.dartagnan.program.memory.MemoryObject.

If you're not sure why you're getting this error, please open an issue on GitHub.


Java               : 25
JVM vendor name    : GraalVM Community
JVM vendor version : 25.0.1+8-jvmci-b01
JVM name           : OpenJDK 64-Bit Server VM
JVM version        : 25.0.1+8-jvmci-b01
JVM info           : mixed mode, sharing
OS name            : Linux
OS version         : 5.15.0-118-generic


You are seeing this disclaimer because Mockito is configured to create inlined mocks.
You can learn about inline mocks and their limitations under item #39 of the Mockito class javadoc.

Underlying exception : org.mockito.exceptions.base.MockitoException: Could not modify all classes [class com.dat3m.dartagnan.expression.base.ExpressionBase, interface com.dat3m.dartagnan.expression.LeafExpression, class com.dat3m.dartagnan.expression.base.LeafExpressionBase, class java.lang.Object, class com.dat3m.dartagnan.program.memory.MemoryObject]
```
This is the reason of the fail [here](https://github.com/hernanponcedeleon/Dat3M/actions/runs/21654538329/job/62426486735).

Apparently the old mockito (with inline mocking) does not work well with java 25, thus this PR updates to the latest mockito version.