### PR TITLE
[DRAFT] Expression templates and generic RMW events

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionFactory.java
@@ -4,6 +4,7 @@ import com.dat3m.dartagnan.expression.aggregates.*;
 import com.dat3m.dartagnan.expression.booleans.*;
 import com.dat3m.dartagnan.expression.floats.*;
 import com.dat3m.dartagnan.expression.integers.*;
+import com.dat3m.dartagnan.expression.misc.ExprHole;
 import com.dat3m.dartagnan.expression.misc.GEPExpr;
 import com.dat3m.dartagnan.expression.misc.ITEExpr;
 import com.dat3m.dartagnan.expression.type.*;
@@ -403,6 +404,10 @@ public final class ExpressionFactory {
 
     // -----------------------------------------------------------------------------------------------------------------
     // Misc
+
+    public Expression makeHole(Type type) {
+        return new ExprHole(type);
+    }
 
     public Expression makeGeneralZero(Type type) {
         if (type instanceof ArrayType arrayType) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/ExpressionVisitor.java
@@ -9,6 +9,7 @@ import com.dat3m.dartagnan.expression.booleans.BoolLiteral;
 import com.dat3m.dartagnan.expression.booleans.BoolUnaryExpr;
 import com.dat3m.dartagnan.expression.floats.*;
 import com.dat3m.dartagnan.expression.integers.*;
+import com.dat3m.dartagnan.expression.misc.ExprHole;
 import com.dat3m.dartagnan.expression.misc.GEPExpr;
 import com.dat3m.dartagnan.expression.misc.ITEExpr;
 import com.dat3m.dartagnan.program.Function;
@@ -59,6 +60,7 @@ public interface ExpressionVisitor<TRet> {
     default TRet visitGEPExpression(GEPExpr expr) { return visitExpression(expr); }
 
     // =================================== Generic ===================================
+    default TRet visitExprHole(ExprHole hole) { return visitLeafExpression(hole); }
     default TRet visitITEExpression(ITEExpr expr) { return visitExpression(expr); }
 
     // =================================== Program-specific ===================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/misc/ExprHole.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/misc/ExprHole.java
@@ -1,0 +1,38 @@
+package com.dat3m.dartagnan.expression.misc;
+
+import com.dat3m.dartagnan.expression.ExpressionKind;
+import com.dat3m.dartagnan.expression.ExpressionVisitor;
+import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.base.LeafExpressionBase;
+
+/*
+    A typed hole expression: can be used to make expression templates
+    where the hole gets later replaced by some concrete expression of the correct type.
+    TODO: Possibly add identifiers to allow to distinguish between different holes.
+ */
+public class ExprHole extends LeafExpressionBase<Type> {
+
+    public ExprHole(Type type) {
+        super(type);
+    }
+
+    @Override
+    public ExpressionKind getKind() {
+        return () -> "HOLE";
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s {_}", type);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof ExprHole other && type.equals(other.type);
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitExprHole(this);
+    }
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprTransformer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprTransformer.java
@@ -12,9 +12,11 @@ import com.dat3m.dartagnan.expression.booleans.BoolBinaryExpr;
 import com.dat3m.dartagnan.expression.booleans.BoolUnaryExpr;
 import com.dat3m.dartagnan.expression.floats.*;
 import com.dat3m.dartagnan.expression.integers.*;
+import com.dat3m.dartagnan.expression.misc.ExprHole;
 import com.dat3m.dartagnan.expression.misc.GEPExpr;
 import com.dat3m.dartagnan.expression.misc.ITEExpr;
 import com.dat3m.dartagnan.expression.type.TypeFactory;
+import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
 
@@ -22,6 +24,16 @@ public abstract class ExprTransformer implements ExpressionVisitor<Expression> {
 
     protected final TypeFactory types = TypeFactory.getInstance();
     protected final ExpressionFactory expressions = ExpressionFactory.getInstance();
+
+    public static Expression replaceHole(Expression exprTemplate, Expression replacement) {
+        return exprTemplate.accept(new ExprTransformer() {
+            @Override
+            public Expression visitExprHole(ExprHole hole) {
+                Preconditions.checkArgument(hole.getType().equals(replacement.getType()));
+                return replacement;
+            }
+        });
+    }
 
     @Override
     public Expression visitBoolBinaryExpression(BoolBinaryExpr expr) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 import static com.dat3m.dartagnan.expression.utils.ExpressionHelper.isAggregateLike;
 import static com.dat3m.dartagnan.program.event.EventFactory.*;
-import static com.dat3m.dartagnan.program.event.EventFactory.Llvm.newCompareExchange;
+import static com.dat3m.dartagnan.program.event.EventFactory.Llvm.newCompareExchangeAlt;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 
@@ -806,7 +806,7 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
     public Expression visitCmpXchgInst(CmpXchgInstContext ctx) {
         // see https://llvm.org/docs/LangRef.html#cmpxchg-instruction
         // TODO LLVM has no distinguished boolean type.
-        final Expression address = visitTypeValue(ctx.typeValue(0));
+        /*final Expression address = visitTypeValue(ctx.typeValue(0));
         final Expression comparator = visitTypeValue(ctx.typeValue(1));
         final Expression substitute = visitTypeValue(ctx.typeValue(2));
         check(comparator.getType().equals(substitute.getType()), "Type mismatch for comparator and new in %s.", ctx);
@@ -823,6 +823,20 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
             final Expression result = expressions.makeConstruct(type, List.of(value, cast));
             block.events.add(newLocal(register, result));
         }
+        return register;*/
+
+        // TODO: THIS IS JUST TEST CODE
+        final Expression address = visitTypeValue(ctx.typeValue(0));
+        final Expression comparator = visitTypeValue(ctx.typeValue(1));
+        final Expression substitute = visitTypeValue(ctx.typeValue(2));
+        check(comparator.getType().equals(substitute.getType()), "Type mismatch for comparator and new in %s.", ctx);
+        final boolean weak = ctx.weak != null;
+        final String mo = parseMemoryOrder(ctx.atomicOrdering(0));
+
+        final Register register = currentRegisterName == null ? null :
+                getOrNewCurrentRegister(types.getAggregateType(List.of(comparator.getType(), getIntegerType(1))));
+
+        block.events.add(newCompareExchangeAlt(register, address, comparator, substitute, mo, weak));
         return register;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -28,13 +28,13 @@ import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.core.annotations.FunCallMarker;
 import com.dat3m.dartagnan.program.event.core.annotations.FunReturnMarker;
 import com.dat3m.dartagnan.program.event.core.annotations.StringAnnotation;
-import com.dat3m.dartagnan.program.event.core.InstructionBoundary;
 import com.dat3m.dartagnan.program.event.core.special.StateSnapshot;
 import com.dat3m.dartagnan.program.event.core.threading.*;
 import com.dat3m.dartagnan.program.event.functions.AbortIf;
 import com.dat3m.dartagnan.program.event.functions.Return;
 import com.dat3m.dartagnan.program.event.functions.ValueFunctionCall;
 import com.dat3m.dartagnan.program.event.functions.VoidFunctionCall;
+import com.dat3m.dartagnan.program.event.lang.GenericRMWReturn;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.dat3m.*;
 import com.dat3m.dartagnan.program.event.lang.linux.*;
@@ -484,6 +484,18 @@ public class EventFactory {
             return new LlvmCmpXchg(oldValueRegister, cmpRegister, address, expectedAddr, desiredValue, mo, isStrong);
         }
 
+        public static Event newCompareExchangeAlt(Register resultRegister, Expression address, Expression expectedValue, Expression desiredValue, String mo, boolean isStrong) {
+            final Expression hole = expressions.makeHole(desiredValue.getType());
+            final Expression cond = expressions.makeEQ(hole, expectedValue);
+            final Expression storeVal = desiredValue;
+            final Expression retVal = expressions.makeConstruct(types.getAggregateType(
+                    List.of(expectedValue.getType(), types.getIntegerType(1))),
+                    List.of(hole, expressions.makeCast(cond, types.getIntegerType(1)))
+            );
+
+            return new GenericRMWReturn(resultRegister, address, storeVal, cond, retVal, mo);
+        }
+
         public static LlvmCmpXchg newCompareExchange(Register oldValueRegister, Register cmpRegister, Expression address, Expression expectedAddr, Expression desiredValue, String mo) {
             return newCompareExchange(oldValueRegister, cmpRegister, address, expectedAddr, desiredValue, mo, false);
         }
@@ -491,6 +503,16 @@ public class EventFactory {
         public static LlvmRMW newRMW(Register register, Expression address, Expression value, IntBinaryOp op, String mo) {
             return new LlvmRMW(register, address, op, value, mo);
         }
+
+        public static Event newRMWAlt(Register register, Expression address, Expression value, IntBinaryOp op, String mo) {
+            final Expression hole = expressions.makeHole(value.getType());
+            final Expression cond = null;
+            final Expression storeVal = expressions.makeIntBinary(hole, op, value);
+            final Expression retVal = hole;
+
+            return new GenericRMWReturn(register, address, storeVal, cond, retVal, mo);
+        }
+
 
         public static LlvmFence newFence(String mo) {
             return new LlvmFence(mo);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventFactory.java
@@ -38,7 +38,10 @@ import com.dat3m.dartagnan.program.event.lang.GenericRMWReturn;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.dat3m.*;
 import com.dat3m.dartagnan.program.event.lang.linux.*;
-import com.dat3m.dartagnan.program.event.lang.llvm.*;
+import com.dat3m.dartagnan.program.event.lang.llvm.LlvmCmpXchg;
+import com.dat3m.dartagnan.program.event.lang.llvm.LlvmFence;
+import com.dat3m.dartagnan.program.event.lang.llvm.LlvmLoad;
+import com.dat3m.dartagnan.program.event.lang.llvm.LlvmStore;
 import com.dat3m.dartagnan.program.event.lang.spirv.*;
 import com.dat3m.dartagnan.program.event.lang.svcomp.*;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
@@ -476,11 +479,24 @@ public class EventFactory {
             return new LlvmStore(address, value, mo);
         }
 
-        public static LlvmXchg newExchange(Register register, Expression address, Expression value, String mo) {
-            return new LlvmXchg(register, address, value, mo);
+        public static Event newExchange(Register register, Expression address, Expression value, String mo) {
+            return newExchangeAlt(register, address, value, mo);
+            //return new LlvmXchg(register, address, value, mo);
         }
 
-        public static LlvmCmpXchg newCompareExchange(Register oldValueRegister, Register cmpRegister, Expression address, Expression expectedAddr, Expression desiredValue, String mo, boolean isStrong) {
+        public static Event newExchangeAlt(Register register, Expression address, Expression value, String mo) {
+            final Expression hole = expressions.makeHole(value.getType());
+            final Expression cond = null;
+            final Expression storeVal = value;
+            final Expression retVal = hole;
+
+            return new GenericRMWReturn(register, address, storeVal, cond, retVal, mo);
+        }
+
+        public static Event newCompareExchange(Register oldValueRegister, Register cmpRegister, Expression address, Expression expectedAddr, Expression desiredValue, String mo, boolean isStrong) {
+            // TODO: We don't forward this because the return signature has changed, and the
+            //  Intrinsics rely on the old one. However, the LLVM parse calls the new version directly.
+            //return newCompareExchangeAlt(oldValueRegister, address, expectedAddr, desiredValue, mo, isStrong);
             return new LlvmCmpXchg(oldValueRegister, cmpRegister, address, expectedAddr, desiredValue, mo, isStrong);
         }
 
@@ -496,12 +512,13 @@ public class EventFactory {
             return new GenericRMWReturn(resultRegister, address, storeVal, cond, retVal, mo);
         }
 
-        public static LlvmCmpXchg newCompareExchange(Register oldValueRegister, Register cmpRegister, Expression address, Expression expectedAddr, Expression desiredValue, String mo) {
+        public static Event newCompareExchange(Register oldValueRegister, Register cmpRegister, Expression address, Expression expectedAddr, Expression desiredValue, String mo) {
             return newCompareExchange(oldValueRegister, cmpRegister, address, expectedAddr, desiredValue, mo, false);
         }
 
-        public static LlvmRMW newRMW(Register register, Expression address, Expression value, IntBinaryOp op, String mo) {
-            return new LlvmRMW(register, address, op, value, mo);
+        public static Event newRMW(Register register, Expression address, Expression value, IntBinaryOp op, String mo) {
+            return newRMWAlt(register, address, value, op, mo);
+            //return new LlvmRMW(register, address, op, value, mo);
         }
 
         public static Event newRMWAlt(Register register, Expression address, Expression value, IntBinaryOp op, String mo) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventVisitor.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/EventVisitor.java
@@ -14,6 +14,8 @@ import com.dat3m.dartagnan.program.event.arch.vulkan.VulkanRMWExtremum;
 import com.dat3m.dartagnan.program.event.arch.vulkan.VulkanRMWOp;
 import com.dat3m.dartagnan.program.event.core.*;
 import com.dat3m.dartagnan.program.event.core.annotations.CodeAnnotation;
+import com.dat3m.dartagnan.program.event.lang.GenericRMWNoReturn;
+import com.dat3m.dartagnan.program.event.lang.GenericRMWReturn;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.linux.*;
 import com.dat3m.dartagnan.program.event.lang.llvm.*;
@@ -55,7 +57,9 @@ public interface EventVisitor<T> {
 
     // ------------------ Common Events ------------------
     default T visitStoreExclusive(StoreExclusive e) { return visitMemEvent(e); }
-    default T visitXchg(Xchg xchg) { return visitMemEvent(xchg); };
+    default T visitXchg(Xchg xchg) { return visitMemEvent(xchg); }
+    default T visitGenericRMWReturn(GenericRMWReturn e) { return visitMemEvent(e); }
+    default T visitGenericRMWNoReturn(GenericRMWNoReturn e) { return visitMemEvent(e); }
 
     // ------------------ Linux Events ------------------
     default T visitLKMMAddUnless(LKMMAddUnless e) { return visitMemEvent(e); }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/GenericRMWNoReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/GenericRMWNoReturn.java
@@ -1,0 +1,68 @@
+package com.dat3m.dartagnan.program.event.lang;
+
+import com.dat3m.dartagnan.expression.Expression;
+import com.dat3m.dartagnan.expression.ExpressionVisitor;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.EventVisitor;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
+
+import java.util.Set;
+
+import static com.dat3m.dartagnan.program.event.Tag.*;
+
+/*
+    This is for non-value-returning RMWs/AMOs, i.e., every operation of shape
+        __temp = load(addr);
+        store(addr, op(__temp));
+ */
+public class GenericRMWNoReturn extends SingleAccessMemoryEvent {
+
+    protected Expression storeTransformer;
+
+    protected GenericRMWNoReturn(Expression address, Expression storeTransformer, String mo) {
+        super(address, storeTransformer.getType(), mo);
+        this.storeTransformer = storeTransformer;
+        addTags(READ, WRITE, RMW);
+    }
+
+    protected GenericRMWNoReturn(GenericRMWNoReturn other) {
+        super(other);
+        this.storeTransformer = other.storeTransformer;
+    }
+
+    public Expression getStoreTransformer() { return storeTransformer; }
+    public void setStoreTransformer(Expression storeTransformer) { this.storeTransformer = storeTransformer; }
+
+    @Override
+    public void transformExpressions(ExpressionVisitor<? extends Expression> exprTransformer) {
+        super.transformExpressions(exprTransformer);
+        this.storeTransformer = storeTransformer.accept(exprTransformer);
+    }
+
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitGenericRMWNoReturn(this);
+    }
+
+    @Override
+    public GenericRMWNoReturn getCopy() {
+        return new GenericRMWNoReturn(this);
+    }
+
+    @Override
+    protected String defaultString() {
+        return String.format("rmw (%s, %s)", address, storeTransformer);
+    }
+
+    @Override
+    public Set<Register.Read> getRegisterReads() {
+        return Register.collectRegisterReads(storeTransformer, Register.UsageType.DATA, super.getRegisterReads());
+    }
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/GenericRMWReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/GenericRMWReturn.java
@@ -1,0 +1,108 @@
+package com.dat3m.dartagnan.program.event.lang;
+
+import com.dat3m.dartagnan.expression.Expression;
+import com.dat3m.dartagnan.expression.ExpressionVisitor;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.EventVisitor;
+import com.dat3m.dartagnan.program.event.MemoryAccess;
+import com.dat3m.dartagnan.program.event.RegWriter;
+import com.dat3m.dartagnan.program.event.common.SingleAccessMemoryEvent;
+
+import java.util.Set;
+
+/*
+    This class can be used for many value-returning RMWs/AMOs of shape
+        __temp = load(addr);
+        if (cmp(__temp))                // (_ == expected) for CAS
+           store(addr, op(__temp));     // ID(_) for CAS
+        result = returnOp(__temp);      // ID(_) for fetch_op, OP(_) for op_return, or some
+                                        // cond(_) for op_and_test
+
+ */
+public class GenericRMWReturn extends SingleAccessMemoryEvent implements RegWriter {
+
+    protected Register resultRegister;
+    protected Expression storeTransformer;
+    protected Expression conditionalExpr;
+    protected Expression returnTransformer;
+
+    public GenericRMWReturn(Register register, Expression address,
+                            Expression storeTransformer,
+                            Expression conditionalExpr,
+                            Expression returnTransformer,
+                            String mo) {
+        super(address, storeTransformer.getType(), mo);
+        this.resultRegister = register;
+        this.storeTransformer = storeTransformer;
+        this.conditionalExpr =  conditionalExpr;
+        this.returnTransformer = returnTransformer;
+    }
+
+    protected GenericRMWReturn(GenericRMWReturn other) {
+        super(other);
+        this.resultRegister = other.resultRegister;
+        this.storeTransformer = other.storeTransformer;
+        this.conditionalExpr = other.conditionalExpr;
+        this.returnTransformer = other.returnTransformer;
+    }
+
+    public Expression getStoreTransformer() { return storeTransformer; }
+    public Expression getConditionalExpr() { return conditionalExpr; }
+    public Expression getReturnTransformer() { return returnTransformer; }
+
+    public boolean hasConditional() { return conditionalExpr != null; }
+
+    @Override
+    public void transformExpressions(ExpressionVisitor<? extends Expression> exprTransformer) {
+        super.transformExpressions(exprTransformer);
+        this.storeTransformer = storeTransformer.accept(exprTransformer);
+        this.conditionalExpr = conditionalExpr == null ? null : conditionalExpr.accept(exprTransformer);
+        this.returnTransformer = returnTransformer.accept(exprTransformer);
+    }
+
+    @Override
+    public Set<Register.Read> getRegisterReads() {
+        Set<Register.Read> reads = super.getRegisterReads();
+        reads = Register.collectRegisterReads(storeTransformer, Register.UsageType.DATA, reads);
+        if (conditionalExpr != null) {
+            reads = Register.collectRegisterReads(conditionalExpr, Register.UsageType.CTRL, reads);
+        }
+        reads = Register.collectRegisterReads(returnTransformer, Register.UsageType.DATA, reads);
+        return reads;
+    }
+
+    @Override
+    public Event getCopy() {
+        return new GenericRMWReturn(this);
+    }
+
+    @Override
+    public <T> T accept(EventVisitor<T> visitor) {
+        return visitor.visitGenericRMWReturn(this);
+    }
+
+    @Override
+    public MemoryAccess getMemoryAccess() {
+        return new MemoryAccess(address, accessType, MemoryAccess.Mode.RMW);
+    }
+
+    @Override
+    public Register getResultRegister() {
+        return resultRegister;
+    }
+
+    @Override
+    public void setResultRegister(Register reg) {
+        this.resultRegister = reg;
+    }
+
+    @Override
+    protected String defaultString() {
+        if (hasConditional()) {
+            return String.format("%s = rmw_return(%s, val='%s', cond='%s', ret='%s')", resultRegister, address, storeTransformer, conditionalExpr, returnTransformer);
+        }
+        return String.format("%s = rmw_return(%s, val='%s', ret='%s')", resultRegister, address, storeTransformer, returnTransformer);
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing.compilation;
 
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.processing.ExprTransformer;
 import com.dat3m.dartagnan.expression.type.BooleanType;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
@@ -12,6 +13,7 @@ import com.dat3m.dartagnan.program.event.Tag.C11;
 import com.dat3m.dartagnan.program.event.arch.StoreExclusive;
 import com.dat3m.dartagnan.program.event.arch.Xchg;
 import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.lang.GenericRMWReturn;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.linux.*;
 import com.dat3m.dartagnan.program.event.lang.llvm.*;
@@ -116,6 +118,39 @@ class VisitorArm8 extends VisitorBase {
                 label,
                 localOp,
                 store
+        );
+    }
+
+    @Override
+    public List<Event> visitGenericRMWReturn(GenericRMWReturn e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+        Type accessType = e.getAccessType();
+
+        Register loadReg = e.getFunction().newRegister(accessType);
+        Expression storeOp = ExprTransformer.replaceHole(e.getStoreTransformer(), loadReg);
+        Expression resultOp = ExprTransformer.replaceHole(e.getReturnTransformer(), loadReg);
+
+        Label condEnd = null;
+        CondJump condJump = null;
+        if (e.hasConditional()) {
+            Expression cond = ExprTransformer.replaceHole(e.getConditionalExpr(), loadReg);
+            condEnd = newLabel("Cond_end");
+            condJump = newJumpUnless(cond, condEnd);
+        }
+
+        // TODO: Distinguish between LL/SC and AMO implementations
+        Load load = newRMWLoadExclusiveWithMo(loadReg, address, Tag.ARMv8.extractLoadMoFromCMo(mo));
+        Store store = newRMWStoreExclusiveWithMo(address, storeOp, true, Tag.ARMv8.extractStoreMoFromCMo(mo));
+        Local result = newLocal(resultRegister, resultOp);
+
+        return eventSequence(
+                load,
+                condJump,
+                store,
+                condEnd,
+                result
         );
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorC11.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan.program.processing.compilation;
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.processing.ExprTransformer;
 import com.dat3m.dartagnan.expression.type.BooleanType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Event;
@@ -12,6 +13,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.Tag.C11;
 import com.dat3m.dartagnan.program.event.arch.opencl.OpenCLRMWExtremum;
 import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.lang.GenericRMWReturn;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.llvm.*;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
@@ -201,6 +203,38 @@ public class VisitorC11 extends VisitorBase {
                 load,
                 localOp,
                 store
+        ));
+    }
+
+    @Override
+    public List<Event> visitGenericRMWReturn(GenericRMWReturn e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+        Type accessType = e.getAccessType();
+
+        Register loadReg = e.getFunction().newRegister(accessType);
+        Expression storeOp = ExprTransformer.replaceHole(e.getStoreTransformer(), loadReg);
+        Expression resultOp = ExprTransformer.replaceHole(e.getReturnTransformer(), loadReg);
+
+        Label condEnd = null;
+        CondJump condJump = null;
+        if (e.hasConditional()) {
+            Expression cond = ExprTransformer.replaceHole(e.getConditionalExpr(), loadReg);
+            condEnd = newLabel("Cond_end");
+            condJump = newJumpUnless(cond, condEnd);
+        }
+
+        Load load = newRMWLoadExclusiveWithMo(loadReg, address, Tag.C11.loadMO(mo));
+        Store store = newRMWStoreExclusiveWithMo(address, storeOp, true, Tag.C11.storeMO(mo));
+        Local result = newLocal(resultRegister, resultOp);
+
+        return tagList(eventSequence(
+                load,
+                condJump,
+                store,
+                condEnd,
+                result
         ));
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -234,7 +234,7 @@ class VisitorIMM extends VisitorBase {
             condJump = newJumpUnless(cond, condEnd);
         } else {
             label = newLabel("FakeDep");
-            fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+            fakeCtrlDep = newFakeCtrlDep(loadReg, label);
         }
 
         Load load = newRMWLoadExclusiveWithMo(loadReg, address, Tag.IMM.extractLoadMo(mo));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorIMM.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing.compilation;
 
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.processing.ExprTransformer;
 import com.dat3m.dartagnan.expression.type.BooleanType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Event;
@@ -9,6 +10,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.Tag.C11;
 import com.dat3m.dartagnan.program.event.Tag.IMM;
 import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.lang.GenericRMWReturn;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.llvm.*;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
@@ -208,6 +210,46 @@ class VisitorIMM extends VisitorBase {
                 label,
                 localOp,
                 store
+        );
+    }
+
+    @Override
+    public List<Event> visitGenericRMWReturn(GenericRMWReturn e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+        Type accessType = e.getAccessType();
+
+        Register loadReg = e.getFunction().newRegister(accessType);
+        Expression storeOp = ExprTransformer.replaceHole(e.getStoreTransformer(), loadReg);
+        Expression resultOp = ExprTransformer.replaceHole(e.getReturnTransformer(), loadReg);
+
+        Label condEnd = null;
+        CondJump condJump = null;
+        Label label = null;
+        Event fakeCtrlDep = null;
+        if (e.hasConditional()) {
+            Expression cond = ExprTransformer.replaceHole(e.getConditionalExpr(), loadReg);
+            condEnd = newLabel("Cond_end");
+            condJump = newJumpUnless(cond, condEnd);
+        } else {
+            label = newLabel("FakeDep");
+            fakeCtrlDep = newFakeCtrlDep(resultRegister, label);
+        }
+
+        Load load = newRMWLoadExclusiveWithMo(loadReg, address, Tag.IMM.extractLoadMo(mo));
+        Store store = newRMWStoreExclusiveWithMo(address, storeOp, true, Tag.IMM.extractStoreMo(mo));
+        Local result = newLocal(resultRegister, resultOp);
+
+
+        return eventSequence(
+                load,
+                fakeCtrlDep,
+                label,
+                condJump,
+                store,
+                condEnd,
+                result
         );
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorPower.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing.compilation;
 
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.processing.ExprTransformer;
 import com.dat3m.dartagnan.expression.type.BooleanType;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
@@ -10,6 +11,7 @@ import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.Tag.C11;
 import com.dat3m.dartagnan.program.event.arch.StoreExclusive;
 import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.lang.GenericRMWReturn;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.linux.*;
 import com.dat3m.dartagnan.program.event.lang.llvm.*;
@@ -274,6 +276,71 @@ public class VisitorPower extends VisitorBase {
                 store,
                 casEnd,
                 optionalBarrierAfter);
+    }
+
+    @Override
+    public List<Event> visitGenericRMWReturn(GenericRMWReturn e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+        Type accessType = e.getAccessType();
+
+        Register loadReg = e.getFunction().newRegister(accessType);
+        Expression storeOp = ExprTransformer.replaceHole(e.getStoreTransformer(), loadReg);
+        Expression resultOp = ExprTransformer.replaceHole(e.getReturnTransformer(), loadReg);
+
+        Label condEnd = null;
+        CondJump condJump = null;
+        Label label = null;
+        Event fakeCtrlDep = null;
+        if (e.hasConditional()) {
+            Expression cond = ExprTransformer.replaceHole(e.getConditionalExpr(), loadReg);
+            condEnd = newLabel("Cond_end");
+            condJump = newJumpUnless(cond, condEnd);
+        } else {
+            label = newLabel("FakeDep");
+            fakeCtrlDep = newFakeCtrlDep(loadReg, label);
+        }
+
+        Event optionalBarrierBefore = null;
+        Event optionalBarrierAfter = null;
+        switch (mo) {
+            case C11.MO_SC:
+                if (cToPowerScheme.equals(LEADING_SYNC)) {
+                    optionalBarrierBefore = Power.newSyncBarrier();
+                    optionalBarrierAfter = Power.newISyncBarrier();
+                } else {
+                    optionalBarrierBefore = Power.newLwSyncBarrier();
+                    optionalBarrierAfter = Power.newSyncBarrier();
+                }
+                break;
+            case C11.MO_ACQUIRE:
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+            case C11.MO_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                break;
+            case C11.MO_ACQUIRE_RELEASE:
+                optionalBarrierBefore = Power.newLwSyncBarrier();
+                optionalBarrierAfter = Power.newISyncBarrier();
+                break;
+        }
+
+        Load load = newRMWLoadExclusive(loadReg, address);
+        Store store = Power.newRMWStoreConditional(address, storeOp, true);
+        Local result = newLocal(resultRegister, resultOp);
+
+        return eventSequence(
+                optionalBarrierBefore,
+                load,
+                fakeCtrlDep,
+                label,
+                condJump,
+                store,
+                condEnd,
+                result,
+                optionalBarrierAfter
+        );
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorRISCV.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing.compilation;
 
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.processing.ExprTransformer;
 import com.dat3m.dartagnan.expression.type.BooleanType;
 import com.dat3m.dartagnan.expression.type.IntegerType;
 import com.dat3m.dartagnan.program.Register;
@@ -9,6 +10,7 @@ import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.arch.StoreExclusive;
 import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.lang.GenericRMWReturn;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.linux.*;
 import com.dat3m.dartagnan.program.event.lang.llvm.*;
@@ -142,6 +144,45 @@ class VisitorRISCV extends VisitorBase {
                 branchOnCasCmpResult,
                 store,
                 casEnd
+        );
+    }
+
+    @Override
+    public List<Event> visitGenericRMWReturn(GenericRMWReturn e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        String mo = e.getMo();
+        Type accessType = e.getAccessType();
+
+        Register loadReg = e.getFunction().newRegister(accessType);
+        Expression storeOp = ExprTransformer.replaceHole(e.getStoreTransformer(), loadReg);
+        Expression resultOp = ExprTransformer.replaceHole(e.getReturnTransformer(), loadReg);
+
+        Label condEnd = null;
+        CondJump condJump = null;
+        Label label = null;
+        Event fakeCtrlDep = null;
+        if (e.hasConditional()) {
+            Expression cond = ExprTransformer.replaceHole(e.getConditionalExpr(), loadReg);
+            condEnd = newLabel("Cond_end");
+            condJump = newJumpUnless(cond, condEnd);
+        } else {
+            label = newLabel("FakeDep");
+            fakeCtrlDep = newFakeCtrlDep(loadReg, label);
+        }
+
+        Load load = newRMWLoadExclusiveWithMo(loadReg, address, Tag.RISCV.extractLoadMoFromCMo(mo));
+        Store store = newRMWStoreExclusiveWithMo(address, storeOp, true, Tag.RISCV.extractStoreMoFromCMo(mo));
+        Local result = newLocal(resultRegister, resultOp);
+
+        return eventSequence(
+                load,
+                fakeCtrlDep,
+                label,
+                condJump,
+                store,
+                condEnd,
+                result
         );
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorTso.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing.compilation;
 
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.processing.ExprTransformer;
 import com.dat3m.dartagnan.expression.type.BooleanType;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.Event;
@@ -9,6 +10,7 @@ import com.dat3m.dartagnan.program.event.MemoryEvent;
 import com.dat3m.dartagnan.program.event.Tag;
 import com.dat3m.dartagnan.program.event.arch.tso.TSOXchg;
 import com.dat3m.dartagnan.program.event.core.*;
+import com.dat3m.dartagnan.program.event.lang.GenericRMWReturn;
 import com.dat3m.dartagnan.program.event.lang.catomic.*;
 import com.dat3m.dartagnan.program.event.lang.llvm.*;
 
@@ -103,6 +105,38 @@ class VisitorTso extends VisitorBase {
                 branchOnCasCmpResult,
                 store,
                 casEnd
+        ));
+    }
+
+    @Override
+    public List<Event> visitGenericRMWReturn(GenericRMWReturn e) {
+        Register resultRegister = e.getResultRegister();
+        Expression address = e.getAddress();
+        Type accessType = e.getAccessType();
+
+        Register loadReg = e.getFunction().newRegister(accessType);
+        Expression storeOp = ExprTransformer.replaceHole(e.getStoreTransformer(), loadReg);
+        Expression resultOp = ExprTransformer.replaceHole(e.getReturnTransformer(), loadReg);
+
+        Label condEnd = null;
+        CondJump condJump = null;
+        if (e.hasConditional()) {
+            Expression cond = ExprTransformer.replaceHole(e.getConditionalExpr(), loadReg);
+            condEnd = newLabel("Cond_end");
+            condJump = newJumpUnless(cond, condEnd);
+        }
+
+        // TODO: Distinguish between LL/SC and AMO implementations
+        Load load = newRMWLoad(loadReg, address);
+        Store store = newRMWStore(load, address, storeOp);
+        Local result = newLocal(resultRegister, resultOp);
+
+        return tagList(eventSequence(
+                load,
+                condJump,
+                store,
+                condEnd,
+                result
         ));
     }
 


### PR DESCRIPTION
This PR is just a proof-of-concept implementation for generic RMW events that can model (hopefully) all standard RMWs by utilizing expression templates (expressions with holes).

~Right now, many unit tests will fail because I didn't add compilation schemes for the new events to all architectures but the LLVM parser will generate a new event already for CAS operations. However, one of the (two) new events can be compiled to IMM/LLVM and so tests on the language level should work.~

