### PR TITLE
Fix several options

### DIFF
--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -275,8 +275,10 @@
                             <className>com.dat3m.dartagnan.program.processing.SparseConditionalConstantPropagation</className>
                             <className>com.dat3m.dartagnan.program.processing.ThreadCreation</className>
                             <className>com.dat3m.dartagnan.program.processing.compilation.Compilation</className>
+                            <className>com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreReasoner</className>
                             <className>com.dat3m.dartagnan.utils.options.BaseOptions</className>
                             <className>com.dat3m.dartagnan.verification.solving.ModelChecker$SMTConfig</className>
+                            <className>com.dat3m.dartagnan.verification.solving.RefinementSolver</className>
                             <className>com.dat3m.dartagnan.wmm.Wmm$Config</className>
                             <className>com.dat3m.dartagnan.wmm.analysis.RelationAnalysis$Config</className>
                             <className>com.dat3m.dartagnan.wmm.analysis.WmmAnalysis</className>

--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -277,6 +277,7 @@
                             <className>com.dat3m.dartagnan.program.processing.compilation.Compilation</className>
                             <className>com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreReasoner</className>
                             <className>com.dat3m.dartagnan.utils.options.BaseOptions</className>
+                            <className>com.dat3m.dartagnan.utils.printer.Printer</className>
                             <className>com.dat3m.dartagnan.verification.solving.ModelChecker$SMTConfig</className>
                             <className>com.dat3m.dartagnan.verification.solving.RefinementSolver</className>
                             <className>com.dat3m.dartagnan.wmm.Wmm$Config</className>

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
@@ -22,8 +22,10 @@ import com.dat3m.dartagnan.program.processing.ProcessingManager;
 import com.dat3m.dartagnan.program.processing.SparseConditionalConstantPropagation;
 import com.dat3m.dartagnan.program.processing.ThreadCreation;
 import com.dat3m.dartagnan.program.processing.compilation.Compilation;
