### PR TITLE
Add back the ability to pass user-specified witness file names

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -99,7 +99,7 @@ public class Dartagnan extends BaseOptions {
 
                 // ----------- Generate output-----------
                 summary = resultAnalyzer.getSummaryFromSolver(taskSolver, progFile.getPath());
-                resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), Utils.getNameWithoutExtension(progFile), o.generateWitnessForUnknown());
+                resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), getWitnessFilename(progFile, o), o.generateWitnessForUnknown());
             } catch (Exception e) {
                 summary = resultAnalyzer.getSummaryFromException(e, progFile.getPath());
             }
@@ -180,5 +180,11 @@ public class Dartagnan extends BaseOptions {
             logger.error("There was an I/O error when accessing path {}", path);
             return List.of();
         }
+    }
+
+    private static String getWitnessFilename(File progFile, BaseOptions options) {
+        return options.hasWitnessFilename()
+                ? options.getWitnessFilename()
+                : Utils.getNameWithoutExtension(progFile);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -73,6 +73,7 @@ public class Dartagnan extends BaseOptions {
         final OutputLogger output = new OutputLogger(catFile, config);
         final TaskResultAnalyzer resultAnalyzer = TaskResultAnalyzer.create();
         ResultSummary summary = null;
+        int it = 0;
         for (File progFile : progFiles) {
             try {
                 // ----------- Generate verification task -----------
@@ -99,7 +100,8 @@ public class Dartagnan extends BaseOptions {
 
                 // ----------- Generate output-----------
                 summary = resultAnalyzer.getSummaryFromSolver(taskSolver, progFile.getPath());
-                resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), getWitnessFilename(progFile, o), o.generateWitnessForUnknown());
+                resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), getWitnessFilename(progFile, o, isBatchMode ? "_batch_#" + String.valueOf(it) : ""), o.generateWitnessForUnknown());
+                it++;
             } catch (Exception e) {
                 summary = resultAnalyzer.getSummaryFromException(e, progFile.getPath());
             }
@@ -182,9 +184,9 @@ public class Dartagnan extends BaseOptions {
         }
     }
 
