### PR TITLE
Introduce getIncludeDirectory()

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/GlobalSettings.java
@@ -73,6 +73,10 @@ public class GlobalSettings {
                 .resolve("libs");
     }
 
+    public static Path getIncludeDirectory() {
+        return getHomeDirectory().resolve("include");
+    }
+
     public static Path getExecutablePath(boolean jar) {
         return getHomeDirectory(true)
                 .resolve("dartagnan")

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import static com.dat3m.dartagnan.GlobalSettings.getOrCreateOutputDirectory;
-import static com.dat3m.dartagnan.GlobalSettings.getHomeDirectory;
+import static com.dat3m.dartagnan.GlobalSettings.getIncludeDirectory;
 import static java.util.Arrays.asList;
 
 public class Compilation {
@@ -22,7 +22,7 @@ public class Compilation {
         final String outputFileName = getOutputName(file, ".ll");
 
         ArrayList<String> cmd = new ArrayList<>(
-                asList("clang", "-I", getHomeDirectory() + "/include", "-Xclang", "-disable-O0-optnone", "-S", "-emit-llvm", "-g", "-gcolumn-info", "-o", outputFileName));
+                asList("clang", "-I", getIncludeDirectory().toString(), "-Xclang", "-disable-O0-optnone", "-S", "-emit-llvm", "-g", "-gcolumn-info", "-o", outputFileName));
         // We use cflags when using the UI and fallback top CFLAGS otherwise
         cflags = cflags.isEmpty() ? System.getenv().getOrDefault("CFLAGS", "") : cflags;
         // Needed to handle more than one flag in CFLAGS


### PR DESCRIPTION
Removes hardcoded `include` folder and aligns with the rest of `GlobalSettings`.