### PR TITLE
Optimize encoding time using caches

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -35,11 +35,10 @@ import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula;
 
 import java.util.*;
 
-import static com.dat3m.dartagnan.configuration.OptionNames.*;
+import static com.dat3m.dartagnan.configuration.OptionNames.MERGE_CF_VARS;
 import static com.dat3m.dartagnan.encoding.ExpressionEncoder.ConversionMode.MEMORY_ROUND_TRIP_RELAXED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sosy_lab.java_smt.api.FloatingPointRoundingMode.NEAREST_TIES_TO_EVEN;
 
 @Options
 public final class EncodingContext {
@@ -249,6 +248,11 @@ public final class EncodingContext {
     @FunctionalInterface
     public interface EdgeEncoder {
         BooleanFormula encode(Event e1, Event e2);
+
+        default EdgeEncoder withCache() {
+            final Map<Event, Map<Event, BooleanFormula>> cache = new HashMap<>();
+            return (x, y) -> cache.computeIfAbsent(x, k -> new HashMap<>()).computeIfAbsent(y, k2 -> encode(x, y));
+        }
     }
 
     public EdgeEncoder edge(Relation relation) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -465,29 +465,41 @@ public class WmmEncoder {
 
         @Override
         public Void visitTransitiveClosure(TransitiveClosure trans) {
+            final Relation inner = trans.getOperand();
             final Relation rel = trans.getDefinedRelation();
-            final Relation r1 = trans.getOperand();
             final EventGraph relMustSet = ra.getKnowledge(rel).getMustSet();
             final EventGraph relMaySet = ra.getKnowledge(rel).getMaySet();
-            final EventGraph r1MaySet = ra.getKnowledge(r1).getMaySet();
-            EncodingContext.EdgeEncoder enc0 = context.edge(rel);
-            EncodingContext.EdgeEncoder enc1 = context.edge(r1);
+            final EventGraph innerMaySet = ra.getKnowledge(inner).getMaySet();
+
+            // TODO: Maybe add a helper method to get cache-backed encoder
+            //  Or let EncodingContext always cache edges?
+            final Map<Event, Map<Event, BooleanFormula>> varCache = new HashMap<>();
+            final EncodingContext.EdgeEncoder innerEdge = (x, y) ->
+                    varCache.computeIfAbsent(x, key -> new HashMap<>())
+                    .computeIfAbsent(y, key -> context.edge(rel, x, y));
+
+            final Map<Event, Map<Event, BooleanFormula>> varCache2 = new HashMap<>();
+            final EncodingContext.EdgeEncoder transEdge = (x, y) ->
+                    varCache2.computeIfAbsent(x, key -> new HashMap<>())
+                            .computeIfAbsent(y, key -> context.edge(inner, x, y));
+
             getActiveSet(trans).apply((e1, e2) -> {
-                BooleanFormula edge = enc0.encode(e1, e2);
+                final BooleanFormula edge = innerEdge.encode(e1, e2);
                 if (relMustSet.contains(e1, e2)) {
                     enc.add(bmgr.equivalence(edge, execution(e1, e2)));
                 } else {
-                    BooleanFormula orClause = bmgr.makeFalse();
-                    if (r1MaySet.contains(e1, e2)) {
-                        orClause = bmgr.or(orClause, enc1.encode(e1, e2));
+                    final List<BooleanFormula> orClause = new ArrayList<>();
+                    if (innerMaySet.contains(e1, e2)) {
+                        orClause.add(transEdge.encode(e1, e2));
                     }
-                    for (Event e : r1MaySet.getRange(e1)) {
+                    for (Event e : innerMaySet.getRange(e1)) {
                         if (e.getGlobalId() != e1.getGlobalId() && e.getGlobalId() != e2.getGlobalId() && relMaySet.contains(e, e2)) {
-                            BooleanFormula tVar = relMustSet.contains(e1, e) ? enc0.encode(e1, e) : enc1.encode(e1, e);
-                            orClause = bmgr.or(orClause, bmgr.and(tVar, enc0.encode(e, e2)));
+                            final BooleanFormula tVar = relMustSet.contains(e1, e) ? innerEdge.encode(e1, e) : transEdge.encode(e1, e);
+                            orClause.add(bmgr.and(tVar, innerEdge.encode(e, e2)));
                         }
                     }
-                    enc.add(bmgr.equivalence(edge, orClause));
+
+                    enc.add(bmgr.equivalence(edge, bmgr.or(orClause)));
                 }
             });
             return null;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -420,25 +420,25 @@ public class WmmEncoder {
             final RelationAnalysis.Knowledge k1 = ra.getKnowledge(r1);
             final RelationAnalysis.Knowledge k2 = ra.getKnowledge(r2);
             EncodingContext.EdgeEncoder enc0 = context.edge(rel);
-            EncodingContext.EdgeEncoder enc1 = context.edge(r1);
-            EncodingContext.EdgeEncoder enc2 = context.edge(r2);
+            EncodingContext.EdgeEncoder enc1 = context.edge(r1).withCache();
+            EncodingContext.EdgeEncoder enc2 = context.edge(r2).withCache();
             final EventGraph a1 = EventGraph.union(getActiveSet(r1.getDefinition()), k1.getMustSet());
             final EventGraph a2 = EventGraph.union(getActiveSet(r2.getDefinition()), k2.getMustSet());
             Map<Event, Set<Event>> out = k1.getMaySet().getOutMap();
             getActiveSet(comp).apply((e1, e2) -> {
-                BooleanFormula expr = bmgr.makeFalse();
+                final List<BooleanFormula> orClause = new ArrayList<>();
                 if (k.getMustSet().contains(e1, e2)) {
-                    expr = execution(e1, e2);
+                    orClause.add(execution(e1, e2));
                 } else {
                     for (Event e : out.getOrDefault(e1, Set.of())) {
                         if (k2.getMaySet().contains(e, e2)) {
                             verify(a1.contains(e1, e) && a2.contains(e, e2),
                                     "Failed to properly propagate active sets across composition at triple: (%s, %s, %s).", e1, e, e2);
-                            expr = bmgr.or(expr, bmgr.and(enc1.encode(e1, e), enc2.encode(e, e2)));
+                            orClause.add(bmgr.and(enc1.encode(e1, e), enc2.encode(e, e2)));
                         }
                     }
                 }
-                enc.add(bmgr.equivalence(enc0.encode(e1, e2), expr));
+                enc.add(bmgr.equivalence(enc0.encode(e1, e2), bmgr.or(orClause)));
             });
             return null;
         }
@@ -1079,20 +1079,22 @@ public class WmmEncoder {
 
             // --- Create encoding ---
             final EventGraph minSet = ra.getKnowledge(rel).getMustSet();
-            List<BooleanFormula> enc = new ArrayList<>();
             final EncodingContext.EdgeEncoder edge = context.edge(rel);
+            final EncodingContext.EdgeEncoder smtCycleVar =
+                    ((EncodingContext.EdgeEncoder)(x, y) -> getSMTCycleVar(rel, x, y)).withCache();
+            List<BooleanFormula> enc = new ArrayList<>();
             // Basic lifting
             relevantEdges.apply((e1, e2) -> {
                 BooleanFormula cond = minSet.contains(e1, e2) ? context.execution(e1, e2) : edge.encode(e1, e2);
-                enc.add(bmgr.implication(cond, getSMTCycleVar(rel, e1, e2)));
+                enc.add(bmgr.implication(cond, smtCycleVar.encode(e1, e2)));
             });
 
             // Encode triangle rules
             for (Event[] tri : triangles) {
                 BooleanFormula cond = minSet.contains(tri[0], tri[2]) ?
                         context.execution(tri[0], tri[2])
-                        : bmgr.and(getSMTCycleVar(rel, tri[0], tri[1]), getSMTCycleVar(rel, tri[1], tri[2]));
-                enc.add(bmgr.implication(cond, getSMTCycleVar(rel, tri[0], tri[2])));
+                        : bmgr.and(smtCycleVar.encode(tri[0], tri[1]), smtCycleVar.encode(tri[1], tri[2]));
+                enc.add(bmgr.implication(cond, smtCycleVar.encode(tri[0], tri[2])));
             }
 
             //  --- Encode inconsistent assignments ---
@@ -1106,8 +1108,8 @@ public class WmmEncoder {
                 Set<Event> out = vertEleOutEdges.get(e1);
                 for (Event e2: out) {
                     if (varOrderings.indexOf(e2) > i && vertEleInEdges.get(e2).contains(e1)) {
-                        BooleanFormula cond = minSet.contains(e1, e2) ? bmgr.makeTrue() : getSMTCycleVar(rel, e1, e2);
-                        enc.add(bmgr.implication(cond, bmgr.not(getSMTCycleVar(rel, e2, e1))));
+                        BooleanFormula cond = minSet.contains(e1, e2) ? bmgr.makeTrue() : smtCycleVar.encode(e1, e2);
+                        enc.add(bmgr.implication(cond, bmgr.not(smtCycleVar.encode(e2, e1))));
                     }
                 }
             }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -471,31 +471,22 @@ public class WmmEncoder {
             final EventGraph relMaySet = ra.getKnowledge(rel).getMaySet();
             final EventGraph innerMaySet = ra.getKnowledge(inner).getMaySet();
 
-            // TODO: Maybe add a helper method to get cache-backed encoder
-            //  Or let EncodingContext always cache edges?
-            final Map<Event, Map<Event, BooleanFormula>> varCache = new HashMap<>();
-            final EncodingContext.EdgeEncoder innerEdge = (x, y) ->
-                    varCache.computeIfAbsent(x, key -> new HashMap<>())
-                    .computeIfAbsent(y, key -> context.edge(rel, x, y));
-
-            final Map<Event, Map<Event, BooleanFormula>> varCache2 = new HashMap<>();
-            final EncodingContext.EdgeEncoder transEdge = (x, y) ->
-                    varCache2.computeIfAbsent(x, key -> new HashMap<>())
-                            .computeIfAbsent(y, key -> context.edge(inner, x, y));
+            final EncodingContext.EdgeEncoder innerEdge = context.edge(inner).withCache();
+            final EncodingContext.EdgeEncoder transEdge = context.edge(rel).withCache();
 
             getActiveSet(trans).apply((e1, e2) -> {
-                final BooleanFormula edge = innerEdge.encode(e1, e2);
+                final BooleanFormula edge = transEdge.encode(e1, e2);
                 if (relMustSet.contains(e1, e2)) {
                     enc.add(bmgr.equivalence(edge, execution(e1, e2)));
                 } else {
                     final List<BooleanFormula> orClause = new ArrayList<>();
                     if (innerMaySet.contains(e1, e2)) {
-                        orClause.add(transEdge.encode(e1, e2));
+                        orClause.add(innerEdge.encode(e1, e2));
                     }
                     for (Event e : innerMaySet.getRange(e1)) {
-                        if (e.getGlobalId() != e1.getGlobalId() && e.getGlobalId() != e2.getGlobalId() && relMaySet.contains(e, e2)) {
-                            final BooleanFormula tVar = relMustSet.contains(e1, e) ? innerEdge.encode(e1, e) : transEdge.encode(e1, e);
-                            orClause.add(bmgr.and(tVar, innerEdge.encode(e, e2)));
+                        if (e != e1 && e != e2 && relMaySet.contains(e, e2)) {
+                            final BooleanFormula tVar = relMustSet.contains(e1, e) ? transEdge.encode(e1, e) : innerEdge.encode(e1, e);
+                            orClause.add(bmgr.and(tVar, transEdge.encode(e, e2)));
                         }
                     }
 


### PR DESCRIPTION
This PR adds the method `EdgeEncoder.withCache` which can transform an `EdgeEncoder` into a caching variant of it.
The caching variants are used in the encoding of transitive closures, compositions, and SAT acyclicity constraints.

For transitive closure and compositions we now generate the or clauses in a single n-ary `bmgr.or` call instead of many binary calls. This saves quite a bit of time as well.

Together, both changes can more than half the encoding time.