### PR TITLE
Remove all thrown exceptions in Dartagnan.main()

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -98,7 +98,7 @@ public class Dartagnan extends BaseOptions {
     }
 
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
 
         initGitInfo();
 
@@ -109,17 +109,30 @@ public class Dartagnan extends BaseOptions {
 
         if (Arrays.asList(args).contains("--version")) {
             final MavenXpp3Reader mvnReader = new MavenXpp3Reader();
-            final FileReader fileReader = new FileReader(System.getenv("DAT3M_HOME") + "/pom.xml");
-            final String base = mvnReader.read(fileReader).getVersion();
-            final String version = base.equals(getGitTags()) ? base : String.format("%s (commit %s)", base, getGitId());
-            System.out.println(version);
+            final String pomPath = System.getenv("DAT3M_HOME") + "/pom.xml";
+            try (FileReader fileReader = new FileReader(pomPath)) {
+                final String base = mvnReader.read(fileReader).getVersion();
+                final String version = base.equals(getGitTags()) ? base : String.format("%s (commit %s)", base, getGitId());
+                System.out.println(version);
+            } catch (Exception e) {
+                logger.warn("Failed to read version from {}", pomPath, e);
+                System.exit(UNKNOWN_ERROR.asInt());
+            }
             return;
         }
 
         logGitInfo();
 
-        final Configuration config = loadConfiguration(args);
-        final Dartagnan o = new Dartagnan(config);
+        final Configuration config;
+        final Dartagnan o;
+        try {
+            config = loadConfiguration(args);
+            o = new Dartagnan(config);
+        } catch (IOException | InvalidConfigurationException e) {
+            logger.error(e.getMessage());
+            System.exit(UNKNOWN_ERROR.asInt());
+            return;
+        }
 
         final File fileModel = new File(Arrays.stream(args).filter(a -> a.endsWith(".cat")).findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("CAT model not given or format not recognized")));
@@ -129,7 +142,13 @@ public class Dartagnan extends BaseOptions {
         final WitnessGraph witness;
         if (o.runValidator()) {
             logger.info("Witness path: {}", o.getWitnessPath());
-            witness = new ParserWitness().parse(new File(o.getWitnessPath()));
+            try {
+                witness = new ParserWitness().parse(new File(o.getWitnessPath()));
+            } catch (IOException e) {
+                logger.error("Failed to read witness file {}", o.getWitnessPath());
+                System.exit(WRONG_WITNESS_FILE.asInt());
+                return;
+            }
         } else {
             witness = new WitnessGraph();
         }
@@ -220,7 +239,9 @@ public class Dartagnan extends BaseOptions {
                 }
             });
         if (files.isEmpty()) {
-            throw new IllegalArgumentException("Path to input program(s) not given or format not recognized");
+            logger.error("Path to input program(s) not given or format not recognized");
+            System.exit(UNKNOWN_ERROR.asInt());
+
         }
         return files;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -18,6 +18,7 @@ import com.dat3m.dartagnan.verification.VerificationTask.VerificationTaskBuilder
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.google.common.io.CharSource;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sosy_lab.common.configuration.Configuration;
@@ -37,6 +38,7 @@ import java.util.stream.Stream;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.TARGET;
 import static com.dat3m.dartagnan.utils.ExitCode.NORMAL_TERMINATION;
+import static com.dat3m.dartagnan.utils.ExitCode.UNKNOWN_ERROR;
 import static com.dat3m.dartagnan.utils.EnvironmentInfo.*;
 import static com.dat3m.dartagnan.GlobalSettings.getHomeDirectory;
 
