### PR TITLE
Document required/recommended versions for clang and graalvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 
 Requirements
 ======
-* [Maven](https://maven.apache.org/) 3.8 or above
-* [Java](https://openjdk.java.net/projects/jdk/17/) 17 or above
-* [GraalVM](https://www.graalvm.org/) (only if you run in native mode; recommended!) 22 or above for optimal performance
-* [Clang](https://clang.llvm.org) (only to verify C programs) 10 above
-* [Graphviz](https://graphviz.org) (only if option `--witness=png` is used)
+* [Maven](https://maven.apache.org/) version 3.8 or above
+* [Java](https://openjdk.java.net/projects/jdk/17/) version 17 or above
+* [GraalVM](https://www.graalvm.org/) version 22 or above for optimal performance (only if you run in native mode; recommended!)
+* [Clang](https://clang.llvm.org) version 10 or above (only to verify C programs)
+* [Graphviz](https://graphviz.org)
 
 Installation
 ======

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Requirements
 ======
 * [Maven](https://maven.apache.org/) 3.8 or above
 * [Java](https://openjdk.java.net/projects/jdk/17/) 17 or above
-* [GraalVM](https://www.graalvm.org/) (only if you run in native mode; recommended!)
-* [Clang](https://clang.llvm.org) (only to verify C programs)
+* [GraalVM](https://www.graalvm.org/) (only if you run in native mode; recommended!) 22 or above for optimal performance
+* [Clang](https://clang.llvm.org) (only to verify C programs) 10 above
 * [Graphviz](https://graphviz.org) (only if option `--witness=png` is used)
 
 Installation


### PR DESCRIPTION
We recently found out that due to a [change in LLVM IR](https://releases.llvm.org/10.0.0/docs/ReleaseNotes.html#id3), our parser does not properly work with older versions of clang (e.g., we report wrong results for races in [this](https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/blob/main/c/goblint-regression/04-mutex_04-munge_nr.c) program).

Also, we noticed due to a [difference garbage collector configuration up to (and including) 21.3](https://www.graalvm.org/jdk24/reference-manual/native-image/optimizations-and-performance/MemoryManagement/), we can have large overhead.