### PR TITLE
Moved floating point rounding mode into Program

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -294,7 +294,7 @@ public class Dartagnan extends BaseOptions {
         StringBuilder details = new StringBuilder();
         // We only show the condition if this is the reason of the failure
         String condition = "";
-        final boolean ignoreFilter = task.getConfig().hasProperty(IGNORE_FILTER_SPECIFICATION) && task.getConfig().getProperty(IGNORE_FILTER_SPECIFICATION).equals("true");
+        final boolean ignoreFilter = Objects.equals(task.getConfig().getProperty(IGNORE_FILTER_SPECIFICATION), "true");
         final boolean nonEmptyFilter = !(p.getFilterSpecification() instanceof BoolLiteral bLit) || !bLit.getValue();
         final String filter = !ignoreFilter && nonEmptyFilter ? p.getFilterSpecification().toString() : "";
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -68,13 +68,6 @@ public final class EncodingContext {
             secure = true)
     boolean useIntegers = false;
 
-    // TODO: If we ever simplify floats, this option will play a role there besides than the encoding.
-    // If that is the case we need to move this option outside of this encoding class.
-    @Option(name = ROUNDING_MODE_FLOATS,
-            description = "Rounding mode for floating point operations.",
-            secure = true)
-    FloatingPointRoundingMode roundingModeFloats = NEAREST_TIES_TO_EVEN;
-
     private final Map<Event, BooleanFormula> controlFlowVariables = new HashMap<>();
     private final Map<Event, BooleanFormula> executionVariables = new HashMap<>();
     private final Map<NamedBarrier, BooleanFormula> syncVariables = new HashMap<>();
@@ -117,7 +110,6 @@ public final class EncodingContext {
         EncodingContext context = new EncodingContext(task, analysisContext, formulaManager, constraintsToEncode);
         task.getConfig().inject(context);
         logger.info("{}: {}", MERGE_CF_VARS, context.shouldMergeCFVars);
-        logger.info("{}: {}", ROUNDING_MODE_FLOATS, context.roundingModeFloats);
         context.initialize();
 
         return context;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/ExpressionEncoder.java
@@ -47,10 +47,14 @@ public class ExpressionEncoder {
     private final ExprSimplifier simplifier = new ExprSimplifier(true);
     private final Visitor visitor = new Visitor();
 
+    private final FloatingPointRoundingMode roundingMode;
+
     ExpressionEncoder(EncodingContext context) {
         this.context = context;
         this.fmgr = context.getFormulaManager();
         this.bmgr = fmgr.getBooleanFormulaManager();
+
+        this.roundingMode = context.getTask().getProgram().getFloatRoundingMode();
     }
 
     private IntegerFormulaManager integerFormulaManager() {
@@ -583,7 +587,7 @@ public class ExpressionEncoder {
             final Formula operand = encodeIntegerExpr(expr.getOperand()).formula();
             final FloatType fType = expr.getTargetType();
             final FloatingPointType targetType = getFloatFormulaType(fType);
-            final Formula enc = floatingPointFormulaManager().castFrom(operand, true, targetType, context.roundingModeFloats);
+            final Formula enc = floatingPointFormulaManager().castFrom(operand, true, targetType, roundingMode);
             return new TypedFormula<>(fType, enc);
         }
 
@@ -603,7 +607,7 @@ public class ExpressionEncoder {
                 result = fpmgr.makeMinusInfinity(fFType);
             } else {
                 assert floatLiteral.hasFiniteValue();
-                final FloatingPointFormula absVal = fpmgr.makeNumber(floatLiteral.getAbsValue(), fFType, context.roundingModeFloats);
+                final FloatingPointFormula absVal = fpmgr.makeNumber(floatLiteral.getAbsValue(), fFType, roundingMode);
                 result = floatLiteral.isNegative() ? fpmgr.negate(absVal) : absVal;
             }
             return new TypedFormula<>(floatLiteral.getType(), result);
@@ -618,10 +622,10 @@ public class ExpressionEncoder {
             final FloatingPointFormulaManager fpmgr = floatingPointFormulaManager();
 
             final FloatingPointFormula result = switch (fBin.getKind()) {
-                case FADD -> fpmgr.add(fp1, fp2, context.roundingModeFloats);
-                case FSUB -> fpmgr.subtract(fp1, fp2, context.roundingModeFloats);
-                case FMUL -> fpmgr.multiply(fp1, fp2, context.roundingModeFloats);
-                case FDIV -> fpmgr.divide(fp1, fp2, context.roundingModeFloats);
+                case FADD -> fpmgr.add(fp1, fp2, roundingMode);
+                case FSUB -> fpmgr.subtract(fp1, fp2, roundingMode);
+                case FMUL -> fpmgr.multiply(fp1, fp2, roundingMode);
+                case FDIV -> fpmgr.divide(fp1, fp2, roundingMode);
                 case FREM -> fpmgr.remainder(fp1, fp2);
                 case FMAX -> fpmgr.max(fp1, fp2);
                 case FMIN -> fpmgr.min(fp1, fp2);
@@ -687,7 +691,7 @@ public class ExpressionEncoder {
 
             final FloatingPointFormulaManager fpmgr = floatingPointFormulaManager();
             final FloatingPointType fType = getFloatFormulaType(expr.getTargetType());
-            final Formula enc = fpmgr.castFrom(inner.formula(), true, fType, context.roundingModeFloats);
+            final Formula enc = fpmgr.castFrom(inner.formula(), true, fType, roundingMode);
             return new TypedFormula<>(expr.getType(), enc);
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
@@ -43,27 +43,25 @@ public class Program {
 
     // Shape
     private final List<Thread> threads;
-    // Semantic options
-    private final SemanticConfig semanticConfig = new SemanticConfig();
     private final List<Function> functions;
     private final List<NonDetValue> constants = new ArrayList<>();
     private final Memory memory;
     private Entrypoint entrypoint = new Entrypoint.None();
-    private final SourceLanguage format;
+
     // Spec
     private SpecificationType specificationType = SpecificationType.ASSERT;
     private Expression spec;
     private Expression filterSpec; // Acts like "assume" statements, filtering out executions
 
+    // Semantic options
+    private final SemanticConfig semanticConfig = new SemanticConfig();
+
     // Metadata
+    private final SourceLanguage format;
     private String name;
     private int unrollingBound = 0;
     private Arch arch;
     private boolean isCompiled;
-
-    public FloatingPointRoundingMode getFloatRoundingMode() {
-        return semanticConfig.floatRoundingMode;
-    }
 
     private int nextThreadId = 0;
     private int nextConstantId = 0;
@@ -152,6 +150,10 @@ public class Program {
     public void setFilterSpecification(Expression spec) {
         Preconditions.checkArgument(spec.getType() instanceof BooleanType);
         this.filterSpec = spec;
+    }
+
+    public FloatingPointRoundingMode getFloatRoundingMode() {
+        return semanticConfig.floatRoundingMode;
     }
 
     public void setFloatRoundingMode(FloatingPointRoundingMode roundingMode) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
@@ -12,9 +12,17 @@ import com.dat3m.dartagnan.program.memory.Memory;
 import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.misc.NonDetValue;
 import com.google.common.base.Preconditions;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.configuration.Option;
+import org.sosy_lab.common.configuration.Options;
+import org.sosy_lab.java_smt.api.FloatingPointRoundingMode;
 
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.dat3m.dartagnan.configuration.OptionNames.ROUNDING_MODE_FLOATS;
+import static org.sosy_lab.java_smt.api.FloatingPointRoundingMode.NEAREST_TIES_TO_EVEN;
 
 public class Program {
 
@@ -25,19 +33,29 @@ public class Program {
 
     public enum SpecificationType { EXISTS, FORALL, NOT_EXISTS, ASSERT }
 
-    private String name;
-    private SpecificationType specificationType = SpecificationType.ASSERT;
-    private Expression spec;
-    private Expression filterSpec; // Acts like "assume" statements, filtering out executions
+    // Shape
     private final List<Thread> threads;
+    // Semantic options
+    private final SemanticConfig semanticConfig = new SemanticConfig();
     private final List<Function> functions;
     private final List<NonDetValue> constants = new ArrayList<>();
     private final Memory memory;
     private Entrypoint entrypoint = new Entrypoint.None();
-    private Arch arch;
-    private int unrollingBound = 0;
-    private boolean isCompiled;
     private final SourceLanguage format;
+    // Spec
+    private SpecificationType specificationType = SpecificationType.ASSERT;
+    private Expression spec;
+    private Expression filterSpec; // Acts like "assume" statements, filtering out executions
+
+    // Metadata
+    private String name;
+    private int unrollingBound = 0;
+    private Arch arch;
+    private boolean isCompiled;
+
+    public FloatingPointRoundingMode getFloatRoundingMode() {
+        return semanticConfig.floatRoundingMode;
+    }
 
     private int nextThreadId = 0;
     private int nextConstantId = 0;
@@ -127,6 +145,24 @@ public class Program {
         Preconditions.checkArgument(spec.getType() instanceof BooleanType);
         this.filterSpec = spec;
     }
+
+    public void setFloatRoundingMode(FloatingPointRoundingMode roundingMode) {
+         this.semanticConfig.floatRoundingMode = roundingMode;
+    }
+
+    public void injectConfig(Configuration configuration) throws InvalidConfigurationException {
+        configuration.inject(semanticConfig);
+    }
+
+    @Options
+    private static class SemanticConfig {
+        @Option(name = ROUNDING_MODE_FLOATS,
+                description = "Default rounding mode for floating point operations (default NEAREST_TIES_TO_EVEN).",
+                secure = true)
+        private FloatingPointRoundingMode floatRoundingMode = NEAREST_TIES_TO_EVEN;
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
 
     public void addThread(Thread t) {
         threads.add(t);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
@@ -42,8 +42,8 @@ public class Program {
     }
 
     // Shape
-    private final List<Thread> threads;
-    private final List<Function> functions;
+    private final List<Function> functions = new ArrayList<>();
+    private final List<Thread> threads = new ArrayList<>();
     private final List<NonDetValue> constants = new ArrayList<>();
     private final Memory memory;
     private Entrypoint entrypoint = new Entrypoint.None();
@@ -75,8 +75,6 @@ public class Program {
     public Program(String name, Memory memory, SourceLanguage format) {
         this.name = name;
         this.memory = memory;
-        this.threads = new ArrayList<>();
-        this.functions = new ArrayList<>();
         this.format = format;
 
         this.filterSpec = ExpressionFactory.getInstance().makeTrue();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/Program.java
@@ -33,6 +33,14 @@ public class Program {
 
     public enum SpecificationType { EXISTS, FORALL, NOT_EXISTS, ASSERT }
 
+    @Options
+    private static class SemanticConfig {
+        @Option(name = ROUNDING_MODE_FLOATS,
+                description = "Default rounding mode for floating point operations (default NEAREST_TIES_TO_EVEN).",
+                secure = true)
+        private FloatingPointRoundingMode floatRoundingMode = NEAREST_TIES_TO_EVEN;
+    }
+
     // Shape
     private final List<Thread> threads;
     // Semantic options
@@ -152,14 +160,6 @@ public class Program {
 
     public void injectConfig(Configuration configuration) throws InvalidConfigurationException {
         configuration.inject(semanticConfig);
-    }
-
-    @Options
-    private static class SemanticConfig {
-        @Option(name = ROUNDING_MODE_FLOATS,
-                description = "Default rounding mode for floating point operations (default NEAREST_TIES_TO_EVEN).",
-                secure = true)
-        private FloatingPointRoundingMode floatRoundingMode = NEAREST_TIES_TO_EVEN;
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTask.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTask.java
@@ -39,6 +39,9 @@ public class VerificationTask {
         this.property = checkNotNull(property);
         this.witness = checkNotNull(witness);
         this.config = checkNotNull(config);
+
+        // TODO: Is it a good idea to inject configs into the program here?
+        program.injectConfig(config);
     }
 
     public static VerificationTaskBuilder builder() {


### PR DESCRIPTION
This is basically the less controversial half of #978 :)
I kept the `Program.SemanticConfig` class even though it contains only a single option right now.

The biggest question is where to best inject the `Configuration` into the `Program`. For simplicity, I do this when constructing the `VerificationTask`, but it is a bit sketchy.