@@ -49,7 +51,7 @@ public class Dartagnan extends BaseOptions {
         config.recursiveInject(this);
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
 
         initEnvironmentInfo();
 
@@ -63,8 +65,16 @@ public class Dartagnan extends BaseOptions {
 
         logEnvironmentInfo();
 
-        final Configuration config = loadConfigurationFromArgs(args);
-        final Dartagnan o = new Dartagnan(config);
+        final Configuration config;
+        final Dartagnan o;
+        try {
+            config = loadConfigurationFromArgs(args);
+            o = new Dartagnan(config);
+        } catch (IOException | InvalidConfigurationException e) {
+            logger.error(e.getMessage());
+            System.exit(UNKNOWN_ERROR.asInt());
+            return;
+        }
 
         final Path catFile = getCatFileFromArgs(args);
         final List<Path> progFiles = getProgramFilesFromArgs(args);
@@ -120,7 +130,7 @@ public class Dartagnan extends BaseOptions {
         OptionInfo.stream().sorted().forEach(System.out::print);
     }
 
-    private static void printVersion() throws Exception {
+    private static void printVersion() {
         final MavenXpp3Reader mvnReader = new MavenXpp3Reader();
         final Path pomPath = getHomeDirectory().resolve("pom.xml");
 
@@ -128,6 +138,8 @@ public class Dartagnan extends BaseOptions {
             final String base = mvnReader.read(reader).getVersion();
             final String version = base.equals(getGitTags()) ? base : String.format("%s (commit %s)", base, getGitId());
             System.out.println(version);
+        } catch (IOException | XmlPullParserException e) {
+            logger.warn("Failed to load {}", pomPath);
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -37,7 +37,6 @@ import java.util.stream.Stream;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.TARGET;
 import static com.dat3m.dartagnan.utils.ExitCode.NORMAL_TERMINATION;
-import static com.dat3m.dartagnan.utils.ExitCode.UNKNOWN_ERROR;
 import static com.dat3m.dartagnan.utils.EnvironmentInfo.*;
 import static com.dat3m.dartagnan.GlobalSettings.getHomeDirectory;
 
@@ -64,6 +63,9 @@ public class Dartagnan extends BaseOptions {
 
         logEnvironmentInfo();
 
+        final TaskResultAnalyzer resultAnalyzer = TaskResultAnalyzer.create();
+        ResultSummary summary = null;
+
         final Configuration config;
         final Dartagnan o;
         final Path catFile;
@@ -74,16 +76,15 @@ public class Dartagnan extends BaseOptions {
             catFile = getCatFileFromArgs(args);
             progFiles = getProgramFilesFromArgs(args);
         } catch (Exception e) {
-            logger.error(e.getMessage());
-            System.exit(UNKNOWN_ERROR.asInt());
+            summary = resultAnalyzer.getSummaryFromException(e, "Unknown");
+            System.out.println(summary);
+            System.exit(summary.code().asInt());
             return;
         }
 
         final boolean isBatchMode = progFiles.size() > 1;
 
         final OutputLogger output = new OutputLogger(catFile, config);
-        final TaskResultAnalyzer resultAnalyzer = TaskResultAnalyzer.create();
-        ResultSummary summary = null;
         int it = 0;
         for (Path progFile : progFiles) {
             try {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -67,17 +67,19 @@ public class Dartagnan extends BaseOptions {
 
         final Configuration config;
         final Dartagnan o;
+        final Path catFile;
+        final List<Path> progFiles;
         try {
             config = loadConfigurationFromArgs(args);
             o = new Dartagnan(config);
+            catFile = getCatFileFromArgs(args);
+            progFiles = getProgramFilesFromArgs(args);
         } catch (IOException | InvalidConfigurationException e) {
             logger.error(e.getMessage());
             System.exit(UNKNOWN_ERROR.asInt());
             return;
         }
 
-        final Path catFile = getCatFileFromArgs(args);
-        final List<Path> progFiles = getProgramFilesFromArgs(args);
         final boolean isBatchMode = progFiles.size() > 1;
 
         final OutputLogger output = new OutputLogger(catFile, config);
@@ -160,17 +162,17 @@ public class Dartagnan extends BaseOptions {
                 .build();
     }
 
-    private static Path getCatFileFromArgs(String[] args) {
+    private static Path getCatFileFromArgs(String[] args) throws IOException {
         Path catFile = Arrays.stream(args)
                 .filter(a -> a.endsWith(".cat"))
                 .findFirst()
                 .map(Path::of)
-                .orElseThrow(() -> new IllegalArgumentException("CAT model not given or format not recognized"));
+                .orElseThrow(() -> new IOException("CAT model not given or format not recognized"));
         logger.info("CAT file path: {}", catFile);
         return catFile;
     }
 
-    private static List<Path> getProgramFilesFromArgs(String[] args) {
+    private static List<Path> getProgramFilesFromArgs(String[] args) throws IOException {
         final List<Path> files = new ArrayList<>();
         Stream.of(args).map(Paths::get).filter(Files::exists)
                 .forEach(path -> {
@@ -181,7 +183,7 @@ public class Dartagnan extends BaseOptions {
                     }
                 });
         if (files.isEmpty()) {
-            throw new IllegalArgumentException("Path to input program(s) not given or format not recognized");
+            throw new IOException("Path to input program(s) not given or format not recognized");
         }
         return files;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -18,7 +18,6 @@ import com.dat3m.dartagnan.verification.VerificationTask.VerificationTaskBuilder
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.google.common.io.CharSource;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sosy_lab.common.configuration.Configuration;
@@ -74,7 +73,7 @@ public class Dartagnan extends BaseOptions {
             o = new Dartagnan(config);
             catFile = getCatFileFromArgs(args);
             progFiles = getProgramFilesFromArgs(args);
-        } catch (IOException | InvalidConfigurationException e) {
+        } catch (Exception e) {
             logger.error(e.getMessage());
             System.exit(UNKNOWN_ERROR.asInt());
             return;
@@ -140,7 +139,7 @@ public class Dartagnan extends BaseOptions {
             final String base = mvnReader.read(reader).getVersion();
             final String version = base.equals(getGitTags()) ? base : String.format("%s (commit %s)", base, getGitId());
             System.out.println(version);
-        } catch (IOException | XmlPullParserException e) {
+        } catch (Exception e) {
             logger.warn("Failed to load {}", pomPath);
         }
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/EnvironmentInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/EnvironmentInfo.java
@@ -16,14 +16,15 @@ public class EnvironmentInfo  {
 
     private final static Properties properties = new Properties();
 
-    public static void initEnvironmentInfo () throws IOException {
+    public static void initEnvironmentInfo () {
         try (InputStream is = Dartagnan.class.getClassLoader()
                 .getResourceAsStream("git.properties")) {
-            if (is == null) {
-                logger.warn("Failed to load git.properties");
+            if (is != null) {
+                properties.load(is);
                 return;
             }
-            properties.load(is);
+        } catch (IOException e) {
+            logger.warn("Failed to load git.properties");
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/GitInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/GitInfo.java
@@ -15,15 +15,15 @@ public class GitInfo {
 
     static Properties properties = new Properties();
 
-    public static void initGitInfo() throws IOException {
+    public static void initGitInfo() {
         try (InputStream is = Dartagnan.class.getClassLoader()
                 .getResourceAsStream("git.properties")) {
-            if (is == null) {
-                logger.warn("Failed to load git.properties");
+            if (is != null) {
+                properties.load(is);
                 return;
             }
-            properties.load(is);
-        }
+        } catch (IOException e) {}
+        logger.warn("Failed to load git.properties");
     }
 
     public static void logGitInfo() {


### PR DESCRIPTION
This solves some SVCOMP problems in which the runner was looping forever e.g., if we would pass the wrong file path. 

However, we still have the looping problem if dartagnan runs OOM. It seems the jvm returns 1 as exit code, which is the same value we use for `ExitCode.BOUNDED_RESULT` (which is also what we used for the looping condition in the runner).