### PR TITLE
Add TaskSolver as abstraction layer over ModelChecker

### DIFF
--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -253,6 +253,7 @@
                         </buildArgs>
                         <initializeAtBuildTime>
                             <!-- Every class should also be registered in OptionsInfo and reflect-config.json -->
+                            <className>com.dat3m.dartagnan.verification.TaskSolver</className>
                             <className>com.dat3m.dartagnan.wmm.RelationNameRepository</className>
                             <className>com.dat3m.dartagnan.configuration.OptionNames</className>
                             <className>com.dat3m.dartagnan.wmm.axiom.Acyclicity</className>

--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -253,6 +253,7 @@
                         </buildArgs>
                         <initializeAtBuildTime>
                             <!-- Every class should also be registered in OptionsInfo and reflect-config.json -->
+                            <className>com.dat3m.dartagnan.witness.graphviz.ExecutionGraphVisualizer</className>
                             <className>com.dat3m.dartagnan.verification.TaskSolver</className>
                             <className>com.dat3m.dartagnan.wmm.RelationNameRepository</className>
                             <className>com.dat3m.dartagnan.configuration.OptionNames</className>

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -1,5 +1,6 @@
 package com.dat3m.dartagnan;
 
+import com.dat3m.dartagnan.configuration.OptionInfo;
 import com.dat3m.dartagnan.configuration.ProgressModel;
 import com.dat3m.dartagnan.exception.MalformedProgramException;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
@@ -16,7 +17,6 @@ import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.VerificationTask.VerificationTaskBuilder;
 import com.dat3m.dartagnan.witness.graphml.WitnessGraph;
 import com.dat3m.dartagnan.wmm.Wmm;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharSource;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.slf4j.Logger;
@@ -31,93 +31,60 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Stream;
 
-import static com.dat3m.dartagnan.configuration.OptionInfo.collectOptions;
-import static com.dat3m.dartagnan.configuration.OptionNames.*;
-import static com.dat3m.dartagnan.utils.ExitCode.*;
+import static com.dat3m.dartagnan.configuration.OptionNames.TARGET;
+import static com.dat3m.dartagnan.utils.ExitCode.NORMAL_TERMINATION;
 import static com.dat3m.dartagnan.utils.GitInfo.*;
