### PR TITLE
Deterministic encoding

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -90,9 +90,11 @@ public final class EncodingContext {
                 .map(n -> t.getMemoryModel().getRelation(n).getDefinition())
                 .toList();
         final Iterable<? extends Constraint> toEncode = Iterables.concat(c, anarchicConstraints);
-        constraintsToEncode = new LinkedHashSet<>(
-                DependencyGraph.from(toEncode, EncodingContext::computeConstraintDependencies).getNodeContents()
-        );
+        var depGraph = DependencyGraph.from(toEncode, EncodingContext::computeConstraintDependencies);
+        // NOTE: This guarantees a deterministic ordering of the constraints to be encoded
+        constraintsToEncode = t.getMemoryModel().getConstraints().stream()
+                .filter(constr -> depGraph.get(constr) != null)
+                .toList();
     }
 
     public static EncodingContext of(VerificationTask task, Context analysisContext, FormulaManager formulaManager) throws InvalidConfigurationException {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/EncodingContext.java
@@ -93,7 +93,7 @@ public final class EncodingContext {
         var depGraph = DependencyGraph.from(toEncode, EncodingContext::computeConstraintDependencies);
         // NOTE: This guarantees a deterministic ordering of the constraints to be encoded
         constraintsToEncode = t.getMemoryModel().getConstraints().stream()
-                .filter(constr -> depGraph.get(constr) != null)
+                .filter(depGraph::contains)
                 .toList();
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/NonTerminationEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/NonTerminationEncoder.java
@@ -118,10 +118,10 @@ public class NonTerminationEncoder {
     private final VerificationTask task;
 
     private final List<Loop> allLoops = new ArrayList<>();
-    private final Map<Event, NonterminationCase> nonterm2Case = new HashMap<>();
-    private final Map<LoopAnalysis.LoopIterationInfo, Iteration> iterInfo2Iter = new HashMap<>();
+    private final Map<Event, NonterminationCase> nonterm2Case = new LinkedHashMap<>();
+    private final Map<LoopAnalysis.LoopIterationInfo, Iteration> iterInfo2Iter = new LinkedHashMap<>();
     // Maps an event to all the loop iterations it is contained in (sorted from innermost to outermost loop)
-    private final Map<Event, List<Iteration>> event2Iterations = new HashMap<>();
+    private final Map<Event, List<Iteration>> event2Iterations = new LinkedHashMap<>();
 
     public NonTerminationEncoder(VerificationTask task, EncodingContext context) {
         this.task = task;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -1058,31 +1058,31 @@ public class WmmEncoder {
             // Build original graph G
             Map<Event, Set<Event>> inEdges = new HashMap<>();
             Map<Event, Set<Event>> outEdges = new HashMap<>();
-            Set<Event> nodes = new HashSet<>();
-            Set<Event> selfloops = new HashSet<>();         // Special treatment for self-loops
+            Set<Event> nodes = new LinkedHashSet<>();
+            Set<Event> selfloops = new LinkedHashSet<>();         // Special treatment for self-loops
             relevantEdges.apply((e1, e2) -> {
                 if (Tuple.isLoop(e1, e2)) {
                     selfloops.add(e1);
                 } else {
                     nodes.add(e1);
                     nodes.add(e2);
-                    outEdges.computeIfAbsent(e1, key -> new HashSet<>()).add(e2);
-                    inEdges.computeIfAbsent(e2, key -> new HashSet<>()).add(e1);
+                    outEdges.computeIfAbsent(e1, key -> new LinkedHashSet<>()).add(e2);
+                    inEdges.computeIfAbsent(e2, key -> new LinkedHashSet<>()).add(e1);
                 }
             });
 
             // Handle corner-cases where some node has no ingoing or outgoing edges
             for (Event node : nodes) {
-                outEdges.putIfAbsent(node, new HashSet<>());
-                inEdges.putIfAbsent(node, new HashSet<>());
+                outEdges.putIfAbsent(node, new LinkedHashSet<>());
+                inEdges.putIfAbsent(node, new LinkedHashSet<>());
             }
 
             // Build vertex elimination graph G*, by iteratively modifying G
             Map<Event, Set<Event>> vertEleInEdges = new HashMap<>();
             Map<Event, Set<Event>> vertEleOutEdges = new HashMap<>();
             for (Event e : nodes) {
-                vertEleInEdges.put(e, new HashSet<>(inEdges.get(e)));
-                vertEleOutEdges.put(e, new HashSet<>(outEdges.get(e)));
+                vertEleInEdges.put(e, new LinkedHashSet<>(inEdges.get(e)));
+                vertEleOutEdges.put(e, new LinkedHashSet<>(outEdges.get(e)));
             }
             List<Event[]> triangles = new ArrayList<>();
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BackwardsReachingDefinitionsAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BackwardsReachingDefinitionsAnalysis.java
@@ -11,6 +11,7 @@ import com.dat3m.dartagnan.program.event.core.Label;
 import com.dat3m.dartagnan.verification.Context;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import java.util.*;
@@ -79,7 +80,7 @@ class BackwardsReachingDefinitionsAnalysis implements ReachingDefinitionsAnalysi
      */
     public static BackwardsReachingDefinitionsAnalysis forFunction(Function function) {
         final var analysis = new BackwardsReachingDefinitionsAnalysis();
-        final Set<Register> finalRegisters = new HashSet<>();
+        final Set<Register> finalRegisters = new LinkedHashSet<>();
         analysis.initialize(function, finalRegisters);
         analysis.run(function, finalRegisters);
         analysis.postProcess();
@@ -110,7 +111,7 @@ class BackwardsReachingDefinitionsAnalysis implements ReachingDefinitionsAnalysi
     }
 
     private static Set<Register> finalRegisters(Program program) {
-        final Set<Register> finalRegisters = new HashSet<>();
+        final Set<Register> finalRegisters = new LinkedHashSet<>();
         if (program.getSpecification() != null) {
             finalRegisters.addAll(program.getSpecification().getRegs());
         }
@@ -125,13 +126,13 @@ class BackwardsReachingDefinitionsAnalysis implements ReachingDefinitionsAnalysi
      */
     private static final class ReaderInfo implements Writers {
 
-        private final Set<Register> used;
+        private final ImmutableSet<Register> used;
         private final List<RegWriter> mayWriters = new ArrayList<>();
         private final List<RegWriter> mustWriters = new ArrayList<>();
         private final Set<Register> uninitialized = new HashSet<>();
 
         private ReaderInfo(Set<Register> u) {
-            used = Set.copyOf(u);
+            used = ImmutableSet.copyOf(u);
         }
 
         @Override
@@ -168,7 +169,7 @@ class BackwardsReachingDefinitionsAnalysis implements ReachingDefinitionsAnalysi
      */
     public static final class Readers {
 
-        private final Set<RegReader> readers = new HashSet<>();
+        private final Set<RegReader> readers = new LinkedHashSet<>();
         private boolean mayBeFinal;
 
         private Readers() {}
@@ -197,10 +198,9 @@ class BackwardsReachingDefinitionsAnalysis implements ReachingDefinitionsAnalysi
         }
         writerMap.put(INITIAL_WRITER, new Readers());
         for (RegReader reader : function.getEvents(RegReader.class)) {
-            final Set<Register> usedRegisters = new HashSet<>();
-            for (Register.Read read : reader.getRegisterReads()) {
-                usedRegisters.add(read.register());
-            }
+            final Set<Register> usedRegisters =  reader.getRegisterReads().stream()
+                    .map(Register.Read::register)
+                    .collect(ImmutableSet.toImmutableSet());
             readerMap.put(reader, new ReaderInfo(usedRegisters));
         }
         readerMap.put(FINAL_READER, new ReaderInfo(finalRegisters));

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/AbstractEvent.java
@@ -15,7 +15,7 @@ public abstract class AbstractEvent implements Event {
 
     private final MetadataMap metadataMap = new MetadataMap();
     private final TagSet tags;
-    private final Set<EventUser> currentUsers = new HashSet<>();
+    private final Set<EventUser> currentUsers = new LinkedHashSet<>();
     // These ids are dynamically changing during processing.
     private transient int globalId = -1; // (Global) ID within a program
     private transient int localId = -1; // (Local) ID within a function

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryEvent.java
@@ -1,6 +1,7 @@
 package com.dat3m.dartagnan.program.event;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -12,7 +13,7 @@ public interface MemoryEvent extends RegReader {
 
     @Override
     default Set<Read> getRegisterReads() {
-        final Set<Read> regReads = new HashSet<>();
+        final Set<Read> regReads = new LinkedHashSet<>();
         getMemoryAccesses().forEach(access -> collectRegisterReads(access.address(), UsageType.ADDR, regReads));
         return regReads;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/MemoryEvent.java
@@ -1,6 +1,5 @@
 package com.dat3m.dartagnan.program.event;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/CallBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/common/CallBase.java
@@ -11,10 +11,7 @@ import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.CallEvent;
 import com.google.common.base.Preconditions;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public abstract class CallBase extends AbstractEvent implements CallEvent {
@@ -71,7 +68,7 @@ public abstract class CallBase extends AbstractEvent implements CallEvent {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        final Set<Register.Read> regReads = new HashSet<>();
+        final Set<Register.Read> regReads = new LinkedHashSet<>();
         Register.collectRegisterReads(callTarget, UsageType.CTRL, regReads);
         Register.collectRegisterReads(arguments, UsageType.DATA, regReads);
         return regReads;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Alloc.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Alloc.java
@@ -16,7 +16,6 @@ import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.google.common.base.Preconditions;
 
 import java.math.BigInteger;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Alloc.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Alloc.java
@@ -17,6 +17,7 @@ import com.google.common.base.Preconditions;
 
 import java.math.BigInteger;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /*
@@ -103,7 +104,7 @@ public final class Alloc extends AbstractEvent implements RegReader, RegWriter {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        final Set<Register.Read> reads = Register.collectRegisterReads(alignment, Register.UsageType.DATA, new HashSet<>());
+        final Set<Register.Read> reads = Register.collectRegisterReads(alignment, Register.UsageType.DATA, new LinkedHashSet<>());
         return Register.collectRegisterReads(arraySize, Register.UsageType.DATA, reads);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assert.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assert.java
@@ -11,6 +11,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class Assert extends AbstractEvent implements RegReader {
@@ -37,7 +38,7 @@ public class Assert extends AbstractEvent implements RegReader {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(expr, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(expr, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assert.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assert.java
@@ -10,7 +10,6 @@ import com.dat3m.dartagnan.program.event.RegReader;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
@@ -9,7 +9,6 @@ import com.dat3m.dartagnan.program.event.EventVisitor;
 import com.dat3m.dartagnan.program.event.RegReader;
 import com.google.common.base.Preconditions;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Assume.java
@@ -10,6 +10,7 @@ import com.dat3m.dartagnan.program.event.RegReader;
 import com.google.common.base.Preconditions;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class Assume extends AbstractEvent implements RegReader {
@@ -34,7 +35,7 @@ public class Assume extends AbstractEvent implements RegReader {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(expr, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(expr, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
@@ -9,6 +9,7 @@ import com.dat3m.dartagnan.program.event.*;
 import com.google.common.base.Preconditions;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,7 +57,7 @@ public class CondJump extends AbstractEvent implements RegReader, EventUser {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(guard, Register.UsageType.CTRL, new HashSet<>());
+        return Register.collectRegisterReads(guard, Register.UsageType.CTRL, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/CondJump.java
@@ -8,7 +8,6 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.*;
 import com.google.common.base.Preconditions;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Label.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Label.java
@@ -3,9 +3,9 @@ package com.dat3m.dartagnan.program.event.core;
 import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.EventVisitor;
 import com.dat3m.dartagnan.program.event.Tag;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class Label extends AbstractEvent {
 
@@ -26,7 +26,7 @@ public class Label extends AbstractEvent {
     public Set<CondJump> getJumpSet() {
         return getUsers().stream()
                 .filter(CondJump.class::isInstance).map(CondJump.class::cast)
-                .collect(Collectors.toSet());
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
@@ -9,7 +9,6 @@ import com.dat3m.dartagnan.program.event.RegReader;
 import com.dat3m.dartagnan.program.event.RegWriter;
 import com.google.common.base.Preconditions;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/Local.java
@@ -10,6 +10,7 @@ import com.dat3m.dartagnan.program.event.RegWriter;
 import com.google.common.base.Preconditions;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class Local extends AbstractEvent implements RegWriter, RegReader {
@@ -49,7 +50,7 @@ public class Local extends AbstractEvent implements RegWriter, RegReader {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(expr, Register.UsageType.DATA, new HashSet<>());
+        return Register.collectRegisterReads(expr, Register.UsageType.DATA, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
@@ -6,7 +6,6 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.MemoryEvent;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/MemoryCoreEvent.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.event.MemoryEvent;
 import com.dat3m.dartagnan.program.event.metadata.MemoryOrder;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -18,7 +19,7 @@ public interface MemoryCoreEvent extends MemoryEvent {
 
     @Override
     default Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(getAddress(), Register.UsageType.ADDR, new HashSet<>());
+        return Register.collectRegisterReads(getAddress(), Register.UsageType.ADDR, new LinkedHashSet<>());
     }
 
     /*

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/NamedBarrier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/NamedBarrier.java
@@ -6,6 +6,7 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.RegReader;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -69,6 +70,6 @@ public class NamedBarrier extends ControlBarrier implements RegReader {
     @Override
     public Set<Register.Read> getRegisterReads() {
         final List<Expression> exprs = quorum != null ? List.of(resourceId, quorum) : List.of(resourceId);
-        return Register.collectRegisterReads(exprs, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(exprs, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/NamedBarrier.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/NamedBarrier.java
@@ -5,7 +5,6 @@ import com.dat3m.dartagnan.expression.ExpressionVisitor;
 import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.RegReader;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/annotations/LoopBound.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/annotations/LoopBound.java
@@ -11,6 +11,7 @@ import com.dat3m.dartagnan.program.event.core.annotations.CodeAnnotation;
 import com.google.common.base.Preconditions;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class LoopBound extends CodeAnnotation implements RegReader {
@@ -52,7 +53,7 @@ public class LoopBound extends CodeAnnotation implements RegReader {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(bound, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(bound, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/annotations/LoopBound.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/annotations/LoopBound.java
@@ -10,7 +10,6 @@ import com.dat3m.dartagnan.program.event.RegReader;
 import com.dat3m.dartagnan.program.event.core.annotations.CodeAnnotation;
 import com.google.common.base.Preconditions;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/special/StateSnapshot.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/special/StateSnapshot.java
@@ -42,7 +42,7 @@ public class StateSnapshot extends AbstractEvent implements RegReader {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(expressions, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(expressions, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadCreate.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadCreate.java
@@ -7,10 +7,7 @@ import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class ThreadCreate extends AbstractEvent implements RegReader {
@@ -39,7 +36,7 @@ public class ThreadCreate extends AbstractEvent implements RegReader {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        final Set<Register.Read> regReads = new HashSet<>();
+        final Set<Register.Read> regReads = new LinkedHashSet<>();
         arguments.forEach(arg -> Register.collectRegisterReads(arg, Register.UsageType.DATA, regReads));
         return regReads;
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadReturn.java
@@ -6,7 +6,6 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadReturn.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/core/threading/ThreadReturn.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -44,9 +45,9 @@ public class ThreadReturn extends AbstractEvent implements RegReader {
     @Override
     public Set<Register.Read> getRegisterReads() {
         if (!hasValue()) {
-            return new HashSet<>();
+            return new LinkedHashSet<>();
         }
-        return Register.collectRegisterReads(expression, Register.UsageType.DATA, new HashSet<>());
+        return Register.collectRegisterReads(expression, Register.UsageType.DATA, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/functions/AbortIf.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/functions/AbortIf.java
@@ -9,6 +9,7 @@ import com.dat3m.dartagnan.program.event.RegReader;
 import com.google.common.base.Preconditions;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /*
@@ -41,7 +42,7 @@ public class AbortIf extends AbstractEvent implements RegReader {
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(condition, Register.UsageType.CTRL, new HashSet<>());
+        return Register.collectRegisterReads(condition, Register.UsageType.CTRL, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/functions/AbortIf.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/functions/AbortIf.java
@@ -8,7 +8,6 @@ import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 import com.google.common.base.Preconditions;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/functions/Return.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/functions/Return.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -46,7 +47,7 @@ public class Return extends AbstractEvent implements RegReader {
         if (!hasValue()) {
             return new HashSet<>();
         }
-        return Register.collectRegisterReads(expression, Register.UsageType.DATA, new HashSet<>());
+        return Register.collectRegisterReads(expression, Register.UsageType.DATA, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicOp.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/catomic/AtomicOp.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.program.event.lang.catomic;
 
 import com.dat3m.dartagnan.expression.Expression;
 import com.dat3m.dartagnan.expression.integers.IntBinaryOp;
-import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.EventVisitor;
 import com.dat3m.dartagnan.program.event.common.RMWOpBase;
 import com.dat3m.dartagnan.program.event.Tag;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadDetach.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadDetach.java
@@ -8,7 +8,6 @@ import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.RegReader;
 import com.dat3m.dartagnan.program.event.RegWriter;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadDetach.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadDetach.java
@@ -9,6 +9,7 @@ import com.dat3m.dartagnan.program.event.RegReader;
 import com.dat3m.dartagnan.program.event.RegWriter;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public final class DynamicThreadDetach extends AbstractEvent implements RegWriter, RegReader {
@@ -53,7 +54,7 @@ public final class DynamicThreadDetach extends AbstractEvent implements RegWrite
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(tid, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(tid, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadJoin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadJoin.java
@@ -13,7 +13,6 @@ import com.dat3m.dartagnan.program.event.RegWriter;
 import com.google.common.base.Preconditions;
 
 import java.math.BigInteger;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadJoin.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadJoin.java
@@ -14,6 +14,7 @@ import com.google.common.base.Preconditions;
 
 import java.math.BigInteger;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 
@@ -84,7 +85,7 @@ public class DynamicThreadJoin extends AbstractEvent implements RegWriter, RegRe
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(tid, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(tid, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalCreate.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalCreate.java
@@ -7,7 +7,6 @@ import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 import com.dat3m.dartagnan.program.event.RegWriter;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalCreate.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalCreate.java
@@ -8,6 +8,7 @@ import com.dat3m.dartagnan.program.event.RegReader;
 import com.dat3m.dartagnan.program.event.RegWriter;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -41,7 +42,7 @@ public final class DynamicThreadLocalCreate extends AbstractEvent implements Reg
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(destructor, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(destructor, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalDelete.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalDelete.java
@@ -6,7 +6,6 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalDelete.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalDelete.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -28,7 +29,7 @@ public class DynamicThreadLocalDelete extends AbstractEvent implements RegReader
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(key, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(key, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalGet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalGet.java
@@ -7,7 +7,6 @@ import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 import com.dat3m.dartagnan.program.event.RegWriter;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalGet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalGet.java
@@ -8,6 +8,7 @@ import com.dat3m.dartagnan.program.event.RegReader;
 import com.dat3m.dartagnan.program.event.RegWriter;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -36,7 +37,7 @@ public final class DynamicThreadLocalGet extends AbstractEvent implements RegWri
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        return Register.collectRegisterReads(key, Register.UsageType.OTHER, new HashSet<>());
+        return Register.collectRegisterReads(key, Register.UsageType.OTHER, new LinkedHashSet<>());
     }
 
     @Override

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalSet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalSet.java
@@ -6,7 +6,6 @@ import com.dat3m.dartagnan.program.Register;
 import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalSet.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/event/lang/dat3m/DynamicThreadLocalSet.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.program.event.AbstractEvent;
 import com.dat3m.dartagnan.program.event.RegReader;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -33,7 +34,7 @@ public final class DynamicThreadLocalSet extends AbstractEvent implements RegRea
 
     @Override
     public Set<Register.Read> getRegisterReads() {
-        final Set<Register.Read> reads = Register.collectRegisterReads(key, Register.UsageType.OTHER, new HashSet<>());
+        final Set<Register.Read> reads = Register.collectRegisterReads(key, Register.UsageType.OTHER, new LinkedHashSet<>());
         return Register.collectRegisterReads(value, Register.UsageType.OTHER, reads);
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/BranchReordering.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/BranchReordering.java
@@ -9,13 +9,10 @@ import com.dat3m.dartagnan.utils.dependable.DependencyGraph;
 import com.google.common.collect.Lists;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
-import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static com.dat3m.dartagnan.configuration.OptionNames.DETERMINISTIC_REORDERING;
 
 /*
     This class performs reordering of code as follows
@@ -31,15 +28,6 @@ import static com.dat3m.dartagnan.configuration.OptionNames.DETERMINISTIC_REORDE
 
 @Options
 public class BranchReordering implements FunctionProcessor {
-
-    // =========================== Configurables ===========================
-
-    @Option(name = DETERMINISTIC_REORDERING,
-            description = "Deterministically reorders branches. Non-deterministic reordering may be used for testing.",
-            secure = true)
-    private boolean reorderDeterministically = true;
-
-    // =====================================================================
 
     private BranchReordering() { }
 
@@ -62,8 +50,8 @@ public class BranchReordering implements FunctionProcessor {
         }
     }
 
-    private class FunctionReordering {
-        private class MovableBranch {
+    private static class FunctionReordering {
+        private static class MovableBranch {
             final int id;
             final List<Event> events = new ArrayList<>();
 
@@ -73,21 +61,12 @@ public class BranchReordering implements FunctionProcessor {
 
             @Override
             public int hashCode() {
-                return reorderDeterministically ? id : super.hashCode();
+                return id;
             }
 
             @Override
             public boolean equals(Object obj) {
-                if (!reorderDeterministically) {
-                    return super.equals(obj);
-                }
-                if (obj == this) {
-                    return true;
-                } else if (obj == null || obj.getClass() != getClass()) {
-                    return false;
-                }
-
-                return id == ((MovableBranch)obj).id;
+                return obj instanceof MovableBranch b && b.id == id;
             }
 
             @Override
@@ -152,21 +131,15 @@ public class BranchReordering implements FunctionProcessor {
             // Compute the actual reordering of the branches
             final DependencyGraph<MovableBranch> depGraph = DependencyGraph.fromSingleton(startBranch, successorMap);
             final List<Set<DependencyGraph<MovableBranch>.Node>> sccs = Lists.reverse(depGraph.getSCCs());
+
             final List<MovableBranch> reorderedBranches = new ArrayList<>();
             for (Set<DependencyGraph<MovableBranch>.Node> scc : sccs) {
                 final List<MovableBranch> branchesInScc = scc.stream().map(DependencyGraph.Node::getContent)
                         .sorted(Comparator.comparingInt(x -> x.id)).collect(Collectors.toList());
                 reorderedBranches.addAll(computeReordering(branchesInScc));
-
             }
 
             return reorderedBranches;
-        }
-
-        private <T> void swap(List<T> list, int i, int j) {
-            T tmp = list.get(i);
-            list.set(i, list.get(j));
-            list.set(j, tmp);
         }
 
         public void run() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/BranchReordering.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/BranchReordering.java
@@ -89,6 +89,11 @@ public class BranchReordering implements FunctionProcessor {
 
                 return id == ((MovableBranch)obj).id;
             }
+
+            @Override
+            public String toString() {
+                return "B" + id;
+            }
         }
 
         private final Function function;
@@ -131,7 +136,7 @@ public class BranchReordering implements FunctionProcessor {
             // Construct successor map of branches
             final Map<MovableBranch, Set<MovableBranch>> successorMap = new HashMap<>();
             for (MovableBranch b : movables) {
-                successorMap.put(b, new HashSet<>());
+                successorMap.put(b, new LinkedHashSet<>());
             }
             for (MovableBranch branch : movables) {
                 for (Event e : branch.events) {
@@ -146,7 +151,39 @@ public class BranchReordering implements FunctionProcessor {
 
             // Compute the actual reordering of the branches
             final DependencyGraph<MovableBranch> depGraph = DependencyGraph.fromSingleton(startBranch, successorMap);
-            final List<Set<DependencyGraph<MovableBranch>.Node>> sccs = Lists.reverse(depGraph.getSCCs());
+            //final List<Set<DependencyGraph<MovableBranch>.Node>> sccs = Lists.reverse(depGraph.getSCCs());
+
+            // TODO: This is a bit hacky: We do not trust the topological ordering given by depGraph and
+            //  instead recompute our own one. If two branches are independent, we order them by their id.
+            final List<DependencyGraph<MovableBranch>.Node> nodes = new ArrayList<>(Lists.reverse(depGraph.getNodes()));
+            int i = 0;
+            while (i < nodes.size() - 1) {
+                final DependencyGraph<MovableBranch>.Node n1 = nodes.get(i);
+                final DependencyGraph<MovableBranch>.Node n2 = nodes.get(i + 1);
+
+                if (n1.getSCC() == n2.getSCC() || n1.getDependents().contains(n2)) {
+                    i++;
+                    continue;
+                }
+
+                if (n1.getContent().id > n2.getContent().id) {
+                    swap(nodes, i, i + 1);
+                    i--;
+                } else {
+                    i++;
+                }
+            }
+
+            final List<Set<DependencyGraph<MovableBranch>.Node>> sccs = new ArrayList<>();
+            Set<DependencyGraph<MovableBranch>.Node> lastScc = null;
+            for (var n : nodes) {
+                if (n.getSCC() != lastScc) {
+                    sccs.add(n.getSCC());
+                    lastScc = n.getSCC();
+                }
+            }
+            // ---------------------
+
             final List<MovableBranch> reorderedBranches = new ArrayList<>();
             for (Set<DependencyGraph<MovableBranch>.Node> scc : sccs) {
                 final List<MovableBranch> branchesInScc = scc.stream().map(DependencyGraph.Node::getContent)
@@ -156,6 +193,12 @@ public class BranchReordering implements FunctionProcessor {
             }
 
             return reorderedBranches;
+        }
+
+        private <T> void swap(List<T> list, int i, int j) {
+            T tmp = list.get(i);
+            list.set(i, list.get(j));
+            list.set(j, tmp);
         }
 
         public void run() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/BranchReordering.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/BranchReordering.java
@@ -151,39 +151,7 @@ public class BranchReordering implements FunctionProcessor {
 
             // Compute the actual reordering of the branches
             final DependencyGraph<MovableBranch> depGraph = DependencyGraph.fromSingleton(startBranch, successorMap);
-            //final List<Set<DependencyGraph<MovableBranch>.Node>> sccs = Lists.reverse(depGraph.getSCCs());
-
-            // TODO: This is a bit hacky: We do not trust the topological ordering given by depGraph and
-            //  instead recompute our own one. If two branches are independent, we order them by their id.
-            final List<DependencyGraph<MovableBranch>.Node> nodes = new ArrayList<>(Lists.reverse(depGraph.getNodes()));
-            int i = 0;
-            while (i < nodes.size() - 1) {
-                final DependencyGraph<MovableBranch>.Node n1 = nodes.get(i);
-                final DependencyGraph<MovableBranch>.Node n2 = nodes.get(i + 1);
-
-                if (n1.getSCC() == n2.getSCC() || n1.getDependents().contains(n2)) {
-                    i++;
-                    continue;
-                }
-
-                if (n1.getContent().id > n2.getContent().id) {
-                    swap(nodes, i, i + 1);
-                    i--;
-                } else {
-                    i++;
-                }
-            }
-
-            final List<Set<DependencyGraph<MovableBranch>.Node>> sccs = new ArrayList<>();
-            Set<DependencyGraph<MovableBranch>.Node> lastScc = null;
-            for (var n : nodes) {
-                if (n.getSCC() != lastScc) {
-                    sccs.add(n.getSCC());
-                    lastScc = n.getSCC();
-                }
-            }
-            // ---------------------
-
+            final List<Set<DependencyGraph<MovableBranch>.Node>> sccs = Lists.reverse(depGraph.getSCCs());
             final List<MovableBranch> reorderedBranches = new ArrayList<>();
             for (Set<DependencyGraph<MovableBranch>.Node> scc : sccs) {
                 final List<MovableBranch> branchesInScc = scc.stream().map(DependencyGraph.Node::getContent)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/dependable/DependencyGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/dependable/DependencyGraph.java
@@ -67,7 +67,7 @@ public class DependencyGraph<T> {
     // ====================================================================
 
     private DependencyGraph(final Iterable<? extends T> items, final Function<? super T, ? extends Iterable<? extends T>> dependencyMap) {
-        nodeMap = new HashMap<>();
+        nodeMap = new LinkedHashMap<>();
         sccs = new ArrayList<>();
         this.dependencyMap = dependencyMap;
 
@@ -174,7 +174,7 @@ public class DependencyGraph<T> {
             }
 
             if (v.lowlink == v.index) {
-                final Set<Node> scc = new HashSet<>();
+                final Set<Node> scc = new LinkedHashSet<>();
                 sccs.add(scc);
                 v.topologicalIndex = ++topIndex;
                 Node w;

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/dependable/DependencyGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/dependable/DependencyGraph.java
@@ -67,7 +67,7 @@ public class DependencyGraph<T> {
     // ====================================================================
 
     private DependencyGraph(final Iterable<? extends T> items, final Function<? super T, ? extends Iterable<? extends T>> dependencyMap) {
-        nodeMap = new LinkedHashMap<>();
+        nodeMap = new HashMap<>();
         sccs = new ArrayList<>();
         this.dependencyMap = dependencyMap;
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/dependable/DependencyGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/dependable/DependencyGraph.java
@@ -6,6 +6,12 @@ import com.google.common.collect.Lists;
 import java.util.*;
 import java.util.function.Function;
 
+// TODO: The class internally iterates over a HashMap whose keys are the user-provided objects.
+//  If the objects have a non-deterministic hash (e.g. default reference-based hash), the iteration
+//  order and thus the computed topological order may differ.
+//  Using a LinkedHashMap would make this algorithm always deterministic, but we cannot do so right now:
+//   BranchReordering relies on the hash-code-induced ordering to compute a "good" ordering.
+//   NaiveLoopBoundAnnotation fails to detect loop bounds if BranchReordering does not provide a "good" ordering.
 public class DependencyGraph<T> {
 
     //TODO: Maybe add a way to enable Identity-based hashmaps
@@ -16,6 +22,10 @@ public class DependencyGraph<T> {
 
     public Node get(T item) {
         return nodeMap.get(item);
+    }
+
+    public boolean contains(T item) {
+        return nodeMap.containsKey(item);
     }
 
     public List<Node> getNodes() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/RefinementSolver.java
@@ -188,7 +188,7 @@ public class RefinementSolver extends ModelChecker {
         performIntervalAnalysis(task, analysisContext, config);
 
         //  ------- Generate refinement model -------
-        final Collection<Constraint> wmmConstraintsToEncode = new HashSet<>(biases);
+        final Collection<Constraint> wmmConstraintsToEncode = new LinkedHashSet<>(biases);
         // The cut has to be encoded.
         wmmConstraintsToEncode.addAll(generateCut(memoryModel));
 
@@ -484,7 +484,7 @@ public class RefinementSolver extends ModelChecker {
         // We cut (i) negated axioms, (ii) negated relations (if derived),
         // and (iii) some special relations because they are derived from internal relations (like data/addr/ctrl)
         // or because we have no dedicated implementation for them in CAAT (like Linux' rscs).
-        final Set<Constraint> constraintsToCut = new HashSet<>();
+        final Set<Constraint> constraintsToCut = new LinkedHashSet<>();
         for (Constraint c : model.getConstraints()) {
             if (c instanceof Axiom ax && ax.isNegated()) {
                 // (i) Negated axioms

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Wmm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Wmm.java
@@ -32,7 +32,7 @@ public class Wmm {
     }
 
     public List<Constraint> getConstraints() {
-        return Stream.concat(constraints.stream(), relations.stream().map(Relation::getDefinition)).toList();
+        return Stream.concat(relations.stream().map(Relation::getDefinition), constraints.stream()).toList();
     }
 
     public List<Axiom> getAxioms() {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Wmm.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/Wmm.java
@@ -40,7 +40,7 @@ public class Wmm {
     }
 
     public Set<Relation> getRelations() {
-        return Set.copyOf(relations);
+        return ImmutableSet.copyOf(relations);
     }
 
     public boolean containsRelation(String name) {


### PR DESCRIPTION
Our encoding was not deterministic. To search for issues, I repeatedly dumped the encoding of the same benchmark and diff'd it to see differences. I then removed the sources of differences, mostly by using `LinkedHashSet` in place of `HashSet`.
I don't see any differences anymore, so the encoding is now deterministic as far as I can see.

What I have tested/fixed:
- Encoding order of relations. To fix this, I needed to make `DependencyGraph` compute deterministic topological orderings (among other things).
- Encoding order of SAT encoding for acyclicity
- Encoding of non-termination
- Encoding of program data/control-flow. In this case, `getRegisterReads` and `ReachingDefinitionsAnalysis.getUsedRegisters` could return register accesses in non-deterministic order.

The only thing I have not tested are recursive memory models and CAT_SPEC encodings. But I think the fix in `DependencyGraph` should work for them as well.

**Impact on runtime:** the SMT solving times seem to be much more stable now (they still have some fluctuation though). However, it is unclear if they are on average better or worse (maybe the fixed order is a bad order?).
There might be a bit of extra overhead in processing time (and memory usage) for using `LinkedHashSet` now. But I think that should be negligible.