### PR TITLE
Add debug information to litmus format

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -390,10 +390,7 @@ public class Dartagnan extends BaseOptions {
     }
 
     private static void appendTo(StringBuilder details, Event event, SyntacticContextAnalysis synContext) {
-        final String callStack = makeContextString(synContext.getContextInfo(event).getContextOfType(CallContext.class), " -> ");
-        details.append("\tE").append(event.getGlobalId())
-                .append(":\t").append(callStack.isEmpty() ? callStack : callStack + " -> ")
-                .append(getSourceLocationString(event));
+        details.append("\t").append(synContext.getSourceLocationWithContext(event, true));
         if (event instanceof Assert ass) {
             details.append(": ").append(ass.getErrorMessage());
         }
@@ -469,6 +466,7 @@ public class Dartagnan extends BaseOptions {
 
         final Wmm wmm = task.getMemoryModel();
         final Program program = task.getProgram();
+        final boolean isLitmus = program.getFormat().equals(SourceLanguage.LITMUS);
         final StringBuilder output = new StringBuilder();
         final SyntacticContextAnalysis synContext = newInstance(program);
         for (Axiom ax : wmm.getAxioms()) {
@@ -484,12 +482,12 @@ public class Dartagnan extends BaseOptions {
                             callSeparator);
 
                     violatingPairs
-                            .append("\tE").append(e1.getGlobalId())
-                            .append(" / E").append(e2.getGlobalId())
                             .append("\t").append(callStackFirst).append(callStackFirst.isEmpty() ? "" : callSeparator)
-                            .append(getSourceLocationString(e1))
+                            .append(isLitmus ? getLitmusLocationString(e1, true) : getSourceLocationString(e1))
                             .append(" / ").append(callStackSecond).append(callStackSecond.isEmpty() ? "" : callSeparator)
-                            .append(getSourceLocationString(e2))
+                            .append(isLitmus ? getLitmusLocationString(e2, true) : getSourceLocationString(e2))
+                            .append("\t(E").append(e1.getGlobalId())
+                            .append(" / E").append(e2.getGlobalId()).append(")")
                             .append("\n");
                 });
                 output.append(violatingPairs);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -466,7 +466,6 @@ public class Dartagnan extends BaseOptions {
 
         final Wmm wmm = task.getMemoryModel();
         final Program program = task.getProgram();
-        final boolean isLitmus = program.getFormat().equals(SourceLanguage.LITMUS);
         final StringBuilder output = new StringBuilder();
         final SyntacticContextAnalysis synContext = newInstance(program);
         for (Axiom ax : wmm.getAxioms()) {
@@ -483,9 +482,9 @@ public class Dartagnan extends BaseOptions {
 
                     violatingPairs
                             .append("\t").append(callStackFirst).append(callStackFirst.isEmpty() ? "" : callSeparator)
-                            .append(isLitmus ? getLitmusLocationString(e1, true) : getSourceLocationString(e1))
+                            .append(getSourceLocationString(e1, true))
                             .append(" / ").append(callStackSecond).append(callStackSecond.isEmpty() ? "" : callSeparator)
-                            .append(isLitmus ? getLitmusLocationString(e2, true) : getSourceLocationString(e2))
+                            .append(getSourceLocationString(e2, true))
                             .append("\t(E").append(e1.getGlobalId())
                             .append(" / E").append(e2.getGlobalId()).append(")")
                             .append("\n");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -482,9 +482,9 @@ public class Dartagnan extends BaseOptions {
 
                     violatingPairs
                             .append("\t").append(callStackFirst).append(callStackFirst.isEmpty() ? "" : callSeparator)
-                            .append(getSourceLocationString(e1, true))
+                            .append(getSourceLocationString(e1))
                             .append(" / ").append(callStackSecond).append(callStackSecond.isEmpty() ? "" : callSeparator)
-                            .append(getSourceLocationString(e2, true))
+                            .append(getSourceLocationString(e2))
                             .append("\t(E").append(e1.getGlobalId())
                             .append(" / E").append(e2.getGlobalId()).append(")")
                             .append("\n");

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -17,6 +17,7 @@ import com.dat3m.dartagnan.program.event.RegWriter;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.dat3m.dartagnan.program.event.metadata.OriginalId;
+import com.dat3m.dartagnan.program.event.metadata.LineNumber;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.memory.VirtualMemoryObject;
@@ -193,6 +194,13 @@ public class ProgramBuilder {
         return child;
     }
 
+    // TODO: make this the default addChild implementation
+    public Event addChildWithMetadata(int fid, Event child, int ln) {
+        Event e = addChild(fid, child);
+        e.setMetadata(new LineNumber(ln));
+        return e;
+    }
+
     // ----------------------------------------------------------------------------------------------------------------
     // Memory & Constants
 
@@ -322,7 +330,7 @@ public class ProgramBuilder {
     }
 
     public void newScopedThread(Arch arch, int id, int ...ids) {
-        newScopedThread(arch, String.valueOf(id), id, ids);
+        newScopedThread(arch, "P" + String.valueOf(id), id, ids);
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -194,10 +194,9 @@ public class ProgramBuilder {
         return child;
     }
 
-    // TODO: make this the default addChild implementation
-    public Event addChildWithMetadata(int fid, Event child, int ln) {
+    public Event addChildWithSourceLocation(int fid, Event child, int lineOfCode) {
         Event e = addChild(fid, child);
-        e.setMetadata(new SourceLocation.Litmus(ln));
+        e.setMetadata(new SourceLocation.Litmus(lineOfCode));
         return e;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -254,20 +254,20 @@ public class ProgramBuilder {
         getOrNewMemoryObject(locName).setInitialValue(0, iValue);
     }
 
-    public void initRegEqLocPtr(int regThread, String regName, String locName, Type type) {
+    public void initRegEqLocPtr(int regThread, String regName, String locName, Type type, int lineOfCode) {
         MemoryObject object = getOrNewMemoryObject(locName);
         Register reg = getOrNewRegister(regThread, regName, type);
-        addChild(regThread, EventFactory.newLocal(reg, object));
+        addChildWithSourceLocation(regThread, EventFactory.newLocal(reg, object), lineOfCode);
     }
 
-    public void initRegEqLocVal(int regThread, String regName, String locName, Type type) {
+    public void initRegEqLocVal(int regThread, String regName, String locName, Type type, int lineOfCode) {
         Register reg = getOrNewRegister(regThread, regName, type);
-        addChild(regThread, EventFactory.newLocal(reg,getInitialValue(locName)));
+        addChildWithSourceLocation(regThread, EventFactory.newLocal(reg,getInitialValue(locName)), lineOfCode);
     }
 
-    public void initRegEqConst(int regThread, String regName, Expression value){
+    public void initRegEqConst(int regThread, String regName, Expression value, int lineOfCode){
         Preconditions.checkArgument(value.getRegs().isEmpty());
-        addChild(regThread, EventFactory.newLocal(getOrNewRegister(regThread, regName, value.getType()), value));
+        addChildWithSourceLocation(regThread, EventFactory.newLocal(getOrNewRegister(regThread, regName, value.getType()), value), lineOfCode);
     }
 
     private Expression getInitialValue(String name) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -185,20 +185,19 @@ public class ProgramBuilder {
         throw new MalformedProgramException("Function or Thread with id " + fid + " does not exist");
     }
 
-    public Event addChild(int fid, Event child) {
+    public Event addChild(int fid, Event child, int lineOfCode) {
         // Every event in litmus tests is non-optimisable
         if (program.getFormat().equals(Program.SourceLanguage.LITMUS)) {
             child.addTags(NOOPT);
         }
         getFunctionOrError(fid).append(child);
+        final String threadName = child.getThread().getName();
+        child.setMetadata(new SourceLocation.Litmus(threadName, lineOfCode));
         return child;
     }
 
-    public Event addChildWithSourceLocation(int fid, Event child, int lineOfCode) {
-        Event e = addChild(fid, child);
-        final String threadName = child.getThread().getName();
-        e.setMetadata(new SourceLocation.Litmus(threadName, lineOfCode));
-        return e;
+    public Event addChild(int fid, Event child) {
+        return addChild(fid, child, -1);
     }
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -257,17 +256,17 @@ public class ProgramBuilder {
     public void initRegEqLocPtr(int regThread, String regName, String locName, Type type, int lineOfCode) {
         MemoryObject object = getOrNewMemoryObject(locName);
         Register reg = getOrNewRegister(regThread, regName, type);
-        addChildWithSourceLocation(regThread, EventFactory.newLocal(reg, object), lineOfCode);
+        addChild(regThread, EventFactory.newLocal(reg, object), lineOfCode);
     }
 
     public void initRegEqLocVal(int regThread, String regName, String locName, Type type, int lineOfCode) {
         Register reg = getOrNewRegister(regThread, regName, type);
-        addChildWithSourceLocation(regThread, EventFactory.newLocal(reg,getInitialValue(locName)), lineOfCode);
+        addChild(regThread, EventFactory.newLocal(reg,getInitialValue(locName)), lineOfCode);
     }
 
     public void initRegEqConst(int regThread, String regName, Expression value, int lineOfCode){
         Preconditions.checkArgument(value.getRegs().isEmpty());
-        addChildWithSourceLocation(regThread, EventFactory.newLocal(getOrNewRegister(regThread, regName, value.getType()), value), lineOfCode);
+        addChild(regThread, EventFactory.newLocal(getOrNewRegister(regThread, regName, value.getType()), value), lineOfCode);
     }
 
     private Expression getInitialValue(String name) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -17,7 +17,7 @@ import com.dat3m.dartagnan.program.event.RegWriter;
 import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.dat3m.dartagnan.program.event.metadata.OriginalId;
-import com.dat3m.dartagnan.program.event.metadata.LineNumber;
+import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.memory.VirtualMemoryObject;
@@ -197,7 +197,7 @@ public class ProgramBuilder {
     // TODO: make this the default addChild implementation
     public Event addChildWithMetadata(int fid, Event child, int ln) {
         Event e = addChild(fid, child);
-        e.setMetadata(new LineNumber(ln));
+        e.setMetadata(new SourceLocation.Litmus(ln));
         return e;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -185,19 +185,20 @@ public class ProgramBuilder {
         throw new MalformedProgramException("Function or Thread with id " + fid + " does not exist");
     }
 
-    public Event addChild(int fid, Event child, int lineOfCode) {
+    public Event addChildWithoutSourceLoc(int fid, Event child) {
         // Every event in litmus tests is non-optimisable
         if (program.getFormat().equals(Program.SourceLanguage.LITMUS)) {
             child.addTags(NOOPT);
         }
         getFunctionOrError(fid).append(child);
-        final String threadName = child.getThread().getName();
-        child.setMetadata(new SourceLocation.Litmus(threadName, lineOfCode));
         return child;
     }
 
-    public Event addChild(int fid, Event child) {
-        return addChild(fid, child, -1);
+    public Event addChild(int fid, Event child, int lineOfCode) {
+        Event e = addChildWithoutSourceLoc(fid, child);
+        final String threadName = e.getThread().getName();
+        e.setMetadata(new SourceLocation.Litmus(threadName, lineOfCode));
+        return e;
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/ProgramBuilder.java
@@ -196,7 +196,8 @@ public class ProgramBuilder {
 
     public Event addChildWithSourceLocation(int fid, Event child, int lineOfCode) {
         Event e = addChild(fid, child);
-        e.setMetadata(new SourceLocation.Litmus(lineOfCode));
+        final String threadName = child.getThread().getName();
+        e.setMetadata(new SourceLocation.Litmus(threadName, lineOfCode));
         return e;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -111,7 +111,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
 
     @Override
     public Object visitVariableDeclaratorRegister(VariableDeclaratorRegisterContext ctx) {
-        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register64().id, parseValue(ctx.constant(), i64));
+        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register64().id, parseValue(ctx.constant(), i64), ctx.getStart().getLine());
         return null;
     }
 
@@ -122,14 +122,14 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         if (ctx.constant() == null) {
             programBuilder.getOrNewRegister(ctx.threadId().id, ctx.register64().id, type);
         } else {
-            programBuilder.initRegEqConst(ctx.threadId().id, ctx.register64().id, parseValue(ctx.constant(), type));
+            programBuilder.initRegEqConst(ctx.threadId().id, ctx.register64().id, parseValue(ctx.constant(), type), ctx.getStart().getLine());
         }
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegisterLocation(VariableDeclaratorRegisterLocationContext ctx) {
-        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register64().id, ctx.location().getText(), i64);
+        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register64().id, ctx.location().getText(), i64, ctx.getStart().getLine());
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -167,7 +167,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
     public Object visitMov(MovContext ctx) {
         final Register r64 = parseRegister64(ctx.r32, ctx.r64);
         final Expression expr = parseExpression(ctx.expr32(), ctx.expr64());
-        return add(EventFactory.newLocal(r64, expressions.makeIntegerCast(expr, i64, false)));
+        return addWithSourceLocation(EventFactory.newLocal(r64, expressions.makeIntegerCast(expr, i64, false)), ctx.getStart().getLine());
     }
 
     @Override
@@ -190,7 +190,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Expression left = expressions.makeIntegerCast(operand, type, false);
         final Expression right = expressions.makeIntegerCast(expr, type, false);
         final Expression result = expressions.makeIntBinary(left, ctx.arithmeticInstruction().op, right);
-        add(EventFactory.newLocal(r64, expressions.makeIntegerCast(result, i64, false)));
+        addWithSourceLocation(EventFactory.newLocal(r64, expressions.makeIntegerCast(result, i64, false)), ctx.getStart().getLine());
         return null;
     }
 
@@ -201,7 +201,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Register register = shrinkRegister(r64, ctx.rD32, inst.halfWordSize, inst.byteSize);
         final Expression address = parseAddress(ctx.address());
         final String mo = inst.acquire ? MO_ACQ : "";
-        add(EventFactory.newLoadWithMo(register, address, mo));
+        addWithSourceLocation(EventFactory.newLoadWithMo(register, address, mo), ctx.getStart().getLine());
         addRegister64Update(r64, register);
         return null;
     }
@@ -215,8 +215,9 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Register value1 = extended ? r164 : shrinkRegister(r164, ctx.rD132, false, false);
         final Expression address0 = parseAddress(ctx.address());
         final Expression address1 = expressions.makeAdd(address0, expressions.makeValue(extended ? 8 : 4, i64));
-        add(EventFactory.newLoad(value0, address0));
-        add(EventFactory.newLoad(value1, address1));
+        final int lineOfCode = ctx.getStart().getLine();
+        addWithSourceLocation(EventFactory.newLoad(value0, address0), lineOfCode);
+        addWithSourceLocation(EventFactory.newLoad(value1, address1), lineOfCode);
         addRegister64Update(r064, value0);
         addRegister64Update(r164, value1);
         return null;
@@ -229,7 +230,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Register register = shrinkRegister(r64, ctx.rD32, inst.halfWordSize, inst.byteSize);
         final Expression address = parseAddress(ctx.address());
         final String mo = inst.acquire ? MO_ACQ : "";
-        add(EventFactory.newRMWLoadExclusiveWithMo(register, address, mo));
+        addWithSourceLocation(EventFactory.newRMWLoadExclusiveWithMo(register, address, mo), ctx.getStart().getLine());
         addRegister64Update(r64, register);
         return null;
     }
@@ -242,7 +243,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Expression value = expressions.makeIntegerCast(r64, type, false);
         final Expression address = parseAddress(ctx.address());
         final String mo = ctx.storeInstruction().release ? MO_REL : "";
-        return add(EventFactory.newStoreWithMo(address, value, mo));
+        return addWithSourceLocation(EventFactory.newStoreWithMo(address, value, mo), ctx.getStart().getLine());
     }
 
     @Override
@@ -255,8 +256,9 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Expression value1 = expressions.makeIntegerCast(s64, type, false);
         final Expression address0 = parseAddress(ctx.address());
         final Expression address1 = expressions.makeAdd(address0, expressions.makeValue(extended ? 8 : 4, i64));
-        add(EventFactory.newStore(address0, value0));
-        return add(EventFactory.newStore(address1, value1));
+        final int lineOfCode = ctx.getStart().getLine();
+        addWithSourceLocation(EventFactory.newStore(address0, value0), lineOfCode);
+        return addWithSourceLocation(EventFactory.newStore(address1, value1), lineOfCode);
     }
 
     @Override
@@ -268,7 +270,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Register status = parseRegister64(ctx.rS32);
         final Expression address = parseAddress(ctx.address());
         final String mo = ctx.storeExclusiveInstruction().release ? MO_REL : "";
-        return add(EventFactory.Common.newExclusiveStore(status, address, value, mo));
+        return addWithSourceLocation(EventFactory.Common.newExclusiveStore(status, address, value, mo), ctx.getStart().getLine());
     }
 
     private static final CustomPrinting SWP_PRINTER = e -> {
@@ -307,7 +309,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         xchg.addTags(mo);
         xchg.setMetadata(SWP_PRINTER);
 
-        add(xchg);
+        addWithSourceLocation(xchg, ctx.getStart().getLine());
         addRegister64Update(r64, lReg);
         return null;
     }
@@ -349,7 +351,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         cas.addTags(mo);
         cas.setMetadata(CAS_PRINTER);
 
-        add(cas);
+        addWithSourceLocation(cas, ctx.getStart().getLine());
         addRegister64Update(rs64, rs);
         return null;
     }
@@ -471,7 +473,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         ldOp.addTags(mo);
         ldOp.setMetadata(LDOP_PRINTER);
 
-        add(ldOp);
+        addWithSourceLocation(ldOp, ctx.getStart().getLine());
         addRegister64Update(rt64, rt);
         return null;
     }
@@ -480,14 +482,14 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
     public Object visitBranch(BranchContext ctx) {
         Label label = programBuilder.getOrCreateLabel(mainThread, ctx.label().getText());
         if(ctx.branchCondition() == null){
-            return add(EventFactory.newGoto(label));
+            return addWithSourceLocation(EventFactory.newGoto(label), ctx.getStart().getLine());
         }
         CmpInstruction cmp = lastCmpInstructionPerThread.put(mainThread, null);
         if(cmp == null){
             throw new ParsingException("Invalid syntax near " + ctx.getText());
         }
         Expression expr = expressions.makeIntCmp(cmp.left, ctx.branchCondition().op, cmp.right);
-        return add(EventFactory.newJump(expr, label));
+        return addWithSourceLocation(EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
@@ -499,23 +501,23 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         IntLiteral zero = expressions.makeZero(integerType);
         Expression expr = expressions.makeIntCmp(register, ctx.branchRegInstruction().op, zero);
         Label label = programBuilder.getOrCreateLabel(mainThread, ctx.label().getText());
-        return add(EventFactory.newJump(expr, label));
+        return addWithSourceLocation(EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitBranchLabel(BranchLabelContext ctx) {
-        return add(programBuilder.getOrCreateLabel(mainThread, ctx.label().getText()));
+        return addWithSourceLocation(programBuilder.getOrCreateLabel(mainThread, ctx.label().getText()), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitFence(FenceContext ctx) {
-        return add(EventFactory.newFenceOpt(ctx.Fence().getText(), ctx.opt));
+        return addWithSourceLocation(EventFactory.newFenceOpt(ctx.Fence().getText(), ctx.opt), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitReturn(ReturnContext ctx) {
         Label end = programBuilder.getEndOfThreadLabel(mainThread);
-        return add(EventFactory.newGoto(end));
+        return addWithSourceLocation(EventFactory.newGoto(end), ctx.getStart().getLine());
     }
 
     @Override
@@ -636,6 +638,11 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         return null;
     }
 
+    private Void addWithSourceLocation(Event event, int lineOfCode) {
+        programBuilder.addChildWithSourceLocation(mainThread, event, lineOfCode);
+        return null;
+    }
+
     @Override
     public Object visitStoreOp(StoreOpContext ctx) {
         final String instr = ctx.storeOpInstruction().getText();
@@ -657,7 +664,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         }
         stOp.setMetadata(STOP_PRINTER);
 
-        add(stOp);
+        addWithSourceLocation(stOp, ctx.getStart().getLine());
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -201,8 +201,9 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Register register = shrinkRegister(r64, ctx.rD32, inst.halfWordSize, inst.byteSize);
         final Expression address = parseAddress(ctx.address());
         final String mo = inst.acquire ? MO_ACQ : "";
-        addWithSourceLocation(EventFactory.newLoadWithMo(register, address, mo), ctx.getStart().getLine());
-        addRegister64Update(r64, register);
+        final int lineOfCode = ctx.getStart().getLine();
+        addWithSourceLocation(EventFactory.newLoadWithMo(register, address, mo), lineOfCode);
+        addRegister64Update(r64, register, lineOfCode);
         return null;
     }
 
@@ -218,8 +219,8 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final int lineOfCode = ctx.getStart().getLine();
         addWithSourceLocation(EventFactory.newLoad(value0, address0), lineOfCode);
         addWithSourceLocation(EventFactory.newLoad(value1, address1), lineOfCode);
-        addRegister64Update(r064, value0);
-        addRegister64Update(r164, value1);
+        addRegister64Update(r064, value0, lineOfCode);
+        addRegister64Update(r164, value1, lineOfCode);
         return null;
     }
 
@@ -230,8 +231,9 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Register register = shrinkRegister(r64, ctx.rD32, inst.halfWordSize, inst.byteSize);
         final Expression address = parseAddress(ctx.address());
         final String mo = inst.acquire ? MO_ACQ : "";
-        addWithSourceLocation(EventFactory.newRMWLoadExclusiveWithMo(register, address, mo), ctx.getStart().getLine());
-        addRegister64Update(r64, register);
+        final int lineOfCode = ctx.getStart().getLine();
+        addWithSourceLocation(EventFactory.newRMWLoadExclusiveWithMo(register, address, mo), lineOfCode);
+        addRegister64Update(r64, register, lineOfCode);
         return null;
     }
 
@@ -309,8 +311,9 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         xchg.addTags(mo);
         xchg.setMetadata(SWP_PRINTER);
 
-        addWithSourceLocation(xchg, ctx.getStart().getLine());
-        addRegister64Update(r64, lReg);
+        final int lineOfCode = ctx.getStart().getLine();
+        addWithSourceLocation(xchg, lineOfCode);
+        addRegister64Update(r64, lReg, lineOfCode);
         return null;
     }
 
@@ -351,8 +354,9 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         cas.addTags(mo);
         cas.setMetadata(CAS_PRINTER);
 
-        addWithSourceLocation(cas, ctx.getStart().getLine());
-        addRegister64Update(rs64, rs);
+        final int lineOfCode = ctx.getStart().getLine();
+        addWithSourceLocation(cas, lineOfCode);
+        addRegister64Update(rs64, rs, lineOfCode);
         return null;
     }
 
@@ -473,8 +477,9 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         ldOp.addTags(mo);
         ldOp.setMetadata(LDOP_PRINTER);
 
-        addWithSourceLocation(ldOp, ctx.getStart().getLine());
-        addRegister64Update(rt64, rt);
+        final int lineOfCode = ctx.getStart().getLine();
+        addWithSourceLocation(ldOp, lineOfCode);
+        addRegister64Update(rt64, rt, lineOfCode);
         return null;
     }
 
@@ -626,10 +631,10 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         }
     }
 
-    private void addRegister64Update(Register r64, Register value) {
+    private void addRegister64Update(Register r64, Register value, int lineOfCode) {
         checkArgument(r64.getType().equals(i64), "Unexpectedly-typed register %s", r64);
         if (r64 != value) {
-            add(EventFactory.newLocal(r64, expressions.makeIntegerCast(value, i64, false)));
+            addWithSourceLocation(EventFactory.newLocal(r64, expressions.makeIntegerCast(value, i64, false)), lineOfCode);
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusAArch64.java
@@ -167,7 +167,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
     public Object visitMov(MovContext ctx) {
         final Register r64 = parseRegister64(ctx.r32, ctx.r64);
         final Expression expr = parseExpression(ctx.expr32(), ctx.expr64());
-        return addWithSourceLocation(EventFactory.newLocal(r64, expressions.makeIntegerCast(expr, i64, false)), ctx.getStart().getLine());
+        return add(EventFactory.newLocal(r64, expressions.makeIntegerCast(expr, i64, false)), ctx.getStart().getLine());
     }
 
     @Override
@@ -190,7 +190,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Expression left = expressions.makeIntegerCast(operand, type, false);
         final Expression right = expressions.makeIntegerCast(expr, type, false);
         final Expression result = expressions.makeIntBinary(left, ctx.arithmeticInstruction().op, right);
-        addWithSourceLocation(EventFactory.newLocal(r64, expressions.makeIntegerCast(result, i64, false)), ctx.getStart().getLine());
+        add(EventFactory.newLocal(r64, expressions.makeIntegerCast(result, i64, false)), ctx.getStart().getLine());
         return null;
     }
 
@@ -202,7 +202,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Expression address = parseAddress(ctx.address());
         final String mo = inst.acquire ? MO_ACQ : "";
         final int lineOfCode = ctx.getStart().getLine();
-        addWithSourceLocation(EventFactory.newLoadWithMo(register, address, mo), lineOfCode);
+        add(EventFactory.newLoadWithMo(register, address, mo), lineOfCode);
         addRegister64Update(r64, register, lineOfCode);
         return null;
     }
@@ -217,8 +217,8 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Expression address0 = parseAddress(ctx.address());
         final Expression address1 = expressions.makeAdd(address0, expressions.makeValue(extended ? 8 : 4, i64));
         final int lineOfCode = ctx.getStart().getLine();
-        addWithSourceLocation(EventFactory.newLoad(value0, address0), lineOfCode);
-        addWithSourceLocation(EventFactory.newLoad(value1, address1), lineOfCode);
+        add(EventFactory.newLoad(value0, address0), lineOfCode);
+        add(EventFactory.newLoad(value1, address1), lineOfCode);
         addRegister64Update(r064, value0, lineOfCode);
         addRegister64Update(r164, value1, lineOfCode);
         return null;
@@ -232,7 +232,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Expression address = parseAddress(ctx.address());
         final String mo = inst.acquire ? MO_ACQ : "";
         final int lineOfCode = ctx.getStart().getLine();
-        addWithSourceLocation(EventFactory.newRMWLoadExclusiveWithMo(register, address, mo), lineOfCode);
+        add(EventFactory.newRMWLoadExclusiveWithMo(register, address, mo), lineOfCode);
         addRegister64Update(r64, register, lineOfCode);
         return null;
     }
@@ -245,7 +245,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Expression value = expressions.makeIntegerCast(r64, type, false);
         final Expression address = parseAddress(ctx.address());
         final String mo = ctx.storeInstruction().release ? MO_REL : "";
-        return addWithSourceLocation(EventFactory.newStoreWithMo(address, value, mo), ctx.getStart().getLine());
+        return add(EventFactory.newStoreWithMo(address, value, mo), ctx.getStart().getLine());
     }
 
     @Override
@@ -259,8 +259,8 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Expression address0 = parseAddress(ctx.address());
         final Expression address1 = expressions.makeAdd(address0, expressions.makeValue(extended ? 8 : 4, i64));
         final int lineOfCode = ctx.getStart().getLine();
-        addWithSourceLocation(EventFactory.newStore(address0, value0), lineOfCode);
-        return addWithSourceLocation(EventFactory.newStore(address1, value1), lineOfCode);
+        add(EventFactory.newStore(address0, value0), lineOfCode);
+        return add(EventFactory.newStore(address1, value1), lineOfCode);
     }
 
     @Override
@@ -272,7 +272,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         final Register status = parseRegister64(ctx.rS32);
         final Expression address = parseAddress(ctx.address());
         final String mo = ctx.storeExclusiveInstruction().release ? MO_REL : "";
-        return addWithSourceLocation(EventFactory.Common.newExclusiveStore(status, address, value, mo), ctx.getStart().getLine());
+        return add(EventFactory.Common.newExclusiveStore(status, address, value, mo), ctx.getStart().getLine());
     }
 
     private static final CustomPrinting SWP_PRINTER = e -> {
@@ -312,7 +312,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         xchg.setMetadata(SWP_PRINTER);
 
         final int lineOfCode = ctx.getStart().getLine();
-        addWithSourceLocation(xchg, lineOfCode);
+        add(xchg, lineOfCode);
         addRegister64Update(r64, lReg, lineOfCode);
         return null;
     }
@@ -355,7 +355,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         cas.setMetadata(CAS_PRINTER);
 
         final int lineOfCode = ctx.getStart().getLine();
-        addWithSourceLocation(cas, lineOfCode);
+        add(cas, lineOfCode);
         addRegister64Update(rs64, rs, lineOfCode);
         return null;
     }
@@ -478,7 +478,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         ldOp.setMetadata(LDOP_PRINTER);
 
         final int lineOfCode = ctx.getStart().getLine();
-        addWithSourceLocation(ldOp, lineOfCode);
+        add(ldOp, lineOfCode);
         addRegister64Update(rt64, rt, lineOfCode);
         return null;
     }
@@ -487,14 +487,14 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
     public Object visitBranch(BranchContext ctx) {
         Label label = programBuilder.getOrCreateLabel(mainThread, ctx.label().getText());
         if(ctx.branchCondition() == null){
-            return addWithSourceLocation(EventFactory.newGoto(label), ctx.getStart().getLine());
+            return add(EventFactory.newGoto(label), ctx.getStart().getLine());
         }
         CmpInstruction cmp = lastCmpInstructionPerThread.put(mainThread, null);
         if(cmp == null){
             throw new ParsingException("Invalid syntax near " + ctx.getText());
         }
         Expression expr = expressions.makeIntCmp(cmp.left, ctx.branchCondition().op, cmp.right);
-        return addWithSourceLocation(EventFactory.newJump(expr, label), ctx.getStart().getLine());
+        return add(EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
@@ -506,23 +506,23 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         IntLiteral zero = expressions.makeZero(integerType);
         Expression expr = expressions.makeIntCmp(register, ctx.branchRegInstruction().op, zero);
         Label label = programBuilder.getOrCreateLabel(mainThread, ctx.label().getText());
-        return addWithSourceLocation(EventFactory.newJump(expr, label), ctx.getStart().getLine());
+        return add(EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitBranchLabel(BranchLabelContext ctx) {
-        return addWithSourceLocation(programBuilder.getOrCreateLabel(mainThread, ctx.label().getText()), ctx.getStart().getLine());
+        return add(programBuilder.getOrCreateLabel(mainThread, ctx.label().getText()), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitFence(FenceContext ctx) {
-        return addWithSourceLocation(EventFactory.newFenceOpt(ctx.Fence().getText(), ctx.opt), ctx.getStart().getLine());
+        return add(EventFactory.newFenceOpt(ctx.Fence().getText(), ctx.opt), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitReturn(ReturnContext ctx) {
         Label end = programBuilder.getEndOfThreadLabel(mainThread);
-        return addWithSourceLocation(EventFactory.newGoto(end), ctx.getStart().getLine());
+        return add(EventFactory.newGoto(end), ctx.getStart().getLine());
     }
 
     @Override
@@ -634,17 +634,12 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
     private void addRegister64Update(Register r64, Register value, int lineOfCode) {
         checkArgument(r64.getType().equals(i64), "Unexpectedly-typed register %s", r64);
         if (r64 != value) {
-            addWithSourceLocation(EventFactory.newLocal(r64, expressions.makeIntegerCast(value, i64, false)), lineOfCode);
+            add(EventFactory.newLocal(r64, expressions.makeIntegerCast(value, i64, false)), lineOfCode);
         }
     }
 
-    private Void add(Event event) {
-        programBuilder.addChild(mainThread, event);
-        return null;
-    }
-
-    private Void addWithSourceLocation(Event event, int lineOfCode) {
-        programBuilder.addChildWithSourceLocation(mainThread, event, lineOfCode);
+    private Void add(Event event, int lineOfCode) {
+        programBuilder.addChild(mainThread, event, lineOfCode);
         return null;
     }
 
@@ -669,7 +664,7 @@ public class VisitorLitmusAArch64 extends LitmusAArch64BaseVisitor<Object> {
         }
         stOp.setMetadata(STOP_PRINTER);
 
-        addWithSourceLocation(stOp, ctx.getStart().getLine());
+        add(stOp, ctx.getStart().getLine());
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -209,7 +209,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
                 object.addFeatureTag(Tag.OpenCL.DEFAULT_SPACE);
             }
         }
-        programBuilder.addChild(currentThread, EventFactory.newLocal(register, object));
+        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newLocal(register, object), ctx.getStart().getLine());
         return null;
     }
 
@@ -222,18 +222,18 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Label endL = programBuilder.getOrCreateLabel(currentThread,"end_" + ifId);
 
         IfAsJump ifEvent = EventFactory.newIfJumpUnless(expressions.makeBooleanCast(expr), elseL, endL);
-        programBuilder.addChild(currentThread, ifEvent);
+        programBuilder.addChildWithSourceLocation(currentThread, ifEvent, ctx.getStart().getLine());
 
         for(LitmusCParser.ExpressionContext expressionContext : ctx.expression())
             expressionContext.accept(this);
         CondJump jumpToEnd = EventFactory.newGoto(endL);
-        programBuilder.addChild(currentThread, jumpToEnd);
+        programBuilder.addChildWithSourceLocation(currentThread, jumpToEnd, ctx.getStart().getLine());
 
-        programBuilder.addChild(currentThread, elseL);
+        programBuilder.addChildWithSourceLocation(currentThread, elseL, ctx.getStart().getLine());
         if(ctx.elseExpression() != null){
             ctx.elseExpression().accept(this);
         }
-        programBuilder.addChild(currentThread, endL);
+        programBuilder.addChildWithSourceLocation(currentThread, endL, ctx.getStart().getLine());
         return null;
     }
 
@@ -243,17 +243,17 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Label headL = programBuilder.getOrCreateLabel(currentThread,"head_" + whileId);
         Label endL = programBuilder.getOrCreateLabel(currentThread,"end_" + whileId);
 
-        programBuilder.addChild(currentThread, headL);
+        programBuilder.addChildWithSourceLocation(currentThread, headL, ctx.getStart().getLine());
         Expression expr = (Expression) ctx.re().accept(this);
 
-        programBuilder.addChild(currentThread, EventFactory.newJumpUnless(expr, endL));
+        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newJumpUnless(expr, endL), ctx.getStart().getLine());
 
         for(LitmusCParser.ExpressionContext expressionContext : ctx.expression()) {
             expressionContext.accept(this);
         }
 
-        programBuilder.addChild(currentThread, EventFactory.newGoto(headL));
-        programBuilder.addChild(currentThread, endL);
+        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newGoto(headL), ctx.getStart().getLine());
+        programBuilder.addChildWithSourceLocation(currentThread, endL, ctx.getStart().getLine());
         return null;
     }
 
@@ -267,7 +267,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = returnExpressionOrOne(ctx.value);
         Event event = EventFactory.Linux.newRMWOpReturn(getAddress(ctx.address), register, value, ctx.op, ctx.mo);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -277,7 +277,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = returnExpressionOrOne(ctx.value);
         Event event = EventFactory.Linux.newRMWFetchOp(getAddress(ctx.address), register, value, ctx.op, ctx.mo);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -288,7 +288,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         Event event = EventFactory.Atomic.newFetchOp(register, address, value, ctx.op, ctx.c11Mo().mo);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -298,7 +298,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = returnExpressionOrOne(ctx.value);
         Event event = EventFactory.Linux.newRMWOpAndTest(getAddress(ctx.address), register, value, ctx.op);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -308,7 +308,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = (Expression) ctx.value.accept(this);
         Expression cmp = (Expression) ctx.cmp.accept(this);
-        programBuilder.addChild(currentThread, EventFactory.Linux.newRMWAddUnless(getAddress(ctx.address), register, cmp, value));
+        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newRMWAddUnless(getAddress(ctx.address), register, cmp, value), ctx.getStart().getLine());
         return register;
     }
 
@@ -319,7 +319,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         Event event = EventFactory.Atomic.newExchange(register, address, value, Tag.C11.MO_SC);
         addScopeTag(event, null);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -330,7 +330,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         Event event = EventFactory.Atomic.newExchange(register, address, value, ctx.c11Mo().mo);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -339,7 +339,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = (Expression) ctx.value.accept(this);
         Event event = EventFactory.Linux.newRMWExchange(getAddress(ctx.address), register, value, ctx.mo);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -352,7 +352,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         String mo = ctx.c11Mo(0).mo;
         Event event = EventFactory.Atomic.newCompareExchange(register, address, expectedAdd, value, mo, true);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -365,7 +365,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Event event = EventFactory.Atomic.newCompareExchange(register, address, expectedAdd, value,
                 C11.DEFAULT_MO, true);
         addScopeTag(event, null);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -378,7 +378,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         String mo = ctx.c11Mo(0).mo;
         Event event = EventFactory.Atomic.newCompareExchange(register, address, expectedAdd, value, mo, false);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -391,7 +391,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Event event = EventFactory.Atomic.newCompareExchange(register, address, expectedAdd, value,
                 C11.DEFAULT_MO, false);
         addScopeTag(event, null);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -401,7 +401,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression cmp = (Expression)ctx.cmp.accept(this);
         Expression value = (Expression)ctx.value.accept(this);
         Event event = EventFactory.Linux.newRMWCompareExchange(getAddress(ctx.address), register, cmp, value, ctx.mo);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -410,7 +410,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         AtomicLoad event = EventFactory.Atomic.newLoad(register, address, ctx.c11Mo().mo);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -419,7 +419,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         AtomicLoad event = EventFactory.Atomic.newLoad(register, address, C11.DEFAULT_MO);
         addScopeTag(event, null);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -427,7 +427,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Expression visitReLoad(LitmusCParser.ReLoadContext ctx){
         Register register = getReturnRegister(true);
         Event event = EventFactory.Linux.newLKMMLoad(register, getAddress(ctx.address), ctx.mo);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -435,7 +435,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Expression visitReReadOnce(LitmusCParser.ReReadOnceContext ctx){
         Register register = getReturnRegister(true);
         Event event = EventFactory.Linux.newLKMMLoad(register, getAddress(ctx.address), ctx.mo);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -444,7 +444,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression address = getAddress(ctx.address);
         Load event = EventFactory.newLoadWithMo(register, address, C11.NONATOMIC);
-        programBuilder.addChildWithMetadata(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -531,21 +531,21 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Object visitNreAtomicOp(LitmusCParser.NreAtomicOpContext ctx){
         Expression value = returnExpressionOrOne(ctx.value);
         Event event = EventFactory.Linux.newRMWOp(getAddress(ctx.address), value, ctx.op);
-        return programBuilder.addChild(currentThread, event);
+        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreStore(LitmusCParser.NreStoreContext ctx){
         Expression value = (Expression)ctx.value.accept(this);
         Event event = EventFactory.Linux.newLKMMStore(getAddress(ctx.address), value, ctx.mo);
-        return programBuilder.addChild(currentThread, event);
+        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreWriteOnce(LitmusCParser.NreWriteOnceContext ctx){
         Expression value = (Expression)ctx.value.accept(this);
         Event event = EventFactory.Linux.newLKMMStore(getAddress(ctx.address), value, ctx.mo);
-        return programBuilder.addChild(currentThread, event);
+        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -554,7 +554,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         AtomicStore event = EventFactory.Atomic.newStore(address, value, ctx.c11Mo().mo);
         addScopeTag(event, ctx.openCLScope());
-        return programBuilder.addChild(currentThread, event);
+        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -563,7 +563,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         AtomicStore event = EventFactory.Atomic.newStore(address, value, C11.DEFAULT_MO);
         addScopeTag(event, null);
-        return programBuilder.addChild(currentThread, event);
+        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -584,7 +584,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
             if (isOpenCL) {
                 event.addTags(Tag.OpenCL.DEFAULT_WEAK_SCOPE);
             }
-            return programBuilder.addChildWithMetadata(currentThread, event, ctx.getStart().getLine());
+            return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
         }
         throw new ParsingException("Invalid syntax near " + ctx.getText());
     }
@@ -606,12 +606,12 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     @Override
     public Object visitNreC11Fence(LitmusCParser.NreC11FenceContext ctx) {
         AtomicThreadFence fence = EventFactory.Atomic.newFence(ctx.c11Mo().mo);
-        return programBuilder.addChild(currentThread, fence);
+        return programBuilder.addChildWithSourceLocation(currentThread, fence, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreFence(LitmusCParser.NreFenceContext ctx){
-        return programBuilder.addChild(currentThread, EventFactory.Linux.newLKMMFence(ctx.name));
+        return programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newLKMMFence(ctx.name), ctx.getStart().getLine());
     }
 
     @Override
@@ -625,7 +625,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
                 fence.addTags(flagCtx.flag);
             }
         }
-        return programBuilder.addChild(currentThread, fence);
+        return programBuilder.addChildWithSourceLocation(currentThread, fence, ctx.getStart().getLine());
     }
 
     @Override
@@ -639,22 +639,22 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
             throw new ParsingException("Unsupported control barrier scope '%s'", barrierScope);
         }
         fence.addTags(barrierScope);
-        return programBuilder.addChild(currentThread, fence);
+        return programBuilder.addChildWithSourceLocation(currentThread, fence, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreSpinLock(LitmusCParser.NreSpinLockContext ctx) {
-        return programBuilder.addChild(currentThread, EventFactory.Linux.newLock(getAddress(ctx.address)));
+        return programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newLock(getAddress(ctx.address)), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreSpinUnlock(LitmusCParser.NreSpinUnlockContext ctx) {
-        return programBuilder.addChild(currentThread, EventFactory.Linux.newUnlock(getAddress(ctx.address)));
+        return programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newUnlock(getAddress(ctx.address)), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreSrcuSync(LitmusCParser.NreSrcuSyncContext ctx) {
-        return programBuilder.addChild(currentThread, EventFactory.Linux.newSrcuSync(getAddress(ctx.address)));
+        return programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newSrcuSync(getAddress(ctx.address)), ctx.getStart().getLine());
     }
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -670,14 +670,14 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
             MemoryObject object = programBuilder.getMemoryObject(ctx.getText());
             if(object != null){
                 register = programBuilder.getOrNewRegister(scope, null, archType);
-                programBuilder.addChild(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC));
+                programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC), ctx.getStart().getLine());
                 return register;
             }
             return programBuilder.getOrNewRegister(scope, ctx.getText(), archType);
         }
         MemoryObject object = programBuilder.newMemoryObject(ctx.getText(), archSize);
         Register register = programBuilder.getOrNewRegister(scope, null, archType);