-    private static String getWitnessFilename(File progFile, BaseOptions options) {
+    private static String getWitnessFilename(File progFile, BaseOptions options, String postfix) {
         return options.hasWitnessFilename()
-                ? options.getWitnessFilename()
+                ? options.getWitnessFilename() + postfix
                 : Utils.getNameWithoutExtension(progFile);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -100,7 +100,8 @@ public class Dartagnan extends BaseOptions {
 
                 // ----------- Generate output-----------
                 summary = resultAnalyzer.getSummaryFromSolver(taskSolver, progFile.getPath());
-                resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), getWitnessFilename(progFile, o, isBatchMode ? "_batch_#" + String.valueOf(it) : ""), o.generateWitnessForUnknown());
+                final String witnessFileName = getWitnessFilename(progFile, o, isBatchMode ? "_batch_#" + String.valueOf(it) : "");
+                resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), witnessFileName, o.generateWitnessForUnknown());
                 it++;
             } catch (Exception e) {
                 summary = resultAnalyzer.getSummaryFromException(e, progFile.getPath());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -69,7 +69,6 @@ public class OptionNames {
 
     // Refinement Options
     public static final String BASELINE = "refinement.baseline";
-    public static final String GRAPHVIZ_DEBUG_FILES = "refinement.generateGraphvizDebugFiles";
     public static final String SYMMETRIC_LEARNING = "refinement.symmetricLearning";
 
     // SMT solver Options

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
@@ -191,7 +191,7 @@ public class TaskResultAnalyzer {
                 // RF edges give both ordering and data flow information, thus even when the pair is in PO
                 // we get some data flow information by observing the edge
                 // CO edges only give ordering information which is known if the pair is also in PO
-                return generateGraphvizFile(model, 1, (x, y) -> true,
+                return generateGraphvizFile(model, task.getProgram().getName(), (x, y) -> true,
                         (x, y) -> !x.getThreadModel().getThread().equals(y.getThreadModel().getThread()),
                         getOrCreateOutputDirectory() + "/", filename,
                         synContext, witnessType.convertToPng(), task.getConfig());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -897,10 +897,10 @@ public class RefinementSolver extends ModelChecker {
         String fileNameBase = String.format("%s-%d", programName, iterationCount);
         final SyntacticContextAnalysis emptySynContext = getEmptyInstance();
         // File with reason edges only
-        generateGraphvizFile(model, iterationCount, edgeFilter, edgeFilter, directoryName, fileNameBase,
+        generateGraphvizFile(model, "Iteration " + iterationCount, edgeFilter, edgeFilter, directoryName, fileNameBase,
                 emptySynContext);
         // File with all edges
-        generateGraphvizFile(model, iterationCount, (x, y) -> true, (x, y) -> true, directoryName,
+        generateGraphvizFile(model, "Iteration " + iterationCount, (x, y) -> true, (x, y) -> true, directoryName,
                 fileNameBase + "-full", emptySynContext);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -96,11 +96,6 @@ public class RefinementSolver extends ModelChecker {
             toUppercase=true)
     private boolean printCovReport = false;
 
-    @Option(name=GRAPHVIZ_DEBUG_FILES,
-            description="This option causes Refinement to generate many .dot and .png files that describe EACH iteration." +
-                    " It is very expensive and should only be used for debugging purposes.")
-    private boolean generateGraphvizDebugFiles = false;
-
     // ================================================================================================================
     // Data classes
 
@@ -388,12 +383,6 @@ public class RefinementSolver extends ModelChecker {
             isFinalIteration = !checkProgress(trace) || iteration.isConclusive();
 
             // ------------------------- Debugging/Logging -------------------------
-            if (generateGraphvizDebugFiles && iteration.smtStatus == SMTStatus.SAT) {
-                try (IREvaluator evaluator = context.newEvaluator(prover)) {
-                    final ExecutionModelNext model = new ExecutionModelManager().buildExecutionModel(evaluator);
-                    generateGraphvizFiles(task, model, trace.size(), iteration.inconsistencyReasons);
-                }
-            }
             if (logger.isDebugEnabled()) {
                 // ---- Internal SMT stats after the first iteration ----
                 if (trace.size() == 1) {
@@ -869,38 +858,4 @@ public class RefinementSolver extends ModelChecker {
         return report;
     }
 
-    // This code is pure debugging code that will generate graphical representations
-    // of each refinement iteration.
-    // Generate .dot files and .png files per iteration
-    private static void generateGraphvizFiles(
-            VerificationTask task, ExecutionModelNext model, int iterationCount, DNF<CoreLiteral> reasons) {
-        // =============== Visualization code ==================
-        // The edgeFilter filters those co/rf that belong to some violation reason
-        BiPredicate<EventModel, EventModel> edgeFilter = (e1, e2) -> {
-            for (Conjunction<CoreLiteral> cube : reasons.getCubes()) {
-                for (CoreLiteral lit : cube.getLiterals()) {
-                    if (lit instanceof RelLiteral edgeLit) {
-                        if (model.getEventModelByEvent(edgeLit.getSource()) == e1 &&
-                                model.getEventModelByEvent(edgeLit.getTarget()) == e2) {
-                            return true;
-                        }
-                    }
-                }
-            }
-            return false;
-        };
-
-        String programName = task.getProgram().getName();
-        programName = programName.substring(0, programName.lastIndexOf("."));
-        String directoryName = String.format("%s/refinement/%s-%s-debug/", getOutputDirectory(), programName,
-                task.getProgram().getArch());
-        String fileNameBase = String.format("%s-%d", programName, iterationCount);
-        final SyntacticContextAnalysis emptySynContext = getEmptyInstance();
-        // File with reason edges only
-        generateGraphvizFile(model, "Iteration " + iterationCount, edgeFilter, edgeFilter, directoryName, fileNameBase,
-                emptySynContext);
-        // File with all edges
-        generateGraphvizFile(model, "Iteration " + iterationCount, (x, y) -> true, (x, y) -> true, directoryName,
-                fileNameBase + "-full", emptySynContext);
-    }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -360,7 +360,7 @@ public class ExecutionGraphVisualizer {
     }
 
     public static File generateGraphvizFile(ExecutionModelNext model,
-                                            int iterationCount,
+                                            String graphName,
                                             BiPredicate<EventModel, EventModel> rfFilter,
                                             BiPredicate<EventModel, EventModel> coFilter,
                                             String directoryName,
@@ -377,7 +377,7 @@ public class ExecutionGraphVisualizer {
             visualizer.setSyntacticContext(synContext)
                       .setFilter(RF, rfFilter)
                       .setFilter(CO, coFilter)
-                      .generateGraphOfExecutionModel(writer, "Iteration " + iterationCount, model);
+                      .generateGraphOfExecutionModel(writer, graphName, model);
 
             writer.flush();
             if (convert) {
@@ -393,14 +393,14 @@ public class ExecutionGraphVisualizer {
     }
 
     public static void generateGraphvizFile(ExecutionModelNext model,
-                                            int iterationCount,
+                                            String graphName,
                                             BiPredicate<EventModel, EventModel> rfFilter,
                                             BiPredicate<EventModel, EventModel> coFilter,
                                             String directoryName,
                                             String fileNameBase,
                                             SyntacticContextAnalysis synContext) {
         generateGraphvizFile(model,
-                             iterationCount,
+                             graphName,
                              rfFilter,
                              coFilter,
                              directoryName,

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LFDSTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/LFDSTest.java
@@ -29,7 +29,7 @@ public class LFDSTest extends AbstractCTest {
 
     @Override
     protected long getTimeout() {
-        return 1000000;
+        return 1500000;
     }
 
     protected Provider<Integer> getBoundProvider() {


### PR DESCRIPTION
Note: passing witness names in batch mode is broken because all witnesses will have the same name.

@hernanponcedeleon Feel free to do changes to this PR as you see fit