### PR TITLE
Fix failure of encoding of sets and SetIdentity if RA is disabled

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -505,7 +505,7 @@ public class WmmEncoder {
                             encSetId.encode(e1, e2),
                             mustSet.contains(e1, e2)
                                     ? execution(e1, e2)
-                                    : encDomain.encode(e1, e2)
+                                    : e1 == e2 ? encDomain.encode(e1, e2) : bmgr.makeFalse()
                     ))
             );
             return null;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/CoarseRelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/CoarseRelationAnalysis.java
@@ -70,18 +70,23 @@ public class CoarseRelationAnalysis extends NativeRelationAnalysis {
     }
 
     private final class EmptyInitializer extends NativeRelationAnalysis.Initializer {
-        final MutableKnowledge defaultKnowledge;
+        final MutableKnowledge defaultBinaryKnowledge;
+        final MutableKnowledge defaultUnaryKnowledge;
 
         EmptyInitializer() {
-            MutableEventGraph may = new MapEventGraph();
+            MutableEventGraph mayBin = new MapEventGraph();
+            MutableEventGraph mayUn = new MapEventGraph();
             Set<Event> events = program.getThreadEvents().stream().filter(e -> e.hasTag(VISIBLE)).collect(toSet());
-            events.forEach(x -> may.addRange(x, events));
-            defaultKnowledge = new MutableKnowledge(may, new MapEventGraph());
+            events.forEach(x -> mayBin.addRange(x, events));
+            events.forEach(x -> mayUn.add(x, x));
+            defaultBinaryKnowledge = new MutableKnowledge(mayBin, new MapEventGraph());
+            defaultUnaryKnowledge = new MutableKnowledge(mayUn, new MapEventGraph());
         }
 
         @Override
         public MutableKnowledge visitDefinition(Definition def) {
-            return !task.getMemoryModel().isInternal(def.getDefinedRelation()) ? defaultKnowledge
+            return !task.getMemoryModel().isInternal(def.getDefinedRelation())
+                    ? (def.getDefinedRelation().isSet() ? defaultUnaryKnowledge : defaultBinaryKnowledge)
                     : new MutableKnowledge(new MapEventGraph(), new MapEventGraph());
         }
     }


### PR DESCRIPTION
The `CoarseRelationAnalysis` computes the may-set $E \times E$ even for set: it should just be $E$.
The encoding of `SetIdentity` fails if RA and active sets are disabled, because `SetIdentity` then tries to encode edges $(x,y)$ where $x \neq y$ and an exception is raised.