-        programBuilder.addChild(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC));
+        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC), ctx.getStart().getLine());
         return register;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -241,7 +241,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
 
 	@Override
     public Object visitWhileExpression(LitmusCParser.WhileExpressionContext ctx) {
-        final int = ctx.getStart().getLine();
+        final int lineOfCode = ctx.getStart().getLine();
         whileId++;
         Label headL = programBuilder.getOrCreateLabel(currentThread,"head_" + whileId);
         Label endL = programBuilder.getOrCreateLabel(currentThread,"end_" + whileId);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -77,7 +77,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Object visitGlobalDeclaratorRegister(LitmusCParser.GlobalDeclaratorRegisterContext ctx) {
         if (ctx.initConstantValue() != null) {
             IntLiteral value = expressions.parseValue(ctx.initConstantValue().constant().getText(), archType);
-            programBuilder.initRegEqConst(ctx.threadId().id,ctx.varName().getText(), value);
+            programBuilder.initRegEqConst(ctx.threadId().id,ctx.varName().getText(), value, ctx.getStart().getLine());
         }
         return null;
     }
@@ -102,14 +102,14 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Object visitGlobalDeclaratorRegisterLocation(LitmusCParser.GlobalDeclaratorRegisterLocationContext ctx) {
         // FIXME: We visit declarators before threads, so we need to create threads early
         if(ctx.Ast() == null){
-            programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.varName(0).getText(), ctx.varName(1).getText(), archType);
+            programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.varName(0).getText(), ctx.varName(1).getText(), archType, ctx.getStart().getLine());
         } else {
             String rightName = ctx.varName(1).getText();
             MemoryObject object = programBuilder.getMemoryObject(rightName);
             if(object != null){
-                programBuilder.initRegEqConst(ctx.threadId().id, ctx.varName(0).getText(), object);
+                programBuilder.initRegEqConst(ctx.threadId().id, ctx.varName(0).getText(), object, ctx.getStart().getLine());
             } else {
-                programBuilder.initRegEqLocVal(ctx.threadId().id, ctx.varName(0).getText(), ctx.varName(1).getText(), archType);
+                programBuilder.initRegEqLocVal(ctx.threadId().id, ctx.varName(0).getText(), ctx.varName(1).getText(), archType, ctx.getStart().getLine());
             }
         }
         return null;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -444,7 +444,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression address = getAddress(ctx.address);
         Load event = EventFactory.newLoadWithMo(register, address, C11.NONATOMIC);