+import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreReasoner;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.verification.solving.ModelChecker;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.analysis.WmmAnalysis;
@@ -77,8 +79,10 @@ public final class OptionInfo implements Comparable<OptionInfo> {
                 SparseConditionalConstantPropagation.class,
                 ThreadCreation.class,
                 Compilation.class,
+                CoreReasoner.class,
                 BaseOptions.class,
                 ModelChecker.SMTConfig.class,
+                RefinementSolver.class,
                 Wmm.Config.class,
                 RelationAnalysis.Config.class,
                 WmmAnalysis.class,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
@@ -24,6 +24,7 @@ import com.dat3m.dartagnan.program.processing.ThreadCreation;
 import com.dat3m.dartagnan.program.processing.compilation.Compilation;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreReasoner;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
+import com.dat3m.dartagnan.utils.printer.Printer;
 import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.wmm.Wmm;
@@ -81,6 +82,7 @@ public final class OptionInfo implements Comparable<OptionInfo> {
                 Compilation.class,
                 CoreReasoner.class,
                 BaseOptions.class,
+                Printer.class,
                 ModelChecker.SMTConfig.class,
                 RefinementSolver.class,
                 Wmm.Config.class,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -61,8 +61,6 @@ public class OptionNames {
     public static final String ALIAS_GRAPHVIZ_SPLIT_BY_THREAD = "program.analysis.generateAliasGraph.splitByThread";
     public static final String ALIAS_GRAPHVIZ_SHOW_ALL = "program.analysis.generateAliasGraph.showAllEvents";
     public static final String ALIAS_GRAPHVIZ_INTERNAL = "program.analysis.generateAliasGraph.internal";
-    public static final String ALWAYS_SPLIT_ON_JUMPS = "program.analysis.cf.alwaysSplitOnJump";
-    public static final String MERGE_BRANCHES = "program.analysis.cf.mergeBranches";
 
     // Memory Model Options
     public static final String WMM_ATOMICITY = "wmm.analysis.assumeAtomicity";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
@@ -23,10 +23,10 @@ public class WMMSolver {
     private final CAATSolver solver;
     private final CoreReasoner reasoner;
 
-    private WMMSolver(EncodingContext c) {
+    private WMMSolver(EncodingContext c) throws InvalidConfigurationException {
         this.executionGraph = new ExecutionGraph(c.getTask().getMemoryModel(), c::isEncoded);
         this.executionModel = ExecutionModel.withContext(c);
-        this.reasoner = new CoreReasoner(c.getAnalysisContext(), executionGraph);
+        this.reasoner = new CoreReasoner(c.getAnalysisContext(), executionGraph, c.getTask().getConfig());
         this.solver = CAATSolver.create();
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/WMMSolver.java
@@ -32,7 +32,6 @@ public class WMMSolver {
 
     public static WMMSolver withContext(EncodingContext context) throws InvalidConfigurationException {
         final var solver = new WMMSolver(context);
-        context.getTask().getConfig().inject(solver.reasoner);
         return solver;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
@@ -62,7 +62,7 @@ public class CoreReasoner {
         this.exec = analysisContext.requires(ExecutionAnalysis.class);
         this.ra = analysisContext.requires(RelationAnalysis.class);
         this.symmGenerators = computeSymmetryGenerators(analysisContext.requires(ThreadSymmetry.class));
-        logger.info("Symmetry learning {}", symmetricLearning);
+        logger.info("Symmetric learning {}", symmetricLearning);
     }
 
     /*

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/coreReasoning/CoreReasoner.java
@@ -20,10 +20,14 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
 
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.SYMMETRIC_LEARNING;
 import static com.dat3m.dartagnan.wmm.RelationNameRepository.*;
@@ -31,6 +35,8 @@ import static com.dat3m.dartagnan.wmm.RelationNameRepository.*;
 // The CoreReasoner transforms base reasons of the CAATSolver to core reasons of the WMMSolver.
 @Options
 public class CoreReasoner {
+
+    private static final Logger logger = LoggerFactory.getLogger(CoreReasoner.class);
 
     // An upper bound on the number of reasons computed per iteration,
     // This is mostly used to limit "reason explosion" for highly symmetric benchmarks.
@@ -50,11 +56,13 @@ public class CoreReasoner {
     private final RelationAnalysis ra;
     private final List<Function<Event, Event>> symmGenerators;
 
-    public CoreReasoner(Context analysisContext, ExecutionGraph executionGraph) {
+    public CoreReasoner(Context analysisContext, ExecutionGraph executionGraph, Configuration config) throws InvalidConfigurationException {
+        config.inject(this);
         this.executionGraph = executionGraph;
         this.exec = analysisContext.requires(ExecutionAnalysis.class);
         this.ra = analysisContext.requires(RelationAnalysis.class);
         this.symmGenerators = computeSymmetryGenerators(analysisContext.requires(ThreadSymmetry.class));
+        logger.info("Symmetry learning {}", symmetricLearning);
     }
 
     /*

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -43,7 +43,6 @@ import static com.dat3m.dartagnan.smt.SMTHelper.createSolverContext;
 import static com.dat3m.dartagnan.utils.Result.*;
 
 // Base class for SMT-based model checkers
-@Options
 public abstract class ModelChecker implements AutoCloseable {
 
     @Options

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/processing/WmmProcessingManager.java
@@ -10,21 +10,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-@Options
 public class WmmProcessingManager implements WmmProcessor {
 
     private final List<WmmProcessor> processors = new ArrayList<>();
 
-    // =========================== Configurables ===========================
-
-
-    // =========================== Debugging options =======================
-
-
-    // =====================================================================
-
     private WmmProcessingManager(Configuration config) throws InvalidConfigurationException {
-        config.inject(this);
         processors.addAll(Arrays.asList(
                 RemoveDeadRelations.newInstance(),
                 MergeEquivalentRelations.newInstance(),

--- a/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/reflect-config.json
+++ b/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/reflect-config.json
@@ -110,14 +110,24 @@
         "queryAllDeclaredMethods":true
       },
       {
+        "name":"com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreReasoner",
+        "allDeclaredFields":true,
+        "queryAllDeclaredMethods":true
+      },
+      {
         "name":"com.dat3m.dartagnan.utils.options.BaseOptions",
         "allDeclaredFields":true,
         "queryAllDeclaredMethods":true
       },
       {
-      "name":"com.dat3m.dartagnan.verification.solving.ModelChecker$SMTConfig",
-      "allDeclaredFields":true,
-      "queryAllDeclaredMethods":true
+        "name":"com.dat3m.dartagnan.verification.solving.ModelChecker$SMTConfig",
+        "allDeclaredFields":true,
+        "queryAllDeclaredMethods":true
+      },
+      {
+        "name":"com.dat3m.dartagnan.verification.solving.RefinementSolver",
+        "allDeclaredFields":true,
+        "queryAllDeclaredMethods":true
       },
       {
         "name":"com.dat3m.dartagnan.witness.graphml.WitnessBuilder",

--- a/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/reflect-config.json
+++ b/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/reflect-config.json
@@ -120,6 +120,11 @@
         "queryAllDeclaredMethods":true
       },
       {
+        "name":"com.dat3m.dartagnan.utils.printer.Printer",
+        "allDeclaredFields":true,
+        "queryAllDeclaredMethods":true
+      },
+      {
         "name":"com.dat3m.dartagnan.verification.solving.ModelChecker$SMTConfig",
         "allDeclaredFields":true,
         "queryAllDeclaredMethods":true


### PR DESCRIPTION
- Add missing injection
- Register some classes for reflection
- Removed unused option names

We still have a warning
```
[WARNING] /home/drc/git/Dat3M/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java:[98,15] Constructor does not receive Configuration instance and may not be able to inject configuration options of this class.
[WARNING] /home/drc/git/Dat3M/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java:[46,1] @Options annotation on class without @Option fields or methods is useless.
```
for this code
```
    protected ModelChecker(VerificationTask task) throws InvalidConfigurationException {
        this.task = Preconditions.checkNotNull(task);
        this.smtConfig = new SMTConfig();
        task.getConfig().inject(smtConfig);
    }
```
Should we get rid of the warning by explicitly passing the config? We don't really need to pass it since we can access it from the task, but the warning annoys me.