### PR TITLE
Set eager and idl2sat as default

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/Method.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/configuration/Method.java
@@ -24,7 +24,7 @@ public enum Method implements OptionInterface {
     }
 
     public static Method getDefault() {
-        return LAZY;
+        return EAGER;
     }
 
     // Used to decide the order shown by the selector in the UI

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -77,7 +77,7 @@ public class WmmEncoder {
     @Option(name=IDL_TO_SAT,
             description = "Use SAT-based encoding for totality and acyclicity.",
             secure = true)
-    boolean useSATEncoding = false;
+    boolean useSATEncoding = true;
 
     // ==============================================================================================
 


### PR DESCRIPTION
I did some benchmarking to evaluate if it is still the case that the lazy encoding performs better than the eager one and to compare the IDL vs SAT encodings for acyclicity. I filtered the results where times were below 1s.

For lazy vs eager, the results are not super clear (except for power, where lazy is much better due to the recursive definition), but considering that currently we return wrong results with eager for ptx tests using proxy (#1039) and that one can expect more deterministic solving times using eager (at least once we merge #1059), I think it makes more sense to use that method as the default.

<img width="718" height="537" alt="image" src="https://github.com/user-attachments/assets/2107ba50-dcea-4bf0-b042-4f9c71d900eb" />
<img width="717" height="538" alt="image" src="https://github.com/user-attachments/assets/0831bae4-ef1c-43f8-928c-346f2b8e49a3" />
<img width="718" height="541" alt="image" src="https://github.com/user-attachments/assets/67baaa26-404d-46c7-ae28-c262091b4868" />
<img width="720" height="540" alt="image" src="https://github.com/user-attachments/assets/2a31b706-92e1-485c-84dc-daa85fad6f4c" />


For IDL vs SAT, the results are clear.

<img width="720" height="538" alt="image" src="https://github.com/user-attachments/assets/635092b7-699e-4e35-82b5-bc2ddd85f296" />
<img width="719" height="540" alt="image" src="https://github.com/user-attachments/assets/aa5dd2d3-c420-440d-9c8f-fd82d50bbcb0" />
<img width="721" height="539" alt="image" src="https://github.com/user-attachments/assets/f3f6c859-9d6d-4e21-9194-c17c9d1fb832" />
<img width="720" height="542" alt="image" src="https://github.com/user-attachments/assets/f84c745d-a0d1-41ea-a3d3-d0c8948cc772" />