-        programBuilder.addChild(currentThread, event);
+        programBuilder.addChildWithMetadata(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -584,7 +584,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
             if (isOpenCL) {
                 event.addTags(Tag.OpenCL.DEFAULT_WEAK_SCOPE);
             }
-            return programBuilder.addChild(currentThread, event);
+            return programBuilder.addChildWithMetadata(currentThread, event, ctx.getStart().getLine());
         }
         throw new ParsingException("Invalid syntax near " + ctx.getText());
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -101,15 +101,16 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     @Override
     public Object visitGlobalDeclaratorRegisterLocation(LitmusCParser.GlobalDeclaratorRegisterLocationContext ctx) {
         // FIXME: We visit declarators before threads, so we need to create threads early
+        final int lineOfCode = ctx.getStart().getLine();
         if(ctx.Ast() == null){
-            programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.varName(0).getText(), ctx.varName(1).getText(), archType, ctx.getStart().getLine());
+            programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.varName(0).getText(), ctx.varName(1).getText(), archType, lineOfCode);
         } else {
             String rightName = ctx.varName(1).getText();
             MemoryObject object = programBuilder.getMemoryObject(rightName);
             if(object != null){
-                programBuilder.initRegEqConst(ctx.threadId().id, ctx.varName(0).getText(), object, ctx.getStart().getLine());
+                programBuilder.initRegEqConst(ctx.threadId().id, ctx.varName(0).getText(), object, lineOfCode);
             } else {
-                programBuilder.initRegEqLocVal(ctx.threadId().id, ctx.varName(0).getText(), ctx.varName(1).getText(), archType, ctx.getStart().getLine());
+                programBuilder.initRegEqLocVal(ctx.threadId().id, ctx.varName(0).getText(), ctx.varName(1).getText(), archType, lineOfCode);
             }
         }
         return null;
@@ -215,6 +216,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
 
     @Override
     public Object visitIfExpression(LitmusCParser.IfExpressionContext ctx) {
+        final int lineOfCode = ctx.getStart().getLine();
         Expression expr = (Expression) ctx.re().accept(this);
 
         ifId++;
@@ -222,38 +224,39 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Label endL = programBuilder.getOrCreateLabel(currentThread,"end_" + ifId);
 
         IfAsJump ifEvent = EventFactory.newIfJumpUnless(expressions.makeBooleanCast(expr), elseL, endL);
-        programBuilder.addChild(currentThread, ifEvent, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, ifEvent, lineOfCode);
 
         for(LitmusCParser.ExpressionContext expressionContext : ctx.expression())
             expressionContext.accept(this);
         CondJump jumpToEnd = EventFactory.newGoto(endL);
-        programBuilder.addChild(currentThread, jumpToEnd, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, jumpToEnd, lineOfCode);
 
-        programBuilder.addChild(currentThread, elseL, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, elseL, lineOfCode);
         if(ctx.elseExpression() != null){
             ctx.elseExpression().accept(this);
         }
-        programBuilder.addChild(currentThread, endL, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, endL, lineOfCode);
         return null;
     }
 
 	@Override
     public Object visitWhileExpression(LitmusCParser.WhileExpressionContext ctx) {
+        final int = ctx.getStart().getLine();
         whileId++;
         Label headL = programBuilder.getOrCreateLabel(currentThread,"head_" + whileId);
         Label endL = programBuilder.getOrCreateLabel(currentThread,"end_" + whileId);
 
-        programBuilder.addChild(currentThread, headL, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, headL, lineOfCode);
         Expression expr = (Expression) ctx.re().accept(this);
 
-        programBuilder.addChild(currentThread, EventFactory.newJumpUnless(expr, endL), ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, EventFactory.newJumpUnless(expr, endL), lineOfCode);
 
         for(LitmusCParser.ExpressionContext expressionContext : ctx.expression()) {
             expressionContext.accept(this);
         }
 
-        programBuilder.addChild(currentThread, EventFactory.newGoto(headL), ctx.getStart().getLine());
-        programBuilder.addChild(currentThread, endL, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, EventFactory.newGoto(headL), lineOfCode);
+        programBuilder.addChild(currentThread, endL, lineOfCode);
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusC.java
@@ -209,7 +209,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
                 object.addFeatureTag(Tag.OpenCL.DEFAULT_SPACE);
             }
         }
-        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newLocal(register, object), ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, EventFactory.newLocal(register, object), ctx.getStart().getLine());
         return null;
     }
 
@@ -222,18 +222,18 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Label endL = programBuilder.getOrCreateLabel(currentThread,"end_" + ifId);
 
         IfAsJump ifEvent = EventFactory.newIfJumpUnless(expressions.makeBooleanCast(expr), elseL, endL);
-        programBuilder.addChildWithSourceLocation(currentThread, ifEvent, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, ifEvent, ctx.getStart().getLine());
 
         for(LitmusCParser.ExpressionContext expressionContext : ctx.expression())
             expressionContext.accept(this);
         CondJump jumpToEnd = EventFactory.newGoto(endL);
-        programBuilder.addChildWithSourceLocation(currentThread, jumpToEnd, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, jumpToEnd, ctx.getStart().getLine());
 
-        programBuilder.addChildWithSourceLocation(currentThread, elseL, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, elseL, ctx.getStart().getLine());
         if(ctx.elseExpression() != null){
             ctx.elseExpression().accept(this);
         }
-        programBuilder.addChildWithSourceLocation(currentThread, endL, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, endL, ctx.getStart().getLine());
         return null;
     }
 
@@ -243,17 +243,17 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Label headL = programBuilder.getOrCreateLabel(currentThread,"head_" + whileId);
         Label endL = programBuilder.getOrCreateLabel(currentThread,"end_" + whileId);
 
-        programBuilder.addChildWithSourceLocation(currentThread, headL, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, headL, ctx.getStart().getLine());
         Expression expr = (Expression) ctx.re().accept(this);
 
-        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newJumpUnless(expr, endL), ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, EventFactory.newJumpUnless(expr, endL), ctx.getStart().getLine());
 
         for(LitmusCParser.ExpressionContext expressionContext : ctx.expression()) {
             expressionContext.accept(this);
         }
 
-        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newGoto(headL), ctx.getStart().getLine());
-        programBuilder.addChildWithSourceLocation(currentThread, endL, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, EventFactory.newGoto(headL), ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, endL, ctx.getStart().getLine());
         return null;
     }
 
@@ -267,7 +267,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = returnExpressionOrOne(ctx.value);
         Event event = EventFactory.Linux.newRMWOpReturn(getAddress(ctx.address), register, value, ctx.op, ctx.mo);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -277,7 +277,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = returnExpressionOrOne(ctx.value);
         Event event = EventFactory.Linux.newRMWFetchOp(getAddress(ctx.address), register, value, ctx.op, ctx.mo);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -288,7 +288,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         Event event = EventFactory.Atomic.newFetchOp(register, address, value, ctx.op, ctx.c11Mo().mo);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -298,7 +298,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = returnExpressionOrOne(ctx.value);
         Event event = EventFactory.Linux.newRMWOpAndTest(getAddress(ctx.address), register, value, ctx.op);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -308,7 +308,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = (Expression) ctx.value.accept(this);
         Expression cmp = (Expression) ctx.cmp.accept(this);
-        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newRMWAddUnless(getAddress(ctx.address), register, cmp, value), ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, EventFactory.Linux.newRMWAddUnless(getAddress(ctx.address), register, cmp, value), ctx.getStart().getLine());
         return register;
     }
 
