### PR TITLE
Fix CAAT adding spurious co-edges to executions with OOB accesses (+ code simplification)

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/CoherenceGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/CoherenceGraph.java
@@ -1,138 +1,33 @@
 package com.dat3m.dartagnan.solver.caat4wmm.basePredicates;
 
 
-import com.dat3m.dartagnan.solver.caat.misc.EdgeDirection;
+import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.encoding.IREvaluator;
 import com.dat3m.dartagnan.solver.caat.predicates.relationGraphs.Edge;
 import com.dat3m.dartagnan.verification.model.EventData;
-import com.google.common.collect.Iterators;
 
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+import java.util.Collection;
 
-import static java.util.Spliterator.*;
+import static com.dat3m.dartagnan.wmm.RelationNameRepository.CO;
 
-public class CoherenceGraph extends StaticWMMGraph {
-
-    private Map<Object, List<EventData>> coMap;
-
-    @Override
-    public int size(int id, EdgeDirection dir) {
-        EventData e = getEvent(id);
-        if (!e.isWrite()) {
-            return 0;
-        }
-        List<EventData> sameAddrWrites = coMap.get(e.getAccessedAddress());
-        if (sameAddrWrites == null) {
-            return 0;
-        }
-        int index = e.getCoherenceIndex();
-        return dir == EdgeDirection.INGOING ? (index - 1) : (sameAddrWrites.size() - index - 1);
-    }
-
-    @Override
-    public boolean containsById(int id1, int id2) {
-        EventData a = getEvent(id1);
-        EventData b = getEvent(id2);
-        return a.getCoherenceIndex() < b.getCoherenceIndex() && a.isWrite() && b.isWrite()
-                && a.getAccessedAddress().equals(b.getAccessedAddress());
-    }
+public class CoherenceGraph extends MaterializedWMMGraph {
 
     @Override
     public void repopulate() {
-        coMap = new HashMap<>(model.getCoherenceMap());
-        coMap.values().removeIf(list -> list.size() <= 1);
-        autoComputeSize();
-    }
+        final EncodingContext ctx = model.getContext();
+        final IREvaluator evaluator = model.getEvaluator();
+        final EncodingContext.EdgeEncoder co = ctx.edge(ctx.getTask().getMemoryModel().getRelation(CO));
 
-    @Override
-    public Stream<Edge> edgeStream() {
-        return StreamSupport.stream(
-                Spliterators.spliterator(edgeIterator(), size, SIZED | NONNULL | DISTINCT | IMMUTABLE | ORDERED),
-                false
-        );
-    }
-
-    @Override
-    public Stream<Edge> edgeStream(int id, EdgeDirection dir) {
-        EventData e = getEvent(id);
-        if (!e.isWrite()) {
-            return Stream.empty();
-        }
-        Function<EventData, Edge> mapping = dir == EdgeDirection.INGOING ?
-                (event -> new Edge(event.getId(), id)) : (event -> new Edge(id, event.getId()));
-        return getCoSuccessorList(e, dir).stream().map(mapping);
-    }
-
-    @Override
-    public Iterator<Edge> edgeIterator() {
-        return new CoIterator();
-    }
-
-    @Override
-    public Iterator<Edge> edgeIterator(int id, EdgeDirection dir) {
-        EventData e = getEvent(id);
-        if (!e.isWrite()) {
-            return Collections.emptyIterator();
-        }
-        com.google.common.base.Function<EventData, Edge> mapping = dir == EdgeDirection.INGOING ?
-                (event -> new Edge(event.getId(), id)) : (event -> new Edge(id, event.getId()));
-        return Iterators.transform(getCoSuccessorList(e, dir).iterator(), mapping);
-    }
-
-    private List<EventData> getCoSuccessorList(EventData e, EdgeDirection dir) {
-        List<EventData> sameAddrWrites = coMap.get(e.getAccessedAddress());
-        if (sameAddrWrites == null) {
-            return Collections.emptyList();
-        }
-        int index = e.getCoherenceIndex();
-        return (dir == EdgeDirection.INGOING ?
-                sameAddrWrites.subList(0, index)
-                : sameAddrWrites.subList(index + 1, sameAddrWrites.size()));
-    }
-
-    private class CoIterator implements Iterator<Edge> {
-
-        private final Iterator<List<EventData>> coListIterator = coMap.values().iterator();
-        private List<EventData> curList = Collections.emptyList();
-        private int low = 0, high = 0;
-        private Edge edge;
-
-        public CoIterator() {
-            findNext();
-        }
-
-        private void findNext() {
-            if (++high >= curList.size()) {
-                if (++low < curList.size() - 1) {
-                    high = low + 1;
-                } else {
-                    if (coListIterator.hasNext()) {
-                        curList = coListIterator.next();
-                        low = 0;
-                        high = 1;
-                    } else {
-                        edge = null;
-                        return;
+        for (Collection<EventData> writes : model.getAddressWritesMap().values()) {
+            for (EventData w1 : writes) {
+                for (EventData w2 : writes) {
+                    if (evaluator.hasEdge(co, w1.getEvent(), w2.getEvent())) {
+                        this.simpleGraph.add(new Edge(w1.getId(), w2.getId()));
                     }
                 }
             }
-            edge = new Edge(curList.get(low).getId(), curList.get(high).getId());
 
         }
-
-        @Override
-        public boolean hasNext() {
-            return edge != null;
-        }
-
-        @Override
-        public Edge next() {
-            Edge e = edge;
-            findNext();
-            return e;
-        }
-
     }
+
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/ReadFromGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/solver/caat4wmm/basePredicates/ReadFromGraph.java
@@ -1,56 +1,33 @@
 package com.dat3m.dartagnan.solver.caat4wmm.basePredicates;
 
 
-import com.dat3m.dartagnan.solver.caat.misc.EdgeDirection;
+import com.dat3m.dartagnan.encoding.EncodingContext;
+import com.dat3m.dartagnan.encoding.IREvaluator;
 import com.dat3m.dartagnan.solver.caat.predicates.relationGraphs.Edge;
 import com.dat3m.dartagnan.verification.model.EventData;
 
-import java.util.stream.Stream;
+import java.util.Map;
+import java.util.Set;
 
-public class ReadFromGraph extends StaticWMMGraph {
+import static com.dat3m.dartagnan.wmm.RelationNameRepository.RF;
 
-    @Override
-    public boolean containsById(int id1, int id2) {
-        EventData e = getEvent(id2).getReadFrom();
-        return e != null && e.getId() == id1;
-    }
-
-    @Override
-    public int size(int id, EdgeDirection dir) {
-        EventData e = getEvent(id);
-        if (dir == EdgeDirection.INGOING) {
-            return e.getReadFrom() == null ? 0 : 1;
-        } else  {
-            return e.isWrite() ? model.getWriteReadsMap().get(e).size() : 0;
-        }
-    }
-
+public class ReadFromGraph extends MaterializedWMMGraph {
     @Override
     public void repopulate() {
-        size = model.getReadWriteMap().size();
-    }
+        final EncodingContext ctx = model.getContext();
+        final EncodingContext.EdgeEncoder rf = ctx.edge(ctx.getTask().getMemoryModel().getRelation(RF));
+        final IREvaluator irModel = model.getEvaluator();
 
-    private Edge makeEdge(int a, int b) {
-        return new Edge(a, b);
-    }
-
-    @Override
-    public Stream<Edge> edgeStream() {
-        return model.getReadWriteMap().entrySet().stream()
-                .map(x -> new Edge(x.getValue().getId(), x.getKey().getId()));
-    }
-
-    @Override
-    public Stream<Edge> edgeStream(int id, EdgeDirection dir) {
-        EventData e = getEvent(id);
-        if (e.isWrite()) {
-            return dir == EdgeDirection.INGOING ? Stream.empty() :
-                    model.getWriteReadsMap().get(e).stream().map(read -> makeEdge(id, read.getId()));
-        } else if (e.isRead() && e.getReadFrom() != null) {
-            return dir == EdgeDirection.INGOING ?
-                    Stream.of(new Edge(e.getReadFrom().getId(), id)) : Stream.empty();
-        } else {
-            return Stream.empty();
+        for (Map.Entry<Object, Set<EventData>> addressedReads : model.getAddressReadsMap().entrySet()) {
+            final Object address = addressedReads.getKey();
+            for (EventData read : addressedReads.getValue()) {
+                for (EventData write : model.getAddressWritesMap().get(address)) {
+                    if (irModel.hasEdge(rf, write.getEvent(), read.getEvent())) {
+                        this.simpleGraph.add(new Edge(write.getId(), read.getId()));
+                        break;
+                    }
+                }
+            }
         }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/EventData.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/EventData.java
@@ -10,13 +10,9 @@ import static com.dat3m.dartagnan.program.event.Tag.*;
 //EventData represents all data associated with an event in a concrete model.
 public class EventData implements Comparable<EventData> {
     private final Event event;
-    private EventData readFrom;
     private int id = -1;
     private int localId = -1;
-    private Object value;
     private Object accessedAddress;
-    private int coIndex = Integer.MIN_VALUE;
-    private boolean wasExecuted;
 
     EventData(Event e) {
         this.event = e;
@@ -49,30 +45,6 @@ public class EventData implements Comparable<EventData> {
     void setAccessedAddress(Object address) {
         accessedAddress = address;
     }
-
-    public Object getValue() {
-    	return value;
-    }
-    void setValue(Object val) {
-    	value = val;
-    }
-
-    public EventData getReadFrom() {
-    	return readFrom;
-    }
-    void setReadFrom(EventData store) {
-    	readFrom = store;
-    }
-
-    public boolean wasExecuted() {
-    	return wasExecuted;
-    }
-    void setWasExecuted(boolean flag) {
-    	wasExecuted = flag;
-    }
-
-    public int getCoherenceIndex() { return coIndex; }
-    void setCoherenceIndex(int index) { coIndex = index; }
 
     public boolean isMemoryEvent() { return event.hasTag(MEMORY); }
     public boolean isInit() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/model/ExecutionModel.java
@@ -14,19 +14,13 @@ import com.dat3m.dartagnan.program.event.core.Dealloc;
 import com.dat3m.dartagnan.program.event.core.MemoryCoreEvent;
 import com.dat3m.dartagnan.program.event.lang.svcomp.BeginAtomic;
 import com.dat3m.dartagnan.program.event.lang.svcomp.EndAtomic;
-import com.dat3m.dartagnan.program.memory.MemoryObject;
-import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
-import java.math.BigInteger;
 import java.util.*;
 
-import static com.dat3m.dartagnan.wmm.RelationNameRepository.CO;
-import static com.dat3m.dartagnan.wmm.RelationNameRepository.RF;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /*
@@ -46,31 +40,18 @@ public class ExecutionModel {
     // The event list is sorted lexicographically by (threadID, cID)
     private final ArrayList<EventData> eventList;
     private final ArrayList<Thread> threadList;
-    private final Map<MemoryObject, MemoryObjectModel> memoryLayoutMap;
     private final Map<Thread, List<EventData>> threadEventsMap;
     private final Map<Thread, List<List<EventData>>> atomicBlocksMap;
-    private final Map<EventData, EventData> readWriteMap;
-    private final Map<EventData, Set<EventData>> writeReadsMap;
     private final Map<Object, Set<EventData>> addressReadsMap;
-    private final Map<Object, Set<EventData>> addressWritesMap; // This ALSO contains the init writes
-    private final Map<Object, EventData> addressInitMap;
-    //Note, we could merge the three above maps into a single one that holds writes, reads and init writes.
-
-    private final Map<Object, List<EventData>> coherenceMap;
+    private final Map<Object, Set<EventData>> addressWritesMap;
 
     // The following are a read-only views which get passed to the outside
     private List<EventData> eventListView;
     private List<Thread> threadListView;
-    private Map<MemoryObject, MemoryObjectModel> memoryLayoutMapView;
     private Map<Thread, List<EventData>> threadEventsMapView;
     private Map<Thread, List<List<EventData>>> atomicBlocksMapView;
-    private Map<EventData, EventData> readWriteMapView;
-    private Map<EventData, Set<EventData>> writeReadsMapView;
     private Map<Object, Set<EventData>> addressReadsMapView;
     private Map<Object, Set<EventData>> addressWritesMapView;
-    private Map<Object, EventData> addressInitMapView;
-
-    private Map<Object, List<EventData>> coherenceMapView;
 
     private ExecutionModel(EncodingContext c) {
         this.ctx = checkNotNull(c);
@@ -78,15 +59,10 @@ public class ExecutionModel {
         eventList = new ArrayList<>(100);
         threadList = new ArrayList<>(getProgram().getThreads().size());
         threadEventsMap = new HashMap<>(getProgram().getThreads().size() * 4/3, 0.75f);
-        memoryLayoutMap = new HashMap<>();
         atomicBlocksMap = new HashMap<>();
-        readWriteMap = new HashMap<>();
-        writeReadsMap = new HashMap<>();
         addressReadsMap = new HashMap<>();
         addressWritesMap = new HashMap<>();
-        addressInitMap = new HashMap<>();
         eventMap = new EventMap();
-        coherenceMap = new HashMap<>();
 
         createViews();
     }
@@ -98,15 +74,10 @@ public class ExecutionModel {
     private void createViews() {
         eventListView = Collections.unmodifiableList(eventList);
         threadListView = Collections.unmodifiableList(threadList);
-        memoryLayoutMapView = Collections.unmodifiableMap(memoryLayoutMap);
         threadEventsMapView = Collections.unmodifiableMap(threadEventsMap);
         atomicBlocksMapView = Collections.unmodifiableMap(atomicBlocksMap);
-        readWriteMapView = Collections.unmodifiableMap(readWriteMap);
-        writeReadsMapView = Collections.unmodifiableMap(writeReadsMap);
         addressReadsMapView = Collections.unmodifiableMap(addressReadsMap);
         addressWritesMapView = Collections.unmodifiableMap(addressWritesMap);
-        addressInitMapView = Collections.unmodifiableMap(addressInitMap);
-        coherenceMapView = Collections.unmodifiableMap(coherenceMap);
     }
 
     //======================== Public data ===========================‚
@@ -140,29 +111,17 @@ public class ExecutionModel {
         return threadListView;
     }
 
-    public Map<MemoryObject, MemoryObjectModel> getMemoryLayoutMap() {
-        return memoryLayoutMapView;
-    }
     public Map<Thread, List<EventData>> getThreadEventsMap() {
         return threadEventsMapView;
     }
     public Map<Thread, List<List<EventData>>> getAtomicBlocksMap() { return atomicBlocksMapView; }
-    public Map<EventData, EventData> getReadWriteMap() {
-        return readWriteMapView;
-    }
-    public Map<EventData, Set<EventData>> getWriteReadsMap() {
-        return writeReadsMapView;
-    }
+
     public Map<Object, Set<EventData>> getAddressReadsMap() {
         return addressReadsMapView;
     }
     public Map<Object, Set<EventData>> getAddressWritesMap() {
         return addressWritesMapView;
     }
-    public Map<Object, EventData> getAddressInitMap() {
-        return addressInitMapView;
-    }
-    public Map<Object, List<EventData>> getCoherenceMap() { return coherenceMapView; }
 
     public Optional<EventData> getData(Event e) {
         return Optional.ofNullable(eventMap.get(e));
@@ -177,9 +136,6 @@ public class ExecutionModel {
         // However, for all intents and purposes, this serves as a constructor.
         irModel = model;
         extractEventsFromModel();
-        extractMemoryLayout();
-        extractReadsFrom();
-        extractCoherences();
     }
 
     //========================== Internal methods  =========================
@@ -192,10 +148,8 @@ public class ExecutionModel {
         threadList.clear();
         threadEventsMap.clear();
         atomicBlocksMap.clear();
-        addressInitMap.clear(); // This one can probably be constant and need not be rebuilt!
         addressWritesMap.clear();
         addressReadsMap.clear();
-        writeReadsMap.clear();
         eventMap.clear();
         uninitRegReads.clear();
         initializedRegisters.clear();
@@ -269,7 +223,6 @@ public class ExecutionModel {
         data.setLocalId(localId);
         eventList.add(data);
 
-        data.setWasExecuted(true);
         if (data.isMemoryEvent()) {
             // ===== Memory Events =====
             Object address = checkNotNull(irModel.address((MemoryCoreEvent) e).value());
@@ -279,26 +232,14 @@ public class ExecutionModel {
                 addressWritesMap.put(address, new HashSet<>());
             }
 
-            if (data.isRead() || data.isWrite()) {
-                data.setValue(irModel.value((MemoryCoreEvent) e).value());
-            }
-
             if (data.isRead()) {
                 addressReadsMap.get(address).add(data);
             } else if (data.isWrite()) {
                 addressWritesMap.get(address).add(data);
-                writeReadsMap.put(data, new HashSet<>());
-                if (data.isInit()) {
-                    addressInitMap.put(address, data);
-                }
             } else if (!(data.getEvent() instanceof Dealloc)) {
                 //FIXME: Handle other kinds of memory events such as SRCU_SYNC.
                 throw new UnsupportedOperationException("Unexpected memory event " + data.getEvent());
             }
-        } else if (data.isJump()) {
-            // ===== Jumps =====
-            // We override the meaning of execution here. A jump is executed IFF its condition was true.
-            data.setWasExecuted(irModel.jumpTaken((CondJump) e));
         } else {
             //TODO: Maybe add some other events (e.g. assertions)
             // But for now all non-visible events are simply registered without
@@ -330,68 +271,4 @@ public class ExecutionModel {
         }
     }
 
-    // ===================================================
-
-    private void extractMemoryLayout() {
-        memoryLayoutMap.clear();
-
-        for (MemoryObject obj : getProgram().getMemory().getObjects()) {
-            final boolean isAllocated = irModel.isAllocated(obj);
-            if (isAllocated) {
-                // TODO: Get rid of ValueModel: replace by TypedValue
-                final ValueModel address = new ValueModel(irModel.address(obj).value());
-                final BigInteger size = irModel.size(obj).value();
-                memoryLayoutMap.put(obj, new MemoryObjectModel(obj, address, size));
-            }
-        }
-    }
-
-    private void extractReadsFrom() {
-        readWriteMap.clear();
-        final EncodingContext.EdgeEncoder rf = ctx.edge(ctx.getTask().getMemoryModel().getRelation(RF));
-
-        for (Map.Entry<Object, Set<EventData>> addressedReads : addressReadsMap.entrySet()) {
-            Object address = addressedReads.getKey();
-            for (EventData read : addressedReads.getValue()) {
-                for (EventData write : addressWritesMap.get(address)) {
-                    if (irModel.hasEdge(rf, write.getEvent(), read.getEvent())) {
-                        readWriteMap.put(read, write);
-                        read.setReadFrom(write);
-                        writeReadsMap.get(write).add(read);
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    private void extractCoherences() {
-        coherenceMap.clear();
-        final EncodingContext.EdgeEncoder co = ctx.edge(ctx.getTask().getMemoryModel().getRelation(CO));
-
-        for (Map.Entry<Object, Set<EventData>> addrWrites : addressWritesMap.entrySet()) {
-            final Object addr = addrWrites.getKey();
-            final Set<EventData> writes = addrWrites.getValue();
-
-            Map<EventData, List<EventData>> coEdges = new HashMap<>();
-            for (EventData w1 : writes) {
-                coEdges.put(w1, new ArrayList<>());
-                for (EventData w2 : writes) {
-                    if (irModel.hasEdge(co, w1.getEvent(), w2.getEvent())) {
-                        coEdges.get(w1).add(w2);
-                    }
-                }
-            }
-            DependencyGraph<EventData> depGraph = DependencyGraph.from(writes, coEdges);
-            final List<EventData> coSortedWrites = new ArrayList<>(Lists.reverse(depGraph.getNodeContents()));
-
-            // --- Apply internal clock orders (we always start from 0) --
-            int i = 0;
-            for (EventData w : coSortedWrites) {
-                w.setCoherenceIndex(i++);
-            }
-            coherenceMap.put(addr, Collections.unmodifiableList(coSortedWrites));
-        }
-
-    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -344,7 +344,6 @@ public class RefinementSolver extends ModelChecker {
         final Map<Object, Set<EventData>> addr2Events = new HashMap<>();
         model.getAddressReadsMap().forEach((addr, reads) -> addr2Events.computeIfAbsent(addr, key -> new HashSet<>()).addAll(reads));
         model.getAddressWritesMap().forEach((addr, writes) -> addr2Events.computeIfAbsent(addr, key -> new HashSet<>()).addAll(writes));
-        model.getAddressInitMap().forEach((addr, init) -> addr2Events.computeIfAbsent(addr, key -> new HashSet<>()).add(init));
 
         for (Set<EventData> sameLocEvents : addr2Events.values()) {
             final List<EventData> events = sameLocEvents.stream().sorted().toList();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -1,12 +1,11 @@
 package com.dat3m.dartagnan.witness.graphviz;
 
-import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.IRHelper;
+import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
 import com.dat3m.dartagnan.program.event.core.Init;
 import com.dat3m.dartagnan.program.event.core.InstructionBoundary;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
-import com.dat3m.dartagnan.program.Program.SourceLanguage;
 import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.dat3m.dartagnan.verification.model.*;
 import com.dat3m.dartagnan.verification.model.RelationModel.EdgeModel;
@@ -14,7 +13,6 @@ import com.dat3m.dartagnan.verification.model.event.*;
 import com.dat3m.dartagnan.wmm.definition.Coherence;
 import com.dat3m.dartagnan.wmm.definition.ProgramOrder;
 import com.dat3m.dartagnan.wmm.definition.SameInstruction;
-
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +54,8 @@ public class ExecutionGraphVisualizer {
     public ExecutionGraphVisualizer() {
         this.graphviz = new Graphviz();
         this.colorMap = new ColorMap();
+
+        relsToShow = Set.of(relsToShowStr.split(",\\s*"));
     }
 
     public ExecutionGraphVisualizer setSyntacticContext(SyntacticContextAnalysis synContext) {
@@ -373,7 +373,7 @@ public class ExecutionGraphVisualizer {
         try (FileWriter writer = new FileWriter(fileVio)) {
             // Create .dot file
             ExecutionGraphVisualizer visualizer = new ExecutionGraphVisualizer();
-            if (config != null) { visualizer.setRelationsToShow(config); }
+            visualizer.setRelationsToShow(config);
             visualizer.setSyntacticContext(synContext)
                       .setFilter(RF, rfFilter)
                       .setFilter(CO, coFilter)
@@ -407,6 +407,7 @@ public class ExecutionGraphVisualizer {
                              fileNameBase,
                              synContext,
                              true,
-                             null);
+                             Configuration.defaultConfiguration()
+        );
     }
 }


### PR DESCRIPTION
If two writes were accessing the same address due to OOB in such a way that it violated AA, we had two same-address writes without a co-edge in the encoding. `ExecutionModel` "completed" such missing coherence edges arbitrarily which could result in a very, very rare inconclusiveness bug.

This PR ensures that we just use the coherence edges appearing in the encoding. This also aligns the behaviors of lazy and eager solving a bit more in the presence of OOB.

Furthermore, I simplified `ExecutionModel`, `EventData`, `ReadFromGraph` and `CoherenceGraph` a lot.
Due to the introduction of `ExecutionModelNext`, `ExecutionModel` is likely never going to be used outside of `RefinementSolver` and so it can be specialized more to its only use-case.

I also fixed a little bug in `ExecutionGraphVisualizer` when invoking it with a `null`-config (we had such code!?).