### PR TITLE
Better messages for errors during Cat parsing.

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/ParserCat.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/ParserCat.java
@@ -26,15 +26,15 @@ public class ParserCat {
 
     public Wmm parse(File file) throws IOException {
         try (FileInputStream stream = new FileInputStream(file)) {
-            return parse(CharStreams.fromStream(stream));
+            return parse(CharStreams.fromStream(stream), file.toString());
         }
     }
 
     public Wmm parse(String raw) {
-        return parse(CharStreams.fromString(raw));
+        return parse(CharStreams.fromString(raw), "<input>");
     }
 
-    private Wmm parse(CharStream charStream){
+    private Wmm parse(CharStream charStream, String currentFileName) {
         CatLexer lexer = new CatLexer(charStream);
         lexer.addErrorListener(new AbortErrorListener());
         lexer.addErrorListener(new DiagnosticErrorListener(true));
@@ -44,6 +44,6 @@ public class ParserCat {
         parser.addErrorListener(new AbortErrorListener());
         parser.addErrorListener(new DiagnosticErrorListener(true));
         ParserRuleContext parserEntryPoint = parser.mcm();
-        return (Wmm) parserEntryPoint.accept(new VisitorCat(includePath));
+        return (Wmm) parserEntryPoint.accept(new VisitorCat(includePath, currentFileName));
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
@@ -48,6 +48,9 @@ class VisitorCat extends CatBaseVisitor<Object> {
     private final Map<String, Integer> nameOccurrenceCounter = new HashMap<>();
     // Used to handle recursive definitions properly
     private Relation relationToBeDefined;
+    // Used for error messages.
+    private String currentFileName;
+    private ParserRuleContext currentInstructionContext;
 
     private record FuncDefinition(String name, List<String> params, String expression,
                                   Map<String, Object> capturedNamespace) {
@@ -61,9 +64,10 @@ class VisitorCat extends CatBaseVisitor<Object> {
         }
     }
 
-    VisitorCat(Path includePath) {
+    VisitorCat(Path includePath, String currentFileName) {
         this.includePath = includePath;
         this.wmm = new Wmm();
+        this.currentFileName = currentFileName;
         includeStdlib();
     }
 
@@ -79,12 +83,18 @@ class VisitorCat extends CatBaseVisitor<Object> {
 
     @Override
     public Object visitMcm(McmContext ctx) {
-        super.visitMcm(ctx);
+        currentInstructionContext = ctx;
+        try {
+            super.visitMcm(ctx);
+        } catch (RuntimeException e) {
+            throw e instanceof ParsingException ? e : parsingException(currentInstructionContext, e, e.getMessage());
+        }
         return wmm;
     }
 
     @Override
     public Object visitLetFuncDefinition(LetFuncDefinitionContext ctx) {
+        currentInstructionContext = ctx;
         final String fname = ctx.fname.getText();
         final List<String> params = ctx.params.NAME().stream().map(Object::toString).toList();
         final String expression = ctx.expression().getText();
@@ -97,6 +107,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
 
     @Override
     public Object visitInclude(IncludeContext ctx) {
+        currentInstructionContext = ctx;
         final String fileName = ctx.path.getText().substring(1, ctx.path.getText().length() - 1);
         final Path filePath = includePath.resolve(Path.of(fileName));
         if (!Files.exists(filePath)) {
@@ -104,16 +115,21 @@ class VisitorCat extends CatBaseVisitor<Object> {
             return null;
         }
 
+        final String currentFileParent = currentFileName;
         try {
             final CatParser parser = getParser(CharStreams.fromPath(filePath));
+            currentFileName = fileName;
             return parser.mcm().accept(this);
         } catch (IOException e) {
-            throw new ParsingException(e, String.format("Error parsing file '%s'", filePath));
+            throw parsingException(ctx, e, "Error parsing file '%s'", filePath);
+        } finally {
+            currentFileName = currentFileParent;
         }
     }
 
     @Override
     public Void visitAxiomDefinition(AxiomDefinitionContext ctx) {
+        currentInstructionContext = ctx;
         try {
             Relation r = parseAsRelation(ctx.e);
             Constructor<?> constructor = ctx.cls.getConstructor(Relation.class, boolean.class, boolean.class);
@@ -128,7 +144,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
             wmm.addConstraint(axiom);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
                  InvocationTargetException e) {
-            throw new ParsingException(ctx.getText());
+            throw parsingException(ctx, e, e.getMessage());
         }
         return null;
     }
@@ -146,7 +162,10 @@ class VisitorCat extends CatBaseVisitor<Object> {
 
     @Override
     public Void visitLetDefinition(LetDefinitionContext ctx) {
+        currentInstructionContext = ctx;
         final String name = ctx.n.getText();
+        // Check for arity issues to give similar errors as in `let rec`.
+        ctx.e.accept(new ArityInspector());
         final Relation definedPredicate = (Relation) ctx.e.accept(this);
         final String alias = createUniqueName(name);
         wmm.addAlias(alias, definedPredicate);
@@ -156,6 +175,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
 
     @Override
     public Void visitLetRecDefinition(LetRecDefinitionContext ctx) {
+        currentInstructionContext = ctx;
         final int recSize = ctx.letRecAndDefinition().size() + 1;
         final Relation[] recursiveGroup = new Relation[recSize];
         final String[] lhsNames = new String[recSize];
@@ -236,15 +256,12 @@ class VisitorCat extends CatBaseVisitor<Object> {
     public Object visitExprCall(ExprCallContext ctx) {
         final String calledFunc = ctx.call.getText();
         if (!(namespace.get(calledFunc) instanceof FuncDefinition funcDef)) {
-            final String error = String.format("Invalid call %s: %s is undefined or no function.", ctx.getText(), calledFunc);
-            throw new ParsingException(error);
+            throw parsingException(ctx, null, "Invalid call %s: %s is undefined or no function.", ctx.getText(), calledFunc);
         }
 
         final List<CatParser.ExpressionContext> args = ctx.args.expression();
         if (args.size() != funcDef.params().size()) {
-            final String error = String.format("Invalid call %s to function %s: wrong number of arguments.",
-                    ctx.getText(), funcDef);
-            throw new ParsingException(error);
+            throw parsingException(ctx, null, "Invalid call %s to function %s: wrong number of arguments.", ctx.getText(), funcDef);
         }
         final List<Object> arguments = ctx.args.expression().stream().map(e -> e.accept(this)).toList();
         final Map<String, Object> functionNamespace = new HashMap<>(funcDef.capturedNamespace());
@@ -375,8 +392,8 @@ class VisitorCat extends CatBaseVisitor<Object> {
     }
 
     private void checkNoRecursion(ExpressionContext c) {
-        if(relationToBeDefined != null) {
-            throw new ParsingException("Unexpected recursive context at expression: " + c.getText());
+        if (relationToBeDefined != null) {
+            throw parsingException(c, null, "Unexpected recursive context at expression: %s.", c.getText());
         }
     }
 
@@ -398,7 +415,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
         if (o instanceof Relation relation) {
             return relation;
         }
-        throw new ParsingException("Expected relation, got " + o.getClass().getSimpleName() + " " + o + " from expression " + t.getText());
+        throw parsingException(t, null, "Expected relation, got %s %s from expression %s.", o.getClass().getSimpleName(), o, t.getText());
     }
 
     private static CatParser getParser(CharStream input) {
@@ -471,15 +488,16 @@ class VisitorCat extends CatBaseVisitor<Object> {
         private Relation.Arity join(ExpressionContext e1, ExpressionContext e2) {
             final Relation.Arity k1 = e1.accept(this);
             final Relation.Arity k2 = e2.accept(this);
-            checkCompatible(k1, k2);
+            if (k1 != null && k2 != null && !k1.equals(k2)) {
+                throw parsingException(e1.getParent(), null, "Incompatible kinds %s and %s.", k1, k2);
+            }
             return k1 == null ? k2 : k1;
         }
+    }
 
-        private static void checkCompatible(Relation.Arity k1, Relation.Arity k2) {
-            if (k1 != null && k2 != null && !k1.equals(k2)) {
-                throw new ParsingException("Incompatible kinds %s and %s".formatted(k1, k2));
-            }
-        }
+    private ParsingException parsingException(ParserRuleContext ctx, Throwable cause, String message, Object... arguments) {
+        final String format = message + " (%s at line %d)".formatted(currentFileName, ctx.getStart().getLine());
+        return new ParsingException(cause, format, arguments);
     }
 }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
@@ -165,7 +165,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
         currentInstructionContext = ctx;
         final String name = ctx.n.getText();
         // Check for arity issues to give similar errors as in `let rec`.
-        ctx.e.accept(new ArityInspector());
+        ctx.e.accept(new ArityInspector(Set.of()));
         final Relation definedPredicate = (Relation) ctx.e.accept(this);
         final String alias = createUniqueName(name);
         wmm.addAlias(alias, definedPredicate);
@@ -193,7 +193,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
         }
         // Create the recursive relations.
         for (int i = 0; i < recSize; i++) {
-            final Relation.Arity probedArity = rhsContexts[i].accept(new ArityInspector());
+            final Relation.Arity probedArity = rhsContexts[i].accept(new ArityInspector(Set.of(lhsNames)));
             final Relation.Arity arity = probedArity != null ? probedArity : Relation.Arity.BINARY;
             recursiveGroup[i] = wmm.newRelation(createUniqueName(lhsNames[i]), arity);
             recursiveGroup[i].setRecursive();
@@ -242,14 +242,8 @@ class VisitorCat extends CatBaseVisitor<Object> {
     @Override
     public Object visitExprBasic(ExprBasicContext ctx) {
         final String name = ctx.n.getText();
-        final Object localObject = namespace.get(name);
-        final Object boundObject = localObject != null ? localObject : wmm.getRelation(name);
-        if (boundObject != null) {
-            return boundObject;
-        }
-        final boolean predefinedName = RelationNameRepository.contains(name);
-        final Relation predefined = predefinedName ? wmm.getOrCreatePredefinedRelation(name) : null;
-        return predefinedName ? predefined : addDefinition(new TagSet(wmm.newSet(name), name));
+        final Relation relation = getRelation(name);
+        return relation != null ? relation : addDefinition(new TagSet(wmm.newSet(name), name));
     }
 
     @Override
@@ -432,7 +426,11 @@ class VisitorCat extends CatBaseVisitor<Object> {
 
     private final class ArityInspector extends CatBaseVisitor<Relation.Arity> {
 
-        private ArityInspector() {}
+        private final Collection<String> recursiveRelations;
+
+        private ArityInspector(Collection<String> recursiveRelations) {
+            this.recursiveRelations = recursiveRelations;
+        }
 
         @Override
         public Relation.Arity visitExpr(ExprContext c) {
@@ -441,8 +439,9 @@ class VisitorCat extends CatBaseVisitor<Object> {
 
         @Override
         public Relation.Arity visitExprBasic(ExprBasicContext c) {
-            final Object object = namespace.get(c.n.getText());
-            return object instanceof Relation r ? r.getArity() : null;
+            final String name = c.n.getText();
+            final Relation relation = getRelation(name);
+            return relation != null ? relation.getArity() : recursiveRelations.contains(name) ? null : Relation.Arity.UNARY;
         }
 
         @Override
@@ -493,6 +492,22 @@ class VisitorCat extends CatBaseVisitor<Object> {
             }
             return k1 == null ? k2 : k1;
         }
+    }
+
+    private Relation getRelation(String name) {
+        final Object fromNamespace = namespace.get(name);
+        final Relation relationFromNamespace = fromNamespace instanceof Relation r ? r : null;
+        if (relationFromNamespace != null) {
+            return relationFromNamespace;
+        }
+        if (fromNamespace != null) {
+            throw new ParsingException("Expected relation, got %s", fromNamespace);
+        }
+        final Relation relationFromGlobalNamespace = wmm.getRelation(name);
+        if (relationFromGlobalNamespace != null) {
+            return relationFromGlobalNamespace;
+        }
+        return RelationNameRepository.contains(name) ? wmm.getOrCreatePredefinedRelation(name) : null;
     }
 
     private ParsingException parsingException(ParserRuleContext ctx, Throwable cause, String message, Object... arguments) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
@@ -242,7 +242,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
     @Override
     public Object visitExprBasic(ExprBasicContext ctx) {
         final String name = ctx.n.getText();
-        final Relation relation = getRelation(name);
+        final Relation relation = getRelation(name, ctx);
         return relation != null ? relation : addDefinition(new TagSet(wmm.newSet(name), name));
     }
 
@@ -250,12 +250,12 @@ class VisitorCat extends CatBaseVisitor<Object> {
     public Object visitExprCall(ExprCallContext ctx) {
         final String calledFunc = ctx.call.getText();
         if (!(namespace.get(calledFunc) instanceof FuncDefinition funcDef)) {
-            throw parsingException(ctx, null, "Invalid call %s: %s is undefined or no function.", ctx.getText(), calledFunc);
+            throw parsingException(ctx, "Invalid call %s: %s is undefined or no function.", ctx.getText(), calledFunc);
         }
 
         final List<CatParser.ExpressionContext> args = ctx.args.expression();
         if (args.size() != funcDef.params().size()) {
-            throw parsingException(ctx, null, "Invalid call %s to function %s: wrong number of arguments.", ctx.getText(), funcDef);
+            throw parsingException(ctx, "Invalid call %s to function %s: wrong number of arguments.", ctx.getText(), funcDef);
         }
         final List<Object> arguments = ctx.args.expression().stream().map(e -> e.accept(this)).toList();
         final Map<String, Object> functionNamespace = new HashMap<>(funcDef.capturedNamespace());
@@ -387,7 +387,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
 
     private void checkNoRecursion(ExpressionContext c) {
         if (relationToBeDefined != null) {
-            throw parsingException(c, null, "Unexpected recursive context at expression: %s.", c.getText());
+            throw parsingException(c, "Unexpected recursive context at expression: %s.", c.getText());
         }
     }
 
@@ -409,7 +409,8 @@ class VisitorCat extends CatBaseVisitor<Object> {
         if (o instanceof Relation relation) {
             return relation;
         }
-        throw parsingException(t, null, "Expected relation, got %s %s from expression %s.", o.getClass().getSimpleName(), o, t.getText());
+        final String className = o.getClass().getSimpleName();
+        throw parsingException(t, "Expected relation, got %s %s from expression %s.", className, o, t.getText());
     }
 
     private static CatParser getParser(CharStream input) {
@@ -440,7 +441,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
         @Override
         public Relation.Arity visitExprBasic(ExprBasicContext c) {
             final String name = c.n.getText();
-            final Relation relation = getRelation(name);
+            final Relation relation = getRelation(name, c);
             return relation != null ? relation.getArity() : recursiveRelations.contains(name) ? null : Relation.Arity.UNARY;
         }
 
@@ -488,20 +489,20 @@ class VisitorCat extends CatBaseVisitor<Object> {
             final Relation.Arity k1 = e1.accept(this);
             final Relation.Arity k2 = e2.accept(this);
             if (k1 != null && k2 != null && !k1.equals(k2)) {
-                throw parsingException(e1.getParent(), null, "Incompatible kinds %s and %s.", k1, k2);
+                throw parsingException(e1.getParent(), "Incompatible kinds %s and %s.", k1, k2);
             }
             return k1 == null ? k2 : k1;
         }
     }
 
-    private Relation getRelation(String name) {
+    private Relation getRelation(String name, ParserRuleContext ctx) {
         final Object fromNamespace = namespace.get(name);
         final Relation relationFromNamespace = fromNamespace instanceof Relation r ? r : null;
         if (relationFromNamespace != null) {
             return relationFromNamespace;
         }
         if (fromNamespace != null) {
-            throw new ParsingException("Expected relation, got %s", fromNamespace);
+            throw parsingException(ctx, "Expected relation, got %s", fromNamespace);
         }
         final Relation relationFromGlobalNamespace = wmm.getRelation(name);
         if (relationFromGlobalNamespace != null) {
@@ -510,9 +511,16 @@ class VisitorCat extends CatBaseVisitor<Object> {
         return RelationNameRepository.contains(name) ? wmm.getOrCreatePredefinedRelation(name) : null;
     }
 
+    private ParsingException parsingException(ParserRuleContext ctx, String message, Object... arguments) {
+        return new ParsingException(message + sourceHint(ctx), arguments);
+    }
+
     private ParsingException parsingException(ParserRuleContext ctx, Throwable cause, String message, Object... arguments) {
-        final String format = message + " (%s at line %d)".formatted(currentFileName, ctx.getStart().getLine());
-        return new ParsingException(cause, format, arguments);
+        return new ParsingException(cause, message + sourceHint(ctx), arguments);
+    }
+
+    private String sourceHint(ParserRuleContext ctx) {
+        return " (%s at line %d)".formatted(currentFileName, ctx.getStart().getLine());
     }
 }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/VisitorCat.java
@@ -87,7 +87,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
         try {
             super.visitMcm(ctx);
         } catch (RuntimeException e) {
-            throw e instanceof ParsingException ? e : parsingException(currentInstructionContext, e, e.getMessage());
+            throw e instanceof ParsingException ? e : parsingException(e, currentInstructionContext);
         }
         return wmm;
     }
@@ -121,7 +121,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
             currentFileName = fileName;
             return parser.mcm().accept(this);
         } catch (IOException e) {
-            throw parsingException(ctx, e, "Error parsing file '%s'", filePath);
+            throw parsingException(e, ctx);
         } finally {
             currentFileName = currentFileParent;
         }
@@ -144,7 +144,7 @@ class VisitorCat extends CatBaseVisitor<Object> {
             wmm.addConstraint(axiom);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
                  InvocationTargetException e) {
-            throw parsingException(ctx, e, e.getMessage());
+            throw parsingException(e, ctx);
         }
         return null;
     }
@@ -512,15 +512,15 @@ class VisitorCat extends CatBaseVisitor<Object> {
     }
 
     private ParsingException parsingException(ParserRuleContext ctx, String message, Object... arguments) {
-        return new ParsingException(message + sourceHint(ctx), arguments);
+        return new ParsingException(messageWithSourceHint(message, ctx), arguments);
     }
 
-    private ParsingException parsingException(ParserRuleContext ctx, Throwable cause, String message, Object... arguments) {
-        return new ParsingException(cause, message + sourceHint(ctx), arguments);
+    private ParsingException parsingException(Throwable cause, ParserRuleContext ctx) {
+        return new ParsingException(cause, messageWithSourceHint(cause.getMessage(), ctx));
     }
 
-    private String sourceHint(ParserRuleContext ctx) {
-        return " (%s at line %d)".formatted(currentFileName, ctx.getStart().getLine());
+    private String messageWithSourceHint(String message, ParserRuleContext ctx) {
+        return message + " (%s at line %d)".formatted(currentFileName, ctx.getStart().getLine());
     }
 }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/parsers/cat/CatParserTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/parsers/cat/CatParserTest.java
@@ -28,6 +28,16 @@ public class CatParserTest {
         parse("let a = R \\ rf");
     }
 
+    @Test(expected = ParsingException.class)
+    public void typeMismatchWithPredefinedRelation() {
+        parse("let rf1 = rf\nlet a = b & rf1");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void typeMismatchWithPredefinedRelationInRecursion() {
+        parse("let rf1 = rf\nlet rec a = b & rf1");
+    }
+
     @Test
     public void recursiveSet() {
         final String text = """

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/parsers/cat/CatParserTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/parsers/cat/CatParserTest.java
@@ -1,5 +1,6 @@
 package com.dat3m.dartagnan.parsers.cat;
 
+import com.dat3m.dartagnan.exception.ParsingException;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.junit.Test;
 
@@ -8,12 +9,40 @@ import static org.junit.Assert.assertTrue;
 public class CatParserTest {
 
     @Test
+    public void undefinedName() {
+        parse("let a = b");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void typeMismatchAtIntersection() {
+        parse("let a = R & rf");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void typeMismatchAtUnion() {
+        parse("let a = R | rf");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void typeMismatchAtDifference() {
+        parse("let a = R \\ rf");
+    }
+
+    @Test
     public void recursiveSet() {
         final String text = """
-                let rec r0 = domain(loc & ([W]; po; [F]; po; [R])) | domain([r0]; addr)
+                let rec r0 = domain(loc & ([W]; po; [F]; po; [R])) | domain(r1)
+                and r1 = [r0]; addr
                 acyclic (po & loc) | addr | data | ctrl | rf | co | fr | po ; [r0]
                 """;
-        final Wmm memoryModel = new ParserCat().parse(text);
+        final Wmm memoryModel = parse(text);
         assertTrue(memoryModel.getRelation("r0").isRecursive());
+        assertTrue(memoryModel.getRelation("r0").isSet());
+        assertTrue(memoryModel.getRelation("r1").isRecursive());
+        assertTrue(memoryModel.getRelation("r1").isRelation());
+    }
+
+    private Wmm parse(String text) {
+        return new ParserCat().parse(text);
     }
 }


### PR DESCRIPTION
Gives better error messages during parsing of `.cat` files.  Adds the file name and the line where the error was encountered.  Solves #1026.