### PR TITLE
Fix cat.include option

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/options/BaseOptions.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/options/BaseOptions.java
@@ -50,7 +50,6 @@ public abstract class BaseOptions {
         return method;
     }
 
-
     @Option(
             name = WITNESS,
             description = "Type of the violation graph to generate in the output directory.")
@@ -86,10 +85,10 @@ public abstract class BaseOptions {
             name = CAT_INCLUDE,
             description = "The directory used to resolve cat include statements. Defaults to $DAT3M_HOME/cat."
     )
-    private Path catIncludePath = GlobalSettings.getCatDirectory();
+    private String catIncludePath = GlobalSettings.getCatDirectory().toString();
 
     public Path getCatIncludePath() {
-        return catIncludePath;
+        return Path.of(catIncludePath);
     }
 
     @Option(


### PR DESCRIPTION
While testing #1038, I noticed that the `cat.include` option is not working.

Apparently the sosy-lab library has some restrictions on how to handle paths in the the options ([there are ways of dealing with full paths, but not with directory paths AFAICT](https://sosy-lab.github.io/java-common-lib/api/org/sosy_lab/common/configuration/FileOption.Type.html)). 

Using strings is consistent with the other option we have related to files/paths (i.e., `bound.save` and `bound.load`).