### PR TITLE
Add more program simplifications

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/expression/processing/ExprSimplifier.java
@@ -1,14 +1,10 @@
 package com.dat3m.dartagnan.expression.processing;
 
 
-import com.dat3m.dartagnan.expression.BinaryExpression;
-import com.dat3m.dartagnan.expression.Expression;
-import com.dat3m.dartagnan.expression.ExpressionKind;
-import com.dat3m.dartagnan.expression.aggregates.AggregateCmpExpr;
-import com.dat3m.dartagnan.expression.aggregates.AggregateCmpOp;
-import com.dat3m.dartagnan.expression.aggregates.ConstructExpr;
-import com.dat3m.dartagnan.expression.aggregates.ExtractExpr;
+import com.dat3m.dartagnan.expression.*;
+import com.dat3m.dartagnan.expression.aggregates.*;
 import com.dat3m.dartagnan.expression.booleans.*;
+import com.dat3m.dartagnan.expression.floats.FloatUnaryOp;
 import com.dat3m.dartagnan.expression.integers.*;
 import com.dat3m.dartagnan.expression.memory.*;
 import com.dat3m.dartagnan.expression.misc.ITEExpr;
@@ -29,7 +25,7 @@ public class ExprSimplifier extends ExprTransformer {
     // If set to "false", the simplifier will not destroy register dependencies, i.e.,
     // it will maintain "expr.getRegs() == simplified(expr).getRegs()".
     // For example, "0*r" will not get simplified to "0";
-    private final boolean aggressive;
+    protected boolean aggressive;
 
     public ExprSimplifier(boolean aggressive) {
         this.aggressive = aggressive;
@@ -59,6 +55,34 @@ public class ExprSimplifier extends ExprTransformer {
         ).accept(this);
 
         return hoistedIte;
+    }
+
+    // Tries to push unary operations into ITE expressions.
+    private Expression tryGeneralRewrite(UnaryExpression expression) {
+        final Expression operand = expression.getOperand().accept(this);
+        if (!(operand instanceof ITEExpr ite)) {
+            return null;
+        }
+
+        final ExpressionKind op = expression.getKind();
+        if (op instanceof BoolUnaryOp || op instanceof IntUnaryOp || op instanceof FloatUnaryOp) {
+            // ------- Standard unary expressions -------
+            return expressions.makeITE(
+                    ite.getCondition(),
+                    expressions.makeUnary(expression.getKind(), ite.getTrueCase()),
+                    expressions.makeUnary(expression.getKind(), ite.getFalseCase())
+            ).accept(this);
+        } else if (expression instanceof IntSizeCast cast) {
+            // ------- Integer casts -------
+            return expressions.makeITE(
+                    ite.getCondition(),
+                    expressions.makeIntegerCast(ite.getTrueCase(), cast.getTargetType(), cast.preservesSign()),
+                    expressions.makeIntegerCast(ite.getFalseCase(), cast.getTargetType(), cast.preservesSign())
+            ).accept(this);
+        } else {
+            return null;
+        }
+
     }
 
     @Override
@@ -171,6 +195,19 @@ public class ExprSimplifier extends ExprTransformer {
             return expressions.makeValue(cmpResult);
         }
 
+        // Case:
+        //    (1) ext(x) cmp ext(y)  <=>  x cmp y  (if size(x)==size(y))
+        //    (2) c' = ext(c) for constants of small size
+        // Result:
+        //     ext(x) cmp c' <=> ext(x) cmp ext(c) <=> x cmp c
+        if (left instanceof IntSizeCast cast && cast.isExtension()
+                && right instanceof IntLiteral lit
+                && IntegerHelper.getNumRequiredBits(lit.getValue()) <= cast.getSourceType().getBitWidth()) {
+            final Expression x = cast.getOperand();
+            final Expression c = expressions.makeValue(lit.getValue(), cast.getSourceType());
+            return expressions.makeIntCmp(x, op, c);
+        }
+
         // ------- Operations on memory objects and functions -------
         if (left instanceof MemoryObject && right instanceof MemoryObject
                 || left instanceof Function && right instanceof Function) {
@@ -195,6 +232,11 @@ public class ExprSimplifier extends ExprTransformer {
 
     @Override
     public Expression visitIntSizeCastExpression(IntSizeCast expr) {
+        final Expression rewrite = tryGeneralRewrite(expr);
+        if (rewrite != null) {
+            return rewrite;
+        }
+
         final Expression operand = expr.getOperand().accept(this);
 
         // ------- Operations with constants -------
@@ -213,7 +255,16 @@ public class ExprSimplifier extends ExprTransformer {
             return expressions.makeValue(newValue, expr.getTargetType());
         }
 
-        // TODO: Simplify nested casts
+        // ------- Nested casts -------
+        if (operand instanceof IntSizeCast innerCast) {
+            if (expr.isTruncation()) {
+                return expressions.makeIntegerCast(innerCast.getOperand(), expr.getTargetType(), expr.preservesSign());
+            } else if (innerCast.isExtension()) {
+                if (!innerCast.preservesSign() || expr.preservesSign()) {
+                    return expressions.makeIntegerCast(innerCast.getOperand(), expr.getTargetType(), innerCast.preservesSign());
+                }
+            }
+        }
 
         // TODO: Push casts into operators?
 
@@ -387,10 +438,13 @@ public class ExprSimplifier extends ExprTransformer {
             if (l.getOperands().size() == r.getOperands().size()) {
                 if (l.getOperands().isEmpty()) {
                     return expressions.makeValue(isEq);
-                } else if (l.getOperands().size() == 1) {
-                    final Expression lOp = l.getOperands().get(0);
-                    final Expression rOp = r.getOperands().get(0);
-                    return (isEq ? expressions.makeEQ(lOp, rOp) : expressions.makeNEQ(lOp, rOp)).accept(this);
+                } else {
+                    Expression check = expressions.makeTrue();
+                    for (int i = 0; i < l.getOperands().size(); i++) {
+                        check = expressions.makeAnd(check,
+                                expressions.makeEQ(l.getOperands().get(i), r.getOperands().get(i)));
+                    }
+                    return (isEq ? check : expressions.makeNot(check)).accept(this);
                 }
             }
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/Tag.java
@@ -12,6 +12,7 @@ import java.util.Set;
         (2) Tags used only internally (prefixed with a double underscore "__");
  */
 public final class Tag {
+
     private Tag() { }
 
     public static final String VISIBLE          = "_";
@@ -38,6 +39,10 @@ public final class Tag {
     // Some events should not be optimized (e.g. fake dependencies) or deleted (e.g. bounds)
     public static final String NOOPT            = "__NOOPT";
     public static final String NO_INSTRUCTION   = "__NO_INSTRUCTION";
+    // Marks events that do not carry deps, either because an analysis said so
+    // or because the event is internally generated and should not affect the program semantics.
+    // TODO: Respect this tag when computing idd and its variants.
+    public static final String NO_CARRY_DEPS    = "__NO_CARRY_DEPS";
 
     // =============================================================================================
     // =========================================== ARMv8 ===========================================

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/AssignmentInlining.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/AssignmentInlining.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.program.processing;
 
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.aggregates.ConstructExpr;
+import com.dat3m.dartagnan.expression.misc.ITEExpr;
 import com.dat3m.dartagnan.expression.processing.ExprTransformer;
 import com.dat3m.dartagnan.program.Function;
 import com.dat3m.dartagnan.program.Register;
@@ -24,8 +25,8 @@ import java.util.Map;
     or it leads to simplifications(*).
     To achieve this, the pass scans the code twice: once to collect usage statistics and once to perform the inlining.
 
-    (*) Currently, we aggressively inline ConstructExprs because they are likely to get combined with an ExtractExpr
-        and then removed by SCCP.
+    (*) Currently, we aggressively inline ConstructExpr and ITEExpr because they are likely to allow for
+        more simplifications.
  */
 public class AssignmentInlining implements FunctionProcessor {
 
@@ -93,7 +94,7 @@ public class AssignmentInlining implements FunctionProcessor {
         };
 
         private boolean allowsSimplification(Event curEvent, Register replacedReg, Expression inlineValue) {
-            return inlineValue instanceof ConstructExpr;
+            return inlineValue instanceof ConstructExpr || inlineValue instanceof ITEExpr;
         }
 
         private Processor(Function function) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicSpinLoopDetection.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/DynamicSpinLoopDetection.java
@@ -185,7 +185,7 @@ public class DynamicSpinLoopDetection implements ProgramProcessor {
 
     private Event newSpinTerminator(Expression guard, LoopData loop) {
         final Function func = loop.getStart().getFunction();
-        final Event terminator = EventFactory.newTerminator(func, guard, Tag.SPINLOOP, Tag.NONTERMINATION);
+        final Event terminator = EventFactory.newTerminator(func, guard, Tag.SPINLOOP, Tag.NONTERMINATION, Tag.NO_CARRY_DEPS);
         terminator.copyAllMetadataFrom(loop.getStart());
         return terminator;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemToReg.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/MemToReg.java
@@ -1,5 +1,6 @@
 package com.dat3m.dartagnan.program.processing;
 
+
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.ExpressionFactory;
 import com.dat3m.dartagnan.expression.Type;
@@ -142,7 +143,8 @@ public class MemToReg implements FunctionProcessor {
     }
 
     private Register newRegister(Alloc allocation, Field field) {
-        return allocation.getFunction().newUniqueRegister("__memToReg", field.type);
+        final String regName = allocation.getResultRegister().getName() + "@" + field.offset + "__m2r";
+        return allocation.getFunction().newUniqueRegister(regName, field.type);
     }
 
     private List<Event> promoteAccess(MemoryCoreEvent event, AddressOffset access,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -140,7 +140,8 @@ public class ProcessingManager implements ProgramProcessor {
                         FunctionProcessor.chain(
                                 ResolveAborts.newInstance(),
                                 RemoveDeadNullChecks.newInstance(),
-                                MemToReg.fromConfig(config)
+                                MemToReg.fromConfig(config),
+                                SROA.newInstance()
                         ), Target.THREADS, true
                 ),
                 simplifyBoundedProgram,

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SROA.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SROA.java
@@ -1,0 +1,127 @@
+package com.dat3m.dartagnan.program.processing;
+
+import com.dat3m.dartagnan.expression.Expression;
+import com.dat3m.dartagnan.expression.ExpressionFactory;
+import com.dat3m.dartagnan.expression.Type;
+import com.dat3m.dartagnan.expression.aggregates.ConstructExpr;
+import com.dat3m.dartagnan.expression.processing.ExprTransformer;
+import com.dat3m.dartagnan.expression.type.AggregateType;
+import com.dat3m.dartagnan.expression.type.TypeOffset;
+import com.dat3m.dartagnan.program.Function;
+import com.dat3m.dartagnan.program.Register;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.EventFactory;
+import com.dat3m.dartagnan.program.event.RegReader;
+import com.dat3m.dartagnan.program.event.RegWriter;
+import com.dat3m.dartagnan.program.event.core.Local;
+import com.google.common.base.Preconditions;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+// Scalar Replacement of Aggregates
+public class SROA implements FunctionProcessor {
+
+    private SROA() {}
+
+    public static SROA newInstance() {
+        return new SROA();
+    }
+
+    @Override
+    public void run(Function function) {
+        // Compute decomposable aggregate registers
+        final Set<Register> decomposableAggRegs = function.getRegisters().stream()
+                .filter(r -> r.getType() instanceof AggregateType)
+                .collect(Collectors.toSet());
+        for (RegWriter writer : function.getEvents(RegWriter.class)) {
+            if (decomposableAggRegs.contains(writer.getResultRegister()) && !(writer instanceof Local)) {
+                decomposableAggRegs.remove(writer.getResultRegister());
+            }
+        }
+
+        // Compute decomposition of aggregate registers
+        final Map<Register, AggregateReg> agg2Scalars = new HashMap<>();
+        for (Register reg : decomposableAggRegs) {
+            agg2Scalars.put(reg, (AggregateReg) decomposeType(function, reg.getType(), reg.getName()));
+        }
+
+        // Transform program
+        final ExprTransformer exprTransformer = new ExprTransformer() {
+            @Override
+            public Expression visitRegister(Register reg) {
+                return agg2Scalars.containsKey(reg) ? toExpression(agg2Scalars.get(reg)) : reg;
+            }
+        };
+
+        for (Event e : function.getEvents()) {
+            if (e instanceof RegReader reader) {
+                reader.transformExpressions(exprTransformer);
+            }
+
+            if (e instanceof Local writer && agg2Scalars.containsKey(writer.getResultRegister())) {
+                decomposeLocal(writer, agg2Scalars.get(writer.getResultRegister()), writer.getExpr());
+                writer.tryDelete();
+            }
+        }
+
+    }
+
+    private void decomposeLocal(Local orig, AnnotatedRegister reg, Expression expr) {
+        Preconditions.checkArgument(reg.getType().equals(expr.getType()));
+
+        if (reg instanceof SimpleReg simpleReg) {
+            final Local local = EventFactory.newLocal(simpleReg.reg, expr);
+            local.copyAllMetadataFrom(orig);
+            orig.insertAfter(local);
+        } else if (reg instanceof AggregateReg aggReg) {
+            assert expr instanceof ConstructExpr;
+            for (int i = aggReg.regs.size() - 1; i >= 0; i--) {
+                decomposeLocal(orig, aggReg.regs.get(i), expr.getOperands().get(i));
+            }
+        }
+    }
+
+
+    private Expression toExpression(AnnotatedRegister annotatedRegister) {
+        if (annotatedRegister instanceof SimpleReg reg) {
+            return reg.reg;
+        } else if (annotatedRegister instanceof AggregateReg aggReg) {
+            final List<Expression> exprs = aggReg.regs.stream().map(this::toExpression).collect(Collectors.toList());
+            return ExpressionFactory.getInstance().makeConstruct(aggReg.getType(), exprs);
+        }
+        return null;
+    }
+
+    private AnnotatedRegister decomposeType(Function func, Type type, String regName) {
+        if (!(type instanceof AggregateType aggType)) {
+            return new SimpleReg(func.newRegister(regName + "__sroa", type));
+        }
+
+        final List<TypeOffset> fields = aggType.getFields();
+        List<AnnotatedRegister> regs = new ArrayList<>(fields.size());
+        for (int i = 0; i < fields.size(); i++) {
+            regs.add(decomposeType(func, fields.get(i).type(), regName + "@" + i));
+        }
+        return new AggregateReg(type, regs);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Helper classes
+
+    sealed interface AnnotatedRegister {
+        Type getType();
+    }
+
+    record SimpleReg(Register reg) implements AnnotatedRegister {
+        @Override
+        public Type getType() { return reg.getType(); }
+    }
+
+    record AggregateReg(Type type, List<AnnotatedRegister> regs) implements AnnotatedRegister {
+        @Override
+        public Type getType() { return type; }
+    }
+
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/SparseConditionalConstantPropagation.java
@@ -118,6 +118,7 @@ public class SparseConditionalConstantPropagation implements FunctionProcessor {
             // Update event with propagation data
             propagator.propagationMap = propagationMap;
             if (cur instanceof RegReader regReader && !cur.hasTag(Tag.NOOPT)) {
+                propagator.setAllowDestroyDeps(regReader.hasTag(Tag.NO_CARRY_DEPS));
                 regReader.transformExpressions(propagator);
             }
             reachableEvents.add(cur);
@@ -202,6 +203,10 @@ public class SparseConditionalConstantPropagation implements FunctionProcessor {
     private static class ConstantPropagator extends ExprSimplifier {
 
         private Map<Register, Expression> propagationMap;
+
+        public void setAllowDestroyDeps(boolean allow) {
+            this.aggressive = allow;
+        }
 
         ConstantPropagator() {
             super(false);


### PR DESCRIPTION
(1) Added SROA (scalar replacement of aggregates), which is mainly applied to aggregate registers generated by spin loop instrumentation.

(2) Added a new `NO_CARRY_DEP` tag for events which signifies that registers read by this event do not carry dependencies, i.e., we are allowed to optimize aggressively.  For now, only the events created by the spin loop instrumentation use that tag.
NOTE: For now, this is only used in optimizations. We still generate dependency edges in the encoding!

(3) Made `AssignmentInlining` more aggressive when inlining ITE expressions. Added more expression simplifications.

Pretty much all changes are related to eliminating the spinloop instrumentation code if we can statically infer that the loop must be side-effectful.