-import static com.dat3m.dartagnan.witness.graphviz.ExecutionGraphVisualizer.generateGraphvizFile;
 
 @Options
 public class Dartagnan extends BaseOptions {
 
     private static final Logger logger = LoggerFactory.getLogger(Dartagnan.class);
 
-    private static final Set<String> supportedFormats = ImmutableSet.copyOf(ProgramParser.SUPPORTED_EXTENSIONS);
-
     private Dartagnan(Configuration config) throws InvalidConfigurationException {
         config.recursiveInject(this);
     }
-
-    private static Configuration loadConfiguration(String[] args) throws InvalidConfigurationException, IOException {
-        final var preamble = new StringBuilder();
-        final var options = new StringBuilder();
-        for (String argument : args) {
-            if (argument.startsWith("--")) {
-                options.append(argument.substring("--".length())).append("\n");
-            } else if (argument.endsWith(".properties")) {
-                preamble.append("#include ").append(argument).append("\n");
-            }
-        }
-        final CharSource source = CharSource.concat(CharSource.wrap(preamble), CharSource.wrap(options));
-        return Configuration.builder()
-                .addConverter(ProgressModel.Hierarchy.class, ProgressModel.HIERARCHY_CONVERTER)
-                .loadFromSource(source, ".", ".")
-                .build();
-    }
-
 
     public static void main(String[] args) throws Exception {
 
         initGitInfo();
 
         if (Arrays.asList(args).contains("--help")) {
-            collectOptions();
+            printOptions();
             return;
-        }
-
-        if (Arrays.asList(args).contains("--version")) {
-            final MavenXpp3Reader mvnReader = new MavenXpp3Reader();
-            final FileReader fileReader = new FileReader(System.getenv("DAT3M_HOME") + "/pom.xml");
-            final String base = mvnReader.read(fileReader).getVersion();
-            final String version = base.equals(getGitTags()) ? base : String.format("%s (commit %s)", base, getGitId());
-            System.out.println(version);
+        } else if (Arrays.asList(args).contains("--version")) {
+            printVersion();
             return;
         }
 
         logGitInfo();
 
-        final Configuration config = loadConfiguration(args);
+        final Configuration config = loadConfigurationFromArgs(args);
         final Dartagnan o = new Dartagnan(config);
 
-        final File wmmFile = new File(Arrays.stream(args).filter(a -> a.endsWith(".cat")).findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("CAT model not given or format not recognized")));
-        logger.info("CAT file path: {}", wmmFile);
-        final OutputLogger output = new OutputLogger(wmmFile, config);
+        final File catFile = getCatFileFromArgs(args);
+        final List<File> progFiles = getProgramFilesFromArgs(args);
+        final boolean isBatchMode = progFiles.size() > 1;
 
-        final WitnessGraph witness;
-        if (o.runValidator()) {
-            logger.info("Witness path: {}", o.getWitnessPath());
-            witness = new ParserWitness().parse(new File(o.getWitnessPath()));
-        } else {
-            witness = new WitnessGraph();
-        }
+        final WitnessGraph witness = getWitnessGraph(o, isBatchMode);
 
-        ResultSummary summary = null;
-        final List<File> files = getProgramFilesFromArgs(args);
+        final OutputLogger output = new OutputLogger(catFile, config);
         final TaskResultAnalyzer resultAnalyzer = TaskResultAnalyzer.create();
-        for (File f : files) {
-            final String progFilePath = f.getPath();
+        ResultSummary summary = null;
+        for (File progFile : progFiles) {
             try {
                 // ----------- Generate verification task -----------
-                final Program p = new ProgramParser().parse(f);
+                final Program p = new ProgramParser().parse(progFile);
                 if (o.overrideEntryFunction()) {
                     p.setEntrypoint(new Entrypoint.Simple(p.getFunctionByName(o.getEntryFunction()).orElseThrow(
                             () -> new MalformedProgramException(String.format("Program has no function named %s. Select a different entry point.", o.getEntryFunction())))));
                 }
-                final Wmm mcm = new ParserCat(Path.of(o.getCatIncludePath())).parse(wmmFile);
+                final Wmm mcm = new ParserCat(Path.of(o.getCatIncludePath())).parse(catFile);
                 final VerificationTaskBuilder builder = VerificationTask.builder()
                         .withConfig(config)
                         .withProgressModel(o.getProgressModel())
@@ -135,65 +102,109 @@ public class Dartagnan extends BaseOptions {
                 taskSolver.run();
 
                 // ----------- Generate output-----------
-                summary = resultAnalyzer.getSummaryFromSolver(taskSolver, f.getPath());
+                summary = resultAnalyzer.getSummaryFromSolver(taskSolver, progFile.getPath());
                 // We only generate witnesses if we are not validating one.
                 if (!o.runValidator()) {
-                    final String progName = task.getProgram().getName();
-                    final int fileSuffixIndex = progName.lastIndexOf('.');
-                    final String filename = o.hasWitnessFilename() ?
-                            o.getWitnessFilename() :
-                            progName.isEmpty() ?
-                                    "unnamed_program" :
-                                    (fileSuffixIndex == -1) ? progName : progName.substring(0, fileSuffixIndex);
-
+                    final String filename = getWitnessFileName(task.getProgram(), o);
                     resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), filename, summary.reason() + "\n" + summary.details(), o.generateWitnessForUnknown());
                 }
             } catch (Exception e) {
-                summary = resultAnalyzer.getSummaryFromException(e, progFilePath);
+                summary = resultAnalyzer.getSummaryFromException(e, progFile.getPath());
             }
             output.addResult(summary);
         }
-        output.toStdOut(files.size() > 1);
+        output.toStdOut(isBatchMode);
         // Running batch mode results in normal termination independent of the individual results
-        System.exit((files.size() > 1 ? NORMAL_TERMINATION : summary.code()).asInt());
+        System.exit((isBatchMode ? NORMAL_TERMINATION : summary.code()).asInt());
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+
+    private static void printOptions() {
+        OptionInfo.stream().sorted().forEach(System.out::print);
+    }
+
+    private static void printVersion() throws Exception {
+        final MavenXpp3Reader mvnReader = new MavenXpp3Reader();
+        final FileReader fileReader = new FileReader(System.getenv("DAT3M_HOME") + "/pom.xml");
+        final String base = mvnReader.read(fileReader).getVersion();
+        final String version = base.equals(getGitTags()) ? base : String.format("%s (commit %s)", base, getGitId());
+
+        System.out.println(version);
+    }
+
+    private static Configuration loadConfigurationFromArgs(String[] args) throws InvalidConfigurationException, IOException {
+        final var preamble = new StringBuilder();
+        final var options = new StringBuilder();
+        for (String argument : args) {
+            if (argument.startsWith("--")) {
+                options.append(argument.substring("--".length())).append("\n");
+            } else if (argument.endsWith(".properties")) {
+                preamble.append("#include ").append(argument).append("\n");
+            }
+        }
+        final CharSource source = CharSource.concat(CharSource.wrap(preamble), CharSource.wrap(options));
+        return Configuration.builder()
+                .addConverter(ProgressModel.Hierarchy.class, ProgressModel.HIERARCHY_CONVERTER)
+                .loadFromSource(source, ".", ".")
+                .build();
+    }
+
+    private static File getCatFileFromArgs(String[] args) {
+        File catFile = Arrays.stream(args)
+                .filter(a -> a.endsWith(".cat"))
+                .findFirst()
+                .map(File::new)
+                .orElseThrow(() -> new IllegalArgumentException("CAT model not given or format not recognized"));
+        logger.info("CAT file path: {}", catFile);
+        return catFile;
     }
 
     private static List<File> getProgramFilesFromArgs(String[] args) {
         final List<File> files = new ArrayList<>();
-        Stream.of(args)
-            .map(File::new)
-            .forEach(file -> {
-                if (file.exists()) {
-                    final String path = file.getAbsolutePath();
-                    if (file.isDirectory()) {
-                        logger.info("Programs path: {}", path);
-                        files.addAll(getProgramFiles(path));
-                    } else if (file.isFile() && supportedFormats.stream().anyMatch(file.getName()::endsWith)) {
-                        logger.info("Program path: {}", path);
-                        files.add(file);
-                    }
-                }
-            });
+        Stream.of(args).map(Paths::get).filter(Files::exists)
+                .forEach(path -> {
+                    logger.info("Program(s) path: {}", path.normalize());
+                    files.addAll(getProgramFiles(path));
+                });
         if (files.isEmpty()) {
             throw new IllegalArgumentException("Path to input program(s) not given or format not recognized");
         }
         return files;
     }
 
-    private static List<File> getProgramFiles(String dirPath) {
-        List<File> files = new ArrayList<>();
-        try (Stream<Path> stream = Files.walk(Paths.get(dirPath))) {
-            files = stream.filter(Files::isRegularFile)
-                .filter(p -> supportedFormats.stream().anyMatch(p.toString()::endsWith))
-                .map(Path::toFile)
-                .sorted(Comparator.comparing(File::toString))
-                .toList();
+    private static List<File> getProgramFiles(Path path) {
+        try (Stream<Path> stream = Files.walk(path)) {
+            return stream.filter(Files::isRegularFile)
+                    .filter(ProgramParser::isSupported)
+                    .sorted(Comparator.comparing(Path::toString))
+                    .map(Path::toFile)
+                    .toList();
         } catch (IOException e) {
-            logger.error("There was an I/O error when accessing path {}", dirPath);
-            System.exit(UNKNOWN_ERROR.asInt());
+            logger.error("There was an I/O error when accessing path {}", path);
+            return List.of();
         }
-        return files;
     }
 
+    private static WitnessGraph getWitnessGraph(Dartagnan o, boolean isBatchMode) throws IOException {
+        if (!o.runValidator()) {
+            return new WitnessGraph();
+        }
 
+        if (isBatchMode) {
+            throw new IllegalArgumentException("Cannot run validator in batch mode.");
+        }
+        logger.info("Witness path: {}", o.getWitnessPath());
+        return new ParserWitness().parse(new File(o.getWitnessPath()));
+    }
+
+    private static String getWitnessFileName(Program program, Dartagnan o) {
+        if (o.hasWitnessFilename()) {
+            return o.getWitnessFilename();
+        }
+
+        return program.getName().isEmpty()
+                ? "unnamed_program"
+                : com.google.common.io.Files.getNameWithoutExtension(program.getName());
+    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -26,6 +26,7 @@ import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.utils.printer.OutputLogger;
 import com.dat3m.dartagnan.utils.printer.OutputLogger.ResultSummary;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.VerificationTask.VerificationTaskBuilder;
 import com.dat3m.dartagnan.verification.model.ExecutionModelNext;
@@ -157,14 +158,14 @@ public class Dartagnan extends BaseOptions {
                 }
                 final VerificationTask task = builder.build(p, mcm, o.getProperty());
 
-                // ----------- Run Model Checker ----------
-                final ModelChecker modelChecker = ModelChecker.create(task, o.getMethod());
+                // ----------- Solve task ----------
+                final TaskSolver taskSolver = TaskSolver.create(task);
                 long startTime = System.currentTimeMillis();
-                modelChecker.run();
+                taskSolver.run();
                 long endTime = System.currentTimeMillis();
 
                 // ----------- Generate output-----------
-                summary = summaryFromResult(task, modelChecker, f.toString(), (endTime - startTime));
+                summary = summaryFromResult(task, taskSolver, f.toString(), (endTime - startTime));
                 // We only generate witnesses if we are not validating one.
                 if (!o.runValidator()) {
                     final String progName = task.getProgram().getName();
@@ -174,7 +175,7 @@ public class Dartagnan extends BaseOptions {
                                         progName.isEmpty() ?
                                             "unnamed_program" :
                                             (fileSuffixIndex == - 1) ? progName : progName.substring(0, fileSuffixIndex);
-                    generateWitnessIfAble(task, modelChecker, o.getWitnessType(), filename, summary.reason() + "\n" + summary.details(), o.generateWitnessForUnknown());
+                    generateWitnessIfAble(task, taskSolver, o.getWitnessType(), filename, summary.reason() + "\n" + summary.details(), o.generateWitnessForUnknown());
                 }
             } catch (InterruptedException e) {
                 final String details;
@@ -240,20 +241,20 @@ public class Dartagnan extends BaseOptions {
         return files;
     }
 
-    public static File generateWitnessIfAble(VerificationTask task, ModelChecker modelChecker,
+    public static File generateWitnessIfAble(VerificationTask task, TaskSolver solver,
         WitnessType witnessType, String filename, String details, boolean generateWitnessForUnknown) throws SolverException, IOException {
-            if (!modelChecker.hasModel() ||
-                (modelChecker.getResult() == UNKNOWN && !generateWitnessForUnknown)) {
+            if (!solver.hasModel() ||
+                (solver.getResult() == UNKNOWN && !generateWitnessForUnknown)) {
                 return null;
             }
             switch (witnessType) {
                 case NONE:
                     break;
                 case GRAPHML:
-                    assert modelChecker.getResult() != UNKNOWN;
+                    assert solver.getResult() != UNKNOWN;
                     if (task.getProgram().getFormat().equals(SourceLanguage.LLVM) && requiresSvcompWitness(task.getProperty())) {
-                        try (IREvaluator evaluator = modelChecker.getModel()) {
-                            WitnessBuilder w = WitnessBuilder.of(evaluator, modelChecker.getResult(), details);
+                        try (IREvaluator evaluator = solver.getModel()) {
+                            WitnessBuilder w = WitnessBuilder.of(evaluator, solver.getResult(), details);
                             if (w.canBeBuilt()) {
                                 w.build().write(filename);
                             }
@@ -264,7 +265,7 @@ public class Dartagnan extends BaseOptions {
                     break;
                 case DOT, PNG:
                     final SyntacticContextAnalysis synContext = newInstance(task.getProgram());
-                    final ExecutionModelNext model = modelChecker.getExecutionGraph();
+                    final ExecutionModelNext model = solver.getExecutionGraph();
                     // RF edges give both ordering and data flow information, thus even when the pair is in PO
                     // we get some data flow information by observing the edge
                     // CO edges only give ordering information which is known if the pair is also in PO
@@ -276,17 +277,16 @@ public class Dartagnan extends BaseOptions {
             return null;
     }
 
-    public static ResultSummary summaryFromResult(VerificationTask task, ModelChecker modelChecker, String path, long time) throws SolverException {
-        try (IREvaluator evaluator = modelChecker.hasModel() ? modelChecker.getModel() : null) {
-            return summaryFromResult(task, modelChecker, evaluator, path, time);
+    public static ResultSummary summaryFromResult(VerificationTask task, TaskSolver solver, String path, long time) throws SolverException {
+        try (IREvaluator evaluator = solver.hasModel() ? solver.getModel() : null) {
+            return summaryFromResult(task, solver.getResult(), evaluator, path, time);
         }
     }
 
-    private static ResultSummary summaryFromResult(VerificationTask task, ModelChecker modelChecker, IREvaluator model, String path, long time) throws SolverException {
+    private static ResultSummary summaryFromResult(VerificationTask task, Result result, IREvaluator model, String path, long time) throws SolverException {
         // ----------------- Generate output of verification result -----------------
         final Program p = task.getProgram();
         final EnumSet<Property> props = task.getProperty();
-        final Result result = modelChecker.getResult();
         final boolean hasViolations = result == FAIL && model != null;
         final boolean hasViolationsWithoutWitness = result == FAIL && model == null;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -1,58 +1,32 @@
 package com.dat3m.dartagnan;
 
-import com.dat3m.dartagnan.configuration.OptionNames;
 import com.dat3m.dartagnan.configuration.ProgressModel;
-import com.dat3m.dartagnan.configuration.Property;
-import com.dat3m.dartagnan.encoding.IREvaluator;
 import com.dat3m.dartagnan.exception.MalformedProgramException;
-import com.dat3m.dartagnan.expression.ExpressionPrinter;
-import com.dat3m.dartagnan.expression.booleans.BoolLiteral;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.parsers.witness.ParserWitness;
 import com.dat3m.dartagnan.program.Entrypoint;
 import com.dat3m.dartagnan.program.Program;
-import com.dat3m.dartagnan.program.Program.SourceLanguage;
-import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
-import com.dat3m.dartagnan.program.event.BlockingEvent;
-import com.dat3m.dartagnan.program.event.Event;
-import com.dat3m.dartagnan.program.event.Tag;
-import com.dat3m.dartagnan.program.event.core.Assert;
-import com.dat3m.dartagnan.program.event.core.CondJump;
-import com.dat3m.dartagnan.program.memory.MemoryObject;
-import com.dat3m.dartagnan.program.processing.LoopUnrolling;
-import com.dat3m.dartagnan.utils.ExitCode;
-import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.utils.printer.OutputLogger;
 import com.dat3m.dartagnan.utils.printer.OutputLogger.ResultSummary;
+import com.dat3m.dartagnan.verification.TaskResultAnalyzer;
 import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.VerificationTask.VerificationTaskBuilder;
-import com.dat3m.dartagnan.verification.model.ExecutionModelNext;
-import com.dat3m.dartagnan.verification.solving.ModelChecker;
-import com.dat3m.dartagnan.witness.WitnessType;
-import com.dat3m.dartagnan.witness.graphml.WitnessBuilder;
 import com.dat3m.dartagnan.witness.graphml.WitnessGraph;
 import com.dat3m.dartagnan.wmm.Wmm;
-import com.dat3m.dartagnan.wmm.axiom.Axiom;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharSource;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.csv.CSVRecord;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Options;
-import org.sosy_lab.java_smt.api.SolverException;
 
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -60,14 +34,10 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Stream;
 
-import static com.dat3m.dartagnan.GlobalSettings.getOrCreateOutputDirectory;
 import static com.dat3m.dartagnan.configuration.OptionInfo.collectOptions;
 import static com.dat3m.dartagnan.configuration.OptionNames.*;
-import static com.dat3m.dartagnan.configuration.Property.*;
-import static com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis.*;
 import static com.dat3m.dartagnan.utils.ExitCode.*;
 import static com.dat3m.dartagnan.utils.GitInfo.*;
-import static com.dat3m.dartagnan.utils.Result.*;
 import static com.dat3m.dartagnan.witness.graphviz.ExecutionGraphVisualizer.generateGraphvizFile;
 
 @Options
@@ -122,10 +92,10 @@ public class Dartagnan extends BaseOptions {
         final Configuration config = loadConfiguration(args);
         final Dartagnan o = new Dartagnan(config);
 
-        final File fileModel = new File(Arrays.stream(args).filter(a -> a.endsWith(".cat")).findFirst()
+        final File wmmFile = new File(Arrays.stream(args).filter(a -> a.endsWith(".cat")).findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("CAT model not given or format not recognized")));
-        logger.info("CAT file path: {}", fileModel);
-        final OutputLogger output = new OutputLogger(fileModel, config);
+        logger.info("CAT file path: {}", wmmFile);
+        final OutputLogger output = new OutputLogger(wmmFile, config);
 
         final WitnessGraph witness;
         if (o.runValidator()) {
@@ -137,15 +107,17 @@ public class Dartagnan extends BaseOptions {
 
         ResultSummary summary = null;
         final List<File> files = getProgramFilesFromArgs(args);
+        final TaskResultAnalyzer resultAnalyzer = TaskResultAnalyzer.create();
         for (File f : files) {
+            final String progFilePath = f.getPath();
             try {
                 // ----------- Generate verification task -----------
                 final Program p = new ProgramParser().parse(f);
                 if (o.overrideEntryFunction()) {
                     p.setEntrypoint(new Entrypoint.Simple(p.getFunctionByName(o.getEntryFunction()).orElseThrow(
-                        () -> new MalformedProgramException(String.format("Program has no function named %s. Select a different entry point.", o.getEntryFunction())))));
+                            () -> new MalformedProgramException(String.format("Program has no function named %s. Select a different entry point.", o.getEntryFunction())))));
                 }
-                final Wmm mcm = new ParserCat(Path.of(o.getCatIncludePath())).parse(fileModel);
+                final Wmm mcm = new ParserCat(Path.of(o.getCatIncludePath())).parse(wmmFile);
                 final VerificationTaskBuilder builder = VerificationTask.builder()
                         .withConfig(config)
                         .withProgressModel(o.getProgressModel())
@@ -160,42 +132,24 @@ public class Dartagnan extends BaseOptions {
 
                 // ----------- Solve task ----------
                 final TaskSolver taskSolver = TaskSolver.create(task);
-                long startTime = System.currentTimeMillis();
                 taskSolver.run();
-                long endTime = System.currentTimeMillis();
 
                 // ----------- Generate output-----------
-                summary = summaryFromResult(task, taskSolver, f.toString(), (endTime - startTime));
+                summary = resultAnalyzer.getSummaryFromSolver(taskSolver, f.getPath());
                 // We only generate witnesses if we are not validating one.
                 if (!o.runValidator()) {
                     final String progName = task.getProgram().getName();
                     final int fileSuffixIndex = progName.lastIndexOf('.');
                     final String filename = o.hasWitnessFilename() ?
-                                        o.getWitnessFilename() :
-                                        progName.isEmpty() ?
-                                            "unnamed_program" :
-                                            (fileSuffixIndex == - 1) ? progName : progName.substring(0, fileSuffixIndex);
-                    generateWitnessIfAble(task, taskSolver, o.getWitnessType(), filename, summary.reason() + "\n" + summary.details(), o.generateWitnessForUnknown());
+                            o.getWitnessFilename() :
+                            progName.isEmpty() ?
+                                    "unnamed_program" :
+                                    (fileSuffixIndex == -1) ? progName : progName.substring(0, fileSuffixIndex);
+
+                    resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), filename, summary.reason() + "\n" + summary.details(), o.generateWitnessForUnknown());
                 }
-            } catch (InterruptedException e) {
-                final String details;
-                final ExitCode exitCode;
-                if (e.getMessage() != null) {
-                    details = "\t" + e.getMessage();
-                    exitCode = e.getMessage().contains("Timeout")
-                            ? TIMEOUT_ELAPSED
-                            : e.getMessage().contains("canceled")
-                            ? CANCELED
-                            : UNKNOWN_ERROR;
-                } else {
-                    details = "\tUnknown error occurred";
-                    exitCode = UNKNOWN_ERROR;
-                }
-                summary = new ResultSummary(f.toString(), "", INTERRUPTED, "", "", details, 0, exitCode);
             } catch (Exception e) {
-                final String reason = e.getClass().getSimpleName();
-                final String details = "\t" + Optional.ofNullable(e.getMessage()).orElse("Unknown error occurred");
-                summary = new ResultSummary(f.toString(), "", ERROR, "", reason, details, 0, UNKNOWN_ERROR);
+                summary = resultAnalyzer.getSummaryFromException(e, progFilePath);
             }
             output.addResult(summary);
         }
@@ -241,259 +195,5 @@ public class Dartagnan extends BaseOptions {
         return files;
     }
 
-    public static File generateWitnessIfAble(VerificationTask task, TaskSolver solver,
-        WitnessType witnessType, String filename, String details, boolean generateWitnessForUnknown) throws SolverException, IOException {
-            if (!solver.hasModel() ||
-                (solver.getResult() == UNKNOWN && !generateWitnessForUnknown)) {
-                return null;
-            }
-            switch (witnessType) {
-                case NONE:
-                    break;
-                case GRAPHML:
-                    assert solver.getResult() != UNKNOWN;
-                    if (task.getProgram().getFormat().equals(SourceLanguage.LLVM) && requiresSvcompWitness(task.getProperty())) {
-                        try (IREvaluator evaluator = solver.getModel()) {
-                            WitnessBuilder w = WitnessBuilder.of(evaluator, solver.getResult(), details);
-                            if (w.canBeBuilt()) {
-                                w.build().write(filename);
-                            }
-                        } catch (InvalidConfigurationException e) {
-                            logger.warn(e.getMessage());
-                        }
-                    }
-                    break;
-                case DOT, PNG:
-                    final SyntacticContextAnalysis synContext = newInstance(task.getProgram());
-                    final ExecutionModelNext model = solver.getExecutionGraph();
-                    // RF edges give both ordering and data flow information, thus even when the pair is in PO
-                    // we get some data flow information by observing the edge
-                    // CO edges only give ordering information which is known if the pair is also in PO
-                    return generateGraphvizFile(model, 1, (x, y) -> true,
-                            (x, y) -> !x.getThreadModel().getThread().equals(y.getThreadModel().getThread()),
-                            getOrCreateOutputDirectory() + "/", filename,
-                            synContext, witnessType.convertToPng(), task.getConfig());
-            }
-            return null;
-    }
-
-    public static ResultSummary summaryFromResult(VerificationTask task, TaskSolver solver, String path, long time) throws SolverException {
-        try (IREvaluator evaluator = solver.hasModel() ? solver.getModel() : null) {
-            return summaryFromResult(task, solver.getResult(), evaluator, path, time);
-        }
-    }
-
-    private static ResultSummary summaryFromResult(VerificationTask task, Result result, IREvaluator model, String path, long time) throws SolverException {
-        // ----------------- Generate output of verification result -----------------
-        final Program p = task.getProgram();
-        final EnumSet<Property> props = task.getProperty();
-        final boolean hasViolations = result == FAIL && model != null;
-        final boolean hasViolationsWithoutWitness = result == FAIL && model == null;
-
-        String reason = "";
-        StringBuilder details = new StringBuilder();
-        // We only show the condition if this is the reason of the failure
-        String condition = "";
-        final boolean ignoreFilter = Objects.equals(task.getConfig().getProperty(IGNORE_FILTER_SPECIFICATION), "true");
-        final boolean nonEmptyFilter = !(p.getFilterSpecification() instanceof BoolLiteral bLit) || !bLit.getValue();
-        final String filter = !ignoreFilter && nonEmptyFilter ? p.getFilterSpecification().toString() : "";
-
-        final SyntacticContextAnalysis synContext = newInstance(p);
-        if (hasViolations) {
-            printWarningIfThreadStartFailed(p, model);
-            if (props.contains(PROGRAM_SPEC) && model.propertyViolated(PROGRAM_SPEC)) {
-                reason = ResultSummary.PROGRAM_SPEC_REASON;
-                condition = getSpecificationString(p);
-                List<Assert> violations = p.getThreadEvents(Assert.class)
-                    .stream().filter(model::assertionViolated)
-                    .toList();
-                for (Assert ass : violations) {
-                    appendTo(details, ass, synContext);
-                }
-                // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
-                ExitCode code = task.getWitness().isEmpty() ? PROGRAM_SPEC_VIOLATION : NORMAL_TERMINATION;
-                return new ResultSummary(path, filter, FAIL, condition, reason, details.toString(), time, code);
-            }
-            if (props.contains(TERMINATION) && model.propertyViolated(TERMINATION)) {
-                reason = ResultSummary.TERMINATION_REASON;
-                for (Event e : p.getThreadEvents()) {
-                    final boolean isStuckLoop = e instanceof CondJump jump
-                            && e.hasTag(Tag.NONTERMINATION) && !e.hasTag(Tag.BOUND)
-                            && model.jumpTaken(jump);
-                    final boolean isStuckBarrier = e instanceof BlockingEvent barrier
-                            && model.isBlocked(barrier);
-
-                    if (isStuckLoop || isStuckBarrier) {
-                        appendTo(details, e, synContext);
-                    }
-                }
-                // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
-                ExitCode code = task.getWitness().isEmpty() ? TERMINATION_VIOLATION : NORMAL_TERMINATION;
-                return new ResultSummary(path, filter, FAIL, condition, reason, details.toString(), time, code);
-            }
-            if (props.contains(DATARACEFREEDOM) && model.propertyViolated(DATARACEFREEDOM)) {
-                reason = ResultSummary.SVCOMP_RACE_REASON;
-                // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
-                ExitCode code = task.getWitness().isEmpty() ? DATA_RACE_FREEDOM_VIOLATION : NORMAL_TERMINATION;
-                return new ResultSummary(path, filter, FAIL, condition, reason, details.toString(), time, code);
-            }
-            if (props.contains(TRACKABILITY) && model.propertyViolated(TRACKABILITY)) {
-                reason = ResultSummary.SVCOMP_UNTRACKABLE_OBJECT_REASON;
-                for (MemoryObject o : p.getMemory().getObjects()) {
-                    if (model.isLeaked(o) && !model.isTrackable(o)) {
-                        appendTo(details, o.getAllocationSite(), synContext);
-                    }
-                }
-                ExitCode code = task.getWitness().isEmpty() ? MEMORY_TRACKABILITY_VIOLATION : NORMAL_TERMINATION;
-                return new ResultSummary(path, filter, FAIL, condition, reason, details.toString(), time, code);
-            }
-            final List<Axiom> violatedCATSpecs = !props.contains(CAT_SPEC) ? List.of()
-                    : task.getMemoryModel().getAxioms().stream()
-                    .filter(Axiom::isFlagged)
-                    .filter(model::isFlaggedAxiomViolated)
-                    .toList();
-            if (!violatedCATSpecs.isEmpty()) {
-                reason = ResultSummary.CAT_SPEC_REASON;
-                // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
-                ExitCode code = task.getWitness().isEmpty() ? CAT_SPEC_VIOLATION : NORMAL_TERMINATION;
-                return new ResultSummary(path, filter, FAIL, condition, reason, getFlaggedPairsOutput(task, model), time, code);
-            }
-        } else if (hasViolationsWithoutWitness) {
-            // Only for programs with exists/forall specifications
-            reason = ResultSummary.PROGRAM_SPEC_REASON;
-            condition = getSpecificationString(p);
-        } else if (result == UNKNOWN && model != null) {
-            // We reached unrolling bounds.
-            final List<Event> reachedBounds = p.getThreadEventsWithAllTags(Tag.BOUND)
-                    .stream().filter(model::isExecuted)
-                    .toList();
-            reason = ResultSummary.BOUND_REASON;
-            for (Event bound : reachedBounds) {
-                details
-                        .append("\t")
-                        .append(synContext.getSourceLocationWithContext(bound, true))
-                        .append("\n");
-            }
-            try {
-                increaseBoundAndDump(reachedBounds, task.getConfig());
-            } catch (IOException e) {
-                logger.warn("Failed to save bounds file: {}", e.getLocalizedMessage());
-            }
-            ExitCode code = BOUNDED_RESULT;
-            return new ResultSummary(path, filter, result, condition, reason, details.toString(), time, code);
-        }
-        // We consider those cases without an explicit return to yield normal termination.
-        // This includes verification of litmus code, independent of the verification result.
-        // In validation mode, we expect to find the violation, thus the WITNESS_NOT_VALIDATED error
-        ExitCode code = task.getWitness().isEmpty() ? NORMAL_TERMINATION : WITNESS_NOT_VALIDATED;
-        return new ResultSummary(path, filter, result, condition, reason, details.toString(), time, code);
-    }
-
-    private static void appendTo(StringBuilder details, Event event, SyntacticContextAnalysis synContext) {
-        details.append("\t").append(synContext.getSourceLocationWithContext(event, true));
-        if (event instanceof Assert ass) {
-            details.append(": ").append(ass.getErrorMessage());
-        }
-        details.append("\n");
-    }
-
-    private static void increaseBoundAndDump(List<Event> boundEvents, Configuration config) throws IOException {
-        if(!config.hasProperty(BOUNDS_SAVE_PATH)) {
-            return;
-        }
-        final File boundsFile = new File(config.getProperty(BOUNDS_SAVE_PATH));
-
-        // Parse old entries
-        final List<CSVRecord> entries;
-        try (CSVParser parser = CSVParser.parse(new FileReader(boundsFile), CSVFormat.DEFAULT)) {
-            entries = parser.getRecords();
-        }
-
-        // Compute update for entries
-        final Map<Integer, Integer> loopId2UpdatedBound = new HashMap<>();
-        for (Event e : boundEvents) {
-            assert e instanceof CondJump;
-            final CondJump loopJump = (CondJump) e;
-            final int loopId = LoopUnrolling.getPersistentLoopId(loopJump);
-            final int bound = LoopUnrolling.getUnrollingBoundAnnotation(loopJump);
-            loopId2UpdatedBound.put(loopId, bound + 1);
-        }
-
-        // Write new entries
-        try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(boundsFile, false), CSVFormat.DEFAULT)) {
-            for (CSVRecord entry : entries) {
-                final int entryId = Integer.parseInt(entry.get(0));
-                if (!loopId2UpdatedBound.containsKey(entryId)) {
-                    csvPrinter.printRecord(entry);
-                } else {
-                    final String[] content = entry.values();
-                    content[1] = String.valueOf(loopId2UpdatedBound.get(entryId));
-                    csvPrinter.printRecord(Arrays.asList(content));
-                }
-            }
-            csvPrinter.flush();
-        }
-    }
-
-    private static void printWarningIfThreadStartFailed(Program p, IREvaluator model) {
-        p.getThreads().stream().filter(t ->
-                t.getEntry().isSpawned()
-                && model.isExecuted(t.getEntry().getCreator())
-                && !model.threadHasStarted(t)
-        ).forEach(t -> System.out.printf(
-                "[WARNING] The call to pthread_create of thread %s failed. To force thread creation to succeed use --%s=true%n",
-                t, OptionNames.THREAD_CREATE_ALWAYS_SUCCEEDS
-        ));
-    }
-
-    private static String getSpecificationString(Program program) {
-        final StringBuilder sb = new StringBuilder();
-        final SourceLanguage format = program.getFormat();
-        if (format == SourceLanguage.LITMUS || format == SourceLanguage.SPV) {
-            sb.append(program.getSpecificationType().toString().toLowerCase()).append(" ");
-            if (program.getSpecification() != null) {
-                sb.append(new ExpressionPrinter(true).visit(program.getSpecification()));
-            }
-            sb.append("\n");
-        }
-        return sb.toString();
-    }
-
-    private static String getFlaggedPairsOutput(VerificationTask task, IREvaluator model) {
-        if (!task.getProperty().contains(CAT_SPEC)) {
-            return "";
-        }
-
-        final Wmm wmm = task.getMemoryModel();
-        final Program program = task.getProgram();
-        final StringBuilder output = new StringBuilder();
-        final SyntacticContextAnalysis synContext = newInstance(program);
-        for (Axiom ax : wmm.getAxioms()) {
-            if (ax.isFlagged() && model.isFlaggedAxiomViolated(ax)) {
-                StringBuilder violatingPairs = new StringBuilder("\tFlag " + Optional.ofNullable(ax.getName()).orElse(ax.getRelation().getNameOrTerm())).append("\n");
-                model.eventGraph(ax.getRelation()).apply((e1, e2) -> {
-                    final String callSeparator = " -> ";
-                    final String callStackFirst = makeContextString(
-                            synContext.getContextInfo(e1).getContextOfType(CallContext.class),
-                            callSeparator);
-                    final String callStackSecond = makeContextString(
-                            synContext.getContextInfo(e2).getContextOfType(CallContext.class),
-                            callSeparator);
-
-                    violatingPairs
-                            .append("\t").append(callStackFirst).append(callStackFirst.isEmpty() ? "" : callSeparator)
-                            .append(getSourceLocationString(e1))
-                            .append(" / ").append(callStackSecond).append(callStackSecond.isEmpty() ? "" : callSeparator)
-                            .append(getSourceLocationString(e2))
-                            .append("\t(E").append(e1.getGlobalId())
-                            .append(" / E").append(e2.getGlobalId()).append(")")
-                            .append("\n");
-                });
-                output.append(violatingPairs);
-            }
-        }
-
-        return output.toString();
-    }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -113,14 +113,15 @@ public class Dartagnan extends BaseOptions {
             }
             output.addResult(summary);
         }
-        output.toStdOut(isBatchMode);
+
+        output.toStdOut();
         // Running batch mode results in normal termination independent of the individual results
         System.exit((isBatchMode ? NORMAL_TERMINATION : summary.code()).asInt());
     }
 
     // ----------------------------------------------------------------------------------------------------
 
-    private static void printOptions() {
+    public static void printOptions() {
         OptionInfo.stream().sorted().forEach(System.out::print);
     }
 
@@ -186,16 +187,16 @@ public class Dartagnan extends BaseOptions {
         }
     }
 
-    private static WitnessGraph getWitnessGraph(Dartagnan o, boolean isBatchMode) throws IOException {
-        if (!o.runValidator()) {
+    private static WitnessGraph getWitnessGraph(BaseOptions options, boolean isBatchMode) throws IOException {
+        if (!options.runValidator()) {
             return new WitnessGraph();
         }
 
         if (isBatchMode) {
             throw new IllegalArgumentException("Cannot run validator in batch mode.");
         }
-        logger.info("Witness path: {}", o.getWitnessPath());
-        return new ParserWitness().parse(new File(o.getWitnessPath()));
+        logger.info("Witness path: {}", options.getWitnessPath());
+        return new ParserWitness().parse(new File(options.getWitnessPath()));
     }
 
     private static String getWitnessFileName(Program program, Dartagnan o) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
@@ -31,10 +31,6 @@ import static com.google.common.base.Verify.verify;
 
 public final class OptionInfo implements Comparable<OptionInfo> {
 
-    public static void collectOptions() {
-        stream().sorted().forEach(System.out::print);
-    }
-
     public static Stream<OptionInfo> stream() {
         return classes().flatMap(OptionInfo::collectOptions);
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
@@ -12,6 +12,7 @@ import com.dat3m.dartagnan.utils.printer.Printer;
 import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.verification.solving.RefinementSolver;
+import com.dat3m.dartagnan.witness.graphviz.ExecutionGraphVisualizer;
 import com.dat3m.dartagnan.wmm.RelationNameRepository;
 import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.analysis.WmmAnalysis;
@@ -69,7 +70,8 @@ public final class OptionInfo implements Comparable<OptionInfo> {
                 RefinementSolver.class,
                 RelationAnalysis.Config.class,
                 WmmAnalysis.class,
-                WmmProcessingManager.class
+                WmmProcessingManager.class,
+                ExecutionGraphVisualizer.class
         );
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionInfo.java
@@ -9,6 +9,7 @@ import com.dat3m.dartagnan.program.processing.compilation.Compilation;
 import com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreReasoner;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.utils.printer.Printer;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.dat3m.dartagnan.wmm.RelationNameRepository;
@@ -37,6 +38,7 @@ public final class OptionInfo implements Comparable<OptionInfo> {
 
     private static Stream<Class<?>> classes() {
         return Stream.of(
+                TaskSolver.class,
                 RelationNameRepository.class,
                 OptionNames.class,
                 Acyclicity.class,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
@@ -2,12 +2,14 @@ package com.dat3m.dartagnan.parsers.program;
 
 import com.dat3m.dartagnan.exception.ParsingException;
 import com.dat3m.dartagnan.program.Program;
+import com.google.common.io.Files;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.util.List;
 
 import static com.dat3m.dartagnan.parsers.program.utils.Compilation.compileWithClang;
@@ -33,6 +35,11 @@ public class ProgramParser {
     public static final String EXTENSION_SPVASM = ".spvasm";
     public static final List<String> SUPPORTED_EXTENSIONS = List.of(
             EXTENSION_C, EXTENSION_I, EXTENSION_LL, EXTENSION_LITMUS, EXTENSION_SPV_DIS, EXTENSION_SPVASM);
+
+    public static boolean isSupported(Path filePath) {
+        final String extension = "." + Files.getFileExtension(filePath.getFileName().toString());
+        return SUPPORTED_EXTENSIONS.contains(extension);
+    }
 
     public Program parse(File file) throws Exception {
         if (needsClang(file)) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/GitInfo.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/GitInfo.java
@@ -1,7 +1,6 @@
 package com.dat3m.dartagnan.utils;
 
 import com.dat3m.dartagnan.Dartagnan;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,7 +12,7 @@ public class GitInfo {
 
     private static final Logger logger = LoggerFactory.getLogger(GitInfo.class);
 
-    static Properties properties = new Properties();
+    private final static Properties properties = new Properties();
 
     public static void initGitInfo() throws IOException {
         try (InputStream is = Dartagnan.class.getClassLoader()

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/printer/OutputLogger.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/printer/OutputLogger.java
@@ -26,18 +26,22 @@ public class OutputLogger {
         results.add(result);
     }
 
-    public void toStdOut(boolean batchMode) {
-        if (batchMode) {
+    public void toStdOut() {
+        if (results.isEmpty()) {
+            return;
+        }
+
+        if (results.size() == 1) {
+            System.out.println(results.get(0));
+        } else {
             System.out.println("================ Configuration ==================");
             System.out.println("cat = " + modelFile);
             System.out.print(config.asPropertiesString()); // it already contains its own \n
             System.out.println("=================================================");
-        }
-        for (ResultSummary r : results) {
-            if (batchMode) {
+            for (ResultSummary r : results) {
                 System.out.println();
+                System.out.println(r);
             }
-            System.out.println(r);
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
@@ -1,8 +1,8 @@
 package com.dat3m.dartagnan.verification;
 
-import com.dat3m.dartagnan.configuration.OptionNames;
 import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.encoding.IREvaluator;
+import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionPrinter;
 import com.dat3m.dartagnan.expression.booleans.BoolLiteral;
 import com.dat3m.dartagnan.program.Program;
@@ -39,6 +39,7 @@ import static com.dat3m.dartagnan.GlobalSettings.getOrCreateOutputDirectory;
 import static com.dat3m.dartagnan.configuration.OptionNames.BOUNDS_SAVE_PATH;
 import static com.dat3m.dartagnan.configuration.OptionNames.IGNORE_FILTER_SPECIFICATION;
 import static com.dat3m.dartagnan.configuration.Property.*;
+import static com.dat3m.dartagnan.program.Program.SourceLanguage.*;
 import static com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis.*;
 import static com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis.getSourceLocationString;
 import static com.dat3m.dartagnan.utils.ExitCode.*;
@@ -58,26 +59,17 @@ public class TaskResultAnalyzer {
     }
 
     public ResultSummary getSummaryFromException(Exception exception, String programPath) {
-        final String message = exception.getMessage();
+        final String message = exception.getMessage() != null ? exception.getMessage() : "Unknown error occurred";
+        final String details = "\t" + message;
 
         if (exception instanceof InterruptedException) {
-            final String details;
-            final ExitCode exitCode;
-            if (message != null) {
-                details = "\t" + message;
-                exitCode = message.contains("Timeout")
-                        ? TIMEOUT_ELAPSED
-                        : message.contains("canceled")
-                        ? CANCELED
-                        : UNKNOWN_ERROR;
-            } else {
-                details = "\tUnknown error occurred";
-                exitCode = UNKNOWN_ERROR;
-            }
+            final ExitCode exitCode =
+                    message.contains("Timeout") ? TIMEOUT_ELAPSED
+                    : message.contains("canceled") ? CANCELED
+                    : UNKNOWN_ERROR;
             return new ResultSummary(programPath, "", INTERRUPTED, "", "", details, 0, exitCode);
         } else {
             final String reason = exception.getClass().getSimpleName();
-            final String details = "\t" + Optional.ofNullable(message).orElse("Unknown error occurred");
             return new ResultSummary(programPath, "", ERROR, "", reason, details, 0, UNKNOWN_ERROR);
         }
     }
@@ -100,7 +92,7 @@ public class TaskResultAnalyzer {
         // We only show the condition if this is the reason of the failure
         String condition = "";
         if (hasViolationsWithModel) {
-            printWarningIfThreadStartFailed(p, model);
+
             if (props.contains(PROGRAM_SPEC) && model.propertyViolated(PROGRAM_SPEC)) {
                 reason = ResultSummary.PROGRAM_SPEC_REASON;
                 condition = getSpecificationString(p);
@@ -114,6 +106,7 @@ public class TaskResultAnalyzer {
                 ExitCode code = task.getWitness().isEmpty() ? PROGRAM_SPEC_VIOLATION : NORMAL_TERMINATION;
                 return new ResultSummary(programPath, filter, FAIL, condition, reason, details.toString(), time, code);
             }
+
             if (props.contains(TERMINATION) && model.propertyViolated(TERMINATION)) {
                 reason = ResultSummary.TERMINATION_REASON;
                 for (Event e : p.getThreadEvents()) {
@@ -131,12 +124,14 @@ public class TaskResultAnalyzer {
                 ExitCode code = task.getWitness().isEmpty() ? TERMINATION_VIOLATION : NORMAL_TERMINATION;
                 return new ResultSummary(programPath, filter, FAIL, condition, reason, details.toString(), time, code);
             }
+
             if (props.contains(DATARACEFREEDOM) && model.propertyViolated(DATARACEFREEDOM)) {
                 reason = ResultSummary.SVCOMP_RACE_REASON;
                 // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
                 ExitCode code = task.getWitness().isEmpty() ? DATA_RACE_FREEDOM_VIOLATION : NORMAL_TERMINATION;
                 return new ResultSummary(programPath, filter, FAIL, condition, reason, details.toString(), time, code);
             }
+
             if (props.contains(TRACKABILITY) && model.propertyViolated(TRACKABILITY)) {
                 reason = ResultSummary.SVCOMP_UNTRACKABLE_OBJECT_REASON;
                 for (MemoryObject o : p.getMemory().getObjects()) {
@@ -147,16 +142,18 @@ public class TaskResultAnalyzer {
                 ExitCode code = task.getWitness().isEmpty() ? MEMORY_TRACKABILITY_VIOLATION : NORMAL_TERMINATION;
                 return new ResultSummary(programPath, filter, FAIL, condition, reason, details.toString(), time, code);
             }
-            final List<Axiom> violatedCATSpecs = !props.contains(CAT_SPEC) ? List.of()
-                    : task.getMemoryModel().getAxioms().stream()
-                    .filter(Axiom::isFlagged)
-                    .filter(model::isFlaggedAxiomViolated)
-                    .toList();
-            if (!violatedCATSpecs.isEmpty()) {
-                reason = ResultSummary.CAT_SPEC_REASON;
-                // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
-                ExitCode code = task.getWitness().isEmpty() ? CAT_SPEC_VIOLATION : NORMAL_TERMINATION;
-                return new ResultSummary(programPath, filter, FAIL, condition, reason, getFlaggedPairsOutput(task, model, synContext), time, code);
+
+            if (props.contains(CAT_SPEC)) {
+                final List<Axiom> violatedCATSpecs = task.getMemoryModel().getAxioms().stream()
+                        .filter(Axiom::isFlagged)
+                        .filter(model::isFlaggedAxiomViolated)
+                        .toList();
+                if (!violatedCATSpecs.isEmpty()) {
+                    reason = ResultSummary.CAT_SPEC_REASON;
+                    // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
+                    ExitCode code = task.getWitness().isEmpty() ? CAT_SPEC_VIOLATION : NORMAL_TERMINATION;
+                    return new ResultSummary(programPath, filter, FAIL, condition, reason, getFlaggedPairsOutput(task, model, synContext), time, code);
+                }
             }
         } else if (hasViolationsWithoutWitness) {
             // Only for programs with exists/forall specifications
@@ -182,6 +179,7 @@ public class TaskResultAnalyzer {
             ExitCode code = BOUNDED_RESULT;
             return new ResultSummary(programPath, filter, result, condition, reason, details.toString(), time, code);
         }
+
         // We consider those cases without an explicit return to yield normal termination.
         // This includes verification of litmus code, independent of the verification result.
         // In validation mode, we expect to find the violation, thus the WITNESS_NOT_VALIDATED error
@@ -191,17 +189,18 @@ public class TaskResultAnalyzer {
 
     public File generateWitnessIfAble(TaskSolver solver, WitnessType witnessType, String filename, String details,
                                       boolean generateWitnessForUnknown) throws IOException {
-        if (!solver.hasModel() || (solver.getResult() == UNKNOWN && !generateWitnessForUnknown)) {
+        if (!solver.hasModel()
+                || (solver.getResult() == UNKNOWN && !generateWitnessForUnknown)
+                || witnessType == WitnessType.NONE) {
             return null;
         }
 
         final VerificationTask task = solver.getTask();
         switch (witnessType) {
-            case NONE: { }
-            case GRAPHML: {
+            case GRAPHML -> {
                 Preconditions.checkArgument(solver.getResult() != UNKNOWN);
 
-                if (!task.getProgram().getFormat().equals(Program.SourceLanguage.LLVM) || !requiresSvcompWitness(task.getProperty())) {
+                if (!task.getProgram().getFormat().equals(LLVM) || !requiresSvcompWitness(task.getProperty())) {
                     return null;
                 }
                 try {
@@ -213,7 +212,7 @@ public class TaskResultAnalyzer {
                     logger.warn(e.getMessage());
                 }
             }
-            case DOT, PNG: {
+            case DOT, PNG -> {
                 final SyntacticContextAnalysis synContext = newInstance(task.getProgram());
                 final ExecutionModelNext model = solver.getExecutionGraph();
                 // RF edges give both ordering and data flow information, thus even when the pair is in PO
@@ -225,6 +224,7 @@ public class TaskResultAnalyzer {
                         synContext, witnessType.convertToPng(), task.getConfig());
             }
         }
+
         return null;
     }
 
@@ -311,36 +311,28 @@ public class TaskResultAnalyzer {
         return output.toString();
     }
 
-    private static void printWarningIfThreadStartFailed(Program p, IREvaluator model) {
-        p.getThreads().stream().filter(t ->
-                t.getEntry().isSpawned()
-                        && model.isExecuted(t.getEntry().getCreator())
-                        && !model.threadHasStarted(t)
-        ).forEach(t -> System.out.printf(
-                "[WARNING] The call to pthread_create of thread %s failed. To force thread creation to succeed use --%s=true%n",
-                t, OptionNames.THREAD_CREATE_ALWAYS_SUCCEEDS
-        ));
-    }
-
     private static String getSpecificationString(Program program) {
-        final StringBuilder sb = new StringBuilder();
-        final Program.SourceLanguage format = program.getFormat();
-        if (format == Program.SourceLanguage.LITMUS || format == Program.SourceLanguage.SPV) {
-            sb.append(program.getSpecificationType().toString().toLowerCase()).append(" ");
-            if (program.getSpecification() != null) {
-                sb.append(new ExpressionPrinter(true).visit(program.getSpecification()));
-            }
-            sb.append("\n");
+        if (!List.of(LITMUS, SPV).contains(program.getFormat())) {
+            return "";
         }
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append(program.getSpecificationType().toString().toLowerCase()).append(" ");
+        // TODO: Can the spec really be null here?
+        if (program.getSpecification() != null) {
+            sb.append(new ExpressionPrinter(true).visit(program.getSpecification()));
+        }
+        sb.append("\n");
         return sb.toString();
     }
 
     private static String getFilterString(VerificationTask task) {
-        final Program p = task.getProgram();
-        final boolean ignoreFilter = task.getConfig().hasProperty(IGNORE_FILTER_SPECIFICATION) && task.getConfig().getProperty(IGNORE_FILTER_SPECIFICATION).equals("true");
-        final boolean nonEmptyFilter = !(p.getFilterSpecification() instanceof BoolLiteral bLit) || !bLit.getValue();
-        final String filter = !ignoreFilter && nonEmptyFilter ? p.getFilterSpecification().toString() : "";
-        return filter;
+        if ("true".equals(task.getConfig().getProperty(IGNORE_FILTER_SPECIFICATION)))
+            return "";
+
+        final Expression filter = task.getProgram().getFilterSpecification();
+        final boolean isTrivialFilter = filter instanceof BoolLiteral bLit && bLit.getValue();
+        return isTrivialFilter ? "" : filter.toString();
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
@@ -1,0 +1,346 @@
+package com.dat3m.dartagnan.verification;
+
+import com.dat3m.dartagnan.configuration.OptionNames;
+import com.dat3m.dartagnan.configuration.Property;
+import com.dat3m.dartagnan.encoding.IREvaluator;
+import com.dat3m.dartagnan.expression.ExpressionPrinter;
+import com.dat3m.dartagnan.expression.booleans.BoolLiteral;
+import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis;
+import com.dat3m.dartagnan.program.event.BlockingEvent;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Tag;
+import com.dat3m.dartagnan.program.event.core.Assert;
+import com.dat3m.dartagnan.program.event.core.CondJump;
+import com.dat3m.dartagnan.program.memory.MemoryObject;
+import com.dat3m.dartagnan.program.processing.LoopUnrolling;
+import com.dat3m.dartagnan.utils.ExitCode;
+import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.utils.printer.OutputLogger.ResultSummary;
+import com.dat3m.dartagnan.verification.model.ExecutionModelNext;
+import com.dat3m.dartagnan.witness.WitnessType;
+import com.dat3m.dartagnan.witness.graphml.WitnessBuilder;
+import com.dat3m.dartagnan.wmm.Wmm;
+import com.dat3m.dartagnan.wmm.axiom.Axiom;
+import com.google.common.base.Preconditions;
+import org.apache.commons.csv.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sosy_lab.common.configuration.Configuration;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.*;
+
+import static com.dat3m.dartagnan.GlobalSettings.getOrCreateOutputDirectory;
+import static com.dat3m.dartagnan.configuration.OptionNames.BOUNDS_SAVE_PATH;
+import static com.dat3m.dartagnan.configuration.OptionNames.IGNORE_FILTER_SPECIFICATION;
+import static com.dat3m.dartagnan.configuration.Property.*;
+import static com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis.*;
+import static com.dat3m.dartagnan.program.analysis.SyntacticContextAnalysis.getSourceLocationString;
+import static com.dat3m.dartagnan.utils.ExitCode.*;
+import static com.dat3m.dartagnan.utils.Result.*;
+import static com.dat3m.dartagnan.utils.Result.ERROR;
+import static com.dat3m.dartagnan.witness.graphviz.ExecutionGraphVisualizer.generateGraphvizFile;
+
+public class TaskResultAnalyzer {
+
+    private static final Logger logger = LoggerFactory.getLogger(TaskResultAnalyzer.class);
+
+    private TaskResultAnalyzer() {
+    }
+
+    public static TaskResultAnalyzer create() {
+        return new TaskResultAnalyzer();
+    }
+
+    public ResultSummary getSummaryFromException(Exception exception, String programPath) {
+        final String message = exception.getMessage();
+
+        if (exception instanceof InterruptedException) {
+            final String details;
+            final ExitCode exitCode;
+            if (message != null) {
+                details = "\t" + message;
+                exitCode = message.contains("Timeout")
+                        ? TIMEOUT_ELAPSED
+                        : message.contains("canceled")
+                        ? CANCELED
+                        : UNKNOWN_ERROR;
+            } else {
+                details = "\tUnknown error occurred";
+                exitCode = UNKNOWN_ERROR;
+            }
+            return new ResultSummary(programPath, "", INTERRUPTED, "", "", details, 0, exitCode);
+        } else {
+            final String reason = exception.getClass().getSimpleName();
+            final String details = "\t" + Optional.ofNullable(message).orElse("Unknown error occurred");
+            return new ResultSummary(programPath, "", ERROR, "", reason, details, 0, UNKNOWN_ERROR);
+        }
+    }
+
+    public ResultSummary getSummaryFromSolver(TaskSolver solver, String programPath) {
+        final VerificationTask task = solver.getTask();
+        final Result result = solver.getResult();
+        final Program p = task.getProgram();
+        final EnumSet<Property> props = task.getProperty();
+        final IREvaluator model = solver.hasModel() ? solver.getModel() : null;
+        final boolean hasViolationsWithModel = result == FAIL && model != null;
+        final boolean hasViolationsWithoutWitness = result == FAIL && model == null;
+        final long time = solver.getRuntime();
+
+        // ----------------- Generate output of verification result -----------------
+        final String filter = getFilterString(task);
+        final SyntacticContextAnalysis synContext = newInstance(p);
+        String reason = "";
+        StringBuilder details = new StringBuilder();
+        // We only show the condition if this is the reason of the failure
+        String condition = "";
+        if (hasViolationsWithModel) {
+            printWarningIfThreadStartFailed(p, model);
+            if (props.contains(PROGRAM_SPEC) && model.propertyViolated(PROGRAM_SPEC)) {
+                reason = ResultSummary.PROGRAM_SPEC_REASON;
+                condition = getSpecificationString(p);
+                List<Assert> violations = p.getThreadEvents(Assert.class)
+                        .stream().filter(model::assertionViolated)
+                        .toList();
+                for (Assert ass : violations) {
+                    appendTo(details, ass, synContext);
+                }
+                // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
+                ExitCode code = task.getWitness().isEmpty() ? PROGRAM_SPEC_VIOLATION : NORMAL_TERMINATION;
+                return new ResultSummary(programPath, filter, FAIL, condition, reason, details.toString(), time, code);
+            }
+            if (props.contains(TERMINATION) && model.propertyViolated(TERMINATION)) {
+                reason = ResultSummary.TERMINATION_REASON;
+                for (Event e : p.getThreadEvents()) {
+                    final boolean isStuckLoop = e instanceof CondJump jump
+                            && e.hasTag(Tag.NONTERMINATION) && !e.hasTag(Tag.BOUND)
+                            && model.jumpTaken(jump);
+                    final boolean isStuckBarrier = e instanceof BlockingEvent barrier
+                            && model.isBlocked(barrier);
+
+                    if (isStuckLoop || isStuckBarrier) {
+                        appendTo(details, e, synContext);
+                    }
+                }
+                // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
+                ExitCode code = task.getWitness().isEmpty() ? TERMINATION_VIOLATION : NORMAL_TERMINATION;
+                return new ResultSummary(programPath, filter, FAIL, condition, reason, details.toString(), time, code);
+            }
+            if (props.contains(DATARACEFREEDOM) && model.propertyViolated(DATARACEFREEDOM)) {
+                reason = ResultSummary.SVCOMP_RACE_REASON;
+                // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
+                ExitCode code = task.getWitness().isEmpty() ? DATA_RACE_FREEDOM_VIOLATION : NORMAL_TERMINATION;
+                return new ResultSummary(programPath, filter, FAIL, condition, reason, details.toString(), time, code);
+            }
+            if (props.contains(TRACKABILITY) && model.propertyViolated(TRACKABILITY)) {
+                reason = ResultSummary.SVCOMP_UNTRACKABLE_OBJECT_REASON;
+                for (MemoryObject o : p.getMemory().getObjects()) {
+                    if (model.isLeaked(o) && !model.isTrackable(o)) {
+                        appendTo(details, o.getAllocationSite(), synContext);
+                    }
+                }
+                ExitCode code = task.getWitness().isEmpty() ? MEMORY_TRACKABILITY_VIOLATION : NORMAL_TERMINATION;
+                return new ResultSummary(programPath, filter, FAIL, condition, reason, details.toString(), time, code);
+            }
+            final List<Axiom> violatedCATSpecs = !props.contains(CAT_SPEC) ? List.of()
+                    : task.getMemoryModel().getAxioms().stream()
+                    .filter(Axiom::isFlagged)
+                    .filter(model::isFlaggedAxiomViolated)
+                    .toList();
+            if (!violatedCATSpecs.isEmpty()) {
+                reason = ResultSummary.CAT_SPEC_REASON;
+                // In validation mode, we expect to find the violation, thus NORMAL_TERMINATION
+                ExitCode code = task.getWitness().isEmpty() ? CAT_SPEC_VIOLATION : NORMAL_TERMINATION;
+                return new ResultSummary(programPath, filter, FAIL, condition, reason, getFlaggedPairsOutput(task, model, synContext), time, code);
+            }
+        } else if (hasViolationsWithoutWitness) {
+            // Only for programs with exists/forall specifications
+            reason = ResultSummary.PROGRAM_SPEC_REASON;
+            condition = getSpecificationString(p);
+        } else if (result == UNKNOWN && model != null) {
+            // We reached unrolling bounds.
+            final List<Event> reachedBounds = p.getThreadEventsWithAllTags(Tag.BOUND)
+                    .stream().filter(model::isExecuted)
+                    .toList();
+            reason = ResultSummary.BOUND_REASON;
+            for (Event bound : reachedBounds) {
+                details
+                        .append("\t")
+                        .append(synContext.getSourceLocationWithContext(bound, true))
+                        .append("\n");
+            }
+            try {
+                increaseBoundAndDump(reachedBounds, task.getConfig());
+            } catch (IOException e) {
+                logger.warn("Failed to save bounds file: {}", e.getLocalizedMessage());
+            }
+            ExitCode code = BOUNDED_RESULT;
+            return new ResultSummary(programPath, filter, result, condition, reason, details.toString(), time, code);
+        }
+        // We consider those cases without an explicit return to yield normal termination.
+        // This includes verification of litmus code, independent of the verification result.
+        // In validation mode, we expect to find the violation, thus the WITNESS_NOT_VALIDATED error
+        ExitCode code = task.getWitness().isEmpty() ? NORMAL_TERMINATION : WITNESS_NOT_VALIDATED;
+        return new ResultSummary(programPath, filter, result, condition, reason, details.toString(), time, code);
+    }
+
+    public File generateWitnessIfAble(TaskSolver solver, WitnessType witnessType, String filename, String details,
+                                      boolean generateWitnessForUnknown) throws IOException {
+        if (!solver.hasModel() || (solver.getResult() == UNKNOWN && !generateWitnessForUnknown)) {
+            return null;
+        }
+
+        final VerificationTask task = solver.getTask();
+        switch (witnessType) {
+            case NONE: { }
+            case GRAPHML: {
+                Preconditions.checkArgument(solver.getResult() != UNKNOWN);
+
+                if (!task.getProgram().getFormat().equals(Program.SourceLanguage.LLVM) || !requiresSvcompWitness(task.getProperty())) {
+                    return null;
+                }
+                try {
+                    WitnessBuilder w = WitnessBuilder.of(solver.getModel(), solver.getResult(), details);
+                    if (w.canBeBuilt()) {
+                        return w.build().write(filename);
+                    }
+                } catch (IOException | InvalidConfigurationException e) {
+                    logger.warn(e.getMessage());
+                }
+            }
+            case DOT, PNG: {
+                final SyntacticContextAnalysis synContext = newInstance(task.getProgram());
+                final ExecutionModelNext model = solver.getExecutionGraph();
+                // RF edges give both ordering and data flow information, thus even when the pair is in PO
+                // we get some data flow information by observing the edge
+                // CO edges only give ordering information which is known if the pair is also in PO
+                return generateGraphvizFile(model, 1, (x, y) -> true,
+                        (x, y) -> !x.getThreadModel().getThread().equals(y.getThreadModel().getThread()),
+                        getOrCreateOutputDirectory() + "/", filename,
+                        synContext, witnessType.convertToPng(), task.getConfig());
+            }
+        }
+        return null;
+    }
+
+    // =========================================== Utility =================================================
+
+    private static void increaseBoundAndDump(List<Event> boundEvents, Configuration config) throws IOException {
+        if(!config.hasProperty(BOUNDS_SAVE_PATH)) {
+            return;
+        }
+        final File boundsFile = new File(config.getProperty(BOUNDS_SAVE_PATH));
+
+        // Parse old entries
+        final List<CSVRecord> entries;
+        try (CSVParser parser = CSVParser.parse(new FileReader(boundsFile), CSVFormat.DEFAULT)) {
+            entries = parser.getRecords();
+        }
+
+        // Compute update for entries
+        final Map<Integer, Integer> loopId2UpdatedBound = new HashMap<>();
+        for (Event e : boundEvents) {
+            assert e instanceof CondJump;
+            final CondJump loopJump = (CondJump) e;
+            final int loopId = LoopUnrolling.getPersistentLoopId(loopJump);
+            final int bound = LoopUnrolling.getUnrollingBoundAnnotation(loopJump);
+            loopId2UpdatedBound.put(loopId, bound + 1);
+        }
+
+        // Write new entries
+        try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(boundsFile, false), CSVFormat.DEFAULT)) {
+            for (CSVRecord entry : entries) {
+                final int entryId = Integer.parseInt(entry.get(0));
+                if (!loopId2UpdatedBound.containsKey(entryId)) {
+                    csvPrinter.printRecord(entry);
+                } else {
+                    final String[] content = entry.values();
+                    content[1] = String.valueOf(loopId2UpdatedBound.get(entryId));
+                    csvPrinter.printRecord(Arrays.asList(content));
+                }
+            }
+            csvPrinter.flush();
+        }
+    }
+
+    private static void appendTo(StringBuilder details, Event event, SyntacticContextAnalysis synContext) {
+        details.append("\t").append(synContext.getSourceLocationWithContext(event, true));
+        if (event instanceof Assert ass) {
+            details.append(": ").append(ass.getErrorMessage());
+        }
+        details.append("\n");
+    }
+
+    private static String getFlaggedPairsOutput(VerificationTask task, IREvaluator model, SyntacticContextAnalysis synContext) {
+        if (!task.getProperty().contains(CAT_SPEC)) {
+            return "";
+        }
+
+        final Wmm wmm = task.getMemoryModel();
+        final StringBuilder output = new StringBuilder();
+        for (Axiom ax : wmm.getAxioms()) {
+            if (ax.isFlagged() && model.isFlaggedAxiomViolated(ax)) {
+                StringBuilder violatingPairs = new StringBuilder("\tFlag " + Optional.ofNullable(ax.getName()).orElse(ax.getRelation().getNameOrTerm())).append("\n");
+                model.eventGraph(ax.getRelation()).apply((e1, e2) -> {
+                    final String callSeparator = " -> ";
+                    final String callStackFirst = makeContextString(
+                            synContext.getContextInfo(e1).getContextOfType(SyntacticContextAnalysis.CallContext.class),
+                            callSeparator);
+                    final String callStackSecond = makeContextString(
+                            synContext.getContextInfo(e2).getContextOfType(SyntacticContextAnalysis.CallContext.class),
+                            callSeparator);
+
+                    violatingPairs
+                            .append("\t").append(callStackFirst).append(callStackFirst.isEmpty() ? "" : callSeparator)
+                            .append(getSourceLocationString(e1))
+                            .append(" / ").append(callStackSecond).append(callStackSecond.isEmpty() ? "" : callSeparator)
+                            .append(getSourceLocationString(e2))
+                            .append("\t(E").append(e1.getGlobalId())
+                            .append(" / E").append(e2.getGlobalId()).append(")")
+                            .append("\n");
+                });
+                output.append(violatingPairs);
+            }
+        }
+
+        return output.toString();
+    }
+
+    private static void printWarningIfThreadStartFailed(Program p, IREvaluator model) {
+        p.getThreads().stream().filter(t ->
+                t.getEntry().isSpawned()
+                        && model.isExecuted(t.getEntry().getCreator())
+                        && !model.threadHasStarted(t)
+        ).forEach(t -> System.out.printf(
+                "[WARNING] The call to pthread_create of thread %s failed. To force thread creation to succeed use --%s=true%n",
+                t, OptionNames.THREAD_CREATE_ALWAYS_SUCCEEDS
+        ));
+    }
+
+    private static String getSpecificationString(Program program) {
+        final StringBuilder sb = new StringBuilder();
+        final Program.SourceLanguage format = program.getFormat();
+        if (format == Program.SourceLanguage.LITMUS || format == Program.SourceLanguage.SPV) {
+            sb.append(program.getSpecificationType().toString().toLowerCase()).append(" ");
+            if (program.getSpecification() != null) {
+                sb.append(new ExpressionPrinter(true).visit(program.getSpecification()));
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    private static String getFilterString(VerificationTask task) {
+        final Program p = task.getProgram();
+        final boolean ignoreFilter = task.getConfig().hasProperty(IGNORE_FILTER_SPECIFICATION) && task.getConfig().getProperty(IGNORE_FILTER_SPECIFICATION).equals("true");
+        final boolean nonEmptyFilter = !(p.getFilterSpecification() instanceof BoolLiteral bLit) || !bLit.getValue();
+        final String filter = !ignoreFilter && nonEmptyFilter ? p.getFilterSpecification().toString() : "";
+        return filter;
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
@@ -42,7 +42,7 @@ public class TaskSolver implements AutoCloseable {
             name = TIMEOUT,
             description = "Timeout before interrupting the task solver. Can specify time units ns, ms, s (default), min, and h.")
     @TimeSpanOption(min = 0, codeUnit = TimeUnit.MILLISECONDS, defaultUserUnit = TimeUnit.SECONDS)
-    private int timeout = 1200;
+    private int timeout = 0;
 
     private boolean hasTimeout() {
         return timeout > 0;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
@@ -1,0 +1,113 @@
+package com.dat3m.dartagnan.verification;
+
+import com.dat3m.dartagnan.configuration.Method;
+import com.dat3m.dartagnan.encoding.IREvaluator;
+import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.verification.model.ExecutionModelManager;
+import com.dat3m.dartagnan.verification.model.ExecutionModelNext;
+import com.dat3m.dartagnan.verification.solving.ModelChecker;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sosy_lab.common.ShutdownManager;
+import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.configuration.Option;
+import org.sosy_lab.common.configuration.Options;
+import org.sosy_lab.java_smt.api.SolverException;
+
+import static com.dat3m.dartagnan.configuration.OptionNames.METHOD;
+
+@Options
+public class TaskSolver implements AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(TaskSolver.class);
+
+    // ================================== Configurables ==================================
+
+    @Option(
+            name = METHOD,
+            description = "Method to be used.",
+            toUppercase = true)
+    private Method method = Method.getDefault();
+
+    // ====================================== State ======================================
+
+    private final VerificationTask task;
+
+    protected transient ModelChecker modelChecker;
+    protected transient ShutdownManager shutdownManager;
+
+    // =================================== Construction ===================================
+
+    private TaskSolver(VerificationTask task) throws InvalidConfigurationException {
+        this.task = task;
+
+        task.getConfig().inject(this);
+    }
+
+    public static TaskSolver create(VerificationTask task) throws InvalidConfigurationException {
+        return new TaskSolver(task);
+    }
+
+    public static TaskSolver createWithMethod(VerificationTask task, Method method) throws InvalidConfigurationException {
+        final TaskSolver solver = new TaskSolver(task);
+        solver.method = method;
+        return solver;
+    }
+
+    public TaskSolver withShutdownManager(ShutdownManager shutdownManager) {
+        this.shutdownManager = shutdownManager;
+        return this;
+    }
+
+    // ===================================== Solving =====================================
+
+    private void initModelChecker() throws InvalidConfigurationException {
+        Preconditions.checkState(modelChecker == null, "Model checker already initialized");
+        modelChecker = ModelChecker.create(task, method);
+        if (shutdownManager != null) {
+            modelChecker.setShutdownManager(shutdownManager);
+        }
+    }
+
+    public void run() throws InterruptedException, InvalidConfigurationException, SolverException {
+        initModelChecker();
+        modelChecker.run();
+    }
+
+    public Result getResult() {
+        checkHasRun();
+        return modelChecker.getResult();
+    }
+
+    public boolean hasModel() {
+        checkHasRun();
+        return modelChecker.hasModel();
+    }
+
+    public IREvaluator getModel() throws SolverException {
+        checkHasRun();
+        return modelChecker.getModel();
+    }
+
+    public ExecutionModelNext getExecutionGraph() throws SolverException {
+        Preconditions.checkState(hasModel(), "No model available");
+        try (IREvaluator evaluator = getModel()) {
+            return new ExecutionModelManager().buildExecutionModel(evaluator);
+        }
+    }
+
+    // ===================================== Misc =====================================
+
+    @Override
+    public void close() {
+        if (modelChecker != null) {
+            modelChecker.close();
+        }
+    }
+
+    private void checkHasRun() {
+        Preconditions.checkState(modelChecker != null, "Model checker has not run yet.");
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
@@ -52,10 +52,10 @@ public class TaskSolver implements AutoCloseable {
 
     private final VerificationTask task;
 
-    protected transient ModelChecker modelChecker;
-    protected transient IREvaluator model;
-    protected transient ShutdownManager shutdownManager;
-    protected transient long runtime = 0;
+    private ModelChecker modelChecker;
+    private IREvaluator model;
+    private ShutdownManager shutdownManager;
+    private long runtime = 0;
 
     public VerificationTask getTask() {
         return task;
@@ -106,22 +106,12 @@ public class TaskSolver implements AutoCloseable {
 
     public void run() throws SolverException, InterruptedException, InvalidConfigurationException {
         final long startTime = System.currentTimeMillis();
-        initModelChecker();
 
+        initModelChecker();
         if (!hasTimeout()) {
             modelChecker.run();
         } else {
-            final java.lang.Thread t = new java.lang.Thread(() -> {
-                try {
-                    final long timeoutInMillis = timeout;
-                    java.lang.Thread.sleep(timeoutInMillis);
-                    final String error = String.format("Timeout of %s exceeded.", Utils.toTimeString(timeoutInMillis));
-                    modelChecker.requestShutdown(error);
-                } catch (InterruptedException e) {
-                    // Verification ended, nothing to be done.
-                }
-            });
-
+            final Thread t = createTimeoutThread();
             t.start();
             modelChecker.run();
             t.interrupt();
@@ -148,7 +138,8 @@ public class TaskSolver implements AutoCloseable {
 
     public boolean hasModel() {
         checkHasRun();
-        return model != null;
+        return modelChecker.hasModel();
+        //return model != null;
     }
 
     public IREvaluator getModel() {
@@ -182,6 +173,19 @@ public class TaskSolver implements AutoCloseable {
 
     protected void checkHasRun() {
         Preconditions.checkState(modelChecker != null, "Model checker has not run yet.");
+    }
+
+    private Thread createTimeoutThread() {
+        return new Thread(() -> {
+            try {
+                final long timeoutInMillis = timeout;
+                Thread.sleep(timeoutInMillis);
+                final String error = String.format("Timeout of %s exceeded.", Utils.toTimeString(timeoutInMillis));
+                modelChecker.requestShutdown(error);
+            } catch (InterruptedException e) {
+                // Verification ended, nothing to be done.
+            }
+        });
     }
 
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
@@ -34,7 +34,7 @@ public class TaskSolver implements AutoCloseable {
 
     @Option(
             name = METHOD,
-            description = "Method to be used.",
+            description = "Solving method to be used.",
             toUppercase = true)
     private Method method = Method.getDefault();
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
@@ -3,9 +3,12 @@ package com.dat3m.dartagnan.verification;
 import com.dat3m.dartagnan.configuration.Method;
 import com.dat3m.dartagnan.encoding.IREvaluator;
 import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.verification.model.ExecutionModelManager;
 import com.dat3m.dartagnan.verification.model.ExecutionModelNext;
+import com.dat3m.dartagnan.verification.solving.AssumeSolver;
 import com.dat3m.dartagnan.verification.solving.ModelChecker;
+import com.dat3m.dartagnan.verification.solving.RefinementSolver;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,9 +16,14 @@ import org.sosy_lab.common.ShutdownManager;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
+import org.sosy_lab.common.configuration.TimeSpanOption;
 import org.sosy_lab.java_smt.api.SolverException;
 
+import java.util.concurrent.TimeUnit;
+
 import static com.dat3m.dartagnan.configuration.OptionNames.METHOD;
+import static com.dat3m.dartagnan.configuration.OptionNames.TIMEOUT;
+import static com.dat3m.dartagnan.configuration.Property.DATARACEFREEDOM;
 
 @Options
 public class TaskSolver implements AutoCloseable {
@@ -29,6 +37,16 @@ public class TaskSolver implements AutoCloseable {
             description = "Method to be used.",
             toUppercase = true)
     private Method method = Method.getDefault();
+
+    @Option(
+            name = TIMEOUT,
+            description = "Timeout before interrupting the task solver. Can specify time units ns, ms, s (default), min, and h.")
+    @TimeSpanOption(min = 0, codeUnit = TimeUnit.MILLISECONDS, defaultUserUnit = TimeUnit.SECONDS)
+    private int timeout = 0;
+
+    private boolean hasTimeout() {
+        return timeout > 0;
+    }
 
     // ====================================== State ======================================
 
@@ -64,15 +82,44 @@ public class TaskSolver implements AutoCloseable {
 
     private void initModelChecker() throws InvalidConfigurationException {
         Preconditions.checkState(modelChecker == null, "Model checker already initialized");
-        modelChecker = ModelChecker.create(task, method);
+
+        if (task.getProperty().contains(DATARACEFREEDOM) && method != Method.EAGER) {
+            // For DATARACEFREEDOM, we always use EAGER
+            logger.warn("Method {} is not supported for property {}. Using EAGER instead.", method, DATARACEFREEDOM);
+            method = Method.EAGER;
+        }
+
+        modelChecker = switch (method) {
+            case EAGER -> AssumeSolver.create(task);
+            case LAZY -> RefinementSolver.create(task);
+        };
         if (shutdownManager != null) {
             modelChecker.setShutdownManager(shutdownManager);
         }
     }
 
-    public void run() throws InterruptedException, InvalidConfigurationException, SolverException {
+    public void run() throws SolverException, InterruptedException, InvalidConfigurationException {
         initModelChecker();
+
+        if (!hasTimeout()) {
+            modelChecker.run();
+            return;
+        }
+
+        final java.lang.Thread t = new java.lang.Thread(() -> {
+            try {
+                final long timeoutInMillis = timeout;
+                java.lang.Thread.sleep(timeoutInMillis);
+                final String error = String.format("Timeout of %s exceeded.", Utils.toTimeString(timeoutInMillis));
+                modelChecker.requestShutdown(error);
+            } catch (InterruptedException e) {
+                // Verification ended, nothing to be done.
+            }
+        });
+
+        t.start();
         modelChecker.run();
+        t.interrupt();
     }
 
     public Result getResult() {
@@ -106,7 +153,7 @@ public class TaskSolver implements AutoCloseable {
         }
     }
 
-    private void checkHasRun() {
+    protected void checkHasRun() {
         Preconditions.checkState(modelChecker != null, "Model checker has not run yet.");
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
@@ -53,7 +53,13 @@ public class TaskSolver implements AutoCloseable {
     private final VerificationTask task;
 
     protected transient ModelChecker modelChecker;
+    protected transient IREvaluator model;
     protected transient ShutdownManager shutdownManager;
+    protected transient long runtime = 0;
+
+    public VerificationTask getTask() {
+        return task;
+    }
 
     // =================================== Construction ===================================
 
@@ -99,27 +105,33 @@ public class TaskSolver implements AutoCloseable {
     }
 
     public void run() throws SolverException, InterruptedException, InvalidConfigurationException {
+        final long startTime = System.currentTimeMillis();
         initModelChecker();
 
         if (!hasTimeout()) {
             modelChecker.run();
-            return;
+        } else {
+            final java.lang.Thread t = new java.lang.Thread(() -> {
+                try {
+                    final long timeoutInMillis = timeout;
+                    java.lang.Thread.sleep(timeoutInMillis);
+                    final String error = String.format("Timeout of %s exceeded.", Utils.toTimeString(timeoutInMillis));
+                    modelChecker.requestShutdown(error);
+                } catch (InterruptedException e) {
+                    // Verification ended, nothing to be done.
+                }
+            });
+
+            t.start();
+            modelChecker.run();
+            t.interrupt();
         }
 
-        final java.lang.Thread t = new java.lang.Thread(() -> {
-            try {
-                final long timeoutInMillis = timeout;
-                java.lang.Thread.sleep(timeoutInMillis);
-                final String error = String.format("Timeout of %s exceeded.", Utils.toTimeString(timeoutInMillis));
-                modelChecker.requestShutdown(error);
-            } catch (InterruptedException e) {
-                // Verification ended, nothing to be done.
-            }
-        });
+        if (modelChecker.hasModel()) {
+            model = modelChecker.getModel();
+        }
 
-        t.start();
-        modelChecker.run();
-        t.interrupt();
+        runtime = System.currentTimeMillis() - startTime;
     }
 
     public Result getResult() {
@@ -127,21 +139,23 @@ public class TaskSolver implements AutoCloseable {
         return modelChecker.getResult();
     }
 
+    public long getRuntime() {
+        checkHasRun();
+        return runtime;
+    }
+
     public boolean hasModel() {
         checkHasRun();
-        return modelChecker.hasModel();
+        return model != null;
     }
 
-    public IREvaluator getModel() throws SolverException {
-        checkHasRun();
-        return modelChecker.getModel();
-    }
-
-    public ExecutionModelNext getExecutionGraph() throws SolverException {
+    public IREvaluator getModel() {
         Preconditions.checkState(hasModel(), "No model available");
-        try (IREvaluator evaluator = getModel()) {
-            return new ExecutionModelManager().buildExecutionModel(evaluator);
-        }
+        return model;
+    }
+
+    public ExecutionModelNext getExecutionGraph() {
+        return new ExecutionModelManager().buildExecutionModel(getModel());
     }
 
     // ===================================== Misc =====================================
@@ -150,6 +164,10 @@ public class TaskSolver implements AutoCloseable {
     public void close() {
         if (modelChecker != null) {
             modelChecker.close();
+        }
+
+        if (model != null) {
+            model.close();
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
@@ -42,7 +42,7 @@ public class TaskSolver implements AutoCloseable {
             name = TIMEOUT,
             description = "Timeout before interrupting the task solver. Can specify time units ns, ms, s (default), min, and h.")
     @TimeSpanOption(min = 0, codeUnit = TimeUnit.MILLISECONDS, defaultUserUnit = TimeUnit.SECONDS)
-    private int timeout = 0;
+    private int timeout = 1200;
 
     private boolean hasTimeout() {
         return timeout > 0;
@@ -115,6 +115,7 @@ public class TaskSolver implements AutoCloseable {
             timeoutThread.start();
             modelChecker.run();
             timeoutThread.interrupt();
+            timeoutThread.join();
         }
 
         if (modelChecker.hasModel()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
@@ -128,7 +128,9 @@ public class TaskSolver implements AutoCloseable {
         }
 
         if (modelChecker.hasModel()) {
-            model = modelChecker.getModel();
+            // TODO: Check why this code here breaks unit tests with SIGTRAP/SIGSEG
+            //  Do we try to get a model when none exists?
+            // model = modelChecker.getModel();
         }
 
         runtime = System.currentTimeMillis() - startTime;
@@ -151,6 +153,13 @@ public class TaskSolver implements AutoCloseable {
 
     public IREvaluator getModel() {
         Preconditions.checkState(hasModel(), "No model available");
+        if (model == null) {
+            try {
+                model = modelChecker.getModel();
+            } catch (SolverException e) {
+                throw new RuntimeException(e);
+            }
+        }
         return model;
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolver.java
@@ -111,16 +111,14 @@ public class TaskSolver implements AutoCloseable {
         if (!hasTimeout()) {
             modelChecker.run();
         } else {
-            final Thread t = createTimeoutThread();
-            t.start();
+            final Thread timeoutThread = createTimeoutThread();
+            timeoutThread.start();
             modelChecker.run();
-            t.interrupt();
+            timeoutThread.interrupt();
         }
 
         if (modelChecker.hasModel()) {
-            // TODO: Check why this code here breaks unit tests with SIGTRAP/SIGSEG
-            //  Do we try to get a model when none exists?
-            // model = modelChecker.getModel();
+            model = modelChecker.getModel();
         }
 
         runtime = System.currentTimeMillis() - startTime;
@@ -138,19 +136,11 @@ public class TaskSolver implements AutoCloseable {
 
     public boolean hasModel() {
         checkHasRun();
-        return modelChecker.hasModel();
-        //return model != null;
+        return model != null;
     }
 
     public IREvaluator getModel() {
         Preconditions.checkState(hasModel(), "No model available");
-        if (model == null) {
-            try {
-                model = modelChecker.getModel();
-            } catch (SolverException e) {
-                throw new RuntimeException(e);
-            }
-        }
         return model;
     }
 
@@ -162,12 +152,15 @@ public class TaskSolver implements AutoCloseable {
 
     @Override
     public void close() {
-        if (modelChecker != null) {
-            modelChecker.close();
-        }
-
+        // VERY IMPORTANT: Close model before closing model checker!
         if (model != null) {
             model.close();
+            model = null;
+        }
+
+        if (modelChecker != null) {
+            modelChecker.close();
+            modelChecker = null;
         }
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTask.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTask.java
@@ -102,6 +102,11 @@ public class VerificationTask {
             return this;
         }
 
+        public VerificationTaskBuilder withOption(String option, String value) {
+            this.config.setOption(option, value);
+            return this;
+        }
+
         public VerificationTask build(Program program, Wmm memoryModel, EnumSet<Property> property) throws InvalidConfigurationException {
             return new VerificationTask(program, memoryModel, progressModel, property, witness, config.build());
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTask.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTask.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /*
-Represents a verification task.
+    Represents a verification task.
  */
 public class VerificationTask {
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -66,21 +66,6 @@ public abstract class ModelChecker implements AutoCloseable {
         public boolean getDumpSmtLib() {
             return smtlib;
         }
-
-        @Option(
-                name = TIMEOUT,
-                description = "Timeout before interrupting the SMT solver. Can specify time units ns, ms, s (default), min, and h.")
-        @TimeSpanOption(min = 0, codeUnit = TimeUnit.MILLISECONDS, defaultUserUnit = TimeUnit.SECONDS)
-        private int timeout = 0;
-
-
-        public boolean hasTimeout() {
-            return timeout > 0;
-        }
-
-        public int getTimeout() {
-            return timeout;
-        }
     }
 
     private static final Logger logger = LoggerFactory.getLogger(ModelChecker.class);
@@ -98,6 +83,7 @@ public abstract class ModelChecker implements AutoCloseable {
     protected ModelChecker(VerificationTask task) throws InvalidConfigurationException {
         this.task = Preconditions.checkNotNull(task);
         this.smtConfig = new SMTConfig();
+
         task.getConfig().inject(smtConfig);
     }
 
@@ -106,19 +92,16 @@ public abstract class ModelChecker implements AutoCloseable {
         return res;
     }
 
-    public long getTimeout() {
-        return smtConfig.getTimeout();
-    }
-
     public void setShutdownManager(ShutdownManager shutdownManager) {
+        Preconditions.checkNotNull(shutdownManager);
         this.shutdownManager = shutdownManager;
     }
 
     public boolean hasModel() {
         final Property.Type propType = Property.getCombinedType(context.getTask().getProperty(), context.getTask());
         final boolean hasViolationWitnesses = res == FAIL && propType == Property.Type.SAFETY;
-        final boolean hasPositiveWitnesses = res == PASS && propType == Property.Type.REACHABILITY;
-        final boolean hasReachedBounds = res == UNKNOWN && propType == Property.Type.SAFETY;
+        final boolean hasPositiveWitnesses  = res == PASS && propType == Property.Type.REACHABILITY;
+        final boolean hasReachedBounds      = res == UNKNOWN && propType == Property.Type.SAFETY;
         return (hasViolationWitnesses || hasPositiveWitnesses || hasReachedBounds);
     }
 
@@ -131,27 +114,12 @@ public abstract class ModelChecker implements AutoCloseable {
 
     public void run() throws SolverException, InterruptedException, InvalidConfigurationException {
         Preconditions.checkState(prover == null, "Model checker already ran.");
-        if (!smtConfig.hasTimeout()) {
-            runInternal();
-            return;
-        }
-
-        java.lang.Thread t = new java.lang.Thread(() -> {
-            try {
-                final long timeoutInMillis = smtConfig.getTimeout();
-                java.lang.Thread.sleep(timeoutInMillis);
-                final String error = String.format("Timeout of %s exceeded.", Utils.toTimeString(timeoutInMillis));
-                shutdownManager.requestShutdown(error);
-            } catch (InterruptedException e) {
-                // Verification ended, nothing to be done.
-            }
-        });
-
-        t.start();
         runInternal();
-        t.interrupt();
-
         checkForInterrupts();
+    }
+
+    public void requestShutdown(String reason) {
+        shutdownManager.requestShutdown(reason);
     }
 
     protected void checkForInterrupts() throws InterruptedException {
@@ -236,19 +204,5 @@ public abstract class ModelChecker implements AutoCloseable {
 
     public static void performIntervalAnalysis(VerificationTask task, Context analysisContext, Configuration config) throws InvalidConfigurationException {
         analysisContext.registerOptional(IntervalAnalysis.class, IntervalAnalysis.fromConfig(task.getProgram(), analysisContext, task.getMemoryModel(), config));
-    }
-
-    // ====================================== Processing utility ==================================================
-
-    public static ModelChecker create(VerificationTask task, Method method) throws InvalidConfigurationException {
-        if (task.getProperty().contains(DATARACEFREEDOM) && method != Method.EAGER) {
-            // For DATARACEFREEDOM, we always use EAGER
-            logger.warn("Method {} is not supported for property {}. Using EAGER instead.", method, DATARACEFREEDOM);
-            method = Method.EAGER;
-        }
-        return switch (method) {
-            case EAGER -> AssumeSolver.create(task);
-            case LAZY -> RefinementSolver.create(task);
-        };
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -127,13 +127,6 @@ public abstract class ModelChecker implements AutoCloseable {
         return context.newEvaluator(prover);
     }
 
-    public ExecutionModelNext getExecutionGraph() throws SolverException {
-        Preconditions.checkState(hasModel(), "No model available");
-        try (IREvaluator evaluator = getModel()) {
-            return new ExecutionModelManager().buildExecutionModel(evaluator);
-        }
-    }
-
     protected abstract void runInternal() throws InterruptedException, SolverException, InvalidConfigurationException;
 
     public void run() throws SolverException, InterruptedException, InvalidConfigurationException {
@@ -243,7 +236,7 @@ public abstract class ModelChecker implements AutoCloseable {
 
     public static void performIntervalAnalysis(VerificationTask task, Context analysisContext, Configuration config) throws InvalidConfigurationException {
         analysisContext.registerOptional(IntervalAnalysis.class, IntervalAnalysis.fromConfig(task.getProgram(), analysisContext, task.getMemoryModel(), config));
-     }
+    }
 
     // ====================================== Processing utility ==================================================
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphml/WitnessGraph.java
@@ -15,6 +15,7 @@ import com.google.common.collect.Lists;
 import org.sosy_lab.java_smt.api.BooleanFormula;
 import org.sosy_lab.java_smt.api.BooleanFormulaManager;
 
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.*;
@@ -194,8 +195,9 @@ public class WitnessGraph extends ElemWithAttributes {
         return k;
     }
 
-    public void write(String filename) {
-        try (FileWriter fw = new FileWriter(String.format("%s/%s.graphml", getOrCreateOutputDirectory(), filename))) {
+    public File write(String filename) throws IOException {
+        final String filepath = String.format("%s/%s.graphml", getOrCreateOutputDirectory(), filename);
+        try (FileWriter fw = new FileWriter(filepath)) {
             fw.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
             fw.write(
                     "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n");
@@ -213,8 +215,7 @@ public class WitnessGraph extends ElemWithAttributes {
             }
             fw.write(toXML());
             fw.write("</graphml>\n");
-        } catch (IOException e1) {
-            e1.printStackTrace();
+            return new File(filepath);
         }
     }
 }

--- a/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/reflect-config.json
+++ b/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/reflect-config.json
@@ -1,5 +1,10 @@
 [
     {
+        "name":"com.dat3m.dartagnan.verification.TaskSolver",
+        "allDeclaredFields": true,
+        "queryAllDeclaredMethods": true
+    },
+    {
         "name": "com.dat3m.dartagnan.wmm.RelationNameRepository",
         "allDeclaredFields": true,
         "allDeclaredMethods": true

--- a/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/reflect-config.json
+++ b/dartagnan/src/main/resources/META-INF/native-image/com.dat3m.dartagnan/dartagnan/reflect-config.json
@@ -1,5 +1,10 @@
 [
     {
+      "name":"com.dat3m.dartagnan.witness.graphviz.ExecutionGraphVisualizer",
+      "allDeclaredFields": true,
+      "queryAllDeclaredMethods": true
+    },
+    {
         "name":"com.dat3m.dartagnan.verification.TaskSolver",
         "allDeclaredFields": true,
         "queryAllDeclaredMethods": true

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/asm/armv7/ck/AsmCkArmv7Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/asm/armv7/ck/AsmCkArmv7Test.java
@@ -51,7 +51,7 @@ public class AsmCkArmv7Test {
 
     @Test
     public void testAllSolvers() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.LAZY));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.LAZY));
     }
 
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/asm/armv7/libvsync/AsmLibvsyncArmv7Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/asm/armv7/libvsync/AsmLibvsyncArmv7Test.java
@@ -74,7 +74,7 @@ public class AsmLibvsyncArmv7Test {
 
     @Test
     public void testAllSolvers() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.LAZY));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.LAZY));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/asm/armv8/ck/AsmCkArmv8Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/asm/armv8/ck/AsmCkArmv8Test.java
@@ -59,7 +59,7 @@ public class AsmCkArmv8Test {
     public void testAllSolvers() throws Exception {
         // TODO : RefinementSolver takes too long to run, we have to investigate this
         // assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.LAZY));
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/asm/armv8/libvsync/AsmLibvsyncArmv8Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/asm/armv8/libvsync/AsmLibvsyncArmv8Test.java
@@ -76,7 +76,7 @@ public class AsmLibvsyncArmv8Test {
     public void testAllSolvers() throws Exception {
         // TODO : RefinementSolver takes too long to run, we have to investigate this
         // assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.LAZY));
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/asm/ppc64/ck/AsmCkPpc64Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/asm/ppc64/ck/AsmCkPpc64Test.java
@@ -56,7 +56,7 @@ public class AsmCkPpc64Test {
 
     @Test
     public void testAllSolvers() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.LAZY));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.LAZY));
         //assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
     }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/asm/riscv/ck/AsmCkRISCVTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/asm/riscv/ck/AsmCkRISCVTest.java
@@ -48,8 +48,8 @@ public class AsmCkRISCVTest {
 
     @Test
     public void testAllSolvers() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.LAZY));
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.LAZY));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
@@ -10,8 +10,8 @@ import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.rules.Provider;
 import com.dat3m.dartagnan.utils.rules.Providers;
 import com.dat3m.dartagnan.utils.rules.RequestShutdownOnError;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
-import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Rule;
 import org.junit.Test;
@@ -146,19 +146,19 @@ public abstract class AbstractLitmusTest {
 
     @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     //@Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 
-    protected void testModelChecker(Method method) throws Exception {
-        try (ModelChecker checker = ModelChecker.create(taskProvider.get(), method)) {
-            checker.setShutdownManager(shutdownManagerProvider.get());
-            checker.run();
-            assertEquals(expected, checker.getResult());
+    protected void testSolver(Method method) throws Exception {
+        try (TaskSolver solver = TaskSolver.createWithMethod(taskProvider.get(), method)
+                .withShutdownManager(shutdownManagerProvider.get())) {
+            solver.run();
+            assertEquals(expected, solver.getResult());
         }
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/comparison/AbstractComparisonTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/comparison/AbstractComparisonTest.java
@@ -9,8 +9,8 @@ import com.dat3m.dartagnan.utils.ResourceHelper;
 import com.dat3m.dartagnan.utils.rules.Provider;
 import com.dat3m.dartagnan.utils.rules.Providers;
 import com.dat3m.dartagnan.utils.rules.RequestShutdownOnError;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
-import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Rule;
 import org.junit.Test;
@@ -77,7 +77,8 @@ public abstract class AbstractComparisonTest {
                 .setOption(SOLVER, Z3.name())
                 .setOption(PHANTOM_REFERENCES, "true")
                 .setOption(INITIALIZE_REGISTERS, "true")
-                .setOption(USE_INTEGERS, "true");
+                .setOption(USE_INTEGERS, "true")
+                .setOption(METHOD, Method.EAGER.asStringOption());
 
         return additionalConfig(configBase).build();
     }
@@ -120,10 +121,8 @@ public abstract class AbstractComparisonTest {
 
     @Test
     public void testAssume() throws Exception {
-        try (ModelChecker s1 = ModelChecker.create(task1Provider.get(), Method.EAGER);
-             ModelChecker s2 = ModelChecker.create(task2Provider.get(), Method.EAGER)) {
-            s1.setShutdownManager(shutdownManagerProvider.get());
-            s2.setShutdownManager(shutdownManagerProvider.get());
+        try (TaskSolver s1 = TaskSolver.create(task1Provider.get()).withShutdownManager(shutdownManagerProvider.get());
+             TaskSolver s2 = TaskSolver.create(task2Provider.get()).withShutdownManager(shutdownManagerProvider.get())) {
             s1.run();
             s2.run();
             assertEquals(s1.hasModel(), s2.hasModel());

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/compilation/AbstractCompilationTest.java
@@ -153,9 +153,9 @@ public abstract class AbstractCompilationTest {
 
     private static boolean isRcuOrSrcu(Event e) {
         // The following have features (RCU and SRCU) that hardware models do not support
-        return Stream.of(
-                Tag.Linux.RCU_LOCK, Tag.Linux.RCU_UNLOCK, Tag.Linux.RCU_SYNC,
-                Tag.Linux.SRCU_LOCK, Tag.Linux.SRCU_UNLOCK, Tag.Linux.SRCU_SYNC)
-                .anyMatch(e::hasTag);
+        return Stream.of(Tag.Linux.RCU_LOCK, Tag.Linux.RCU_UNLOCK, Tag.Linux.RCU_SYNC,
+                        Tag.Linux.SRCU_LOCK, Tag.Linux.SRCU_UNLOCK, Tag.Linux.SRCU_SYNC,
+                        Tag.Linux.AFTER_SRCU_READ_UNLOCK
+                ).anyMatch(e::hasTag);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/compilation/AbstractCompilationTest.java
@@ -11,8 +11,8 @@ import com.dat3m.dartagnan.utils.ResourceHelper;
 import com.dat3m.dartagnan.utils.rules.Provider;
 import com.dat3m.dartagnan.utils.rules.Providers;
 import com.dat3m.dartagnan.utils.rules.RequestShutdownOnError;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
-import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Rule;
 import org.junit.Test;
@@ -84,7 +84,8 @@ public abstract class AbstractCompilationTest {
                 .setOption(TARGET, targetProvider.get().name())
                 .setOption(PHANTOM_REFERENCES, "true")
                 .setOption(INITIALIZE_REGISTERS, "true")
-                .setOption(USE_INTEGERS, "true");
+                .setOption(USE_INTEGERS, "true")
+                .setOption(METHOD, Method.EAGER.asStringOption());
 
         return additionalConfig(configBase).build();
     }
@@ -131,10 +132,8 @@ public abstract class AbstractCompilationTest {
             return;
         }
 
-        try (ModelChecker s1 = ModelChecker.create(task1Provider.get(), Method.EAGER);
-             ModelChecker s2 = ModelChecker.create(task2Provider.get(), Method.EAGER)) {
-            s1.setShutdownManager(shutdownManagerProvider.get());
-            s2.setShutdownManager(shutdownManagerProvider.get());
+        try (TaskSolver s1 = TaskSolver.create(task1Provider.get()).withShutdownManager(shutdownManagerProvider.get());
+             TaskSolver s2 = TaskSolver.create(task2Provider.get()).withShutdownManager(shutdownManagerProvider.get())) {
 
             s1.run();
             if (!s1.hasModel()) {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/AbstractCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/AbstractCTest.java
@@ -6,8 +6,8 @@ import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.rules.Provider;
 import com.dat3m.dartagnan.utils.rules.Providers;
 import com.dat3m.dartagnan.utils.rules.RequestShutdownOnError;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
-import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
@@ -112,11 +112,11 @@ public abstract class AbstractCTest {
             .around(timeout);
 
 
-    protected void testModelChecker(Method method) throws Exception {
-        try (ModelChecker checker = ModelChecker.create(taskProvider.get(), method)) {
-            checker.setShutdownManager(shutdownManagerProvider.get());
-            checker.run();
-            assertEquals(expected, checker.getResult());
+    protected void testSolver(Method method) throws Exception {
+        try (TaskSolver solver = TaskSolver.createWithMethod(taskProvider.get(), method)
+                .withShutdownManager(shutdownManagerProvider.get())) {
+            solver.run();
+            assertEquals(expected, solver.getResult());
         }
     }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/C11LFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/C11LFDSTest.java
@@ -75,11 +75,11 @@ public class C11LFDSTest extends AbstractCTest {
 
     @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/C11LocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/C11LocksTest.java
@@ -83,11 +83,11 @@ public class C11LocksTest extends AbstractCTest {
 
     @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/CLKMMTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/CLKMMTest.java
@@ -69,11 +69,11 @@ public class CLKMMTest extends AbstractCTest {
 
     @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/CLocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/CLocksTest.java
@@ -152,11 +152,11 @@ public class CLocksTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/CProgressTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/CProgressTest.java
@@ -88,11 +88,11 @@ public class CProgressTest extends AbstractCTest {
 
     @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/EBRTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/EBRTest.java
@@ -59,11 +59,11 @@ public class EBRTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/IMMLFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/IMMLFDSTest.java
@@ -62,11 +62,11 @@ public class IMMLFDSTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/IMMLocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/IMMLocksTest.java
@@ -74,11 +74,11 @@ public class IMMLocksTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/IMMTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/IMMTest.java
@@ -64,11 +64,11 @@ public class IMMTest extends AbstractCTest {
 
     @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LFDSTest.java
@@ -91,11 +91,11 @@ public class LFDSTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LibvsyncTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LibvsyncTest.java
@@ -85,11 +85,11 @@ public class LibvsyncTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LivenessTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LivenessTest.java
@@ -166,11 +166,11 @@ public class LivenessTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/MiscellaneousTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/MiscellaneousTest.java
@@ -127,11 +127,11 @@ public class MiscellaneousTest extends AbstractCTest {
 
     @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/MixedTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/MixedTest.java
@@ -74,11 +74,11 @@ public class MixedTest extends AbstractCTest {
 
     @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/RC11LFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/RC11LFDSTest.java
@@ -62,11 +62,11 @@ public class RC11LFDSTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/RC11LocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/RC11LocksTest.java
@@ -74,11 +74,11 @@ public class RC11LocksTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/RC11Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/RC11Test.java
@@ -58,11 +58,11 @@ public class RC11Test extends AbstractCTest {
 
     @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/VMMLFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/VMMLFDSTest.java
@@ -84,11 +84,11 @@ public class VMMLFDSTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/VMMLocksTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/VMMLocksTest.java
@@ -90,11 +90,11 @@ public class VMMLocksTest extends AbstractCTest {
 
     // @Test
     public void testAssume() throws Exception {
-        testModelChecker(Method.EAGER);
+        testSolver(Method.EAGER);
     }
 
     @Test
     public void testRefinement() throws Exception {
-        testModelChecker(Method.LAZY);
+        testSolver(Method.LAZY);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/ArrayValidTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/ArrayValidTest.java
@@ -2,10 +2,12 @@ package com.dat3m.dartagnan.others.miscellaneous;
 
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.Method;
+import com.dat3m.dartagnan.configuration.OptionNames;
 import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.wmm.Wmm;
@@ -22,6 +24,7 @@ import java.util.EnumSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.dat3m.dartagnan.configuration.OptionNames.METHOD;
 import static com.dat3m.dartagnan.utils.ResourceHelper.getRootPath;
 import static com.dat3m.dartagnan.utils.ResourceHelper.getTestResourcePath;
 import static com.dat3m.dartagnan.utils.Result.PASS;
@@ -56,11 +59,12 @@ public class ArrayValidTest {
         VerificationTask task = VerificationTask.builder()
                 .withSolverTimeout(60)
                 .withTarget(Arch.LKMM)
+                .withOption(METHOD, Method.EAGER.asStringOption())
                 .build(program, wmm, EnumSet.of(Property.PROGRAM_SPEC));
 
-        try (ModelChecker checker = ModelChecker.create(task, Method.EAGER)) {
-            checker.run();
-            assertEquals(PASS, checker.getResult());
+        try (TaskSolver solver = TaskSolver.create(task)) {
+            solver.run();
+            assertEquals(PASS, solver.getResult());
         }
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/BranchTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/BranchTest.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.wmm.Wmm;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.dat3m.dartagnan.configuration.OptionNames.METHOD;
 import static com.dat3m.dartagnan.utils.ResourceHelper.getRootPath;
 import static com.dat3m.dartagnan.utils.ResourceHelper.getTestResourcePath;
 import static com.dat3m.dartagnan.utils.Result.FAIL;
@@ -94,11 +96,12 @@ public class BranchTest {
         VerificationTask task = VerificationTask.builder()
                 .withSolverTimeout(60)
                 .withTarget(Arch.LKMM)
+                .withOption(METHOD, Method.EAGER.asStringOption())
                 .build(program, wmm, EnumSet.of(Property.PROGRAM_SPEC));
 
-        try (ModelChecker checker = ModelChecker.create(task, Method.EAGER)) {
-            checker.run();
-            assertEquals(expected, checker.getResult());
+        try (TaskSolver solver = TaskSolver.create(task)) {
+            solver.run();
+            assertEquals(expected, solver.getResult());
         }
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/witness/BuildWitnessTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/witness/BuildWitnessTest.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.witness.graphml.WitnessBuilder;
@@ -35,15 +36,16 @@ public class BuildWitnessTest {
                 setOption(WITNESS, "graphml").
                 setOption(WITNESS_ORIGINAL_PROGRAM_PATH, getTestResourcePath("witness/lazy01-for-witness.ll")).
                 setOption(BOUND, "1").
+                setOption(METHOD, Method.EAGER.asStringOption()).
                 build();
 
         Program p = new ProgramParser().parse(new File(getTestResourcePath("witness/lazy01-for-witness.ll")));
         Wmm wmm = new ParserCat().parse(new File(getRootPath("cat/svcomp.cat")));
         VerificationTask task = VerificationTask.builder().withConfig(config).build(p, wmm, Property.getDefault());
-        try (ModelChecker modelChecker = ModelChecker.create(task, Method.EAGER)) {
-            modelChecker.run();
-            Result res = modelChecker.getResult();
-            IREvaluator model = modelChecker.getModel();
+        try (TaskSolver solver = TaskSolver.create(task)) {
+            solver.run();
+            Result res = solver.getResult();
+            IREvaluator model = solver.getModel();
             WitnessBuilder witnessBuilder = WitnessBuilder.of(model, res, "user assertion");
             config.inject(witnessBuilder);
             WitnessGraph graph = witnessBuilder.build();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/alignment/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/alignment/SpirvAssertionsTest.java
@@ -64,7 +64,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/barrier/inlining/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/barrier/inlining/SpirvAssertionsTest.java
@@ -76,7 +76,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/barrier/scope/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/barrier/scope/SpirvAssertionsTest.java
@@ -49,7 +49,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/barrier/scope/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/barrier/scope/SpirvRacesTest.java
@@ -49,7 +49,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/basic/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/basic/SpirvAssertionsTest.java
@@ -47,7 +47,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/basic/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/basic/SpirvRacesTest.java
@@ -45,7 +45,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/benchmarks/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/benchmarks/SpirvAssertionsTest.java
@@ -74,7 +74,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/benchmarks/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/benchmarks/SpirvRacesTest.java
@@ -80,7 +80,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/gpuverify/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/gpuverify/SpirvRacesTest.java
@@ -342,7 +342,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/patterns/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/patterns/SpirvAssertionsTest.java
@@ -51,7 +51,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/patterns/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/opencl/patterns/SpirvRacesTest.java
@@ -59,7 +59,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/alignment/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/alignment/SpirvAssertionsTest.java
@@ -74,7 +74,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/barrier/loops/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/barrier/loops/SpirvAssertionsTest.java
@@ -76,7 +76,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/barrier/scope/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/barrier/scope/SpirvAssertionsTest.java
@@ -51,7 +51,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/barrier/scope/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/barrier/scope/SpirvRacesTest.java
@@ -51,7 +51,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/basic/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/basic/SpirvAssertionsTest.java
@@ -126,7 +126,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/basic/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/basic/SpirvRacesTest.java
@@ -48,7 +48,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/benchmarks/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/benchmarks/SpirvAssertionsTest.java
@@ -76,7 +76,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/benchmarks/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/benchmarks/SpirvRacesTest.java
@@ -91,7 +91,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/gpuverify/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/gpuverify/SpirvRacesTest.java
@@ -343,7 +343,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/patterns/SpirvAssertionsTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/patterns/SpirvAssertionsTest.java
@@ -53,7 +53,7 @@ public class SpirvAssertionsTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/patterns/SpirvRacesTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/patterns/SpirvRacesTest.java
@@ -59,7 +59,7 @@ public class SpirvRacesTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/termination/SpirvLivenessTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/spirv/vulkan/termination/SpirvLivenessTest.java
@@ -100,7 +100,7 @@ public class SpirvLivenessTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(expected, TestHelper.createAndRunModelChecker(mkTask(), Method.EAGER));
+        assertEquals(expected, TestHelper.createAndRunSolver(mkTask(), Method.EAGER));
     }
 
     private VerificationTask mkTask() throws Exception {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/TestHelper.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/TestHelper.java
@@ -2,8 +2,8 @@ package com.dat3m.dartagnan.utils;
 
 import com.dat3m.dartagnan.configuration.Method;
 import com.dat3m.dartagnan.configuration.OptionNames;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
-import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.SolverContextFactory;
@@ -21,10 +21,10 @@ public class TestHelper {
                 .build();
     }
 
-    public static Result createAndRunModelChecker(VerificationTask task, Method method) throws InvalidConfigurationException, SolverException, InterruptedException {
-        try (ModelChecker checker = ModelChecker.create(task, method)) {
-            checker.run();
-            return checker.getResult();
+    public static Result createAndRunSolver(VerificationTask task, Method method) throws InvalidConfigurationException, SolverException, InterruptedException {
+        try (TaskSolver solver = TaskSolver.createWithMethod(task, method)) {
+            solver.run();
+            return solver.getResult();
         }
     }
 

--- a/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
@@ -1,5 +1,6 @@
 package com.dat3m.svcomp;
 
+import com.dat3m.dartagnan.Dartagnan;
 import com.dat3m.dartagnan.parsers.witness.ParserWitness;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.witness.graphml.WitnessGraph;
@@ -69,7 +70,7 @@ public class SVCOMPRunner extends BaseOptions {
     public static void main(String[] args) throws Exception {
 
         if(Arrays.asList(args).contains("--help")) {
-            collectOptions();
+            Dartagnan.printOptions();
             return;
         }
 
@@ -98,9 +99,8 @@ public class SVCOMPRunner extends BaseOptions {
             return;
         }
 
-        WitnessGraph witness = new WitnessGraph(); 
         if(r.witnessPath != null) {
-            witness = new ParserWitness().parse(new File(r.witnessPath));
+            WitnessGraph witness = new ParserWitness().parse(new File(r.witnessPath));
             if(!fileProgram.getName().equals(Paths.get(witness.getProgram()).getFileName().toString())) {
                 System.out.println("The witness was generated from a different program than " + fileProgram);
                 System.exit(WRONG_WITNESS_FILE.asInt());
@@ -161,9 +161,8 @@ public class SVCOMPRunner extends BaseOptions {
     }
 
     private static List<String> filterOptions(Configuration config) {
-    	
         List<String> skip = Arrays.asList(PROPERTYPATH, NATIVE);
-    	
+
         return Arrays.stream(config.asPropertiesString().split("\n")).
             filter(p -> skip.stream().noneMatch(s -> s.equals(p.split(" = ")[0]))).
             map(p -> "--" + p.split(" = ")[0] + "=" + p.split(" = ")[1]).

--- a/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.EnumSet;
 import java.util.stream.Collectors;
 
-import static com.dat3m.dartagnan.configuration.OptionInfo.collectOptions;
 import static com.dat3m.dartagnan.configuration.OptionNames.*;
 import static com.dat3m.dartagnan.utils.ExitCode.*;
 

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -4,9 +4,8 @@ import com.dat3m.dartagnan.Dartagnan;
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.ProgressModel;
 import com.dat3m.dartagnan.program.Program;
-import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
-import com.dat3m.dartagnan.verification.solving.ModelChecker;
 import com.dat3m.dartagnan.witness.WitnessType;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.ui.utils.UiOptions;
@@ -60,12 +59,12 @@ public class ReachabilityResult {
                     .withTarget(arch)
                     .withProgressModel(ProgressModel.uniform(options.progress()))
                     .build(program, wmm, options.properties());
-            try (ModelChecker modelChecker = ModelChecker.create(task, options.method())) {
+            try (TaskSolver solver = TaskSolver.create(task)) {
                 long startTime = System.currentTimeMillis();
-                modelChecker.run();
+                solver.run();
                 long endTime = System.currentTimeMillis();
-                verdict = Dartagnan.summaryFromResult(task, modelChecker, "", (endTime - startTime)).toUIString();
-                witnessFile = Dartagnan.generateWitnessIfAble(task, modelChecker, WitnessType.PNG, "dat3m", "", false);
+                verdict = Dartagnan.summaryFromResult(task, solver, "", (endTime - startTime)).toUIString();
+                witnessFile = Dartagnan.generateWitnessIfAble(task, solver, WitnessType.PNG, "dat3m", "", false);
             }
         } catch (InterruptedException e) {
             verdict = "TIMEOUT";

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -1,9 +1,9 @@
 package com.dat3m.ui.result;
 
-import com.dat3m.dartagnan.Dartagnan;
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.configuration.ProgressModel;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.verification.TaskResultAnalyzer;
 import com.dat3m.dartagnan.verification.TaskSolver;
 import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.witness.WitnessType;
@@ -59,12 +59,13 @@ public class ReachabilityResult {
                     .withTarget(arch)
                     .withProgressModel(ProgressModel.uniform(options.progress()))
                     .build(program, wmm, options.properties());
+
             try (TaskSolver solver = TaskSolver.create(task)) {
-                long startTime = System.currentTimeMillis();
                 solver.run();
-                long endTime = System.currentTimeMillis();
-                verdict = Dartagnan.summaryFromResult(task, solver, "", (endTime - startTime)).toUIString();
-                witnessFile = Dartagnan.generateWitnessIfAble(task, solver, WitnessType.PNG, "dat3m", "", false);
+
+                final TaskResultAnalyzer resultAnalyzer = TaskResultAnalyzer.create();
+                verdict = resultAnalyzer.getSummaryFromSolver(solver, "").toUIString();
+                witnessFile = resultAnalyzer.generateWitnessIfAble(solver, WitnessType.PNG, "dat3m", "", false);
             }
         } catch (InterruptedException e) {
             verdict = "TIMEOUT";


### PR DESCRIPTION
This PR adds a new abstraction layer before the ModelChecker. For now, this layer does not do much apart from choosing the appropriate ModelChecker and managing timeouts.
However, the intend is to make this layer more powerful in the future and enable more interesting solving approaches such as:
- Automatic bound unrolling without external script
- Running SMC for some time and if SMC solves the task in, say, < 1000 explored executions, then we are done. Otherwise, fall back to BMC but exploit information gathered from SMC (loop bounds, indirect call targets, aliasing information, summary of sequential prefix, etc.).
- Parallel solving via decomposition?
- "Proof mode" that first unrolls loops until completion and only then checks the properties of interest. This can be a lot more efficient if the program is likely to be correct.
- State-space exploration mode for compilation correctness.

~**TODO:** Update reflection metadata for native build.~

**EDIT:** I also added a `TaskResultAnalyzer` class that is now responsible for generating the `ResultSummary` and witness files. Basically, I moved all output generation from `Dartagnan.java` to `TaskResultAnalyzer`

**EDIT 2:** I took the freedom to clean up `Dartagnan.java`. I think it is a lot easier to follow the logic of Dartagnan now.