@@ -319,7 +319,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         Event event = EventFactory.Atomic.newExchange(register, address, value, Tag.C11.MO_SC);
         addScopeTag(event, null);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -330,7 +330,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         Event event = EventFactory.Atomic.newExchange(register, address, value, ctx.c11Mo().mo);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -339,7 +339,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression value = (Expression) ctx.value.accept(this);
         Event event = EventFactory.Linux.newRMWExchange(getAddress(ctx.address), register, value, ctx.mo);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -352,7 +352,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         String mo = ctx.c11Mo(0).mo;
         Event event = EventFactory.Atomic.newCompareExchange(register, address, expectedAdd, value, mo, true);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -365,7 +365,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Event event = EventFactory.Atomic.newCompareExchange(register, address, expectedAdd, value,
                 C11.DEFAULT_MO, true);
         addScopeTag(event, null);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -378,7 +378,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         String mo = ctx.c11Mo(0).mo;
         Event event = EventFactory.Atomic.newCompareExchange(register, address, expectedAdd, value, mo, false);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -391,7 +391,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Event event = EventFactory.Atomic.newCompareExchange(register, address, expectedAdd, value,
                 C11.DEFAULT_MO, false);
         addScopeTag(event, null);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -401,7 +401,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression cmp = (Expression)ctx.cmp.accept(this);
         Expression value = (Expression)ctx.value.accept(this);
         Event event = EventFactory.Linux.newRMWCompareExchange(getAddress(ctx.address), register, cmp, value, ctx.mo);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -410,7 +410,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         AtomicLoad event = EventFactory.Atomic.newLoad(register, address, ctx.c11Mo().mo);
         addScopeTag(event, ctx.openCLScope());
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -419,7 +419,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         AtomicLoad event = EventFactory.Atomic.newLoad(register, address, C11.DEFAULT_MO);
         addScopeTag(event, null);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -427,7 +427,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Expression visitReLoad(LitmusCParser.ReLoadContext ctx){
         Register register = getReturnRegister(true);
         Event event = EventFactory.Linux.newLKMMLoad(register, getAddress(ctx.address), ctx.mo);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -435,7 +435,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Expression visitReReadOnce(LitmusCParser.ReReadOnceContext ctx){
         Register register = getReturnRegister(true);
         Event event = EventFactory.Linux.newLKMMLoad(register, getAddress(ctx.address), ctx.mo);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -444,7 +444,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(true);
         Expression address = getAddress(ctx.address);
         Load event = EventFactory.newLoadWithMo(register, address, C11.NONATOMIC);
-        programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         return register;
     }
 
@@ -457,7 +457,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression v1 = (Expression)ctx.re(0).accept(this);
         Expression v2 = (Expression)ctx.re(1).accept(this);
         Expression result = expressions.makeIntCmp(v1, ctx.opCompare().op, v2);
-        return assignToReturnRegister(register, result);
+        return assignToReturnRegister(register, result, ctx.getStart().getLine());
     }
 
     @Override
@@ -466,7 +466,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression v1 = (Expression)ctx.re(0).accept(this);
         Expression v2 = (Expression)ctx.re(1).accept(this);
         Expression result = expressions.makeIntBinary(v1, ctx.opArith().op, v2);
-        return assignToReturnRegister(register, result);
+        return assignToReturnRegister(register, result, ctx.getStart().getLine());
     }
 
     @Override
@@ -477,7 +477,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         v1 = expressions.makeBooleanCast(v1);
         v2 = expressions.makeBooleanCast(v2);
         Expression result = expressions.makeBoolBinary(v1, ctx.opBool().op, v2);
-        return assignToReturnRegister(register, result);
+        return assignToReturnRegister(register, result, ctx.getStart().getLine());
     }
 
     @Override
@@ -486,7 +486,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression v = (Expression)ctx.re().accept(this);
         v = expressions.makeBooleanCast(v);
         Expression result = expressions.makeNot(v);
-        return assignToReturnRegister(register, result);
+        return assignToReturnRegister(register, result, ctx.getStart().getLine());
     }
 
     @Override
@@ -503,7 +503,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Expression visitReCast(LitmusCParser.ReCastContext ctx){
         Register register = getReturnRegister(false);
         Expression result = (Expression)ctx.re().accept(this);
-        return assignToReturnRegister(register, result);
+        return assignToReturnRegister(register, result, ctx.getStart().getLine());
     }
 
     @Override
@@ -511,7 +511,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Register register = getReturnRegister(false);
         Expression variable = visitVarName(ctx.varName());
         if (variable instanceof Register result) {
-            return assignToReturnRegister(register, result);
+            return assignToReturnRegister(register, result, ctx.getStart().getLine());
         }
         throw new ParsingException("Invalid syntax near " + ctx.getText());
     }
@@ -520,7 +520,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Expression visitReConst(LitmusCParser.ReConstContext ctx){
         Register register = getReturnRegister(false);
         IntLiteral result = expressions.parseValue(ctx.getText(), archType);
-        return assignToReturnRegister(register, result);
+        return assignToReturnRegister(register, result, ctx.getStart().getLine());
     }
 
 
@@ -531,21 +531,21 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     public Object visitNreAtomicOp(LitmusCParser.NreAtomicOpContext ctx){
         Expression value = returnExpressionOrOne(ctx.value);
         Event event = EventFactory.Linux.newRMWOp(getAddress(ctx.address), value, ctx.op);
-        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreStore(LitmusCParser.NreStoreContext ctx){
         Expression value = (Expression)ctx.value.accept(this);
         Event event = EventFactory.Linux.newLKMMStore(getAddress(ctx.address), value, ctx.mo);
-        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreWriteOnce(LitmusCParser.NreWriteOnceContext ctx){
         Expression value = (Expression)ctx.value.accept(this);
         Event event = EventFactory.Linux.newLKMMStore(getAddress(ctx.address), value, ctx.mo);
-        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -554,7 +554,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         AtomicStore event = EventFactory.Atomic.newStore(address, value, ctx.c11Mo().mo);
         addScopeTag(event, ctx.openCLScope());
-        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -563,7 +563,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         Expression address = getAddress(ctx.address);
         AtomicStore event = EventFactory.Atomic.newStore(address, value, C11.DEFAULT_MO);
         addScopeTag(event, null);
-        return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -584,7 +584,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
             if (isOpenCL) {
                 event.addTags(Tag.OpenCL.DEFAULT_WEAK_SCOPE);
             }
-            return programBuilder.addChildWithSourceLocation(currentThread, event, ctx.getStart().getLine());
+            return programBuilder.addChild(currentThread, event, ctx.getStart().getLine());
         }
         throw new ParsingException("Invalid syntax near " + ctx.getText());
     }
@@ -606,12 +606,12 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
     @Override
     public Object visitNreC11Fence(LitmusCParser.NreC11FenceContext ctx) {
         AtomicThreadFence fence = EventFactory.Atomic.newFence(ctx.c11Mo().mo);
-        return programBuilder.addChildWithSourceLocation(currentThread, fence, ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, fence, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreFence(LitmusCParser.NreFenceContext ctx){
-        return programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newLKMMFence(ctx.name), ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, EventFactory.Linux.newLKMMFence(ctx.name), ctx.getStart().getLine());
     }
 
     @Override
@@ -625,7 +625,7 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
                 fence.addTags(flagCtx.flag);
             }
         }
-        return programBuilder.addChildWithSourceLocation(currentThread, fence, ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, fence, ctx.getStart().getLine());
     }
 
     @Override
@@ -639,22 +639,22 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
             throw new ParsingException("Unsupported control barrier scope '%s'", barrierScope);
         }
         fence.addTags(barrierScope);
-        return programBuilder.addChildWithSourceLocation(currentThread, fence, ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, fence, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreSpinLock(LitmusCParser.NreSpinLockContext ctx) {
-        return programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newLock(getAddress(ctx.address)), ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, EventFactory.Linux.newLock(getAddress(ctx.address)), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreSpinUnlock(LitmusCParser.NreSpinUnlockContext ctx) {
-        return programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newUnlock(getAddress(ctx.address)), ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, EventFactory.Linux.newUnlock(getAddress(ctx.address)), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitNreSrcuSync(LitmusCParser.NreSrcuSyncContext ctx) {
-        return programBuilder.addChildWithSourceLocation(currentThread, EventFactory.Linux.newSrcuSync(getAddress(ctx.address)), ctx.getStart().getLine());
+        return programBuilder.addChild(currentThread, EventFactory.Linux.newSrcuSync(getAddress(ctx.address)), ctx.getStart().getLine());
     }
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -670,14 +670,14 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
             MemoryObject object = programBuilder.getMemoryObject(ctx.getText());
             if(object != null){
                 register = programBuilder.getOrNewRegister(scope, null, archType);
-                programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC), ctx.getStart().getLine());
+                programBuilder.addChild(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC), ctx.getStart().getLine());
                 return register;
             }
             return programBuilder.getOrNewRegister(scope, ctx.getText(), archType);
         }
         MemoryObject object = programBuilder.newMemoryObject(ctx.getText(), archSize);
         Register register = programBuilder.getOrNewRegister(scope, null, archType);
-        programBuilder.addChildWithSourceLocation(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC), ctx.getStart().getLine());
+        programBuilder.addChild(currentThread, EventFactory.newLoadWithMo(register, object, C11.NONATOMIC), ctx.getStart().getLine());
         return register;
     }
 
@@ -702,10 +702,10 @@ public class VisitorLitmusC extends LitmusCBaseVisitor<Object> {
         return register;
     }
 
-    private Expression assignToReturnRegister(Register register, Expression value) {
+    private Expression assignToReturnRegister(Register register, Expression value, int lineOfCode) {
         if (register != null) {
             Expression cast = expressions.makeCast(value, register.getType());
-            programBuilder.addChild(currentThread, EventFactory.newLocal(register, cast));
+            programBuilder.addChild(currentThread, EventFactory.newLocal(register, cast), lineOfCode);
         }
         return value;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -109,14 +109,14 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
     public Object visitLi(LitmusPPCParser.LiContext ctx) {
         Register register = (Register) ctx.register().accept(this);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(register, constant), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(register, constant), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLwz(LitmusPPCParser.LwzContext ctx) {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register ra = (Register) ctx.register(1).accept(this);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLoad(r1, ra), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLoad(r1, ra), ctx.getStart().getLine());
     }
 
     @Override
@@ -130,14 +130,14 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register ra = (Register) ctx.register(1).accept(this);
         Register rb = (Register) ctx.register(2).accept(this);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newRMWLoadExclusive(r1, expressions.makeAdd(ra, rb)), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newRMWLoadExclusive(r1, expressions.makeAdd(ra, rb)), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitStw(LitmusPPCParser.StwContext ctx) {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register ra = (Register) ctx.register(1).accept(this);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newStore(ra, r1), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newStore(ra, r1), ctx.getStart().getLine());
     }
 
     @Override
@@ -155,14 +155,14 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register ra = (Register) ctx.register(1).accept(this);
         Register rb = (Register) ctx.register(2).accept(this);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.Common.newExclusiveStore(rs, expressions.makeAdd(ra, rb), r1, ""), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.Common.newExclusiveStore(rs, expressions.makeAdd(ra, rb), r1, ""), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitMr(LitmusPPCParser.MrContext ctx) {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register r2 = (Register) ctx.register(1).accept(this);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(r1, r2), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, r2), ctx.getStart().getLine());
     }
 
     @Override
@@ -170,7 +170,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register r2 = (Register) ctx.register(1).accept(this);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(r1, expressions.makeAdd(r2, constant)), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeAdd(r2, constant)), ctx.getStart().getLine());
     }
 
     @Override
@@ -178,7 +178,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register r2 = (Register) ctx.register(1).accept(this);
         Register r3 = (Register) ctx.register(2).accept(this);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(r1, expressions.makeIntXor(r2, r3)), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeIntXor(r2, r3)), ctx.getStart().getLine());
     }
 
     @Override
@@ -198,19 +198,19 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
             // the value of r0 is used as the branching condition
             expressions.makeBooleanCast(programBuilder.getOrNewRegister(mainThread, "r0")) :
             expressions.makeIntCmp(cmp.left, ctx.cond().op, cmp.right);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newJump(expr, label), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLabel(LitmusPPCParser.LabelContext ctx) {
-        return programBuilder.addChildWithSourceLocation(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitFence(LitmusPPCParser.FenceContext ctx) {
         String name = ctx.getText().toLowerCase();
         if(fences.contains(name)){
-            return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newFence(name), ctx.getStart().getLine());
+            return programBuilder.addChild(mainThread, EventFactory.newFence(name), ctx.getStart().getLine());
         }
         throw new ParsingException("Unrecognised fence " + name);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -109,14 +109,14 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
     public Object visitLi(LitmusPPCParser.LiContext ctx) {
         Register register = (Register) ctx.register().accept(this);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(register, constant));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(register, constant), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLwz(LitmusPPCParser.LwzContext ctx) {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register ra = (Register) ctx.register(1).accept(this);
-        return programBuilder.addChild(mainThread, EventFactory.newLoad(r1, ra));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLoad(r1, ra), ctx.getStart().getLine());
     }
 
     @Override
@@ -130,14 +130,14 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register ra = (Register) ctx.register(1).accept(this);
         Register rb = (Register) ctx.register(2).accept(this);
-        return programBuilder.addChild(mainThread, EventFactory.newRMWLoadExclusive(r1, expressions.makeAdd(ra, rb)));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newRMWLoadExclusive(r1, expressions.makeAdd(ra, rb)), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitStw(LitmusPPCParser.StwContext ctx) {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register ra = (Register) ctx.register(1).accept(this);
-        return programBuilder.addChild(mainThread, EventFactory.newStore(ra, r1));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newStore(ra, r1), ctx.getStart().getLine());
     }
 
     @Override
@@ -155,14 +155,14 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register ra = (Register) ctx.register(1).accept(this);
         Register rb = (Register) ctx.register(2).accept(this);
-        return programBuilder.addChild(mainThread, EventFactory.Common.newExclusiveStore(rs, expressions.makeAdd(ra, rb), r1, ""));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.Common.newExclusiveStore(rs, expressions.makeAdd(ra, rb), r1, ""), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitMr(LitmusPPCParser.MrContext ctx) {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register r2 = (Register) ctx.register(1).accept(this);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, r2));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(r1, r2), ctx.getStart().getLine());
     }
 
     @Override
@@ -170,7 +170,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register r2 = (Register) ctx.register(1).accept(this);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeAdd(r2, constant)));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(r1, expressions.makeAdd(r2, constant)), ctx.getStart().getLine());
     }
 
     @Override
@@ -178,7 +178,7 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
         Register r1 = (Register) ctx.register(0).accept(this);
         Register r2 = (Register) ctx.register(1).accept(this);
         Register r3 = (Register) ctx.register(2).accept(this);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeIntXor(r2, r3)));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(r1, expressions.makeIntXor(r2, r3)), ctx.getStart().getLine());
     }
 
     @Override
@@ -198,19 +198,19 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
             // the value of r0 is used as the branching condition
             expressions.makeBooleanCast(programBuilder.getOrNewRegister(mainThread, "r0")) :
             expressions.makeIntCmp(cmp.left, ctx.cond().op, cmp.right);
-        return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLabel(LitmusPPCParser.LabelContext ctx) {
-        return programBuilder.addChild(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()));
+        return programBuilder.addChildWithSourceLocation(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitFence(LitmusPPCParser.FenceContext ctx) {
         String name = ctx.getText().toLowerCase();
         if(fences.contains(name)){
-            return programBuilder.addChild(mainThread, EventFactory.newFence(name));
+            return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newFence(name), ctx.getStart().getLine());
         }
         throw new ParsingException("Unrecognised fence " + name);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPPC.java
@@ -63,13 +63,13 @@ public class VisitorLitmusPPC extends LitmusPPCBaseVisitor<Object> {
     @Override
     public Object visitVariableDeclaratorRegister(LitmusPPCParser.VariableDeclaratorRegisterContext ctx) {
         IntLiteral value = expressions.parseValue(ctx.constant().getText(), archType);
-        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), value);
+        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), value, ctx.getStart().getLine());
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegisterLocation(LitmusPPCParser.VariableDeclaratorRegisterLocationContext ctx) {
-        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType);
+        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType, ctx.getStart().getLine());
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPTX.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPTX.java
@@ -143,14 +143,14 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
             default -> throw new ParsingException("Store instruction doesn't support mo: " + mo);
         }
         store.addTags(ctx.store().storeProxy);
-        return programBuilder.addChild(mainThread, store);
+        return programBuilder.addChildWithSourceLocation(mainThread, store, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLocalValue(LitmusPTXParser.LocalValueContext ctx) {
         Register register = (Register) ctx.register().accept(this);
         Expression value = (Expression) ctx.value().accept(this);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(register, value));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(register, value), ctx.getStart().getLine());
     }
 
     @Override
@@ -159,7 +159,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeAdd(lhs, rhs);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
@@ -168,7 +168,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeSub(lhs, rhs);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
@@ -177,7 +177,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeMul(lhs, rhs);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
@@ -186,7 +186,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeDiv(lhs, rhs, true);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
@@ -205,7 +205,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
             default -> throw new ParsingException("Load instruction doesn't support mo: " + mo);
         }
         load.addTags(ctx.load().loadProxy);
-        return programBuilder.addChild(mainThread, load);
+        return programBuilder.addChildWithSourceLocation(mainThread, load, ctx.getStart().getLine());
     }
 
     @Override
@@ -221,7 +221,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         PTXAtomOp atom = EventFactory.PTX.newAtomOp(object, register_destination, value, op, mo, scope);
         atom.addTags(ctx.atom().atomProxy);
