### PR TITLE
Fix warnings in native build

### DIFF
--- a/dartagnan/pom.xml
+++ b/dartagnan/pom.xml
@@ -233,51 +233,14 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <noFallback>true</noFallback>
                         <metadataRepository>
                             <enabled>true</enabled>
                         </metadataRepository>
                         <buildArgs>
                             <buildArg>-Dlogback.statusListenerClass=</buildArg>
                             <buildArg>--enable-native-access=ALL-UNNAMED</buildArg>
+                            <buildArg>--no-fallback</buildArg>
                         </buildArgs>
-                        <initializeAtBuildTime>
-                            <!-- Every class should also be registered in OptionsInfo and reflect-config.json -->
-                            <className>com.dat3m.dartagnan.witness.graphviz.ExecutionGraphVisualizer</className>
-                            <className>com.dat3m.dartagnan.verification.TaskSolver</className>
-                            <className>com.dat3m.dartagnan.wmm.RelationNameRepository</className>
-                            <className>com.dat3m.dartagnan.configuration.OptionNames</className>
-                            <className>com.dat3m.dartagnan.wmm.axiom.Acyclicity</className>
-                            <className>com.dat3m.dartagnan.wmm.axiom.Emptiness</className>
-                            <className>com.dat3m.dartagnan.wmm.axiom.Irreflexivity</className>
-                            <className>com.dat3m.dartagnan.Dartagnan</className>
-                            <className>com.dat3m.dartagnan.encoding.ActiveSetAnalysis</className>
-                            <className>com.dat3m.dartagnan.encoding.EncodingContext</className>
-                            <className>com.dat3m.dartagnan.encoding.ProgramEncoder</className>
-                            <className>com.dat3m.dartagnan.encoding.SymmetryEncoder</className>
-                            <className>com.dat3m.dartagnan.encoding.WmmEncoder</className>
-                            <className>com.dat3m.dartagnan.program.analysis.ReachingDefinitionsAnalysis$Config</className>
-                            <className>com.dat3m.dartagnan.program.analysis.alias.AliasAnalysis$Config</className>
-                            <className>com.dat3m.dartagnan.program.analysis.interval.IntervalAnalysis$Config</className>
-                            <className>com.dat3m.dartagnan.program.processing.BranchReordering</className>
-                            <className>com.dat3m.dartagnan.program.processing.Inlining</className>
-                            <className>com.dat3m.dartagnan.program.processing.Intrinsics</className>
-                            <className>com.dat3m.dartagnan.program.processing.LoopUnrolling</className>
-                            <className>com.dat3m.dartagnan.program.processing.MemoryAllocation</className>
-                            <className>com.dat3m.dartagnan.program.processing.NonterminationDetection</className>
-                            <className>com.dat3m.dartagnan.program.processing.ProcessingManager</className>
-                            <className>com.dat3m.dartagnan.program.processing.SparseConditionalConstantPropagation</className>
-                            <className>com.dat3m.dartagnan.program.processing.ThreadCreation</className>
-                            <className>com.dat3m.dartagnan.program.processing.compilation.Compilation</className>
-                            <className>com.dat3m.dartagnan.solver.caat4wmm.coreReasoning.CoreReasoner</className>
-                            <className>com.dat3m.dartagnan.utils.options.BaseOptions</className>
-                            <className>com.dat3m.dartagnan.utils.printer.Printer</className>
-                            <className>com.dat3m.dartagnan.verification.solving.ModelChecker$SMTConfig</className>
-                            <className>com.dat3m.dartagnan.verification.solving.RefinementSolver</className>
-                            <className>com.dat3m.dartagnan.wmm.analysis.RelationAnalysis$Config</className>
-                            <className>com.dat3m.dartagnan.wmm.analysis.WmmAnalysis</className>
-                            <className>com.dat3m.dartagnan.wmm.processing.WmmProcessingManager</className>
-                        </initializeAtBuildTime>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libz3-x64</classifier>
                 </dependency>
                 <dependency>
