### PR TITLE
Add back missing witness generation

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.parsers.program.ProgramParser;
 import com.dat3m.dartagnan.program.Entrypoint;
 import com.dat3m.dartagnan.program.Program;
+import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.options.BaseOptions;
 import com.dat3m.dartagnan.utils.printer.OutputLogger;
 import com.dat3m.dartagnan.utils.printer.OutputLogger.ResultSummary;
@@ -98,6 +99,7 @@ public class Dartagnan extends BaseOptions {
 
                 // ----------- Generate output-----------
                 summary = resultAnalyzer.getSummaryFromSolver(taskSolver, progFile.getPath());
+                resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), Utils.getNameWithoutExtension(progFile), o.generateWitnessForUnknown());
             } catch (Exception e) {
                 summary = resultAnalyzer.getSummaryFromException(e, progFile.getPath());
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
@@ -1,10 +1,21 @@
 package com.dat3m.dartagnan.utils;
 
+import com.google.common.io.Files;
+
+import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 public class Utils {
 
     private Utils() {
+    }
+
+    public static String getNameWithoutExtension(File file) {
+        return getNameWithoutExtension(file.getName());
+    }
+
+    public static String getNameWithoutExtension(String fileName) {
+        return Files.getNameWithoutExtension(fileName);
     }
 
     public static String toTimeString(long milliseconds) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
@@ -175,7 +175,7 @@ public class TaskResultAnalyzer {
         return new ResultSummary(programPath, filter, result, condition, reason, details.toString(), time, NORMAL_TERMINATION);
     }
 
-    public File generateWitnessIfAble(TaskSolver solver, WitnessType witnessType, String filename, String details,
+    public File generateWitnessIfAble(TaskSolver solver, WitnessType witnessType, String filename,
                                       boolean generateWitnessForUnknown) throws IOException {
         if (!solver.hasModel()
                 || (solver.getResult() == UNKNOWN && !generateWitnessForUnknown)

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -65,7 +65,7 @@ public class ReachabilityResult {
 
                 final TaskResultAnalyzer resultAnalyzer = TaskResultAnalyzer.create();
                 verdict = resultAnalyzer.getSummaryFromSolver(solver, "").toUIString();
-                witnessFile = resultAnalyzer.generateWitnessIfAble(solver, WitnessType.PNG, "dat3m", "", false);
+                witnessFile = resultAnalyzer.generateWitnessIfAble(solver, WitnessType.PNG, "dat3m", false);
             }
         } catch (InterruptedException e) {
             verdict = "TIMEOUT";


### PR DESCRIPTION
- Remove unused parameter from generateWitnessIfAble.
- Add back missing witness generation in Dartagnan.java (this was accidentally lost)