### PR TITLE
Distinguish release version from unstable ones

### DIFF
--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.dat3m</groupId>
         <artifactId>dat3m</artifactId>
-        <version>4.3.1</version>
+        <version>4.4.0-alpha</version>
     </parent>
     <artifactId>dartagnan</artifactId>
     <packaging>jar</packaging>

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -113,7 +113,8 @@ public class Dartagnan extends BaseOptions {
         if (Arrays.asList(args).contains("--version")) {
             final MavenXpp3Reader mvnReader = new MavenXpp3Reader();
             final FileReader fileReader = new FileReader(System.getenv("DAT3M_HOME") + "/pom.xml");
-            final String version = String.format("%s (commit %s)", mvnReader.read(fileReader).getVersion(), getGitId());
+            final String base = mvnReader.read(fileReader).getVersion();
+            final String version = base.equals(getGitTags()) ? base : String.format("%s (commit %s)", base, getGitId());
             System.out.println(version);
             return;
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/GitInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/GitInfo.java
@@ -35,4 +35,8 @@ public class GitInfo {
         return properties.getProperty("git.commit.id", "unknown");
     }
 
+    public static String getGitTags() {
+        return properties.getProperty("git.tags", "unknown");
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.dat3m</groupId>
     <artifactId>dat3m</artifactId>
-    <version>4.3.1</version>
+    <version>4.4.0-alpha</version>
     <packaging>pom</packaging>
 
     <url>https://github.com/hernanponcedeleon/Dat3M</url>

--- a/svcomp/pom.xml
+++ b/svcomp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.dat3m</groupId>
         <artifactId>dat3m</artifactId>
-        <version>4.3.1</version>
+        <version>4.4.0-alpha</version>
     </parent>
     <artifactId>svcomp</artifactId>
     <packaging>jar</packaging>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.dat3m</groupId>
         <artifactId>dat3m</artifactId>
-        <version>4.3.1</version>
+        <version>4.4.0-alpha</version>
     </parent>
     <artifactId>ui</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
This PR changes a bit how we handle version development. Rather than always reporting the commit id, we will distinguish between stable versions (those that get tagged) and development versions.

As soon as we make a release, the first commit after that will increase the version number (to mark the start of a new development cycle) and mark it as apha. Then, until we make a new release, we will report "next-stable-version-id-alpha (commit id)".

The last commit before a release will remove the alpha from the version string in the pom file, and we will tag, effectively reporting  this version as "latest-stable-version-id"