@@ -166,6 +167,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libz3java-x64</classifier>
                 </dependency>
 
@@ -183,6 +185,7 @@
                     <version>${bitwuzla.version}</version>
                     <classifier>libbitwuzlaj</classifier>
                     <type>so</type>
+                    <scope>provided</scope>
                 </dependency>
 
                 <!-- MathSAT5 dependencies -->
@@ -192,6 +195,7 @@
                     <version>${mathsat.version}</version>
                     <classifier>libmathsat5j</classifier>
                     <type>so</type>
+                    <scope>provided</scope>
                 </dependency>
 
                 <!-- Boolector dependencies -->
@@ -200,6 +204,7 @@
                     <artifactId>javasmt-solver-boolector</artifactId>
                     <version>${boolector.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libboolector</classifier>
                 </dependency>
                 <dependency>
@@ -207,6 +212,7 @@
                     <artifactId>javasmt-solver-boolector</artifactId>
                     <version>${boolector.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libminisat</classifier>
                 </dependency>
                 <dependency>
@@ -214,6 +220,7 @@
                     <artifactId>javasmt-solver-boolector</artifactId>
                     <version>${boolector.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libpicosat</classifier>
                 </dependency>
 
@@ -229,6 +236,7 @@
                     <artifactId>javasmt-solver-cvc4</artifactId>
                     <version>${cvc4.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libcvc4</classifier>
                 </dependency>
                 <dependency>
@@ -236,6 +244,7 @@
                     <artifactId>javasmt-solver-cvc4</artifactId>
                     <version>${cvc4.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libcvc4jni</classifier>
                 </dependency>
                 <dependency>
@@ -243,6 +252,7 @@
                     <artifactId>javasmt-solver-cvc4</artifactId>
                     <version>${cvc4.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libcvc4parser</classifier>
                 </dependency>
 
@@ -258,6 +268,7 @@
                     <artifactId>javasmt-solver-cvc5</artifactId>
                     <version>${cvc5.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libcvc5</classifier>
                 </dependency>
                 <dependency>
@@ -265,6 +276,7 @@
                     <artifactId>javasmt-solver-cvc5</artifactId>
                     <version>${cvc5.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libcvc5jni</classifier>
                 </dependency>
                 <dependency>
@@ -272,6 +284,7 @@
                     <artifactId>javasmt-solver-cvc5</artifactId>
                     <version>${cvc5.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libcvc5parser</classifier>
                 </dependency>
                 <dependency>
@@ -279,6 +292,7 @@
                     <artifactId>javasmt-solver-cvc5</artifactId>
                     <version>${cvc5.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libpoly</classifier>
                 </dependency>
                 <dependency>
@@ -286,6 +300,7 @@
                     <artifactId>javasmt-solver-cvc5</artifactId>
                     <version>${cvc5.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libpolyxx</classifier>
                 </dependency>
 
@@ -301,6 +316,7 @@
                     <artifactId>javasmt-solver-opensmt</artifactId>
                     <version>${opensmt.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libopensmt</classifier>
                 </dependency>
                 <dependency>
@@ -308,6 +324,7 @@
                     <artifactId>javasmt-solver-opensmt</artifactId>
                     <version>${opensmt.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libopensmtjava</classifier>
                 </dependency>
 
@@ -322,6 +339,7 @@
                     <artifactId>javasmt-solver-yices2</artifactId>
                     <version>${yices2.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libyices2j</classifier>
                 </dependency>
             </dependencies>
@@ -515,6 +533,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libz3-arm64</classifier>
                 </dependency>
                 <dependency>
@@ -522,6 +541,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>so</type>
+                    <scope>provided</scope>
                     <classifier>libz3java-arm64</classifier>
                 </dependency>
             </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -605,6 +605,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>dylib</type>
+                    <scope>provided</scope>
                     <classifier>libz3-x64</classifier>
                 </dependency>
                 <dependency>
@@ -612,6 +613,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>dylib</type>
+                    <scope>provided</scope>
                     <classifier>libz3java-x64</classifier>
                 </dependency>
             </dependencies>
@@ -675,6 +677,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>dylib</type>
+                    <scope>provided</scope>
                     <classifier>libz3-arm64</classifier>
                 </dependency>
                 <dependency>
@@ -682,6 +685,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>dylib</type>
+                    <scope>provided</scope>
                     <classifier>libz3java-arm64</classifier>
                 </dependency>
              </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -748,6 +748,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>dll</type>
+                    <scope>provided</scope>
                     <classifier>libz3-x64</classifier>
                 </dependency>
                 <dependency>
@@ -755,6 +756,7 @@
                     <artifactId>javasmt-solver-z3</artifactId>
                     <version>${z3.version}</version>
                     <type>dll</type>
+                    <scope>provided</scope>
                     <classifier>libz3java-x64</classifier>
                 </dependency>
 
@@ -764,6 +766,7 @@
                     <artifactId>javasmt-solver-bitwuzla</artifactId>
                     <version>${bitwuzla.version}</version>
                     <type>dll</type>
+                    <scope>provided</scope>
                     <classifier>libbitwuzlaj</classifier>
                 </dependency>
 
@@ -774,6 +777,7 @@
                     <version>${mathsat.version}</version>
                     <classifier>mathsat5j</classifier>
                     <type>dll</type>
+                    <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.sosy-lab</groupId>
@@ -781,6 +785,7 @@
                     <version>${mathsat.version}</version>
                     <classifier>mathsat</classifier>
                     <type>dll</type>
+                    <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.sosy-lab</groupId>
@@ -788,6 +793,7 @@
                     <version>${mathsat.version}</version>
                     <classifier>mpir</classifier>
                     <type>dll</type>
+                    <scope>provided</scope>
                 </dependency>
             </dependencies>
             <build>

--- a/svcomp/pom.xml
+++ b/svcomp/pom.xml
@@ -55,9 +55,9 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <noFallback>true</noFallback>
                         <buildArgs>
                             <buildArg>-Dlogback.statusListenerClass=</buildArg>
+                            <buildArg>--no-fallback</buildArg>
                         </buildArgs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
The native build has currently these warnings about the libraries
```
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-z3:so:libz3-x64:4.14.0:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-z3:so:libz3java-x64:4.14.0:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-bitwuzla:so:libbitwuzlaj:0.4.0-g4dbf3b1f:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-mathsat5:so:libmathsat5j:5.6.10:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-boolector:so:libboolector:3.2.2-g1a89c229:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-boolector:so:libminisat:3.2.2-g1a89c229:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-boolector:so:libpicosat:3.2.2-g1a89c229:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-cvc4:so:libcvc4:1.8-prerelease-2020-06-24-g7825d8f28:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-cvc4:so:libcvc4jni:1.8-prerelease-2020-06-24-g7825d8f28:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-cvc4:so:libcvc4parser:1.8-prerelease-2020-06-24-g7825d8f28:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-cvc5:so:libcvc5:1.0.5-g4cb2ab9eb:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-cvc5:so:libcvc5jni:1.0.5-g4cb2ab9eb:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-cvc5:so:libcvc5parser:1.0.5-g4cb2ab9eb:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-cvc5:so:libpoly:1.0.5-g4cb2ab9eb:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-cvc5:so:libpolyxx:1.0.5-g4cb2ab9eb:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-opensmt:so:libopensmt:2.6.0-g2f72cc0e:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-opensmt:so:libopensmtjava:2.6.0-g2f72cc0e:compile' with unsupported type 'so'
[WARNING] Ignoring ImageClasspath Entry 'org.sosy-lab:javasmt-solver-yices2:so:libyices2j:2.6.2-396-g194350c1:compile' with unsupported type 'so'
```
The changes solve the problem on linux, but I assume we have the same issue on MacOS (@ThomasHaas can you check?) and windows (IIRC @xeren has a windows environment; can you check there?) and we also need to add the "provided scope" there, thus the DRAFT status 