-        return programBuilder.addChild(mainThread, atom);
+        return programBuilder.addChildWithSourceLocation(mainThread, atom, ctx.getStart().getLine());
     }
 
     @Override
@@ -237,7 +237,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         PTXAtomCAS atom = EventFactory.PTX.newAtomCAS(object, register_destination, expected, value, mo, scope);
         atom.addTags(ctx.atom().atomProxy);
-        return programBuilder.addChild(mainThread, atom);
+        return programBuilder.addChildWithSourceLocation(mainThread, atom, ctx.getStart().getLine());
     }
 
     @Override 
@@ -252,7 +252,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         PTXAtomExch atom = EventFactory.PTX.newAtomExch(object, register_destination, value, mo, scope);
         atom.addTags(ctx.atom().atomProxy);
-        return programBuilder.addChild(mainThread, atom);
+        return programBuilder.addChildWithSourceLocation(mainThread, atom, ctx.getStart().getLine());
     }
 
     @Override
@@ -267,7 +267,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         PTXRedOp red = EventFactory.PTX.newRedOp(object, value, op, mo, scope);
         red.addTags(ctx.red().redProxy);
-        return programBuilder.addChild(mainThread, red);
+        return programBuilder.addChildWithSourceLocation(mainThread, red, ctx.getStart().getLine());
     }
 
     @Override
@@ -279,21 +279,21 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         Event fence = EventFactory.newFence(ctx.getText().toLowerCase());
         fence.addTags(mo, scope, Tag.PTX.GEN);
-        return programBuilder.addChild(mainThread, fence);
+        return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitFenceProxy(LitmusPTXParser.FenceProxyContext ctx) {
         Event fence = EventFactory.newFence(ctx.getText().toLowerCase());
         fence.addTags(ctx.proxyType().content);
-        return programBuilder.addChild(mainThread, fence);
+        return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitFenceAlias(LitmusPTXParser.FenceAliasContext ctx) {
         Event fence = EventFactory.newFence(ctx.getText().toLowerCase());
         fence.addTags(Tag.PTX.ALIAS);
-        return programBuilder.addChild(mainThread, fence);
+        return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
     }
 
     @Override
@@ -314,12 +314,12 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         if(ctx.barrierMode().Arrive() != null) {
             barrier.addTags(Tag.PTX.ARRIVE);
         }
-        return programBuilder.addChild(mainThread, barrier);
+        return programBuilder.addChildWithSourceLocation(mainThread, barrier, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLabel(LitmusPTXParser.LabelContext ctx) {
-        return programBuilder.addChild(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()));
+        return programBuilder.addChildWithSourceLocation(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()), ctx.getStart().getLine());
     }
 
     @Override
@@ -328,13 +328,13 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression expr = expressions.makeIntCmp(lhs, ctx.cond().op, rhs);
-        return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitJump(LitmusPTXParser.JumpContext ctx) {
         Label label = programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText());
-        return programBuilder.addChild(mainThread, EventFactory.newGoto(label));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newGoto(label), ctx.getStart().getLine());
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPTX.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPTX.java
@@ -143,14 +143,14 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
             default -> throw new ParsingException("Store instruction doesn't support mo: " + mo);
         }
         store.addTags(ctx.store().storeProxy);
-        return programBuilder.addChildWithSourceLocation(mainThread, store, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, store, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLocalValue(LitmusPTXParser.LocalValueContext ctx) {
         Register register = (Register) ctx.register().accept(this);
         Expression value = (Expression) ctx.value().accept(this);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(register, value), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(register, value), ctx.getStart().getLine());
     }
 
     @Override
@@ -159,7 +159,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeAdd(lhs, rhs);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
@@ -168,7 +168,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeSub(lhs, rhs);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
@@ -177,7 +177,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeMul(lhs, rhs);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
@@ -186,7 +186,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeDiv(lhs, rhs, true);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
@@ -205,7 +205,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
             default -> throw new ParsingException("Load instruction doesn't support mo: " + mo);
         }
         load.addTags(ctx.load().loadProxy);
-        return programBuilder.addChildWithSourceLocation(mainThread, load, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, load, ctx.getStart().getLine());
     }
 
     @Override
@@ -221,7 +221,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         PTXAtomOp atom = EventFactory.PTX.newAtomOp(object, register_destination, value, op, mo, scope);
         atom.addTags(ctx.atom().atomProxy);
-        return programBuilder.addChildWithSourceLocation(mainThread, atom, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, atom, ctx.getStart().getLine());
     }
 
     @Override
@@ -237,7 +237,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         PTXAtomCAS atom = EventFactory.PTX.newAtomCAS(object, register_destination, expected, value, mo, scope);
         atom.addTags(ctx.atom().atomProxy);
-        return programBuilder.addChildWithSourceLocation(mainThread, atom, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, atom, ctx.getStart().getLine());
     }
 
     @Override 
@@ -252,7 +252,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         PTXAtomExch atom = EventFactory.PTX.newAtomExch(object, register_destination, value, mo, scope);
         atom.addTags(ctx.atom().atomProxy);
-        return programBuilder.addChildWithSourceLocation(mainThread, atom, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, atom, ctx.getStart().getLine());
     }
 
     @Override
@@ -267,7 +267,7 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         PTXRedOp red = EventFactory.PTX.newRedOp(object, value, op, mo, scope);
         red.addTags(ctx.red().redProxy);
-        return programBuilder.addChildWithSourceLocation(mainThread, red, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, red, ctx.getStart().getLine());
     }
 
     @Override
@@ -279,21 +279,21 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         }
         Event fence = EventFactory.newFence(ctx.getText().toLowerCase());
         fence.addTags(mo, scope, Tag.PTX.GEN);
-        return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, fence, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitFenceProxy(LitmusPTXParser.FenceProxyContext ctx) {
         Event fence = EventFactory.newFence(ctx.getText().toLowerCase());
         fence.addTags(ctx.proxyType().content);
-        return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, fence, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitFenceAlias(LitmusPTXParser.FenceAliasContext ctx) {
         Event fence = EventFactory.newFence(ctx.getText().toLowerCase());
         fence.addTags(Tag.PTX.ALIAS);
-        return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, fence, ctx.getStart().getLine());
     }
 
     @Override
@@ -314,12 +314,12 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         if(ctx.barrierMode().Arrive() != null) {
             barrier.addTags(Tag.PTX.ARRIVE);
         }
-        return programBuilder.addChildWithSourceLocation(mainThread, barrier, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, barrier, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLabel(LitmusPTXParser.LabelContext ctx) {
-        return programBuilder.addChildWithSourceLocation(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()), ctx.getStart().getLine());
     }
 
     @Override
@@ -328,13 +328,13 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression expr = expressions.makeIntCmp(lhs, ctx.cond().op, rhs);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newJump(expr, label), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitJump(LitmusPTXParser.JumpContext ctx) {
         Label label = programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText());
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newGoto(label), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newGoto(label), ctx.getStart().getLine());
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPTX.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusPTX.java
@@ -61,14 +61,14 @@ public class VisitorLitmusPTX extends LitmusPTXBaseVisitor<Object> {
     @Override
     public Object visitVariableDeclaratorRegister(LitmusPTXParser.VariableDeclaratorRegisterContext ctx) {
         programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(),
-                (IntLiteral) ctx.constant().accept(this));
+                (IntLiteral) ctx.constant().accept(this), ctx.getStart().getLine());
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegisterLocation(LitmusPTXParser.VariableDeclaratorRegisterLocationContext ctx) {
         programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(),
-                archType);
+                archType, ctx.getStart().getLine());
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -107,7 +107,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register register = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
         Event event = EventFactory.newLocal(register, constant);
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -116,7 +116,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
         Event event = EventFactory.newLocal(r1, expressions.makeIntXor(r2, r3));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 
 	}
 
@@ -126,7 +126,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
         Event event = EventFactory.newLocal(r1, expressions.makeIntAnd(r2, r3));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 
 	}
 
@@ -136,7 +136,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
         Event event = EventFactory.newLocal(r1, expressions.makeIntOr(r2, r3));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 
 	}
 
@@ -146,7 +146,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
         Event event = EventFactory.newLocal(r1, expressions.makeAdd(r2, r3));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 
 	}
 
@@ -156,7 +156,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
         Event event = EventFactory.newLocal(r1, expressions.makeIntXor(r2, constant));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -165,7 +165,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
         Event event = EventFactory.newLocal(r1, expressions.makeIntAnd(r2, constant));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -174,7 +174,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
         Event event = EventFactory.newLocal(r1, expressions.makeIntOr(r2, constant));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -183,7 +183,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
         Event event = EventFactory.newLocal(r1, expressions.makeAdd(r2, constant));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -191,7 +191,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Event event = EventFactory.newLoadWithMo(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1)));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -199,7 +199,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrErrorRegister(mainThread, ctx.register(0).getText());
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Event event = EventFactory.newStoreWithMo(ra, r1, getMo(ctx.moRISCV(0), ctx.moRISCV(1)));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -207,7 +207,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Event event = EventFactory.newRMWLoadExclusiveWithMo(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1)));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -216,13 +216,13 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
         Event event = EventFactory.Common.newExclusiveStore(r1, ra, r2, getMo(ctx.moRISCV(0), ctx.moRISCV(1)));
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
 	public Object visitLabel(LitmusRISCVParser.LabelContext ctx) {
         Event event = programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText());
-		return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+		return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -232,7 +232,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         Expression expr = expressions.makeIntCmp(r1, ctx.cond().op, r2);
         Event event = EventFactory.newJump(expr, label);
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -252,7 +252,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
             case "i" -> EventFactory.RISCV.newSynchronizeFence();
             default -> throw new ParsingException("Invalid fence mode " + mo);
         };
-		return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
+		return programBuilder.addChild(mainThread, fence, ctx.getStart().getLine());
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -106,7 +106,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
 	public Object visitLi(LitmusRISCVParser.LiContext ctx) {
         Register register = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(register, constant));
+        Event event = EventFactory.newLocal(register, constant);
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -114,7 +115,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeIntXor(r2, r3)));
+        Event event = EventFactory.newLocal(r1, expressions.makeIntXor(r2, r3));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 
 	}
 
@@ -123,7 +125,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeIntAnd(r2, r3)));
+        Event event = EventFactory.newLocal(r1, expressions.makeIntAnd(r2, r3));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 
 	}
 
@@ -132,7 +135,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeIntOr(r2, r3)));
+        Event event = EventFactory.newLocal(r1, expressions.makeIntOr(r2, r3));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 
 	}
 
@@ -141,7 +145,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         Register r3 = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeAdd(r2, r3)));
+        Event event = EventFactory.newLocal(r1, expressions.makeAdd(r2, r3));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 
 	}
 
@@ -150,7 +155,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeIntXor(r2, constant)));
+        Event event = EventFactory.newLocal(r1, expressions.makeIntXor(r2, constant));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -158,7 +164,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeIntAnd(r2, constant)));
+        Event event = EventFactory.newLocal(r1, expressions.makeIntAnd(r2, constant));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -166,7 +173,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeIntOr(r2, constant)));
+        Event event = EventFactory.newLocal(r1, expressions.makeIntOr(r2, constant));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -174,28 +182,32 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(r1, expressions.makeAdd(r2, constant)));
+        Event event = EventFactory.newLocal(r1, expressions.makeAdd(r2, constant));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
 	public Object visitLw(LitmusRISCVParser.LwContext ctx) {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLoadWithMo(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
+        Event event = EventFactory.newLoadWithMo(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1)));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
 	public Object visitSw(LitmusRISCVParser.SwContext ctx) {
         Register r1 = programBuilder.getOrErrorRegister(mainThread, ctx.register(0).getText());
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newStoreWithMo(ra, r1, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
+        Event event = EventFactory.newStoreWithMo(ra, r1, getMo(ctx.moRISCV(0), ctx.moRISCV(1)));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
 	public Object visitLr(LitmusRISCVParser.LrContext ctx) {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(1).getText());
-        return programBuilder.addChild(mainThread, EventFactory.newRMWLoadExclusiveWithMo(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
+        Event event = EventFactory.newRMWLoadExclusiveWithMo(r1, ra, getMo(ctx.moRISCV(0), ctx.moRISCV(1)));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -203,12 +215,14 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         Register ra = programBuilder.getOrErrorRegister(mainThread, ctx.register(2).getText());
-        return programBuilder.addChild(mainThread, EventFactory.Common.newExclusiveStore(r1, ra, r2, getMo(ctx.moRISCV(0), ctx.moRISCV(1))));
+        Event event = EventFactory.Common.newExclusiveStore(r1, ra, r2, getMo(ctx.moRISCV(0), ctx.moRISCV(1)));
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
 	public Object visitLabel(LitmusRISCVParser.LabelContext ctx) {
-		return programBuilder.addChild(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()));
+        Event event = programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText());
+		return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -217,7 +231,8 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
         Register r1 = programBuilder.getOrNewRegister(mainThread, ctx.register(0).getText(), archType);
         Register r2 = programBuilder.getOrNewRegister(mainThread, ctx.register(1).getText(), archType);
         Expression expr = expressions.makeIntCmp(r1, ctx.cond().op, r2);
-        return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label));
+        Event event = EventFactory.newJump(expr, label);
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
 	}
 
 	@Override
@@ -237,7 +252,7 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
             case "i" -> EventFactory.RISCV.newSynchronizeFence();
             default -> throw new ParsingException("Invalid fence mode " + mo);
         };
-		return programBuilder.addChild(mainThread, fence);
+		return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
 	}
 
 	@Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusRISCV.java
@@ -60,13 +60,13 @@ public class VisitorLitmusRISCV extends LitmusRISCVBaseVisitor<Object> {
     @Override
     public Object visitVariableDeclaratorRegister(LitmusRISCVParser.VariableDeclaratorRegisterContext ctx) {
         IntLiteral value = expressions.parseValue(ctx.constant().getText(), archType);
-        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), value);
+        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), value, ctx.getStart().getLine());
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegisterLocation(LitmusRISCVParser.VariableDeclaratorRegisterLocationContext ctx) {
-        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType);
+        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType, ctx.getStart().getLine());
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
@@ -188,7 +188,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             store.addTags(Tag.Vulkan.SEM_AVAILABLE);
         }
         store.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChild(mainThread, store);
+        return programBuilder.addChildWithMetadata(mainThread, store, ctx.getStart().getLine());
     }
 
     @Override
@@ -208,7 +208,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             load.addTags(Tag.Vulkan.SEM_VISIBLE);
         }
         load.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChild(mainThread, load);
+        return programBuilder.addChildWithMetadata(mainThread, load, ctx.getStart().getLine());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
@@ -151,7 +151,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             store.addTags(Tag.Vulkan.AVAILABLE);
             store.addTags(ctx.scope().content);
         }
-        return programBuilder.addChildWithSourceLocation(mainThread, store, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, store, ctx.getStart().getLine());
     }
 
     @Override
@@ -168,7 +168,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             load.addTags(Tag.Vulkan.VISIBLE);
             load.addTags(ctx.scope().content);
         }
-        return programBuilder.addChildWithSourceLocation(mainThread, load, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, load, ctx.getStart().getLine());
     }
 
     @Override
@@ -188,7 +188,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             store.addTags(Tag.Vulkan.SEM_AVAILABLE);
         }
         store.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChildWithSourceLocation(mainThread, store, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, store, ctx.getStart().getLine());
     }
 
     @Override
@@ -208,7 +208,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             load.addTags(Tag.Vulkan.SEM_VISIBLE);
         }
         load.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChildWithSourceLocation(mainThread, load, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, load, ctx.getStart().getLine());
     }
 
     @Override
@@ -233,7 +233,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             rmw.addTags(Tag.Vulkan.SEM_VISIBLE);
         }
         rmw.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChildWithSourceLocation(mainThread, rmw, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, rmw, ctx.getStart().getLine());
     }
 
     @Override
@@ -251,7 +251,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             fence.addTags(Tag.Vulkan.SEM_VISIBLE);
         }
         fence.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, fence, ctx.getStart().getLine());
     }
 
     @Override
@@ -283,7 +283,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             }
             barrier.addTags(ctx.semSc().stream().map(c -> c.content).toList());
         }
-        return programBuilder.addChildWithSourceLocation(mainThread, barrier, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, barrier, ctx.getStart().getLine());
     }
 
     @Override
@@ -292,18 +292,18 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeIntBinary(lhs, ctx.operation().op, rhs);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLabelInstruction(LitmusVulkanParser.LabelInstructionContext ctx) {
-        return programBuilder.addChildWithSourceLocation(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitJumpInstruction(LitmusVulkanParser.JumpInstructionContext ctx) {
         Label label = programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText());
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newGoto(label), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newGoto(label), ctx.getStart().getLine());
     }
 
     @Override
@@ -312,7 +312,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression expr = expressions.makeIntCmp(lhs, ctx.cond().op, rhs);
-        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newJump(expr, label), ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
@@ -325,7 +325,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
         } else {
             throw new ParsingException("Unknown device operation");
         }
-        return programBuilder.addChildWithSourceLocation(mainThread, e, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, e, ctx.getStart().getLine());
     }
 
     private String getMemoryOrderOrDefault(ParserRuleContext ctx, String defaultMo) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
@@ -188,7 +188,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             store.addTags(Tag.Vulkan.SEM_AVAILABLE);
         }
         store.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChildWithMetadata(mainThread, store, ctx.getStart().getLine());
