### PR TITLE
Add new JumpForwarding pass

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -55,6 +55,7 @@ public class OptionNames {
 
     // Program Property Options
     public static final String REACHING_DEFINITIONS_METHOD = "program.analysis.reachingDefinitions";
+    public static final String SIMPLE_BRANCH_EQUIVALENCE = "program.analysis.simpleBranchEquivalence";
     public static final String ALIAS_METHOD = "program.analysis.alias";
     public static final String ALIAS_GRAPHVIZ = "program.analysis.generateAliasGraph";
     public static final String ALIAS_GRAPHVIZ_SPLIT_BY_THREAD = "program.analysis.generateAliasGraph.splitByThread";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/OptionNames.java
@@ -43,7 +43,6 @@ public class OptionNames {
     public static final String ROUNDING_MODE_FLOATS = "encoding.roundingModeFloat";
 
     // Program Processing Options
-    public static final String DETERMINISTIC_REORDERING = "program.processing.detReordering";
     public static final String REDUCE_SYMMETRY = "program.processing.reduceSymmetry";
     public static final String CONSTANT_PROPAGATION = "program.processing.constantPropagation";
     public static final String DEAD_ASSIGNMENT_ELIMINATION = "program.processing.dce";
@@ -55,7 +54,6 @@ public class OptionNames {
 
     // Program Property Options
     public static final String REACHING_DEFINITIONS_METHOD = "program.analysis.reachingDefinitions";
-    public static final String SIMPLE_BRANCH_EQUIVALENCE = "program.analysis.simpleBranchEquivalence";
     public static final String ALIAS_METHOD = "program.analysis.alias";
     public static final String ALIAS_GRAPHVIZ = "program.analysis.generateAliasGraph";
     public static final String ALIAS_GRAPHVIZ_SPLIT_BY_THREAD = "program.analysis.generateAliasGraph.splitByThread";

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
@@ -58,7 +58,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
     @Option(secure = true, name = SIMPLE_BRANCH_EQUIVALENCE,
             description = "If true, put every control-flow branch into its own class. " +
                     "If false, merge branches that are implied by each other into a single class.")
-    private boolean simpleBranchEquivalence = false;
+    private boolean simpleBranchEquivalence = true;
 
     // ============================= State ==============================
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
@@ -16,9 +16,14 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
+import org.sosy_lab.common.configuration.Option;
+import org.sosy_lab.common.configuration.Options;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static com.dat3m.dartagnan.configuration.OptionNames.SIMPLE_BRANCH_EQUIVALENCE;
 
 /* Procedure:
     (1) Decompose the program into simple branches (~ basic blocks).
@@ -36,6 +41,7 @@ import java.util.stream.Collectors;
           when an event is in the control-flow then so is one of its successors.
 */
 
+@Options
 public class BranchEquivalence extends AbstractEquivalence<Event> {
     /*
        NOTE: If the initial class or the unreachable class is empty, they will be treated (almost) non-existent:
@@ -46,6 +52,13 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
              - empty and have NULL as representative
              - the impliedClasses will only contain themselves, the exclusiveClasses will be empty
     */
+
+    // ============================= Configurables ==============================
+
+    @Option(secure = true, name = SIMPLE_BRANCH_EQUIVALENCE,
+            description = "If true, put every control-flow branch into its own class. " +
+                    "If false, merge branches that are implied by each other into a single class.")
+    private boolean simpleBranchEquivalence = false;
 
     // ============================= State ==============================
 
@@ -82,13 +95,14 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
         return (Set<Class>)super.getNonTrivialClasses();
     }
 
-    private BranchEquivalence(Program program) {
+    private BranchEquivalence(Program program, Configuration config) throws InvalidConfigurationException {
         Preconditions.checkArgument(program.isUnrolled(), "The program must be unrolled first.");
+        config.inject(this);
         run(program);
     }
 
     public static BranchEquivalence fromConfig(Program program, Configuration config) throws InvalidConfigurationException {
-        return new BranchEquivalence(program);
+        return new BranchEquivalence(program, config);
     }
 
     private void run(Program program) {
@@ -299,7 +313,10 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
 
     private void createBranchClasses(BranchDecomposition decomposition) {
         // -------------------------- Create branch classes --------------------------
-        final DependencyGraph<Branch> depGraph = DependencyGraph.from(decomposition.branches, Branch::getImpliedBranches);
+        final Function<Branch, Collection<Branch>> impliedBranches = simpleBranchEquivalence
+                ? List::of
+                : Branch::getImpliedBranches;
+        final DependencyGraph<Branch> depGraph = DependencyGraph.from(decomposition.branches, impliedBranches);
         final Map<Branch, BranchClass> branch2ClassMap = Maps.newIdentityHashMap();
         final Map<BranchClass, Set<Branch>> class2BranchesMap = Maps.newIdentityHashMap();
         for (Set<DependencyGraph<Branch>.Node> scc : depGraph.getSCCs()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
@@ -16,14 +16,11 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
-import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.dat3m.dartagnan.configuration.OptionNames.SIMPLE_BRANCH_EQUIVALENCE;
 
 /* Procedure:
     (1) Decompose the program into simple branches (~ basic blocks).
@@ -41,7 +38,6 @@ import static com.dat3m.dartagnan.configuration.OptionNames.SIMPLE_BRANCH_EQUIVA
           when an event is in the control-flow then so is one of its successors.
 */
 
-@Options
 public class BranchEquivalence extends AbstractEquivalence<Event> {
     /*
        NOTE: If the initial class or the unreachable class is empty, they will be treated (almost) non-existent:
@@ -52,13 +48,6 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
              - empty and have NULL as representative
              - the impliedClasses will only contain themselves, the exclusiveClasses will be empty
     */
-
-    // ============================= Configurables ==============================
-
-    @Option(secure = true, name = SIMPLE_BRANCH_EQUIVALENCE,
-            description = "If true, put every control-flow branch into its own class. " +
-                    "If false, merge branches that are implied by each other into a single class.")
-    private boolean simpleBranchEquivalence = true;
 
     // ============================= State ==============================
 
@@ -95,14 +84,13 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
         return (Set<Class>)super.getNonTrivialClasses();
     }
 
-    private BranchEquivalence(Program program, Configuration config) throws InvalidConfigurationException {
+    private BranchEquivalence(Program program) {
         Preconditions.checkArgument(program.isUnrolled(), "The program must be unrolled first.");
-        config.inject(this);
         run(program);
     }
 
     public static BranchEquivalence fromConfig(Program program, Configuration config) throws InvalidConfigurationException {
-        return new BranchEquivalence(program, config);
+        return new BranchEquivalence(program);
     }
 
     private void run(Program program) {
@@ -313,10 +301,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
 
     private void createBranchClasses(BranchDecomposition decomposition) {
         // -------------------------- Create branch classes --------------------------
-        final Function<Branch, Collection<Branch>> impliedBranches = simpleBranchEquivalence
-                ? List::of
-                : Branch::getImpliedBranches;
-        final DependencyGraph<Branch> depGraph = DependencyGraph.from(decomposition.branches, impliedBranches);
+        final DependencyGraph<Branch> depGraph = DependencyGraph.from(decomposition.branches, Branch::getImpliedBranches);
         final Map<Branch, BranchClass> branch2ClassMap = Maps.newIdentityHashMap();
         final Map<BranchClass, Set<Branch>> class2BranchesMap = Maps.newIdentityHashMap();
         for (Set<DependencyGraph<Branch>.Node> scc : depGraph.getSCCs()) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/JumpForwarding.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/JumpForwarding.java
@@ -1,0 +1,104 @@
+package com.dat3m.dartagnan.program.processing;
+
+import com.dat3m.dartagnan.program.Function;
+import com.dat3m.dartagnan.program.IRHelper;
+import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.Tag;
+import com.dat3m.dartagnan.program.event.core.CondJump;
+import com.dat3m.dartagnan.program.event.core.IfAsJump;
+import com.dat3m.dartagnan.program.event.core.Label;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/*
+    This pass replaces the following code patterns:
+
+    ------ Pattern 1:
+    goto L1                         goto L2 // Forwarded
+    ...                             ...
+    L1            ======>           L1
+    goto L2                         goto L2
+    ...                             ...
+    L2                              L2
+
+    ------ Pattern 2:
+    goto L1                         goto L2: // Forwarded
+    ...           ======>           ...
+    L1:                             L1:
+    L2:                             L2:
+
+    In both cases, the label 'L1' and possibly the intermediary jump 'goto L2'
+    may become dead code. Other simplification passes will delete those.
+ */
+public class JumpForwarding implements FunctionProcessor {
+
+    private JumpForwarding() { }
+
+    public static JumpForwarding newInstance() {
+        return new JumpForwarding();
+    }
+
+    @Override
+    public void run(Function function) {
+        if (!function.hasBody()) {
+            return;
+        }
+
+        final List<ForwardingEdge> forwardingEdges = computeForwarding(function);
+        for (ForwardingEdge edge : forwardingEdges) {
+            final Map<Event, Event> forwardingMap = Map.of(edge.from(), edge.to());
+            edge.from().getJumpSet().forEach(j -> j.updateReferences(forwardingMap));
+        }
+    }
+
+    private List<ForwardingEdge> computeForwarding(Function function) {
+        final List<ForwardingEdge> forwardingEdges = new ArrayList<>();
+        for (Label label : function.getEvents(Label.class)) {
+            if (label.getSuccessor() instanceof CondJump jump && jump.isGoto()) {
+                if (isValidForwarding(label, jump)) {
+                    forwardingEdges.add(new ForwardingEdge(label, jump.getLabel()));
+                }
+            } else if (label.getSuccessor() instanceof Label other) {
+                if (isValidForwarding(label, null)) {
+                    forwardingEdges.add(new ForwardingEdge(label, other));
+                }
+            }
+        }
+
+        return forwardingEdges;
+    }
+
+    private boolean isValidForwarding(Label from, CondJump over) {
+        if (from.hasTag(Tag.NOOPT)) {
+            return false;
+        }
+        if (!from.getUsers().stream().allMatch(e -> e instanceof CondJump j && !(j instanceof IfAsJump))) {
+            // Only forward if all users are plain jumps (no if-as-jumps, nor special events)
+            return false;
+        }
+
+        // Check if forwarding over jump is valid (if jump is present)
+        if (over == null) {
+            return true;
+        }
+        if (over.hasTag(Tag.NOOPT) || over.hasTag(Tag.SPINLOOP) || over.hasTag(Tag.BOUND)) {
+            return false;
+        }
+        if (IRHelper.isBackJump(over)) {
+            // Don't forward over backjumps
+            return false;
+        }
+
+        return true;
+    }
+
+    private record ForwardingEdge(Label from, Label to) {
+        @Override
+        public String toString() {
+            return "E%s --> E%s :: %s --> %s".formatted(from.getGlobalId(), to.getGlobalId(), from, to);
+        }
+    }
+
+}

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/ProcessingManager.java
@@ -118,6 +118,7 @@ public class ProcessingManager implements ProgramProcessor {
                 Compilation.fromConfig(config), // We keep compilation global for now
                 LoopFormVerification.fromConfig(config),
                 printAfterCompilation ? DebugPrint.withHeader("After compilation", Printer.Mode.ALL, config) : null,
+                ProgramProcessor.fromFunctionProcessor(JumpForwarding.newInstance(), Target.FUNCTIONS, false),
                 ProgramProcessor.fromFunctionProcessor(MemToReg.fromConfig(config), Target.FUNCTIONS, true),
                 ProgramProcessor.fromFunctionProcessor(sccp, Target.FUNCTIONS, false),
                 dynamicSpinLoopDetection ? DynamicSpinLoopDetection.fromConfig(config) : null,


### PR DESCRIPTION
I added a jump forwarding pass that simplifies some ugly branching code like this:

```
goto L1  // This can directly jump to L2
L1:        // This label and the following jump can be deleted once all jumps are forwarded to L2
goto L2:
L2:
```

Oddly, this consistently yielded slower runtimes for `challenging/cna.c` under SC with `B=2` (UNKNOWN).
Looking more into this, I noticed that the simplified code has less equivalence classes according to `BranchEquivalence`.
This yields stronger merging of `cf`-variables in the encoding stage.
This seems to be able to have negative impact for UNKNOWN programs, possibly because the solver cannot reason so easily about only the branch that contains the reachable bound event if that branch is merged with others (not sure though).
So I also added an option to `BranchEquivalence` that puts every branch into its own class (which leads to less aggressive merging of `cf`-variables). With this option enabled, the jump forwarding seems beneficial again.
Interestingly, for the `B=3` (PASS) version of `cna.c` the stronger merging enabled by jump forwarding also seems to be beneficial. Maybe this is because the solver has to reason about all branches anyhow (since it is PASS) and so it is better to have them merged.

So overall my impression is this:
- More aggressive merging of cf-variables, whether due to the jump forwarding or aggressive `BranchEquivalence`, is good for PASS programs
- Less aggressive merging of cf-variables might be better for FAIL/UNKNOWN programs. No merging at all is still quite bad though.
- The sweet spot might be the following: merging cf-variables only of same-branch events (the new option of `BranchEquivalence`) but reducing the total number of branches (the new pass).
- The above claims are just from observing `cna.c` and might be different across different benchmarks.