+        return programBuilder.addChildWithSourceLocation(mainThread, store, ctx.getStart().getLine());
     }
 
     @Override
@@ -208,7 +208,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             load.addTags(Tag.Vulkan.SEM_VISIBLE);
         }
         load.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChildWithMetadata(mainThread, load, ctx.getStart().getLine());
+        return programBuilder.addChildWithSourceLocation(mainThread, load, ctx.getStart().getLine());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
@@ -151,7 +151,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             store.addTags(Tag.Vulkan.AVAILABLE);
             store.addTags(ctx.scope().content);
         }
-        return programBuilder.addChild(mainThread, store);
+        return programBuilder.addChildWithSourceLocation(mainThread, store, ctx.getStart().getLine());
     }
 
     @Override
@@ -168,7 +168,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             load.addTags(Tag.Vulkan.VISIBLE);
             load.addTags(ctx.scope().content);
         }
-        return programBuilder.addChild(mainThread, load);
+        return programBuilder.addChildWithSourceLocation(mainThread, load, ctx.getStart().getLine());
     }
 
     @Override
@@ -233,7 +233,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             rmw.addTags(Tag.Vulkan.SEM_VISIBLE);
         }
         rmw.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChild(mainThread, rmw);
+        return programBuilder.addChildWithSourceLocation(mainThread, rmw, ctx.getStart().getLine());
     }
 
     @Override
@@ -251,7 +251,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             fence.addTags(Tag.Vulkan.SEM_VISIBLE);
         }
         fence.addTags(ctx.semSc().stream().map(c -> c.content).toList());
-        return programBuilder.addChild(mainThread, fence);
+        return programBuilder.addChildWithSourceLocation(mainThread, fence, ctx.getStart().getLine());
     }
 
     @Override
@@ -283,7 +283,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
             }
             barrier.addTags(ctx.semSc().stream().map(c -> c.content).toList());
         }
-        return programBuilder.addChild(mainThread, barrier);
+        return programBuilder.addChildWithSourceLocation(mainThread, barrier, ctx.getStart().getLine());
     }
 
     @Override
@@ -292,18 +292,18 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression exp = expressions.makeIntBinary(lhs, ctx.operation().op, rhs);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(rd, exp));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newLocal(rd, exp), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLabelInstruction(LitmusVulkanParser.LabelInstructionContext ctx) {
-        return programBuilder.addChild(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()));
+        return programBuilder.addChildWithSourceLocation(mainThread, programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText()), ctx.getStart().getLine());
     }
 
     @Override
     public Object visitJumpInstruction(LitmusVulkanParser.JumpInstructionContext ctx) {
         Label label = programBuilder.getOrCreateLabel(mainThread, ctx.Label().getText());
-        return programBuilder.addChild(mainThread, EventFactory.newGoto(label));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newGoto(label), ctx.getStart().getLine());
     }
 
     @Override
@@ -312,7 +312,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
         Expression lhs = (Expression) ctx.value(0).accept(this);
         Expression rhs = (Expression) ctx.value(1).accept(this);
         Expression expr = expressions.makeIntCmp(lhs, ctx.cond().op, rhs);
-        return programBuilder.addChild(mainThread, EventFactory.newJump(expr, label));
+        return programBuilder.addChildWithSourceLocation(mainThread, EventFactory.newJump(expr, label), ctx.getStart().getLine());
     }
 
     @Override
@@ -325,7 +325,7 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
         } else {
             throw new ParsingException("Unknown device operation");
         }
-        return programBuilder.addChild(mainThread, e);
+        return programBuilder.addChildWithSourceLocation(mainThread, e, ctx.getStart().getLine());
     }
 
     private String getMemoryOrderOrDefault(ParserRuleContext ctx, String defaultMo) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusVulkan.java
@@ -63,13 +63,13 @@ public class VisitorLitmusVulkan extends LitmusVulkanBaseVisitor<Object> {
     @Override
     public Object visitVariableDeclaratorRegister(LitmusVulkanParser.VariableDeclaratorRegisterContext ctx) {
         programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(),
-                (IntLiteral) ctx.constant().accept(this));
+                (IntLiteral) ctx.constant().accept(this), ctx.getStart().getLine());
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegisterLocation(LitmusVulkanParser.VariableDeclaratorRegisterLocationContext ctx) {
-        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType);
+        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType, ctx.getStart().getLine());
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
@@ -105,7 +105,7 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
         Register register = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
         Event event = EventFactory.newLocal(register, constant);
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -113,7 +113,7 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
         Register register = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
         MemoryObject object = programBuilder.getOrNewMemoryObject(ctx.location().getText());
         Event event = EventFactory.newLoad(register, object);
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -121,7 +121,7 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
         MemoryObject object = programBuilder.getOrNewMemoryObject(ctx.location().getText());
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
         Event event = EventFactory.newStore(object, constant);
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -129,7 +129,7 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
         Register register = programBuilder.getOrErrorRegister(mainThread, ctx.register().getText());
         MemoryObject object = programBuilder.getOrNewMemoryObject(ctx.location().getText());
         Event event = EventFactory.newStore(object, register);
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -137,7 +137,7 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
         Register register = programBuilder.getOrErrorRegister(mainThread, ctx.register().getText());
         MemoryObject object = programBuilder.getOrNewMemoryObject(ctx.location().getText());
         Event event = EventFactory.X86.newExchange(object, register);
-        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+        return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -175,7 +175,7 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
         String name = ctx.getText().toLowerCase();
         if(fences.contains(name)) {
             Event event = EventFactory.newFence(name);
-            return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
+            return programBuilder.addChild(mainThread, event, ctx.getStart().getLine());
         }
         throw new ParsingException("Unrecognised fence " + name);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
@@ -12,6 +12,7 @@ import com.dat3m.dartagnan.parsers.program.utils.ProgramBuilder;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventFactory;
+import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.collect.ImmutableSet;
 
@@ -103,35 +104,40 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
     public Object visitLoadValueToRegister(LitmusX86Parser.LoadValueToRegisterContext ctx) {
         Register register = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newLocal(register, constant));
+        Event event = EventFactory.newLocal(register, constant);
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitLoadLocationToRegister(LitmusX86Parser.LoadLocationToRegisterContext ctx) {
         Register register = programBuilder.getOrNewRegister(mainThread, ctx.register().getText(), archType);
         MemoryObject object = programBuilder.getOrNewMemoryObject(ctx.location().getText());
-        return programBuilder.addChild(mainThread, EventFactory.newLoad(register, object));
+        Event event = EventFactory.newLoad(register, object);
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitStoreValueToLocation(LitmusX86Parser.StoreValueToLocationContext ctx) {
         MemoryObject object = programBuilder.getOrNewMemoryObject(ctx.location().getText());
         IntLiteral constant = expressions.parseValue(ctx.constant().getText(), archType);
-        return programBuilder.addChild(mainThread, EventFactory.newStore(object, constant));
+        Event event = EventFactory.newStore(object, constant);
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitStoreRegisterToLocation(LitmusX86Parser.StoreRegisterToLocationContext ctx) {
         Register register = programBuilder.getOrErrorRegister(mainThread, ctx.register().getText());
         MemoryObject object = programBuilder.getOrNewMemoryObject(ctx.location().getText());
-        return programBuilder.addChild(mainThread, EventFactory.newStore(object, register));
+        Event event = EventFactory.newStore(object, register);
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
     public Object visitExchangeRegisterLocation(LitmusX86Parser.ExchangeRegisterLocationContext ctx) {
         Register register = programBuilder.getOrErrorRegister(mainThread, ctx.register().getText());
         MemoryObject object = programBuilder.getOrNewMemoryObject(ctx.location().getText());
-        return programBuilder.addChild(mainThread, EventFactory.X86.newExchange(object, register));
+        Event event = EventFactory.X86.newExchange(object, register);
+        return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
     }
 
     @Override
@@ -168,7 +174,8 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
     public Object visitFence(LitmusX86Parser.FenceContext ctx) {
         String name = ctx.getText().toLowerCase();
         if(fences.contains(name)) {
-            return programBuilder.addChild(mainThread, EventFactory.newFence(name));
+            Event event = EventFactory.newFence(name);
+            return programBuilder.addChildWithSourceLocation(mainThread, event, ctx.getStart().getLine());
         }
         throw new ParsingException("Unrecognised fence " + name);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLitmusX86.java
@@ -58,13 +58,13 @@ public class VisitorLitmusX86 extends LitmusX86BaseVisitor<Object> {
     @Override
     public Object visitVariableDeclaratorRegister(LitmusX86Parser.VariableDeclaratorRegisterContext ctx) {
         IntLiteral value = expressions.parseValue(ctx.constant().getText(), archType);
-        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), value);
+        programBuilder.initRegEqConst(ctx.threadId().id, ctx.register().getText(), value, ctx.getStart().getLine());
         return null;
     }
 
     @Override
     public Object visitVariableDeclaratorRegisterLocation(LitmusX86Parser.VariableDeclaratorRegisterLocationContext ctx) {
-        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType);
+        programBuilder.initRegEqLocPtr(ctx.threadId().id, ctx.register().getText(), ctx.location().getText(), archType, ctx.getStart().getLine());
         return null;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/VisitorLlvm.java
@@ -314,7 +314,7 @@ public class VisitorLlvm extends LLVMIRBaseVisitor<Expression> {
                 // Field "line" is optional. When missing we assume value 0
                 final int lineNumber = diLocationNode.<MdGenericValue<BigInteger>>getField("line")
                         .orElse(new MdGenericValue<>(BigInteger.ZERO)).value().intValue();
-                metadata.add(new SourceLocation((directory + "/" + filename).intern(), lineNumber));
+                metadata.add(new SourceLocation.Generic((directory + "/" + filename).intern(), lineNumber));
             }
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/spirv/VisitorOpsDebug.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/visitors/spirv/VisitorOpsDebug.java
@@ -30,7 +30,7 @@ public class VisitorOpsDebug extends SpirvBaseVisitor<Void> {
     public Void visitOpLine(SpirvParser.OpLineContext ctx) {
         String file = builder.getDebugInfo(ctx.file().getText());
         int line = Integer.parseInt(ctx.line().getText());
-        SourceLocation loc = new SourceLocation(file, line);
+        SourceLocation loc = new SourceLocation.Generic(file, line);
         cfBuilder.setCurrentLocation(loc);
         return null;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.core.annotations.FunCallMarker;
 import com.dat3m.dartagnan.program.event.core.annotations.FunReturnMarker;
 import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
+import com.dat3m.dartagnan.program.event.metadata.LineNumber;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -132,13 +133,11 @@ public class SyntacticContextAnalysis {
     public String getSourceLocationWithContext(Event e, boolean addGlobalId) {
         final StringBuilder builder = new StringBuilder();
         final String ctx = makeContextString(this.getContextInfo(e).getContextStack(), " -> ");
-        if (addGlobalId) {
-            builder.append("E").append(e.getGlobalId()).append(": \t");
-        }
-        builder
-                .append(ctx.isEmpty() ? ctx : ctx + " -> ")
+        builder.append(ctx.isEmpty() ? ctx : ctx + " -> ")
                 .append(getSourceLocationString(e));
-
+        if (addGlobalId) {
+            builder.append("\t(E").append(e.getGlobalId()).append(")");
+        }
         return builder.toString();
     }
 
@@ -220,6 +219,13 @@ public class SyntacticContextAnalysis {
     public static String getSourceLocationString(Event ev) {
         SourceLocation loc = ev.getMetadata(SourceLocation.class);
         return loc != null ? String.format("@%s#%s", loc.getSourceCodeFileName(), loc.lineNumber()) : "@unknown";
+    }
+
+    public static String getLitmusLocationString(Event ev, boolean showThread) {
+        final String prefix = showThread ? ev.getThread().getName() : "";
+        return ev.hasMetadata(LineNumber.class) ?
+            String.format("%s#%s", prefix, ev.getMetadata(LineNumber.class).lineNumber()) :
+            "@unknown";
     }
 
     public static <T extends Context> String makeContextString(Iterable<T> contextStack, String separator) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
@@ -218,7 +218,7 @@ public class SyntacticContextAnalysis {
     public static String getSourceLocationString(Event ev) {
         final SourceLocation loc = ev.getMetadata(SourceLocation.class);
         final String prefix = ev.getThread().getName();
-        return String.format("@%s%s", prefix, loc != null ? loc : "unknown");
+        return String.format("@%s%s", prefix, loc != null ? loc : "#unknown");
     }
 
     public static <T extends Context> String makeContextString(Iterable<T> contextStack, String separator) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
@@ -217,7 +217,8 @@ public class SyntacticContextAnalysis {
 
     public static String getSourceLocationString(Event ev) {
         final SourceLocation loc = ev.getMetadata(SourceLocation.class);
-        final String prefix = ev.getThread().getName();
+        // We generate the thread prefix only for litmus for now
+        final String prefix = loc instanceof SourceLocation.Litmus ? ev.getThread().getName() : "";
         return String.format("@%s%s", prefix, loc != null ? loc : "#unknown");
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
@@ -217,9 +217,7 @@ public class SyntacticContextAnalysis {
 
     public static String getSourceLocationString(Event ev) {
         final SourceLocation loc = ev.getMetadata(SourceLocation.class);
-        // We generate the thread prefix only for litmus for now
-        final String prefix = loc instanceof SourceLocation.Litmus ? ev.getThread().getName() : "";
-        return String.format("@%s%s", prefix, loc != null ? loc : "#unknown");
+        return String.format("@%s", loc != null ? loc : "#unknown");
     }
 
     public static <T extends Context> String makeContextString(Iterable<T> contextStack, String separator) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
@@ -216,13 +216,8 @@ public class SyntacticContextAnalysis {
     // ============================================================================
 
     public static String getSourceLocationString(Event ev) {
-        return getSourceLocationString(ev, false);
-    }
-
-    public static String getSourceLocationString(Event ev, boolean showThread) {
         final SourceLocation loc = ev.getMetadata(SourceLocation.class);
-        // We generate the thread prefix only for litmus for now
-        final String prefix = (showThread && loc instanceof SourceLocation.Litmus) ? ev.getThread().getName() : "";
+        final String prefix = ev.getThread().getName();
         return String.format("@%s%s", prefix, loc != null ? loc : "unknown");
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
@@ -217,7 +217,7 @@ public class SyntacticContextAnalysis {
 
     public static String getSourceLocationString(Event ev) {
         final SourceLocation loc = ev.getMetadata(SourceLocation.class);
-        return String.format("@%s", loc != null ? loc : "#unknown");
+        return String.format("@%s", loc != null ? loc : "unknown");
     }
 
     public static <T extends Context> String makeContextString(Iterable<T> contextStack, String separator) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/SyntacticContextAnalysis.java
@@ -5,9 +5,8 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.core.annotations.FunCallMarker;
 import com.dat3m.dartagnan.program.event.core.annotations.FunReturnMarker;
-import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
-import com.dat3m.dartagnan.program.event.metadata.LineNumber;
 
+import com.dat3m.dartagnan.program.event.metadata.SourceLocation;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
@@ -217,15 +216,14 @@ public class SyntacticContextAnalysis {
     // ============================================================================
 
     public static String getSourceLocationString(Event ev) {
-        SourceLocation loc = ev.getMetadata(SourceLocation.class);
-        return loc != null ? String.format("@%s#%s", loc.getSourceCodeFileName(), loc.lineNumber()) : "@unknown";
+        return getSourceLocationString(ev, false);
     }
 
-    public static String getLitmusLocationString(Event ev, boolean showThread) {
-        final String prefix = showThread ? ev.getThread().getName() : "";
-        return ev.hasMetadata(LineNumber.class) ?
-            String.format("%s#%s", prefix, ev.getMetadata(LineNumber.class).lineNumber()) :
-            "@unknown";
+    public static String getSourceLocationString(Event ev, boolean showThread) {
+        final SourceLocation loc = ev.getMetadata(SourceLocation.class);
+        // We generate the thread prefix only for litmus for now
+        final String prefix = (showThread && loc instanceof SourceLocation.Litmus) ? ev.getThread().getName() : "";
+        return String.format("@%s%s", prefix, loc != null ? loc : "unknown");
     }
 
     public static <T extends Context> String makeContextString(Iterable<T> contextStack, String separator) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/DebugInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/DebugInfo.java
@@ -1,0 +1,3 @@
+package com.dat3m.dartagnan.program.event.metadata;
+
+sealed interface DebugInfo extends Metadata permits SourceLocation, LineNumber {}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/DebugInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/DebugInfo.java
@@ -1,3 +1,0 @@
-package com.dat3m.dartagnan.program.event.metadata;
-
-sealed interface DebugInfo extends Metadata permits SourceLocation, LineNumber {}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/LineNumber.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/LineNumber.java
@@ -1,0 +1,3 @@
+package com.dat3m.dartagnan.program.event.metadata;
+
+public record LineNumber(int lineNumber) implements DebugInfo {}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/LineNumber.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/LineNumber.java
@@ -1,3 +1,0 @@
-package com.dat3m.dartagnan.program.event.metadata;
-
-public record LineNumber(int lineNumber) implements DebugInfo {}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/MetadataMap.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/MetadataMap.java
@@ -11,7 +11,7 @@ public class MetadataMap {
     private final List<Metadata> metadataList = new ArrayList<>();
 
     public boolean contains(Class<? extends Metadata> metadataClass) {
-        return metadataList.stream().anyMatch(m -> m.getClass() == metadataClass);
+        return metadataList.stream().anyMatch(m -> metadataClass.isAssignableFrom(m.getClass()));
     }
 
     @SuppressWarnings("unchecked") // The class guarantees that the unchecked cast is valid.

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/SourceLocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/SourceLocation.java
@@ -4,13 +4,13 @@ public sealed interface SourceLocation extends Metadata {
 
     int getLineNumber();
 
-    record Litmus(int lineNumber) implements SourceLocation {
+    record Litmus(String threadName, int lineNumber) implements SourceLocation {
         @Override
         public int getLineNumber() { return lineNumber; }
 
         @Override
         public String toString() {
-            return "#" + lineNumber;
+            return threadName + "#" + lineNumber;
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/SourceLocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/SourceLocation.java
@@ -3,7 +3,7 @@ package com.dat3m.dartagnan.program.event.metadata;
 import java.util.Collection;
 import java.util.List;
 
-public record SourceLocation(String sourceCodeFilePath, int lineNumber) implements Metadata {
+public record SourceLocation(String sourceCodeFilePath, int lineNumber) implements DebugInfo {
 
     public String getSourceCodeFileName() {
         return getSourceCodeFileName(sourceCodeFilePath);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/SourceLocation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/metadata/SourceLocation.java
@@ -1,25 +1,31 @@
 package com.dat3m.dartagnan.program.event.metadata;
 
-import java.util.Collection;
-import java.util.List;
+public sealed interface SourceLocation extends Metadata {
 
-public record SourceLocation(String sourceCodeFilePath, int lineNumber) implements DebugInfo {
+    int getLineNumber();
 
-    public String getSourceCodeFileName() {
-        return getSourceCodeFileName(sourceCodeFilePath);
+    record Litmus(int lineNumber) implements SourceLocation {
+        @Override
+        public int getLineNumber() { return lineNumber; }
+
+        @Override
+        public String toString() {
+            return "#" + lineNumber;
+        }
     }
 
-    public static String getSourceCodeFileName(String path) {
-        return path.contains("/") ? path.substring(path.lastIndexOf("/") + 1) : path;
-    }
+    record Generic(String sourceCodeFilePath, int lineNumber) implements SourceLocation {
+        @Override
+        public int getLineNumber() { return lineNumber; }
 
-    public static String toString(String sourceCodeFilePath, Collection<Integer> lineNumbers) {
-        final Object numbers = lineNumbers.size() != 1 ? lineNumbers : lineNumbers.iterator().next();
-        return "@" + getSourceCodeFileName(sourceCodeFilePath) + "#" + numbers;
-    }
+        public String getSourceCodeFileName() {
+            final String path = sourceCodeFilePath;
+            return path.contains("/") ? path.substring(path.lastIndexOf("/") + 1) : path;
+        }
 
-    @Override
-    public String toString() {
-        return toString(sourceCodeFilePath, List.of(lineNumber));
+        @Override
+        public String toString() {
+            return getSourceCodeFileName() + "#" + lineNumber;
+        }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessBuilder.java
@@ -149,7 +149,7 @@ public class WitnessBuilder {
                 }
             }
 
-            int cLine = e.hasMetadata(SourceLocation.class) ? e.getMetadata(SourceLocation.class).lineNumber() : -1;
+            int cLine = e.hasMetadata(SourceLocation.class) ? e.getMetadata(SourceLocation.class).getLineNumber() : -1;
             edge = new Edge(new Node("N" + nextNode), new Node("N" + (nextNode + 1)));
             edge.addAttribute(THREADID.toString(), valueOf(eventThreadMap.get(e)));
             edge.addAttribute(STARTLINE.toString(), valueOf(cLine));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessGraph.java
@@ -108,7 +108,7 @@ public class WitnessGraph extends ElemWithAttributes {
         return edge.hasCline() ?
             program.getThreadEvents(MemoryCoreEvent.class).stream()
                 .filter(e -> e.hasMetadata(SourceLocation.class))
-                .filter(e -> e.getMetadata(SourceLocation.class).lineNumber() == edge.getCline())
+                .filter(e -> e.getMetadata(SourceLocation.class).getLineNumber() == edge.getCline())
                 .toList() :
             Collections.emptyList();
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.event.core.Init;
 import com.dat3m.dartagnan.program.event.core.InstructionBoundary;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
+import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.verification.model.*;
 import com.dat3m.dartagnan.verification.model.RelationModel.EdgeModel;
@@ -332,6 +333,7 @@ public class ExecutionGraphVisualizer {
             tag = String.format("Assertion(%s)", am.getResult());
         }
         final Thread thread = e.getThreadModel().getThread();
+        final boolean isLitmus = thread.getProgram().getFormat().equals(SourceLanguage.LITMUS);
         final String callStack = makeContextString(
             synContext.getContextInfo(e.getEvent()).getContextOfType(CallContext.class), " -> \\n");
         final String scope = thread.hasScope() ? "@" + thread.getScopeHierarchy() : "";
@@ -341,7 +343,7 @@ public class ExecutionGraphVisualizer {
                 scope,
                 e.getEvent().getGlobalId(),
                 callStack.isEmpty() ? callStack : callStack + " -> \\n",
-                getSourceLocationString(e.getEvent()),
+                isLitmus ? getLitmusLocationString(e.getEvent(), false) : getSourceLocationString(e.getEvent()),
                 tag)
                 .replace("%", "\\%")
                 .replace("\"", "\\\""); // We need to escape quotes inside the string

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -333,7 +333,6 @@ public class ExecutionGraphVisualizer {
             tag = String.format("Assertion(%s)", am.getResult());
         }
         final Thread thread = e.getThreadModel().getThread();
-        final boolean isLitmus = thread.getProgram().getFormat().equals(SourceLanguage.LITMUS);
         final String callStack = makeContextString(
             synContext.getContextInfo(e.getEvent()).getContextOfType(CallContext.class), " -> \\n");
         final String scope = thread.hasScope() ? "@" + thread.getScopeHierarchy() : "";
@@ -343,7 +342,7 @@ public class ExecutionGraphVisualizer {
                 scope,
                 e.getEvent().getGlobalId(),
                 callStack.isEmpty() ? callStack : callStack + " -> \\n",
-                isLitmus ? getLitmusLocationString(e.getEvent(), false) : getSourceLocationString(e.getEvent()),
+                getSourceLocationString(e.getEvent()),
                 tag)
                 .replace("%", "\\%")
                 .replace("\"", "\\\""); // We need to escape quotes inside the string

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/exceptions/ExceptionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/exceptions/ExceptionsTest.java
@@ -33,7 +33,7 @@ public class ExceptionsTest {
     public void noThread() {
         ProgramBuilder pb = ProgramBuilder.forLanguage(SourceLanguage.LITMUS);
         // Thread 1 does not exist
-        pb.addChild(1, new Skip());
+        pb.addChildWithoutSourceLoc(1, new Skip());
     }
 
     @Test(expected = MalformedProgramException.class)

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/AnalysisTest.java
@@ -81,23 +81,23 @@ public class AnalysisTest {
         Register r1 = b.getOrNewRegister(0, "r1");
         Register r2 = b.getOrNewRegister(0, "r2");
         Label alt = b.getOrCreateLabel(0, "alt");
-        b.addChild(0, newJump(b.newConstant(types.getBooleanType()), alt));
+        b.addChildWithoutSourceLoc(0, newJump(b.newConstant(types.getBooleanType()), alt));
         Local e0 = newLocal(r0, value(1));
-        b.addChild(0, e0);
+        b.addChildWithoutSourceLoc(0, e0);
         Local e1 = newLocal(r1, r0);
-        b.addChild(0, e1);
+        b.addChildWithoutSourceLoc(0, e1);
         Label join = b.getOrCreateLabel(0, "join");
-        b.addChild(0, newGoto(join));
-        b.addChild(0, alt);
+        b.addChildWithoutSourceLoc(0, newGoto(join));
+        b.addChildWithoutSourceLoc(0, alt);
         Local e2 = newLocal(r1, value(2));
-        b.addChild(0, e2);
-        b.addChild(0, join);
+        b.addChildWithoutSourceLoc(0, e2);
+        b.addChildWithoutSourceLoc(0, join);
         Local e3 = newLocal(r2, r0);
-        b.addChild(0, e3);
+        b.addChildWithoutSourceLoc(0, e3);
         Local e4 = newLocal(r2, r1);
-        b.addChild(0, e4);
+        b.addChildWithoutSourceLoc(0, e4);
         Local e5 = newLocal(r0, r2);
-        b.addChild(0, e5);
+        b.addChildWithoutSourceLoc(0, e5);
 
         Program program = b.build();
         Compilation.newInstance().run(program);
@@ -140,69 +140,69 @@ public class AnalysisTest {
         Register r3 = b.getOrNewRegister(0, "r3");
         //  if * {
         Label skip0 = b.getOrCreateLabel(0, "skip0");
-        b.addChild(0, newJump(b.newConstant(types.getBooleanType()), skip0));
+        b.addChildWithoutSourceLoc(0, newJump(b.newConstant(types.getBooleanType()), skip0));
         //      r0 = r0
         Local r00 = newLocal(r0, r0);
-        b.addChild(0, r00);
+        b.addChildWithoutSourceLoc(0, r00);
         //  }
-        b.addChild(0, skip0);
+        b.addChildWithoutSourceLoc(0, skip0);
         //  r1 = r0
         Local r10 = newLocal(r1, r0);
-        b.addChild(0, r10);
+        b.addChildWithoutSourceLoc(0, r10);
         //  r2 = r0
         Local r20 = newLocal(r2, r0);
-        b.addChild(0, r20);
+        b.addChildWithoutSourceLoc(0, r20);
         //  r3 = 0
         Local r30 = newLocal(r3, expressions.makeZero(types.getArchType()));
-        b.addChild(0, r30);
+        b.addChildWithoutSourceLoc(0, r30);
         //  do {
         Label begin = b.getOrCreateLabel(0, "begin");
-        b.addChild(0, begin);
+        b.addChildWithoutSourceLoc(0, begin);
         //      if * {
         Label skip1 = b.getOrCreateLabel(0, "skip1");
-        b.addChild(0, newJump(b.newConstant(types.getBooleanType()), skip1));
+        b.addChildWithoutSourceLoc(0, newJump(b.newConstant(types.getBooleanType()), skip1));
         //          r0 = r1
         Local r01 = newLocal(r0, r1);
-        b.addChild(0, r01);
+        b.addChildWithoutSourceLoc(0, r01);
         //          r1 = r1
         Local r11 = newLocal(r1, r1);
-        b.addChild(0, r11);
+        b.addChildWithoutSourceLoc(0, r11);
         //          r2 = r1
         Local r21 = newLocal(r2, r1);
-        b.addChild(0, r21);
+        b.addChildWithoutSourceLoc(0, r21);
         //      }
-        b.addChild(0, skip1);
+        b.addChildWithoutSourceLoc(0, skip1);
         //      r3 = r1
         Local r31 = newLocal(r3, r1);
-        b.addChild(0, r31);
+        b.addChildWithoutSourceLoc(0, r31);
         //  } while *
-        b.addChild(0, newJump(b.newConstant(types.getBooleanType()), begin));
+        b.addChildWithoutSourceLoc(0, newJump(b.newConstant(types.getBooleanType()), begin));
         //  if * {
         Label skip2 = b.getOrCreateLabel(0, "skip2");
-        b.addChild(0, newJump(b.newConstant(types.getBooleanType()), skip2));
+        b.addChildWithoutSourceLoc(0, newJump(b.newConstant(types.getBooleanType()), skip2));
         //      r0 = r2
         Local r02 = newLocal(r0, r2);
-        b.addChild(0, r02);
+        b.addChildWithoutSourceLoc(0, r02);
         //      r1 = r2
         Local r12 = newLocal(r1, r2);
-        b.addChild(0, r12);
+        b.addChildWithoutSourceLoc(0, r12);
         //  }
-        b.addChild(0, skip2);
+        b.addChildWithoutSourceLoc(0, skip2);
         //  r2 = r2
         Local r22 = newLocal(r2, r2);
-        b.addChild(0, r22);
+        b.addChildWithoutSourceLoc(0, r22);
         //  if * {
         Label skip3 = b.getOrCreateLabel(0, "skip3");
-        b.addChild(0, newJump(b.newConstant(types.getBooleanType()), skip3));
+        b.addChildWithoutSourceLoc(0, newJump(b.newConstant(types.getBooleanType()), skip3));
         //      r3 = r2
         Local r32 = newLocal(r3, r2);
-        b.addChild(0, r32);
+        b.addChildWithoutSourceLoc(0, r32);
         //  }
-        b.addChild(0, skip3);
+        b.addChildWithoutSourceLoc(0, skip3);
         //  return (r0 + r1) ^ (r2 | r3)
         Return ret = newFunctionReturn(
                 expressions.makeIntXor(expressions.makeAdd(r0, r1), expressions.makeIntOr(r2, r3)));
-        b.addChild(0, ret);
+        b.addChildWithoutSourceLoc(0, ret);
 
         Program program = b.build();
         Configuration config = Configuration.builder()
@@ -268,15 +268,15 @@ public class AnalysisTest {
         b.newThread(0);
         Register r0 = b.getOrNewRegister(0, "r0");
         //In C11, this is well-defined: ((uint64_t*) ((uintptr_t) x * 1))
-        b.addChild(0, newLocal(r0, mult(x, 1)));
+        b.addChildWithoutSourceLoc(0, newLocal(r0, mult(x, 1)));
         Store e0 = newStore(r0);
-        b.addChild(0, e0);
+        b.addChildWithoutSourceLoc(0, e0);
         Store e1 = newStore(plus(r0, 8));
-        b.addChild(0, e1);
+        b.addChildWithoutSourceLoc(0, e1);
         Store e2 = newStore(x);
-        b.addChild(0, e2);
+        b.addChildWithoutSourceLoc(0, e2);
         Store e3 = newStore(y);
-        b.addChild(0, e3);
+        b.addChildWithoutSourceLoc(0, e3);
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
@@ -315,14 +315,14 @@ public class AnalysisTest {
 
         b.newThread(0);
         Store e0 = newStore(plus(x, 8));
-        b.addChild(0, e0);
+        b.addChildWithoutSourceLoc(0, e0);
         Register r0 = b.getOrNewRegister(0, "r0");
         Load e1 = newLoad(r0, x);
-        b.addChild(0, e1);
+        b.addChildWithoutSourceLoc(0, e1);
         Store e2 = newStore(r0);
-        b.addChild(0, e2);
+        b.addChildWithoutSourceLoc(0, e2);
         Store e3 = newStore(plus(r0, 8), r0);
-        b.addChild(0, e3);
+        b.addChildWithoutSourceLoc(0, e3);
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
@@ -361,24 +361,24 @@ public class AnalysisTest {
 
         b.newThread(0);
         Register r0 = b.getOrNewRegister(0, "r0");
-        b.addChild(0, newLocal(r0, b.newConstant(type)));
+        b.addChildWithoutSourceLoc(0, newLocal(r0, b.newConstant(type)));
         Label l0 = b.getOrCreateLabel(0,"l0");
-        b.addChild(0, newJump(expressions.makeOr(
+        b.addChildWithoutSourceLoc(0, newJump(expressions.makeOr(
                 expressions.makeGT(r0, expressions.makeOne(type), true),
                 expressions.makeLT(r0, expressions.makeZero(type), true)), l0));
         Store e0 = newStore(x);
-        b.addChild(0, e0);
+        b.addChildWithoutSourceLoc(0, e0);
         Store e1 = newStore(plus(x, 8));
-        b.addChild(0, e1);
+        b.addChildWithoutSourceLoc(0, e1);
         Store e2 = newStore(plus(x, 16));
-        b.addChild(0, e2);
+        b.addChildWithoutSourceLoc(0, e2);
         Register r1 = b.getOrNewRegister(0, "r1");
-        b.addChild(0, newLocal(r1, expressions.makeZero(type)));
+        b.addChildWithoutSourceLoc(0, newLocal(r1, expressions.makeZero(type)));
         Store e3 = newStore(expressions.makeAdd(
                 expressions.makeAdd(x, mult(r0, 16)),
                 mult(r1, 32)));
-        b.addChild(0, e3);
-        b.addChild(0, l0);
+        b.addChildWithoutSourceLoc(0, e3);
+        b.addChildWithoutSourceLoc(0, l0);
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
@@ -418,13 +418,13 @@ public class AnalysisTest {
         b.newThread(0);
         Register r0 = b.getOrNewRegister(0, "r0");
         Load e0 = newLoad(r0, x);
-        b.addChild(0, e0);
+        b.addChildWithoutSourceLoc(0, e0);
         Store e1 = newStore(x, plus(r0, 8));
-        b.addChild(0, e1);
+        b.addChildWithoutSourceLoc(0, e1);
         Store e2 = newStore(plus(x, 16));
-        b.addChild(0, e2);
+        b.addChildWithoutSourceLoc(0, e2);
         Store e3 = newStore(r0);
-        b.addChild(0, e3);
+        b.addChildWithoutSourceLoc(0, e3);
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
@@ -464,16 +464,16 @@ public class AnalysisTest {
 
         b.newThread(0);
         Register r0 = b.getOrNewRegister(0, "r0");
-        b.addChild(0, newLocal(r0, mult(x, 0)));
-        b.addChild(0, newLocal(r0, y));
+        b.addChildWithoutSourceLoc(0, newLocal(r0, mult(x, 0)));
+        b.addChildWithoutSourceLoc(0, newLocal(r0, y));
         Store e0 = newStore(r0);
-        b.addChild(0, e0);
+        b.addChildWithoutSourceLoc(0, e0);
         Store e1 = newStore(x);
-        b.addChild(0, e1);
+        b.addChildWithoutSourceLoc(0, e1);
         Store e2 = newStore(y);
-        b.addChild(0, e2);
+        b.addChildWithoutSourceLoc(0, e2);
         Store e3 = newStore(z);
-        b.addChild(0, e3);
+        b.addChildWithoutSourceLoc(0, e3);
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
@@ -513,16 +513,16 @@ public class AnalysisTest {
 
         b.newThread(0);
         Register r0 = b.getOrNewRegister(0, "r0");
-        b.addChild(0, newLocal(r0, y));
+        b.addChildWithoutSourceLoc(0, newLocal(r0, y));
         Store e0 = newStore(r0);
-        b.addChild(0, e0);
-        b.addChild(0, newLocal(r0, mult(x, 0)));
+        b.addChildWithoutSourceLoc(0, e0);
+        b.addChildWithoutSourceLoc(0, newLocal(r0, mult(x, 0)));
         Store e1 = newStore(x);
-        b.addChild(0, e1);
+        b.addChildWithoutSourceLoc(0, e1);
         Store e2 = newStore(y);
-        b.addChild(0, e2);
+        b.addChildWithoutSourceLoc(0, e2);
         Store e3 = newStore(z);
-        b.addChild(0, e3);
+        b.addChildWithoutSourceLoc(0, e3);
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, method);
@@ -553,15 +553,15 @@ public class AnalysisTest {
         Register r2 = b.getOrNewRegister(0, "r2");
         Register r3 = b.getOrNewRegister(0, "r3");
         Load e0 = newLoad(r0, y); // reads x
-        b.addChild(0, e0);
+        b.addChildWithoutSourceLoc(0, e0);
         Load e1 = newLoad(r1, r0); // reads y
-        b.addChild(0, e1);
+        b.addChildWithoutSourceLoc(0, e1);
         Load e2 = newLoad(r2, r1); // reads x
-        b.addChild(0, e2);
+        b.addChildWithoutSourceLoc(0, e2);
         Load e3 = newLoad(r3, r2); // reads y
-        b.addChild(0, e3);
+        b.addChildWithoutSourceLoc(0, e3);
         Store e4 = newStore(y, r3); // stores y
-        b.addChild(0, e4);
+        b.addChildWithoutSourceLoc(0, e4);
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, FULL);
@@ -591,18 +591,18 @@ public class AnalysisTest {
         Register r1 = b.getOrNewRegister(0, "r1");
         Register r2 = b.getOrNewRegister(0, "r2");
         Load e0 = newLoad(r0, y); // reads x
-        b.addChild(0, e0);
+        b.addChildWithoutSourceLoc(0, e0);
         Label l0 = newLabel("l0");
-        b.addChild(0, newJump(expressions.makeEQ(r0, x), l0));
+        b.addChildWithoutSourceLoc(0, newJump(expressions.makeEQ(r0, x), l0));
         Load e1 = newLoad(r0, x); // reads y
-        b.addChild(0, e1);
-        b.addChild(0, l0);
+        b.addChildWithoutSourceLoc(0, e1);
+        b.addChildWithoutSourceLoc(0, l0);
         Load e2 = newLoad(r1, r0); // reads x
-        b.addChild(0, e2);
+        b.addChildWithoutSourceLoc(0, e2);
         Load e3 = newLoad(r2, r1); // reads y
-        b.addChild(0, e3);
+        b.addChildWithoutSourceLoc(0, e3);
         Store e4 = newStore(r0, r2); // stores y
-        b.addChild(0, e4);
+        b.addChildWithoutSourceLoc(0, e4);
 
         Program program = b.build();
         AliasAnalysis a = analyze(program, FULL);
@@ -741,8 +741,8 @@ public class AnalysisTest {
             for (int offset = 0; offset < 9; offset++) {
                 final MemoryObject x = b.getOrNewMemoryObject(String.format("x%d:%d", i, offset), OBJECT_SIZE);
                 final Expression address = expressions.makeAdd(x, expressions.makeValue(offset, pointerType));
-                b.addChild(0, newLoad(r, x));
-                b.addChild(0, newLoad(s, address));
+                b.addChildWithoutSourceLoc(0, newLoad(r, x));
+                b.addChildWithoutSourceLoc(0, newLoad(s, address));
                 if (0 < offset && offset < rBytes) {
                     exp.append(offset);
                 }
@@ -800,9 +800,9 @@ public class AnalysisTest {
         IntegerType u32 = types.getIntegerType(32);
         IntegerType u64 = types.getIntegerType(64);
         Register r64 = b.getOrNewRegister(0, "r64", u64);
-        b.addChild(0, newRMWLoadExclusive(r64, x));
-        b.addChild(0, newRMWStoreExclusive(x, expressions.makeValue(0, u64), true));
-        b.addChild(1, newStore(x, expressions.makeValue(0, u32)));
+        b.addChildWithoutSourceLoc(0, newRMWLoadExclusive(r64, x));
+        b.addChildWithoutSourceLoc(0, newRMWStoreExclusive(x, expressions.makeValue(0, u64), true));
+        b.addChildWithoutSourceLoc(1, newStore(x, expressions.makeValue(0, u32)));
 
         Program program = b.build();
         Wmm wmm = new Wmm();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/IntervalAnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/IntervalAnalysisTest.java
@@ -70,10 +70,10 @@ public class IntervalAnalysisTest {
         Local assignment2 = new Local(r2, expressions.makeValue(7, type));
         Label exit = b.getOrCreateLabel(0, "exit");
 
-        b.addChild(0, assignment0);
-        b.addChild(0, assignment1);
-        b.addChild(0, assignment2);
-        b.addChild(0, exit);
+        b.addChildWithoutSourceLoc(0, assignment0);
+        b.addChildWithoutSourceLoc(0, assignment1);
+        b.addChildWithoutSourceLoc(0, assignment2);
+        b.addChildWithoutSourceLoc(0, exit);
 
         Program p = b.build();
         IntervalAnalysis analysis = runIntervalAnalysis(p, IntervalAnalysisMethod.LOCAL);
@@ -109,14 +109,14 @@ public class IntervalAnalysisTest {
         Local assignment0 = new Local(r0, expressions.makeZero(type));
         Local assignment1 = new Local(r0, expressions.makeValue(42, type));
 
-        b.addChild(0, jump);
-        b.addChild(0, assignment0);
-        b.addChild(0, goto1);
-        b.addChild(0, trueb);
-        b.addChild(0, assignment1);
-        b.addChild(0, goto2);
-        b.addChild(0, join);
-        b.addChild(0, exit);
+        b.addChildWithoutSourceLoc(0, jump);
+        b.addChildWithoutSourceLoc(0, assignment0);
+        b.addChildWithoutSourceLoc(0, goto1);
+        b.addChildWithoutSourceLoc(0, trueb);
+        b.addChildWithoutSourceLoc(0, assignment1);
+        b.addChildWithoutSourceLoc(0, goto2);
+        b.addChildWithoutSourceLoc(0, join);
+        b.addChildWithoutSourceLoc(0, exit);
 
         Program p = b.build();
 
@@ -146,18 +146,18 @@ public class IntervalAnalysisTest {
         Local assignment1 = new Local(r0, expressions.makeValue(42, type));
         Local assignment2 = new Local(r0, expressions.makeValue(7, type));
 
-        b.addChild(0, jump1);
-        b.addChild(0, jump2);
-        b.addChild(0, assignment0);
-        b.addChild(0, goto1);
-        b.addChild(0, branch1);
-        b.addChild(0, assignment1);
-        b.addChild(0, goto2);
-        b.addChild(0, branch2);
-        b.addChild(0, assignment2);
-        b.addChild(0, goto3);
-        b.addChild(0, join);
-        b.addChild(0, exit);
+        b.addChildWithoutSourceLoc(0, jump1);
+        b.addChildWithoutSourceLoc(0, jump2);
+        b.addChildWithoutSourceLoc(0, assignment0);
+        b.addChildWithoutSourceLoc(0, goto1);
+        b.addChildWithoutSourceLoc(0, branch1);
+        b.addChildWithoutSourceLoc(0, assignment1);
+        b.addChildWithoutSourceLoc(0, goto2);
+        b.addChildWithoutSourceLoc(0, branch2);
+        b.addChildWithoutSourceLoc(0, assignment2);
+        b.addChildWithoutSourceLoc(0, goto3);
+        b.addChildWithoutSourceLoc(0, join);
+        b.addChildWithoutSourceLoc(0, exit);
 
         Program p = b.build();
         IntervalAnalysis analysis = runIntervalAnalysis(p, IntervalAnalysisMethod.LOCAL);
@@ -180,10 +180,10 @@ public class IntervalAnalysisTest {
 
         Label exit = b.getOrCreateLabel(0, "exit");
 
-        b.addChild(0, loc1);
-        b.addChild(0, loc2);
-        b.addChild(0, loc3);
-        b.addChild(0, exit);
+        b.addChildWithoutSourceLoc(0, loc1);
+        b.addChildWithoutSourceLoc(0, loc2);
+        b.addChildWithoutSourceLoc(0, loc3);
+        b.addChildWithoutSourceLoc(0, exit);
 
         Program p = b.build();
         IntervalAnalysis analysis = runIntervalAnalysis(p, IntervalAnalysisMethod.LOCAL);
@@ -205,10 +205,10 @@ public class IntervalAnalysisTest {
         Local loc3 = newLocal(r1, expressions.makeAdd(r0, r0));
         Label exit = b.getOrCreateLabel(0, "exit");
 
-        b.addChild(0, loc1);
-        b.addChild(0, loc2);
-        b.addChild(0, loc3);
-        b.addChild(0, exit);
+        b.addChildWithoutSourceLoc(0, loc1);
+        b.addChildWithoutSourceLoc(0, loc2);
+        b.addChildWithoutSourceLoc(0, loc3);
+        b.addChildWithoutSourceLoc(0, exit);
 
         Program p = b.build();
         IntervalAnalysis analysis = runIntervalAnalysis(p, IntervalAnalysisMethod.LOCAL);
@@ -231,10 +231,10 @@ public class IntervalAnalysisTest {
         Local loc3 = newLocal(r1, expressions.makeAdd(r0, r1));
         Label exit = b.getOrCreateLabel(0, "exit");
 
-        b.addChild(0, loc1);
-        b.addChild(0, loc2);
-        b.addChild(0, loc3);
-        b.addChild(0, exit);
+        b.addChildWithoutSourceLoc(0, loc1);
+        b.addChildWithoutSourceLoc(0, loc2);
+        b.addChildWithoutSourceLoc(0, loc3);
+        b.addChildWithoutSourceLoc(0, exit);
 
         Program p = b.build();
         IntervalAnalysis analysis = runIntervalAnalysis(p, IntervalAnalysisMethod.LOCAL);
@@ -259,10 +259,10 @@ public class IntervalAnalysisTest {
         Local loc3 = newLocal(r2, expressions.makeIntegerCast(r0, intType, true));
         Label exit = b.getOrCreateLabel(0, "exit");
 
-        b.addChild(0, loc1);
-        b.addChild(0, loc2);
-        b.addChild(0, loc3);
-        b.addChild(0, exit);
+        b.addChildWithoutSourceLoc(0, loc1);
+        b.addChildWithoutSourceLoc(0, loc2);
+        b.addChildWithoutSourceLoc(0, loc3);
+        b.addChildWithoutSourceLoc(0, exit);
 
         Program p = b.build();
         IntervalAnalysis analysis = runIntervalAnalysis(p, IntervalAnalysisMethod.LOCAL);
@@ -285,9 +285,9 @@ public class IntervalAnalysisTest {
         Local loc2  = newLocal(r1, expressions.makeIntegerCast(r0, byteType, true));
         Label exit = b.getOrCreateLabel(0, "exit");
 
-        b.addChild(0, loc1);
-        b.addChild(0, loc2);
-        b.addChild(0, exit);
+        b.addChildWithoutSourceLoc(0, loc1);
+        b.addChildWithoutSourceLoc(0, loc2);
+        b.addChildWithoutSourceLoc(0, exit);
         Program p = b.build();
         IntervalAnalysis analysis = runIntervalAnalysis(p, IntervalAnalysisMethod.LOCAL);
         Interval expected = Interval.getTop(byteType);
@@ -307,8 +307,8 @@ public class IntervalAnalysisTest {
         Local loc1 = newLocal(r0, expressions.makeITE(b.newConstant(types.getBooleanType()), expressions.makeZero(type), expressions.makeOne(type)));
         Label exit = b.getOrCreateLabel(0, "exit");
 
-        b.addChild(0, loc1);
-        b.addChild(0, exit);
+        b.addChildWithoutSourceLoc(0, loc1);
+        b.addChildWithoutSourceLoc(0, exit);
 
         Program p = b.build();
         IntervalAnalysis analysis = runIntervalAnalysis(p, IntervalAnalysisMethod.LOCAL);
@@ -359,21 +359,21 @@ public class IntervalAnalysisTest {
         Label exit2 =  b.getOrCreateLabel(2, "exit2");
 
         // T0
-        b.addChild(0, l0);
-        b.addChild(0, loc0);
-        b.addChild(0, exit0);
+        b.addChildWithoutSourceLoc(0, l0);
+        b.addChildWithoutSourceLoc(0, loc0);
+        b.addChildWithoutSourceLoc(0, exit0);
 
         // T1
-        b.addChild(1, l1);
-        b.addChild(1, s0);
-        b.addChild(1, exit1);
+        b.addChildWithoutSourceLoc(1, l1);
+        b.addChildWithoutSourceLoc(1, s0);
+        b.addChildWithoutSourceLoc(1, exit1);
 
         // T2
-        b.addChild(2, l2);
-        b.addChild(2, s1);
-        b.addChild(2, s2);
-        b.addChild(2, s3);
-        b.addChild(2, exit2);
+        b.addChildWithoutSourceLoc(2, l2);
+        b.addChildWithoutSourceLoc(2, s1);
+        b.addChildWithoutSourceLoc(2, s2);
+        b.addChildWithoutSourceLoc(2, s3);
+        b.addChildWithoutSourceLoc(2, exit2);
 
         Program p = b.build();
         IntervalAnalysis analysis = runIntervalAnalysis(p, IntervalAnalysisMethod.GLOBAL);


### PR DESCRIPTION
We currently provide no useful debug information to the user for litmus programs . For example
```
> java -jar dartagnan/target/dartagnan.jar cat/vmm.cat --property=cat_spec litmus/C11/auto/cyc_na.litmus
Test: litmus/C11/auto/cyc_na.litmus
Result: FAIL
Reason: CAT specification violation found
Details:
        Flag r-data-race
        E3 / E3 @unknown / @unknown
Time: 0.582 secs
```
The same is also true for witnesses.

This PR adds line number debug information to litmus code. So far it only does so for a few instructions (thus the draft status), but once we agree on code and the format we want for the output/witness, I will move the code in `addChildWithMetadata` to `addChild` and pass the LOC in all litmus visitors.

**Output format:** once we have proper lines of code for every format, which we already have for spirv/llvm (unless they fail to provide debug info, but I have rarely seen this happen), I think the information about the events id becomes completely useless for the user (it is probably already useless unless they know how to use the printer). However, it might still be useful for developers, so I will keep it, but at the end of the output.

The output for the example above looks like this now
```
> cat -n litmus/C11/auto/cyc_na.litmus 
     1  C cyc_na
     2  { [x] = 0; [y] = 0; }
     3
     4  P0 (volatile int* x, volatile int* y) {
     5    int r0 = *x;
     6    if (r0) {
     7      *y = 1;
     8    }
     9  }
    10
    11  P1 (volatile int* x, volatile int* y) {
    12    int r1 = *y;
    13    if (r1) {
    14      *x = 1;
    15    }
    16  }
    17
    18  exists (0:r0=1 /\ 1:r1=1)

> java -jar dartagnan/target/dartagnan.jar cat/vmm.cat --property=cat_spec litmus/C11/auto/cyc_na.litmus
Test: litmus/C11/auto/cyc_na.litmus
Result: FAIL
Reason: CAT specification violation found
Details:
        Flag r-data-race
        P1#12 / P1#12   (E14 / E14)
Time: 0.489 secs
```
This is even more useful for litmus syntax where each thread is a column
```
> cat -n /home/drc/git/Dat3M/litmus/VULKAN/Data-Race/mpnotinscope2-filter.litmus
     1  Vulkan mpnotinscope2-filter
     2  {
     3  x=0;
     4  y=0;
     5  }
     6  P0@sg 0, wg 0, qf 0            | P1@sg 0, wg 1, qf 0             ;
     7  st.atom.rel.wg.sc0.semsc0 x, 1 | ld.atom.acq.dv.sc0.semsc0 r0, y ;
     8  st.atom.rel.dv.sc0.semsc0 y, 1 | ld.atom.acq.wg.sc0.semsc0 r1, x ;
     9
    10  filter
    11  (P1:r0 == 1)

> java -jar dartagnan/target/dartagnan.jar cat/vulkan.cat --target=vulkan --property=cat_spec /home/drc/git/Dat3M/litmus/VULKAN/Data-Race/mpnotinscope2-filter.litmus
Test: /home/drc/git/Dat3M/litmus/VULKAN/Data-Race/mpnotinscope2-filter.litmus
Filter: bv64 r0 == bv64(1)
Result: FAIL
Reason: CAT specification violation found
Details:
        Flag racy
        P0#7 / P1#8     (E1 / E7)
Time: 0.661 secs
```

For the witness, since the nodes already contain the thread, I only use the LOC. 