### PR TITLE
Simplify Parsers and use Path instead of File

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -101,7 +101,7 @@ public class Dartagnan extends BaseOptions {
 
                 // ----------- Generate output-----------
                 summary = resultAnalyzer.getSummaryFromSolver(taskSolver, progFile.getPath());
-                final String witnessFileName = getWitnessFilename(progFile, o, isBatchMode ? "_batch_#" + String.valueOf(it) : "");
+                final String witnessFileName = getWitnessFilename(progFile, o, isBatchMode ? "_batch_#" + it : "");
                 resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), witnessFileName, o.generateWitnessForUnknown());
                 it++;
             } catch (Exception e) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -67,15 +67,15 @@ public class Dartagnan extends BaseOptions {
         final Configuration config = loadConfigurationFromArgs(args);
         final Dartagnan o = new Dartagnan(config);
 
-        final File catFile = getCatFileFromArgs(args);
-        final List<File> progFiles = getProgramFilesFromArgs(args);
+        final Path catFile = getCatFileFromArgs(args);
+        final List<Path> progFiles = getProgramFilesFromArgs(args);
         final boolean isBatchMode = progFiles.size() > 1;
 
         final OutputLogger output = new OutputLogger(catFile, config);
         final TaskResultAnalyzer resultAnalyzer = TaskResultAnalyzer.create();
         ResultSummary summary = null;
         int it = 0;
-        for (File progFile : progFiles) {
+        for (Path progFile : progFiles) {
             try {
                 // ----------- Generate verification task -----------
                 final Program p = new ProgramParser().parse(progFile);
@@ -100,12 +100,12 @@ public class Dartagnan extends BaseOptions {
                 taskSolver.run();
 
                 // ----------- Generate output-----------
-                summary = resultAnalyzer.getSummaryFromSolver(taskSolver, progFile.getPath());
+                summary = resultAnalyzer.getSummaryFromSolver(taskSolver, progFile.toString());
                 final String witnessFileName = getWitnessFilename(progFile, o, isBatchMode ? "_batch_#" + it : "");
                 resultAnalyzer.generateWitnessIfAble(taskSolver, o.getWitnessType(), witnessFileName, o.generateWitnessForUnknown());
                 it++;
             } catch (Exception e) {
-                summary = resultAnalyzer.getSummaryFromException(e, progFile.getPath());
+                summary = resultAnalyzer.getSummaryFromException(e, progFile.toString());
             }
             output.addResult(summary);
         }
@@ -149,21 +149,21 @@ public class Dartagnan extends BaseOptions {
                 .build();
     }
 
-    private static File getCatFileFromArgs(String[] args) {
-        File catFile = Arrays.stream(args)
+    private static Path getCatFileFromArgs(String[] args) {
+        Path catFile = Arrays.stream(args)
                 .filter(a -> a.endsWith(".cat"))
                 .findFirst()
-                .map(File::new)
+                .map(Path::of)
                 .orElseThrow(() -> new IllegalArgumentException("CAT model not given or format not recognized"));
         logger.info("CAT file path: {}", catFile);
         return catFile;
     }
 
-    private static List<File> getProgramFilesFromArgs(String[] args) {
-        final List<File> files = new ArrayList<>();
+    private static List<Path> getProgramFilesFromArgs(String[] args) {
+        final List<Path> files = new ArrayList<>();
         Stream.of(args).map(Paths::get).filter(Files::exists)
                 .forEach(path -> {
-                    List<File> supported = getProgramFiles(path);
+                    List<Path> supported = getProgramFiles(path);
                     if (!supported.isEmpty()) {
                         logger.info("Program(s) path: {}", path.normalize());
                         files.addAll(supported);
@@ -175,12 +175,11 @@ public class Dartagnan extends BaseOptions {
         return files;
     }
 
-    private static List<File> getProgramFiles(Path path) {
+    private static List<Path> getProgramFiles(Path path) {
         try (Stream<Path> stream = Files.walk(path)) {
             return stream.filter(Files::isRegularFile)
                     .filter(ProgramParser::isSupported)
                     .sorted(Comparator.comparing(Path::toString))
-                    .map(Path::toFile)
                     .toList();
         } catch (IOException e) {
             logger.error("There was an I/O error when accessing path {}", path);
@@ -188,7 +187,7 @@ public class Dartagnan extends BaseOptions {
         }
     }
 
-    private static String getWitnessFilename(File progFile, BaseOptions options, String postfix) {
+    private static String getWitnessFilename(Path progFile, BaseOptions options, String postfix) {
         return options.hasWitnessFilename()
                 ? options.getWitnessFilename() + postfix
                 : Utils.getNameWithoutExtension(progFile);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/Dartagnan.java
@@ -24,7 +24,6 @@ import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Options;
 
-import java.io.File;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -178,7 +177,7 @@ public class Dartagnan extends BaseOptions {
     private static List<Path> getProgramFiles(Path path) {
         try (Stream<Path> stream = Files.walk(path)) {
             return stream.filter(Files::isRegularFile)
-                    .filter(ProgramParser::isSupported)
+                    .filter(ProgramParser::isSupportedFile)
                     .sorted(Comparator.comparing(Path::toString))
                     .toList();
         } catch (IOException e) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/ParserCat.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/cat/ParserCat.java
@@ -24,10 +24,13 @@ public class ParserCat {
         this.includePath = includePath;
     }
 
+    // TODO: Update call-sites to use Path instead of File
     public Wmm parse(File file) throws IOException {
-        try (FileInputStream stream = new FileInputStream(file)) {
-            return parse(CharStreams.fromStream(stream), file.toString());
-        }
+        return parse(file.toPath());
+    }
+
+    public Wmm parse(Path path) throws IOException {
+        return parse(CharStreams.fromPath(path), path.toString());
     }
 
     public Wmm parse(String raw) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
@@ -138,7 +138,7 @@ public class ProgramParser {
             }
 
             if (c != '\r') {
-                sb.append(c);
+                sb.append((char) c);
             }
         }
         return sb.toString();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
@@ -35,9 +35,11 @@ public class ProgramParser {
     public static final String EXTENSION_SPV_DIS = ".spv.dis"; // Deprecated.
     public static final String EXTENSION_SPVASM = ".spvasm";
     public static final List<String> SUPPORTED_EXTENSIONS = List.of(
-            EXTENSION_C, EXTENSION_I, EXTENSION_LL, EXTENSION_LITMUS, EXTENSION_SPV_DIS, EXTENSION_SPVASM);
+            EXTENSION_C, EXTENSION_I, EXTENSION_LL,
+            EXTENSION_LITMUS, EXTENSION_SPV_DIS, EXTENSION_SPVASM
+    );
 
-    public static boolean isSupported(Path filePath) {
+    public static boolean isSupportedFile(Path filePath) {
         return SUPPORTED_EXTENSIONS.contains(getFileExtension(filePath));
     }
 
@@ -72,18 +74,8 @@ public class ProgramParser {
     }
 
     private Program parse(CharStream sourceCode, String extension) {
-        final ParserInterface parser = switch (extension) {
-            case EXTENSION_LL -> new ParserLlvm();
-            case EXTENSION_SPV_DIS -> {
-                logger.warn("Extension {} is deprecated. Please rename your file to {} instead.", EXTENSION_SPV_DIS, EXTENSION_SPVASM);
-                yield new ParserSpirv();
-            }
-            case EXTENSION_SPVASM -> new ParserSpirv();
-            case EXTENSION_LITMUS -> inferLitmusParserFromCode(sourceCode);
-            default -> throw new ParsingException("Unknown input file type");
-        };
-
         try {
+            final ParserInterface parser = getParser(sourceCode, extension);
             return parser.parse(sourceCode);
         } catch (RuntimeException exception) {
             // Wrap into ParsingException.
@@ -93,7 +85,22 @@ public class ProgramParser {
         }
     }
 
-    private ParserInterface inferLitmusParserFromCode(CharStream sourceCode) {
+    // =========================== Private Utility =====================================
+
+    private ParserInterface getParser(CharStream sourceCode, String extension) {
+        return switch (extension) {
+            case EXTENSION_LL -> new ParserLlvm();
+            case EXTENSION_SPV_DIS -> {
+                logger.warn("Extension {} is deprecated. Please rename your file to {} instead.", EXTENSION_SPV_DIS, EXTENSION_SPVASM);
+                yield new ParserSpirv();
+            }
+            case EXTENSION_SPVASM -> new ParserSpirv();
+            case EXTENSION_LITMUS -> getParserForLitmus(sourceCode);
+            default -> throw new ParsingException("Unknown input file type");
+        };
+    }
+
+    private ParserInterface getParserForLitmus(CharStream sourceCode) {
         final String litmusType = getFirstWord(peekFirstLine(sourceCode));
         return switch (litmusType.toUpperCase()) {
             case TYPE_LITMUS_AARCH64 -> new ParserLitmusAArch64();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
@@ -2,14 +2,15 @@ package com.dat3m.dartagnan.parsers.program;
 
 import com.dat3m.dartagnan.exception.ParsingException;
 import com.dat3m.dartagnan.program.Program;
-import com.google.common.io.Files;
+import com.dat3m.dartagnan.utils.Utils;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
-import java.nio.file.Path;
+import java.nio.file.*;
 import java.util.List;
 
 import static com.dat3m.dartagnan.parsers.program.utils.Compilation.compileWithClang;
@@ -37,119 +38,103 @@ public class ProgramParser {
             EXTENSION_C, EXTENSION_I, EXTENSION_LL, EXTENSION_LITMUS, EXTENSION_SPV_DIS, EXTENSION_SPVASM);
 
     public static boolean isSupported(Path filePath) {
-        final String extension = "." + Files.getFileExtension(filePath.getFileName().toString());
-        return SUPPORTED_EXTENSIONS.contains(extension);
+        return SUPPORTED_EXTENSIONS.contains(getFileExtension(filePath));
     }
 
+    // TODO: Change call-sites to use Path instead of File
     public Program parse(File file) throws Exception {
-        if (needsClang(file)) {
-            file = compileWithClang(file, "");
-            return new ProgramParser().parse(file);
+        return parse(file.toPath());
+    }
+
+    public Program parse(Path path) throws Exception {
+        if (needsClang(getFileExtension(path))) {
+            final String cflags = System.getenv().getOrDefault("CFLAGS", "");
+            path = compileWithClang(path, cflags);
         }
 
-        Program program;
-        try (FileInputStream stream = new FileInputStream(file)) {
-            ParserInterface parser = getConcreteParser(file);
-            CharStream charStream = CharStreams.fromStream(stream);
-            program = parseAndWrap(parser, charStream);
-        }
-        program.setName(file.getName());
+        final Program program = parse(CharStreams.fromPath(path), getFileExtension(path));
+        program.setName(path.getFileName().toString());
         return program;
     }
 
-    private boolean needsClang(File f) {
-        return f.getPath().endsWith(EXTENSION_C) || f.getPath().endsWith(EXTENSION_I);
+    public Program parse(String rawSourceCode, String extension, String cflags) throws Exception {
+        final CharStream sourceCode;
+        if (needsClang(extension)) {
+            sourceCode = CharStreams.fromPath(compileWithClang(rawSourceCode, cflags));
+            extension = EXTENSION_LL;
+        } else {
+            sourceCode = CharStreams.fromString(rawSourceCode, "raw_input" + extension);
+        }
+
+        final Program program = parse(sourceCode, extension);
+        program.setName("raw_input" + extension);
+        return program;
     }
 
-    public Program parse(String raw, String path, String format, String cflags) throws Exception {
-        final ParserInterface parser;
-        switch (format) {
-            case EXTENSION_C, EXTENSION_I -> {
-                File file = path.isEmpty() ?
-                        // This is for the case where the user fully typed the program instead of loading it
-                        File.createTempFile("dat3m", EXTENSION_C) :
-                        // This is for the case where the user loaded the program
-                        new File(path, "dat3m.c");
-                try (FileWriter writer = new FileWriter(file)) {
-                    writer.write(raw);
-                }
-                file = compileWithClang(file, cflags);
-                Program p = new ProgramParser().parse(file);
-                file.delete();
-                return p;
-            }
-            case EXTENSION_LL -> {
-                parser = new ParserLlvm();
-            }
-            case EXTENSION_SPVASM -> {
-                parser = new ParserSpirv();
-            }
+    private Program parse(CharStream sourceCode, String extension) {
+        final ParserInterface parser = switch (extension) {
+            case EXTENSION_LL -> new ParserLlvm();
             case EXTENSION_SPV_DIS -> {
                 logger.warn("Extension {} is deprecated. Please rename your file to {} instead.", EXTENSION_SPV_DIS, EXTENSION_SPVASM);
-                parser = new ParserSpirv();
+                yield new ParserSpirv();
             }
-            case EXTENSION_LITMUS -> {
-                parser = getConcreteLitmusParser(raw.toUpperCase());
-            }
+            case EXTENSION_SPVASM -> new ParserSpirv();
+            case EXTENSION_LITMUS -> inferLitmusParserFromCode(sourceCode);
             default -> throw new ParsingException("Unknown input file type");
-        }
-        return parseAndWrap(parser, CharStreams.fromString(raw));
-    }
+        };
 
-    private Program parseAndWrap(ParserInterface parser, CharStream charStream) {
         try {
-            return parser.parse(charStream);
+            return parser.parse(sourceCode);
         } catch (RuntimeException exception) {
             // Wrap into ParsingException.
-            throw exception instanceof ParsingException ? exception
+            throw exception instanceof ParsingException
+                    ? exception
                     : new ParsingException(exception, exception.getMessage());
         }
     }
 
-    private ParserInterface getConcreteParser(File file) throws IOException {
-        String name = file.getName();
-        if (name.endsWith(EXTENSION_LL)) {
-            return new ParserLlvm();
-        }
-        if (name.endsWith(EXTENSION_SPV_DIS)) {
-                logger.warn("Extension {} is deprecated. Please rename your file to {} instead.", EXTENSION_SPV_DIS, EXTENSION_SPVASM);
-            return new ParserSpirv();
-        }
-        if (name.endsWith(EXTENSION_SPVASM)) {
-            return new ParserSpirv();
-        }
-        if (name.endsWith(EXTENSION_LITMUS)) {
-            return getConcreteLitmusParser(readFirstLine(file).toUpperCase());
-        }
-        throw new ParsingException("Unknown input file type");
+    private ParserInterface inferLitmusParserFromCode(CharStream sourceCode) {
+        final String litmusType = getFirstWord(peekFirstLine(sourceCode));
+        return switch (litmusType.toUpperCase()) {
+            case TYPE_LITMUS_AARCH64 -> new ParserLitmusAArch64();
+            case TYPE_LITMUS_PPC -> new ParserLitmusPPC();
+            case TYPE_LITMUS_X86 -> new ParserLitmusX86();
+            case TYPE_LITMUS_RISCV -> new ParserLitmusRISCV();
+            case TYPE_LITMUS_PTX -> new ParserLitmusPTX();
+            case TYPE_LITMUS_VULKAN -> new ParserLitmusVulkan();
+            case TYPE_LITMUS_C, TYPE_LITMUS_OPENCL -> new ParserLitmusC();
+            default -> throw new ParsingException("Unknown litmus format" + litmusType);
+        };
     }
 
-    private ParserInterface getConcreteLitmusParser(String programText) {
-        if (programText.indexOf(TYPE_LITMUS_AARCH64) == 0) {
-            return new ParserLitmusAArch64();
-        } else if (programText.indexOf(TYPE_LITMUS_C) == 0 || programText.indexOf(TYPE_LITMUS_OPENCL) == 0) {
-            return new ParserLitmusC();
-        } else if (programText.indexOf(TYPE_LITMUS_PPC) == 0) {
-            return new ParserLitmusPPC();
-        } else if (programText.indexOf(TYPE_LITMUS_X86) == 0) {
-            return new ParserLitmusX86();
-        } else if (programText.indexOf(TYPE_LITMUS_RISCV) == 0) {
-            return new ParserLitmusRISCV();
-        } else if (programText.indexOf(TYPE_LITMUS_PTX) == 0) {
-            return new ParserLitmusPTX();
-        } else if(programText.indexOf(TYPE_LITMUS_VULKAN) == 0) {
-            return new ParserLitmusVulkan();
-        }
-        final int spaceIndex = programText.indexOf(" ");
-        final String litmusFormat = (spaceIndex != -1) ? " " + programText.substring(0, spaceIndex) : "";
-        throw new ParsingException("Unknown litmus format" + litmusFormat);
+    private static String getFileExtension(Path path) {
+        return "." + Utils.getFileExtension(path);
     }
 
-    private String readFirstLine(File file) throws IOException {
-        String line;
-        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
-            line = bufferedReader.readLine();
+    private static boolean needsClang(String ext) {
+        return ext.equals(EXTENSION_C) || ext.equals(EXTENSION_I);
+    }
+
+    private static String getFirstWord(String string) {
+        string = string.stripLeading();
+        int endOfFirstWord = string.indexOf(" ");
+        return endOfFirstWord == -1 ? string : string.substring(0, endOfFirstWord);
+    }
+
+    private static String peekFirstLine(CharStream input) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1;; i++) {
+            int c = input.LA(i);
+
+            if (c == IntStream.EOF || c == '\n') {
+                break;
+            }
+
+            if (c != '\r') {
+                sb.append((char) c);
+            }
         }
-        return line;
+        return sb.toString();
+
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/ProgramParser.java
@@ -65,11 +65,11 @@ public class ProgramParser {
             sourceCode = CharStreams.fromPath(compileWithClang(rawSourceCode, cflags));
             extension = EXTENSION_LL;
         } else {
-            sourceCode = CharStreams.fromString(rawSourceCode, "raw_input" + extension);
+            sourceCode = CharStreams.fromString(rawSourceCode, "<input>" + extension);
         }
 
         final Program program = parse(sourceCode, extension);
-        program.setName("raw_input" + extension);
+        program.setName("<input>" + extension);
         return program;
     }
 
@@ -138,7 +138,7 @@ public class ProgramParser {
             }
 
             if (c != '\r') {
-                sb.append((char) c);
+                sb.append(c);
             }
         }
         return sb.toString();

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -23,9 +23,9 @@ public class Compilation {
         final Path tempFilePath = Files.createTempFile("dat3m", ".c");
         Files.writeString(tempFilePath, rawCSource);
 
-        final Path clangResultPath = compileWithClang(tempFilePath, cflags);
+        final Path outputFile = compileWithClang(tempFilePath, cflags);
         Files.delete(tempFilePath);
-        return clangResultPath;
+        return outputFile;
     }
 
     public static Path compileWithClang(Path sourceFile, String cflags) throws Exception {
@@ -63,7 +63,6 @@ public class Compilation {
         processBuilder.redirectOutput(log.toFile());
 
         final Process proc = processBuilder.start();
-
         if (proc.waitFor() != 0) {
             final String logString = Files.readString(log, Charsets.UTF_8);
             final String errorMsg = "'%s': %s".formatted(String.join("' '", cmd), logString);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -2,6 +2,7 @@ package com.dat3m.dartagnan.parsers.program.utils;
 
 import com.dat3m.dartagnan.utils.Utils;
 import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,14 +32,14 @@ public class Compilation {
     public static Path compileWithClang(Path sourceFile, String cflags) throws Exception {
         final String outputFileName = getOutputName(sourceFile, ".ll");
 
-        final List<String> clangCmd = new ArrayList<>(List.of(
+        final List<String> clangCmd = ImmutableList.<String>builder().add(
                 "clang",
                 "-I", getIncludeDirectory().toString(),
                 "-Xclang", "-disable-O0-optnone", "-S", "-emit-llvm", "-g", "-gcolumn-info",
                 "-o", outputFileName
-        ));
-        clangCmd.addAll(asList(cflags.split(" ")));
-        clangCmd.add(sourceFile.toAbsolutePath().toString());
+                ).addAll(asList(cflags.split(" ")))
+                .add(sourceFile.toAbsolutePath().toString())
+                .build();
 
         runCmd(clangCmd);
         return Path.of(outputFileName);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -1,14 +1,15 @@
 package com.dat3m.dartagnan.parsers.program.utils;
 
+import com.dat3m.dartagnan.utils.Utils;
 import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.List;
 
 import static com.dat3m.dartagnan.GlobalSettings.getOrCreateOutputDirectory;
 import static com.dat3m.dartagnan.GlobalSettings.getIncludeDirectory;
@@ -18,41 +19,55 @@ public class Compilation {
 
     private static final Logger logger = LoggerFactory.getLogger(Compilation.class);
 
-    public static File compileWithClang(File file, String cflags) throws Exception {
-        final String outputFileName = getOutputName(file, ".ll");
+    public static Path compileWithClang(String rawCSource, String cflags) throws Exception {
+        final Path tempFilePath = Files.createTempFile("dat3m", ".c");
+        Files.writeString(tempFilePath, rawCSource);
 
-        ArrayList<String> cmd = new ArrayList<>(
-                asList("clang", "-I", getIncludeDirectory().toString(), "-Xclang", "-disable-O0-optnone", "-S", "-emit-llvm", "-g", "-gcolumn-info", "-o", outputFileName));
-        // We use cflags when using the UI and fallback top CFLAGS otherwise
-        cflags = cflags.isEmpty() ? System.getenv().getOrDefault("CFLAGS", "") : cflags;
-        // Needed to handle more than one flag in CFLAGS
-        Collections.addAll(cmd, cflags.split(" "));
-        cmd.add(file.getAbsolutePath());
-
-        runCmd(cmd);
-        return new File(outputFileName);
+        final Path clangResultPath = compileWithClang(tempFilePath, cflags);
+        Files.delete(tempFilePath);
+        return clangResultPath;
     }
 
-    private static String getOutputName(File file, String postfix) throws IOException {
-        return getOrCreateOutputDirectory() + "/" +
-                file.getName().substring(0, file.getName().lastIndexOf('.')) + postfix;
+    public static Path compileWithClang(Path sourceFile, String cflags) throws Exception {
+        final String outputFileName = getOutputName(sourceFile, ".ll");
+
+        final List<String> clangCmd = new ArrayList<>(List.of(
+                "clang",
+                "-I", getIncludeDirectory().toString(),
+                "-Xclang", "-disable-O0-optnone", "-S", "-emit-llvm", "-g", "-gcolumn-info",
+                "-o", outputFileName
+        ));
+        clangCmd.addAll(asList(cflags.split(" ")));
+        clangCmd.add(sourceFile.toAbsolutePath().toString());
+
+        runCmd(clangCmd);
+        return Path.of(outputFileName);
     }
 
-    private static void runCmd(ArrayList<String> cmd) throws Exception {
+    private static String getOutputName(Path path, String postfix) throws IOException {
+        return getOrCreateOutputDirectory()
+                .resolve(Utils.getNameWithoutExtension(path) + postfix)
+                .toString();
+
+    }
+
+    private static void runCmd(List<String> cmd) throws Exception {
         logger.debug(String.join(" ", cmd));
-        ProcessBuilder processBuilder = new ProcessBuilder(cmd);
         // "Unless the standard input and output streams are promptly written and read respectively
         // of the sub process, it may block or deadlock the sub process."
-        //		https://www.developer.com/design/understanding-java-process-and-java-processbuilder/
+        //      https://www.developer.com/design/understanding-java-process-and-java-processbuilder/
         // The lines below take care of this.
-        File log = File.createTempFile("log", null);
+        final Path log = Files.createTempFile("log", null);
+        final ProcessBuilder processBuilder = new ProcessBuilder(cmd);
         processBuilder.redirectErrorStream(true);
-        processBuilder.redirectOutput(log);
-        Process proc = processBuilder.start();
-        proc.waitFor();
-        if(proc.exitValue() != 0) {
-            String errorString =  Files.asCharSource(log, Charsets.UTF_8).read();
-            throw new IOException("'" + String.join("' '", cmd) + "': " + errorString);
+        processBuilder.redirectOutput(log.toFile());
+
+        final Process proc = processBuilder.start();
+
+        if (proc.waitFor() != 0) {
+            final String logString = Files.readString(log, Charsets.UTF_8);
+            final String errorMsg = "'%s': %s".formatted(String.join("' '", cmd), logString);
+            throw new IOException(errorMsg);
         }
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/parsers/program/utils/Compilation.java
@@ -21,7 +21,8 @@ public class Compilation {
     private static final Logger logger = LoggerFactory.getLogger(Compilation.class);
 
     public static Path compileWithClang(String rawCSource, String cflags) throws Exception {
-        final Path tempFilePath = Files.createTempFile("dat3m", ".c");
+        final Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
+        final Path tempFilePath = tempDir.resolve("dat3m-input.c");
         Files.writeString(tempFilePath, rawCSource);
 
         final Path outputFile = compileWithClang(tempFilePath, cflags);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AliasAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/alias/AliasAnalysis.java
@@ -20,9 +20,9 @@ import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 
 import static com.dat3m.dartagnan.GlobalSettings.getOrCreateOutputDirectory;
@@ -226,8 +226,8 @@ public interface AliasAnalysis {
         String programName = program.getName();
         String programBase = programName.substring(0, programName.lastIndexOf('.'));
         try {
-            File dotFile = new File(getOrCreateOutputDirectory() + "/" + programBase + "-alias.dot");
-            try (var writer = new FileWriter(dotFile)) {
+            final Path dotFile = getOrCreateOutputDirectory().resolve(programBase + "-alias.dot");
+            try (var writer = Files.newBufferedWriter(dotFile)) {
                 graphviz.generateOutput(writer);
                 writer.flush();
                 logger.info("Alias graph written to {}.", dotFile);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/smt/ProverWithTracker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/smt/ProverWithTracker.java
@@ -4,69 +4,69 @@ import com.google.common.collect.ImmutableMap;
 import org.sosy_lab.java_smt.api.*;
 import org.sosy_lab.java_smt.api.SolverContext.ProverOptions;
 
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+
+import static java.nio.file.StandardOpenOption.*;
 
 public class ProverWithTracker implements ProverEnvironment {
 
     private final FormulaManager fmgr;
     private final ProverEnvironment prover;
-    private final String fileName;
+    private final Path filePath;
     private final Set<String> declarations;
 
-    public ProverWithTracker(SolverContext ctx, String fileName, ProverOptions... options) {
+    public ProverWithTracker(SolverContext ctx, Path filePath, ProverOptions... options) {
         this.fmgr = ctx.getFormulaManager();
         this.prover = ctx.newProverEnvironment(options);
-        this.fileName = fileName;
+        this.filePath = filePath;
         this.declarations = new HashSet<>();
         init();
     }
 
     // An empty filename means there is no need to dump the encoding
     private boolean dump() {
-        return !fileName.isEmpty();
+        return filePath != null;
     }
 
     private void init() {
-        if(dump()) {
-            try {
-                Files.deleteIfExists(Paths.get(fileName));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            StringBuilder description = new StringBuilder();
-            LocalDate currentDate = LocalDate.now();
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-            description.append("Generated on: ").append(currentDate.format(formatter)).append("\n");
-            description.append("Generator: Dartagnan\n");
-            description.append("Application: Bounded model checking for weak memory models\n");
-            description.append("""
-                    Publications:\s
-                    - Hernán Ponce de León, Florian Furbach, Keijo Heljanko, \
-                    Roland Meyer: Dartagnan: Bounded Model Checking for Weak Memory Models \
-                    (Competition Contribution). TACAS (2) 2020: 378-382
-                    - Thomas Haas, Roland Meyer, Hernán Ponce de León: \
-                    CAAT: consistency as a theory. Proc. ACM Program. Lang. 6(OOPSLA2): 114-144 (2022)"""
-            );
-            write("(set-info :smt-lib-version 2.6)\n");
-            write("(set-logic ALL)\n");
-            write("(set-info :category \"industrial\")\n");
-            write("(set-info :source |\n" + description + "\n|)\n");
-            write("(set-info :license \"https://creativecommons.org/licenses/by/4.0/\")\n");
+        if (!dump()) {
+            return;
         }
+
+        try {
+            Files.deleteIfExists(filePath);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        StringBuilder description = new StringBuilder();
+        LocalDate currentDate = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        description.append("Generated on: ").append(currentDate.format(formatter)).append("\n");
+        description.append("Generator: Dartagnan\n");
+        description.append("Application: Bounded model checking for weak memory models\n");
+        description.append("""
+                Publications:\s
+                - Hernán Ponce de León, Florian Furbach, Keijo Heljanko, \
+                Roland Meyer: Dartagnan: Bounded Model Checking for Weak Memory Models \
+                (Competition Contribution). TACAS (2) 2020: 378-382
+                - Thomas Haas, Roland Meyer, Hernán Ponce de León: \
+                CAAT: consistency as a theory. Proc. ACM Program. Lang. 6(OOPSLA2): 114-144 (2022)"""
+        );
+        write("(set-info :smt-lib-version 2.6)\n");
+        write("(set-logic ALL)\n");
+        write("(set-info :category \"industrial\")\n");
+        write("(set-info :source |\n" + description + "\n|)\n");
+        write("(set-info :license \"https://creativecommons.org/licenses/by/4.0/\")\n");
     }
 
     @Override
     public void close() {
         if(dump()) {
-            removeDuplicatedDeclarations(fileName);
             write("(exit)\n");
         }
         prover.close();
@@ -149,6 +149,11 @@ public class ProverWithTracker implements ProverEnvironment {
     }
 
     @Override
+    public boolean registerUserPropagator(UserPropagator propagator) {
+        return  prover.registerUserPropagator(propagator);
+    }
+
+    @Override
     public List<BooleanFormula> getUnsatCore() {
         return prover.getUnsatCore();
     }
@@ -165,14 +170,14 @@ public class ProverWithTracker implements ProverEnvironment {
     }
 
     private void write(String content) {
-        if (dump()) {
-            File file = new File(fileName);
-            try (FileWriter writer = new FileWriter(file, true);
-                    PrintWriter printer = new PrintWriter(writer)) {
-                printer.append(removeDuplicatedDeclarations(content));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+        if (!dump()) {
+            return;
+        }
+
+        try {
+            Files.writeString(filePath, removeDuplicatedDeclarations(content),  WRITE, APPEND, CREATE);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 
@@ -181,7 +186,7 @@ public class ProverWithTracker implements ProverEnvironment {
     }
 
     // FIXME: This is only correct as long as no declarations are popped and then
-    // later redeclared (which is currently guarenteed by the way we use the solver)
+    //  later redeclared (which is currently guaranteed by the way we use the solver)
     private StringBuilder removeDuplicatedDeclarations(String content) {
         StringBuilder builder = new StringBuilder();
         for(String line : content.split("\n")) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/smt/ProverWithTracker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/smt/ProverWithTracker.java
@@ -16,20 +16,19 @@ public class ProverWithTracker implements ProverEnvironment {
 
     private final FormulaManager fmgr;
     private final ProverEnvironment prover;
-    private final Path filePath;
+    private final Path dumpFilePath;
     private final Set<String> declarations;
 
-    public ProverWithTracker(SolverContext ctx, Path filePath, ProverOptions... options) {
+    public ProverWithTracker(SolverContext ctx, Path dumpFilePath, ProverOptions... options) {
         this.fmgr = ctx.getFormulaManager();
         this.prover = ctx.newProverEnvironment(options);
-        this.filePath = filePath;
+        this.dumpFilePath = dumpFilePath;
         this.declarations = new HashSet<>();
         init();
     }
 
-    // An empty filename means there is no need to dump the encoding
     private boolean dump() {
-        return filePath != null;
+        return dumpFilePath != null;
     }
 
     private void init() {
@@ -38,7 +37,7 @@ public class ProverWithTracker implements ProverEnvironment {
         }
 
         try {
-            Files.deleteIfExists(filePath);
+            Files.deleteIfExists(dumpFilePath);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -150,7 +149,7 @@ public class ProverWithTracker implements ProverEnvironment {
 
     @Override
     public boolean registerUserPropagator(UserPropagator propagator) {
-        return  prover.registerUserPropagator(propagator);
+        return prover.registerUserPropagator(propagator);
     }
 
     @Override
@@ -175,7 +174,7 @@ public class ProverWithTracker implements ProverEnvironment {
         }
 
         try {
-            Files.writeString(filePath, removeDuplicatedDeclarations(content),  WRITE, APPEND, CREATE);
+            Files.writeString(dumpFilePath, removeDuplicatedDeclarations(content),  WRITE, APPEND, CREATE);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
@@ -3,6 +3,7 @@ package com.dat3m.dartagnan.utils;
 import com.google.common.io.Files;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 public class Utils {
@@ -10,8 +11,17 @@ public class Utils {
     private Utils() {
     }
 
+    public static String getFileExtension(Path path) {
+        return Files.getFileExtension(path.getFileName().toString());
+    }
+
+    public static String getNameWithoutExtension(Path path) {
+        return getNameWithoutExtension(path.getFileName().toString());
+    }
+
+
     public static String getNameWithoutExtension(File file) {
-        return getNameWithoutExtension(file.getName());
+        return getNameWithoutExtension(file.toPath());
     }
 
     public static String getNameWithoutExtension(String fileName) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
@@ -2,7 +2,6 @@ package com.dat3m.dartagnan.utils;
 
 import com.google.common.io.Files;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
@@ -17,11 +16,6 @@ public class Utils {
 
     public static String getNameWithoutExtension(Path path) {
         return getNameWithoutExtension(path.getFileName().toString());
-    }
-
-
-    public static String getNameWithoutExtension(File file) {
-        return getNameWithoutExtension(file.toPath());
     }
 
     public static String getNameWithoutExtension(String fileName) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/Utils.java
@@ -10,6 +10,14 @@ public class Utils {
     private Utils() {
     }
 
+    public static boolean containsSubpath(Path path, Path subpath) {
+        return path.toString().contains(subpath.toString());
+    }
+
+    public static Path subpath(Path path, int from) {
+        return path.subpath(from, path.getNameCount() - 1);
+    }
+
     public static String getFileExtension(Path path) {
         return Files.getFileExtension(path.getFileName().toString());
     }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/utils/printer/OutputLogger.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/utils/printer/OutputLogger.java
@@ -5,7 +5,7 @@ import com.dat3m.dartagnan.utils.Result;
 import com.dat3m.dartagnan.utils.Utils;
 import org.sosy_lab.common.configuration.Configuration;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,10 +14,10 @@ import static com.dat3m.dartagnan.utils.Result.PASS;
 public class OutputLogger {
 
     private final List<ResultSummary> results = new ArrayList<>();
-    private final File modelFile;
+    private final Path modelFile;
     private final Configuration config;
 
-    public OutputLogger(File file, Configuration config) {
+    public OutputLogger(Path file, Configuration config) {
         this.modelFile = file;
         this.config = config;
     }
@@ -52,7 +52,6 @@ public class OutputLogger {
         public static final String PROGRAM_SPEC_REASON = "Program specification violation found";
         public static final String TERMINATION_REASON = "Termination violation found";
         public static final String CAT_SPEC_REASON = "CAT specification violation found";
-        public static final String SVCOMP_RACE_REASON = "SVCOMP data race found";
         public static final String SVCOMP_UNTRACKABLE_OBJECT_REASON = "Untrackable object found";
         public static final String BOUND_REASON = "Not fully unrolled loops";
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
@@ -21,15 +21,14 @@ import com.dat3m.dartagnan.verification.model.ExecutionModelNext;
 import com.dat3m.dartagnan.witness.WitnessType;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.axiom.Axiom;
+import com.google.common.base.Charsets;
 import org.apache.commons.csv.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sosy_lab.common.configuration.Configuration;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 
@@ -201,11 +200,11 @@ public class TaskResultAnalyzer {
         if(!config.hasProperty(BOUNDS_SAVE_PATH)) {
             return;
         }
-        final File boundsFile = new File(config.getProperty(BOUNDS_SAVE_PATH));
+        final Path boundsFile = Path.of(config.getProperty(BOUNDS_SAVE_PATH));
 
         // Parse old entries
         final List<CSVRecord> entries;
-        try (CSVParser parser = CSVParser.parse(new FileReader(boundsFile), CSVFormat.DEFAULT)) {
+        try (CSVParser parser = CSVParser.parse(boundsFile, Charsets.UTF_8, CSVFormat.DEFAULT)) {
             entries = parser.getRecords();
         }
 
@@ -220,7 +219,7 @@ public class TaskResultAnalyzer {
         }
 
         // Write new entries
-        try (CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(boundsFile, false), CSVFormat.DEFAULT)) {
+        try (CSVPrinter csvPrinter = new CSVPrinter(Files.newBufferedWriter(boundsFile), CSVFormat.DEFAULT)) {
             for (CSVRecord entry : entries) {
                 final int entryId = Integer.parseInt(entry.get(0));
                 if (!loopId2UpdatedBound.containsKey(entryId)) {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
@@ -21,17 +21,16 @@ import com.dat3m.dartagnan.verification.model.ExecutionModelNext;
 import com.dat3m.dartagnan.witness.WitnessType;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.wmm.axiom.Axiom;
-import com.google.common.base.Preconditions;
 import org.apache.commons.csv.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sosy_lab.common.configuration.Configuration;
-import org.sosy_lab.common.configuration.InvalidConfigurationException;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 
 import static com.dat3m.dartagnan.GlobalSettings.getOrCreateOutputDirectory;
@@ -170,7 +169,7 @@ public class TaskResultAnalyzer {
         return new ResultSummary(programPath, filter, result, condition, reason, details.toString(), time, NORMAL_TERMINATION);
     }
 
-    public File generateWitnessIfAble(TaskSolver solver, WitnessType witnessType, String filename,
+    public Path generateWitnessIfAble(TaskSolver solver, WitnessType witnessType, String filename,
                                       boolean generateWitnessForUnknown) throws IOException {
         if (!solver.hasModel()
                 || (solver.getResult() == UNKNOWN && !generateWitnessForUnknown)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskResultAnalyzer.java
@@ -186,7 +186,7 @@ public class TaskResultAnalyzer {
                 // CO edges only give ordering information which is known if the pair is also in PO
                 return generateGraphvizFile(model, task.getProgram().getName(), (x, y) -> true,
                         (x, y) -> !x.getThreadModel().getThread().equals(y.getThreadModel().getThread()),
-                        getOrCreateOutputDirectory() + "/", filename,
+                        getOrCreateOutputDirectory(), filename,
                         synContext, witnessType.convertToPng(), task.getConfig());
             }
         }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/solving/ModelChecker.java
@@ -35,6 +35,7 @@ import org.sosy_lab.java_smt.SolverContextFactory;
 import org.sosy_lab.java_smt.api.SolverContext;
 import org.sosy_lab.java_smt.api.SolverException;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.*;
@@ -142,9 +143,9 @@ public abstract class ModelChecker implements AutoCloseable {
     protected void initSMTSolver(Configuration config) throws InvalidConfigurationException {
         Preconditions.checkState(solverContext == null, "SolverContext already initialized");
 
-        final String smtDumpPath = smtConfig.getDumpSmtLib()
-                ? GlobalSettings.getOutputDirectory() + String.format("/%s.smt2", task.getProgram().getName())
-                : "";
+        final Path smtDumpPath = smtConfig.getDumpSmtLib()
+                ? GlobalSettings.getOutputDirectory().resolve(String.format("%s.smt2", task.getProgram().getName()))
+                : null;
 
         solverContext = createSolverContext(config, shutdownManager.getNotifier(), smtConfig.getSolver());
         prover = new ProverWithTracker(solverContext, smtDumpPath, SolverContext.ProverOptions.GENERATE_MODELS);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -21,11 +21,11 @@ import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.function.BiPredicate;
 
@@ -359,7 +359,7 @@ public class ExecutionGraphVisualizer {
         graphviz.addNode(eventToNode(e), attributes);
     }
 
-    public static File generateGraphvizFile(ExecutionModelNext model,
+    public static Path generateGraphvizFile(ExecutionModelNext model,
                                             String graphName,
                                             BiPredicate<EventModel, EventModel> rfFilter,
                                             BiPredicate<EventModel, EventModel> coFilter,
@@ -368,9 +368,15 @@ public class ExecutionGraphVisualizer {
                                             SyntacticContextAnalysis synContext,
                                             boolean convert,
                                             Configuration config) {
-        File fileVio = new File(directoryName + fileNameBase + ".dot");
-        fileVio.getParentFile().mkdirs();
-        try (FileWriter writer = new FileWriter(fileVio)) {
+        Path fileVio = Path.of(directoryName + fileNameBase + ".dot");
+        try {
+            Files.createDirectories(fileVio.getParent());
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+            return null;
+        }
+
+        try (Writer writer = Files.newBufferedWriter(fileVio)) {
             // Create .dot file
             ExecutionGraphVisualizer visualizer = new ExecutionGraphVisualizer();
             visualizer.setRelationsToShow(config);
@@ -383,7 +389,7 @@ public class ExecutionGraphVisualizer {
             if (convert) {
                 fileVio = Graphviz.convert(fileVio);
             }
-            logger.info("Witness stored into {}.", fileVio.getAbsolutePath());
+            logger.info("Witness stored into {}.", fileVio);
             return fileVio;
         } catch (Exception e) {
             logger.error(e.getMessage());

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/ExecutionGraphVisualizer.java
@@ -363,12 +363,12 @@ public class ExecutionGraphVisualizer {
                                             String graphName,
                                             BiPredicate<EventModel, EventModel> rfFilter,
                                             BiPredicate<EventModel, EventModel> coFilter,
-                                            String directoryName,
+                                            Path dir,
                                             String fileNameBase,
                                             SyntacticContextAnalysis synContext,
-                                            boolean convert,
+                                            boolean convertToPNG,
                                             Configuration config) {
-        Path fileVio = Path.of(directoryName + fileNameBase + ".dot");
+        Path fileVio = dir.resolve(fileNameBase + ".dot");
         try {
             Files.createDirectories(fileVio.getParent());
         } catch (IOException e) {
@@ -386,7 +386,7 @@ public class ExecutionGraphVisualizer {
                       .generateGraphOfExecutionModel(writer, graphName, model);
 
             writer.flush();
-            if (convert) {
+            if (convertToPNG) {
                 fileVio = Graphviz.convert(fileVio);
             }
             logger.info("Witness stored into {}.", fileVio);
@@ -396,24 +396,5 @@ public class ExecutionGraphVisualizer {
         }
 
         return null;
-    }
-
-    public static void generateGraphvizFile(ExecutionModelNext model,
-                                            String graphName,
-                                            BiPredicate<EventModel, EventModel> rfFilter,
-                                            BiPredicate<EventModel, EventModel> coFilter,
-                                            String directoryName,
-                                            String fileNameBase,
-                                            SyntacticContextAnalysis synContext) {
-        generateGraphvizFile(model,
-                             graphName,
-                             rfFilter,
-                             coFilter,
-                             directoryName,
-                             fileNameBase,
-                             synContext,
-                             true,
-                             Configuration.defaultConfiguration()
-        );
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/Graphviz.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/Graphviz.java
@@ -1,9 +1,9 @@
 package com.dat3m.dartagnan.witness.graphviz;
 
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -103,13 +103,13 @@ public class Graphviz {
      * @throws IOException          The program is not installed, or the directory of {@code dotFile} does not exist.
      * @throws InterruptedException The current thread is interrupted while waiting for the command to finish.
      */
-    public static File convert(File dotFile) throws IOException, InterruptedException {
-        final String dotFileName = dotFile.getName();
+    public static Path convert(Path dotFile) throws IOException, InterruptedException {
+        final String dotFileName = dotFile.getFileName().toString();
         final String pngFileName = dotFileName.substring(0, dotFileName.lastIndexOf('.')) + ".png";
-        Process p = new ProcessBuilder().directory(dotFile.getParentFile())
+        Process p = new ProcessBuilder().directory(dotFile.getParent().toFile())
                 .command("dot", "-Tpng", dotFileName, "-o", pngFileName).start();
         p.waitFor(1000, TimeUnit.MILLISECONDS);
 
-        return new File(dotFile.getParentFile(), pngFileName);
+        return dotFile.getParent().resolve(pngFileName);
     }
 }

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/Graphviz.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/witness/graphviz/Graphviz.java
@@ -110,6 +110,6 @@ public class Graphviz {
                 .command("dot", "-Tpng", dotFileName, "-o", pngFileName).start();
         p.waitFor(1000, TimeUnit.MILLISECONDS);
 
-        return dotFile.getParent().resolve(pngFileName);
+        return dotFile.resolveSibling(pngFileName);
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
@@ -117,7 +117,7 @@ public abstract class AbstractLitmusTest {
     protected final Provider<String> filePathProvider = () -> path;
     protected final Provider<String> nameProvider = Provider.fromSupplier(() -> getNameWithoutExtension(Path.of(path).getFileName().toString()));
     protected final Provider<Integer> boundProvider = getBoundProvider();
-    protected final Provider<Program> programProvider = Providers.createProgramFromPath(filePathProvider);
+    protected final Provider<Program> programProvider = Providers.createProgramFromPathString(filePathProvider);
     protected final Provider<Wmm> wmmProvider = getWmmProvider();
     protected final Provider<ProgressModel.Hierarchy> progressModelProvider = getProgressModelProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/AbstractLitmusTest.java
@@ -7,6 +7,7 @@ import com.dat3m.dartagnan.configuration.Property;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.utils.ResourceHelper;
 import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.rules.Provider;
 import com.dat3m.dartagnan.utils.rules.Providers;
 import com.dat3m.dartagnan.utils.rules.RequestShutdownOnError;
@@ -114,14 +115,14 @@ public abstract class AbstractLitmusTest {
 
     protected final Provider<ShutdownManager> shutdownManagerProvider = Provider.fromSupplier(ShutdownManager::create);
     protected final Provider<Arch> targetProvider = getTargetProvider();
-    protected final Provider<String> filePathProvider = () -> path;
+    protected final Provider<Path> filePathProvider = () -> Path.of(path);
     protected final Provider<String> nameProvider = Provider.fromSupplier(() -> getNameWithoutExtension(Path.of(path).getFileName().toString()));
     protected final Provider<Integer> boundProvider = getBoundProvider();
-    protected final Provider<Program> programProvider = Providers.createProgramFromPathString(filePathProvider);
+    protected final Provider<Program> programProvider = Providers.createProgramFromPath(filePathProvider);
     protected final Provider<Wmm> wmmProvider = getWmmProvider();
     protected final Provider<ProgressModel.Hierarchy> progressModelProvider = getProgressModelProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();
-    protected final Provider<Result> expectedResultProvider = Provider.fromSupplier(() -> expectedResults.get(filePathProvider.get().substring(filePathProvider.get().indexOf("/") + 1)));
+    protected final Provider<Result> expectedResultProvider = Provider.fromSupplier(() -> expectedResults.get(Utils.subpath(filePathProvider.get(), 1).toString()));
     protected final Provider<Configuration> configProvider = Provider.fromSupplier(this::getConfiguration);
     protected final Provider<VerificationTask> taskProvider = Providers.createTask(programProvider, wmmProvider, propertyProvider, progressModelProvider, configProvider);
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/LitmusAARCH64Test.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/LitmusAARCH64Test.java
@@ -2,12 +2,14 @@ package com.dat3m.dartagnan.litmus;
 
 import com.dat3m.dartagnan.configuration.Arch;
 import com.dat3m.dartagnan.utils.Result;
+import com.dat3m.dartagnan.utils.Utils;
 import com.dat3m.dartagnan.utils.rules.Provider;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.sosy_lab.common.configuration.ConfigurationBuilder;
 
 import java.io.IOException;
+import java.nio.file.Path;
 
 import static com.dat3m.dartagnan.configuration.OptionNames.MIXED_SIZE;
 
@@ -35,7 +37,10 @@ public class LitmusAARCH64Test extends AbstractLitmusTest {
 
     @Override
     protected ConfigurationBuilder additionalConfig(ConfigurationBuilder builder) {
-        return builder
-                .setOption(MIXED_SIZE, String.valueOf(filePathProvider.get().contains("litmus/AARCH64/mixed/")));
+        final boolean isMixedSize = Utils.containsSubpath(
+                filePathProvider.get(),
+                Path.of("litmus", "AARCH64", "mixed")
+        );
+        return builder.setOption(MIXED_SIZE, String.valueOf(isMixedSize));
     }
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/comparison/AbstractComparisonTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/comparison/AbstractComparisonTest.java
@@ -92,8 +92,8 @@ public abstract class AbstractComparisonTest {
     protected final Provider<Arch> sourceProvider = getSourceProvider();
     protected final Provider<Arch> targetProvider = getTargetProvider();
     protected final Provider<String> filePathProvider = () -> path;
-    protected final Provider<Program> program1Provider = Providers.createProgramFromPath(filePathProvider);
-    protected final Provider<Program> program2Provider = Providers.createProgramFromPath(filePathProvider);
+    protected final Provider<Program> program1Provider = Providers.createProgramFromPathString(filePathProvider);
+    protected final Provider<Program> program2Provider = Providers.createProgramFromPathString(filePathProvider);
     protected final Provider<Wmm> wmm1Provider = getSourceWmmProvider();
     protected final Provider<Wmm> wmm2Provider = getTargetWmmProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/comparison/AbstractComparisonTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/comparison/AbstractComparisonTest.java
@@ -91,9 +91,9 @@ public abstract class AbstractComparisonTest {
     protected final Provider<ShutdownManager> shutdownManagerProvider = Provider.fromSupplier(ShutdownManager::create);
     protected final Provider<Arch> sourceProvider = getSourceProvider();
     protected final Provider<Arch> targetProvider = getTargetProvider();
-    protected final Provider<String> filePathProvider = () -> path;
-    protected final Provider<Program> program1Provider = Providers.createProgramFromPathString(filePathProvider);
-    protected final Provider<Program> program2Provider = Providers.createProgramFromPathString(filePathProvider);
+    protected final Provider<Path> filePathProvider = () -> Path.of(path);
+    protected final Provider<Program> program1Provider = Providers.createProgramFromPath(filePathProvider);
+    protected final Provider<Program> program2Provider = Providers.createProgramFromPath(filePathProvider);
     protected final Provider<Wmm> wmm1Provider = getSourceWmmProvider();
     protected final Provider<Wmm> wmm2Provider = getTargetWmmProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/compilation/AbstractCompilationTest.java
@@ -99,8 +99,8 @@ public abstract class AbstractCompilationTest {
     protected final Provider<Arch> sourceProvider = getSourceProvider();
     protected final Provider<Arch> targetProvider = getTargetProvider();
     protected final Provider<String> filePathProvider = () -> path;
-    protected final Provider<Program> program1Provider = Providers.createProgramFromPath(filePathProvider);
-    protected final Provider<Program> program2Provider = Providers.createProgramFromPath(filePathProvider);
+    protected final Provider<Program> program1Provider = Providers.createProgramFromPathString(filePathProvider);
+    protected final Provider<Program> program2Provider = Providers.createProgramFromPathString(filePathProvider);
     protected final Provider<Wmm> wmm1Provider = getSourceWmmProvider();
     protected final Provider<Wmm> wmm2Provider = getTargetWmmProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/compilation/AbstractCompilationTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/litmus/compilation/AbstractCompilationTest.java
@@ -98,9 +98,9 @@ public abstract class AbstractCompilationTest {
     protected final Provider<ShutdownManager> shutdownManagerProvider = Provider.fromSupplier(ShutdownManager::create);
     protected final Provider<Arch> sourceProvider = getSourceProvider();
     protected final Provider<Arch> targetProvider = getTargetProvider();
-    protected final Provider<String> filePathProvider = () -> path;
-    protected final Provider<Program> program1Provider = Providers.createProgramFromPathString(filePathProvider);
-    protected final Provider<Program> program2Provider = Providers.createProgramFromPathString(filePathProvider);
+    protected final Provider<Path> filePathProvider = () -> Path.of(path);
+    protected final Provider<Program> program1Provider = Providers.createProgramFromPath(filePathProvider);
+    protected final Provider<Program> program2Provider = Providers.createProgramFromPath(filePathProvider);
     protected final Provider<Wmm> wmm1Provider = getSourceWmmProvider();
     protected final Provider<Wmm> wmm2Provider = getTargetWmmProvider();
     protected final Provider<EnumSet<Property>> propertyProvider = getPropertyProvider();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/AbstractCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/AbstractCTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractCTest {
     protected final Provider<Arch> targetProvider = () -> target;
     protected final Provider<String> filePathProvider = getProgramPathProvider();
     protected final Provider<Integer> boundProvider = getBoundProvider();
-    protected final Provider<Program> programProvider = Providers.createProgramFromPath(filePathProvider);
+    protected final Provider<Program> programProvider = Providers.createProgramFromPathString(filePathProvider);
     protected final Provider<Wmm> wmmProvider = getWmmProvider();
     protected final Provider<ProgressModel.Hierarchy> progressModelProvider = getProgressModelProvider();
     protected final Provider<Solvers> solverProvider = getSolverProvider();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/AbstractCTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/llvm/AbstractCTest.java
@@ -18,6 +18,7 @@ import org.sosy_lab.common.configuration.ConfigurationBuilder;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
 import org.sosy_lab.java_smt.SolverContextFactory.Solvers;
 
+import java.nio.file.Path;
 import java.util.EnumSet;
 
 import static com.dat3m.dartagnan.utils.ResourceHelper.getTestResourcePath;
@@ -82,9 +83,9 @@ public abstract class AbstractCTest {
     // Provider rules
     protected final Provider<ShutdownManager> shutdownManagerProvider = Provider.fromSupplier(ShutdownManager::create);
     protected final Provider<Arch> targetProvider = () -> target;
-    protected final Provider<String> filePathProvider = getProgramPathProvider();
+    protected final Provider<Path> filePathProvider = () -> Path.of(getProgramPathProvider().get());
     protected final Provider<Integer> boundProvider = getBoundProvider();
-    protected final Provider<Program> programProvider = Providers.createProgramFromPathString(filePathProvider);
+    protected final Provider<Program> programProvider = Providers.createProgramFromPath(filePathProvider);
     protected final Provider<Wmm> wmmProvider = getWmmProvider();
     protected final Provider<ProgressModel.Hierarchy> progressModelProvider = getProgressModelProvider();
     protected final Provider<Solvers> solverProvider = getSolverProvider();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/ResourceHelper.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/ResourceHelper.java
@@ -4,8 +4,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Predicate;
 
 import static com.dat3m.dartagnan.utils.Result.FAIL;
 import static com.dat3m.dartagnan.utils.Result.PASS;
@@ -30,50 +32,23 @@ public class ResourceHelper {
 
     public static ImmutableMap<String, Result> getExpectedResults(String arch, String postfix) throws IOException {
         String path = getTestResourcePath(arch + postfix + "-expected.csv");
-        try (BufferedReader reader = new BufferedReader(new FileReader(path))) {
-            HashMap<String, Result> data = new HashMap<>();
-            String str;
-            while((str = reader.readLine()) != null){
-                if(str.startsWith("//") || str.isBlank()) {
-                    continue;
-                }
-                String[] line = str.split(",");
-                if(line.length == 2){
-                    data.put(getRootPath(line[0]), Integer.parseInt(line[1]) == 1 ? PASS : FAIL);
-                }
+        var data = ImmutableMap.<String, Result>builder();
+        Files.readAllLines(Path.of(path)).stream().filter(ResourceHelper::isValidEntry).forEach(str -> {
+            String[] line = str.split(",");
+            if(line.length == 2){
+                data.put(getRootPath(line[0]), Integer.parseInt(line[1]) == 1 ? PASS : FAIL);
             }
-            return ImmutableMap.copyOf(data);
-        }
+        });
+        return data.build();
     }
 
     public static ImmutableSet<String> getSkipSet() throws IOException {
         String path = getTestResourcePath("dartagnan-skip.csv");
-        try (BufferedReader reader = new BufferedReader(new FileReader(path))) {
-            Set<String> data = new HashSet<>();
-            String str;
-            while((str = reader.readLine()) != null){
-            	if(str.startsWith("//") || str.isBlank()) {
-            		continue;
-                }
-            	data.add(getRootPath(str));
-            }
-            return ImmutableSet.copyOf(data);
-        }
+        return Files.readAllLines(Path.of(path)).stream().filter(ResourceHelper::isValidEntry).collect(ImmutableSet.toImmutableSet());
     }
 
-    public static Result readExpected(String filepath, String property) {
-        try (BufferedReader br = new BufferedReader(new FileReader(filepath))) {
-            String str;
-            while((str = br.readLine()) != null){
-                if (str.contains(property)) {
-                    return br.readLine().contains("false") ? FAIL : PASS;
-                }
-            }
-            throw new IllegalArgumentException("Missing expected result for property " + property);
-        } catch (Exception e) {
-            System.out.println(e.getMessage());
-            System.exit(0);
-        }
-        return null;
+    private static boolean isValidEntry(String line) {
+        return !line.isBlank() && !line.startsWith("//");
     }
+
 }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/ResourceHelper.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/ResourceHelper.java
@@ -35,7 +35,7 @@ public class ResourceHelper {
         var data = ImmutableMap.<String, Result>builder();
         Files.readAllLines(Path.of(path)).stream().filter(ResourceHelper::isValidEntry).forEach(str -> {
             String[] line = str.split(",");
-            if(line.length == 2){
+            if (line.length == 2) {
                 data.put(getRootPath(line[0]), Integer.parseInt(line[1]) == 1 ? PASS : FAIL);
             }
         });
@@ -43,8 +43,10 @@ public class ResourceHelper {
     }
 
     public static ImmutableSet<String> getSkipSet() throws IOException {
-        String path = getTestResourcePath("dartagnan-skip.csv");
-        return Files.readAllLines(Path.of(path)).stream().filter(ResourceHelper::isValidEntry).collect(ImmutableSet.toImmutableSet());
+        return Files.readAllLines(Path.of(getTestResourcePath("dartagnan-skip.csv"))).stream()
+                .filter(ResourceHelper::isValidEntry)
+                .map(ResourceHelper::getRootPath)
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     private static boolean isValidEntry(String line) {

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
@@ -10,7 +10,7 @@ import com.dat3m.dartagnan.verification.VerificationTask;
 import com.dat3m.dartagnan.wmm.Wmm;
 import org.sosy_lab.common.configuration.Configuration;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.function.Supplier;
 
@@ -32,26 +32,22 @@ public class Providers {
         return WmmFromArchitectureProvider.create(archSupplier);
     }
 
-    public static Provider<Wmm> createWmmFromFile(Supplier<File> fileSupplier) {
-        return Provider.fromSupplier(() -> new ParserCat().parse(fileSupplier.get()));
-    }
-
-    public static Provider<Wmm> createWmmFromPath(Supplier<String> pathSupplier) {
-        return createWmmFromFile(() -> new File(pathSupplier.get()));
+    public static Provider<Wmm> createWmmFromPath(Supplier<Path> pathSupplier) {
+        return Provider.fromSupplier(() -> new ParserCat().parse(pathSupplier.get()));
     }
 
     public static Provider<Wmm> createWmmFromName(Supplier<String> nameSupplier) {
-        return createWmmFromPath(() -> getRootPath("cat/" + nameSupplier.get() + ".cat"));
+        return createWmmFromPath(() -> Path.of(getRootPath("cat/" + nameSupplier.get() + ".cat")));
     }
 
     // =========================== Program providers ==============================
 
-    public static Provider<Program> createProgramFromPath(Supplier<String> pathSupplier) {
-        return createProgramFromFile(() -> new File(pathSupplier.get()));
+    public static Provider<Program> createProgramFromPathString(Supplier<String> pathSupplier) {
+        return createProgramFromPath(() -> Path.of(pathSupplier.get()));
     }
 
-    public static Provider<Program> createProgramFromFile(Supplier<File> fileSupplier) {
-        return Provider.fromSupplier(() -> new ProgramParser().parse(fileSupplier.get()));
+    public static Provider<Program> createProgramFromPath(Supplier<Path> pathSupplier) {
+        return Provider.fromSupplier(() -> new ProgramParser().parse(pathSupplier.get()));
     }
 
     // =========================== Task related providers ==============================

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/Providers.java
@@ -42,10 +42,6 @@ public class Providers {
 
     // =========================== Program providers ==============================
 
-    public static Provider<Program> createProgramFromPathString(Supplier<String> pathSupplier) {
-        return createProgramFromPath(() -> Path.of(pathSupplier.get()));
-    }
-
     public static Provider<Program> createProgramFromPath(Supplier<Path> pathSupplier) {
         return Provider.fromSupplier(() -> new ProgramParser().parse(pathSupplier.get()));
     }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/WmmFromArchitectureProvider.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/utils/rules/WmmFromArchitectureProvider.java
@@ -4,7 +4,7 @@ import com.dat3m.dartagnan.parsers.cat.ParserCat;
 import com.dat3m.dartagnan.wmm.Wmm;
 import com.dat3m.dartagnan.configuration.Arch;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -26,14 +26,14 @@ public class WmmFromArchitectureProvider extends AbstractProvider<Wmm> {
     private static final Map<Arch, UncheckedSupplier<Wmm>> ARCH_WMM_MAP = new HashMap<>();
 
     static {
-        ARCH_WMM_MAP.put(Arch.TSO, () -> new ParserCat().parse(new File(getRootPath("cat/tso.cat"))));
-        ARCH_WMM_MAP.put(Arch.ARM8, () -> new ParserCat().parse(new File(getRootPath("cat/aarch64.cat"))));
-        ARCH_WMM_MAP.put(Arch.POWER, () -> new ParserCat().parse(new File(getRootPath("cat/power.cat"))));
-        ARCH_WMM_MAP.put(Arch.RISCV, () -> new ParserCat().parse(new File(getRootPath("cat/riscv.cat"))));
-        ARCH_WMM_MAP.put(Arch.LKMM, () -> new ParserCat().parse(new File(getRootPath("cat/linux-kernel.cat"))));
-        ARCH_WMM_MAP.put(Arch.IMM, () -> new ParserCat().parse(new File(getRootPath("cat/imm.cat"))));
-        ARCH_WMM_MAP.put(Arch.VULKAN, () -> new ParserCat().parse(new File(getRootPath("cat/vulkan.cat"))));
-        ARCH_WMM_MAP.put(Arch.OPENCL, () -> new ParserCat().parse(new File(getRootPath("cat/opencl.cat"))));
+        ARCH_WMM_MAP.put(Arch.TSO, () -> new ParserCat().parse(Path.of(getRootPath("cat/tso.cat"))));
+        ARCH_WMM_MAP.put(Arch.ARM8, () -> new ParserCat().parse(Path.of(getRootPath("cat/aarch64.cat"))));
+        ARCH_WMM_MAP.put(Arch.POWER, () -> new ParserCat().parse(Path.of(getRootPath("cat/power.cat"))));
+        ARCH_WMM_MAP.put(Arch.RISCV, () -> new ParserCat().parse(Path.of(getRootPath("cat/riscv.cat"))));
+        ARCH_WMM_MAP.put(Arch.LKMM, () -> new ParserCat().parse(Path.of(getRootPath("cat/linux-kernel.cat"))));
+        ARCH_WMM_MAP.put(Arch.IMM, () -> new ParserCat().parse(Path.of(getRootPath("cat/imm.cat"))));
+        ARCH_WMM_MAP.put(Arch.VULKAN, () -> new ParserCat().parse(Path.of(getRootPath("cat/vulkan.cat"))));
+        ARCH_WMM_MAP.put(Arch.OPENCL, () -> new ParserCat().parse(Path.of(getRootPath("cat/opencl.cat"))));
     }
 
     private final Supplier<Arch> archSupplier;

--- a/dartagnan/src/test/resources/OPENCL-DR-expected.csv
+++ b/dartagnan/src/test/resources/OPENCL-DR-expected.csv
@@ -37,4 +37,3 @@ litmus/OPENCL/overhauling/ISA2_broken.litmus,0
 litmus/OPENCL/overhauling/MP_ra_dev.litmus,1
 litmus/OPENCL/overhauling/MP_ra_dev_broken.litmus,0
 litmus/OPENCL/overhauling/MP_ra_wg.litmus,0
-litmus/OPENCL/overhauling/MP_ra_dev.litmus,1

--- a/dartagnan/src/test/resources/OPENCL-expected.csv
+++ b/dartagnan/src/test/resources/OPENCL-expected.csv
@@ -38,7 +38,6 @@ litmus/OPENCL/overhauling/ISA2_broken.litmus,1
 litmus/OPENCL/overhauling/MP_ra_dev.litmus,0
 litmus/OPENCL/overhauling/MP_ra_dev_broken.litmus,1
 litmus/OPENCL/overhauling/MP_ra_wg.litmus,1
-litmus/OPENCL/overhauling/MP_ra_dev.litmus,0
 litmus/OPENCL/portedFromC11/auto/a3+sc+Racq.litmus,1
 litmus/OPENCL/portedFromC11/auto/linearisation.litmus,0
 litmus/OPENCL/portedFromC11/auto/a3+sc+Rrlx.litmus,1

--- a/dartagnan/src/test/resources/PPC-expected.csv
+++ b/dartagnan/src/test/resources/PPC-expected.csv
@@ -1850,7 +1850,6 @@ litmus/PPC/Z6.5+lwsyncs.litmus,1
 litmus/PPC/Z6.5+po+lwsync+lwsync.litmus,1
 litmus/PPC/Z6.5+po+lwsync+po.litmus,1
 litmus/PPC/Z6.5+po+lwsync+sync.litmus,1
-litmus/PPC/Z6.5+po+lwsync+sync.litmus,1
 litmus/PPC/Z6.5+po+po+lwsync.litmus,1
 litmus/PPC/Z6.5+po+po+sync.litmus,1
 litmus/PPC/Z6.5+po+sync+lwsync.litmus,1

--- a/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
+++ b/svcomp/src/main/java/com/dat3m/svcomp/SVCOMPRunner.java
@@ -11,10 +11,8 @@ import org.sosy_lab.common.configuration.Option;
 import org.sosy_lab.common.configuration.Options;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,7 +72,7 @@ public class SVCOMPRunner extends BaseOptions {
         if(Arrays.stream(args).noneMatch(a -> a.endsWith(".cat"))) {
             throw new IllegalArgumentException("CAT model not given or format not recognized");
         }
-        File fileModel = new File(Arrays.stream(args).filter(a -> a.endsWith(".cat")).findFirst().get());
+        Path fileModel = Path.of(Arrays.stream(args).filter(a -> a.endsWith(".cat")).findFirst().get());
         Path programPath = Arrays.stream(args).filter(a -> supportedFormats.stream().anyMatch(a::endsWith)).map(Path::of).findFirst().get();
         // To be sure we do not mixed benchmarks, if the bounds file exists, delete it
         Path boundsFilePath = getHomeDirectory().resolve("bounds.csv");

--- a/ui/src/main/java/com/dat3m/ui/Dat3M.java
+++ b/ui/src/main/java/com/dat3m/ui/Dat3M.java
@@ -141,9 +141,13 @@ public class Dat3M extends JFrame implements ActionListener {
             final String format = programEditor.getLoadedFormat().isEmpty()
                     ? ProgramParser.EXTENSION_C            // We default to "c" code, if we do not know
                     : programEditor.getLoadedFormat();
-            final String cflags = options.cflags().isEmpty()
+            String cflags = options.cflags().isEmpty()
                     ? System.getenv().getOrDefault("CFLAGS", "")
                     : options.cflags();
+            if (format.equals(ProgramParser.EXTENSION_C) && !programEditor.getLoadedDir().isEmpty()) {
+                // Include directory of loaded C file
+                cflags += " -I" + programEditor.getLoadedDir();
+            }
             final Program program = new ProgramParser().parse(sourceCode, format, cflags);
             program.setName("dat3mUI");
             try {

--- a/ui/src/main/java/com/dat3m/ui/Dat3M.java
+++ b/ui/src/main/java/com/dat3m/ui/Dat3M.java
@@ -137,16 +137,18 @@ public class Dat3M extends JFrame implements ActionListener {
         testResult = null;
         try {
             final Editor programEditor = editorsPane.getEditor(EditorCode.PROGRAM);
-            // We default to "c" code, if we do not know
-            final String format = programEditor.getLoadedFormat().isEmpty() ? ProgramParser.EXTENSION_C : programEditor.getLoadedFormat();
-            final String cflags = options.cflags().isEmpty() ? System.getenv().getOrDefault("CFLAGS", "") : options.cflags();
-            final Program program = new ProgramParser().parse(programEditor.getEditorPane().getText(),
-                    format,
-                    cflags
-            );
+            final String sourceCode = programEditor.getEditorPane().getText();
+            final String format = programEditor.getLoadedFormat().isEmpty()
+                    ? ProgramParser.EXTENSION_C            // We default to "c" code, if we do not know
+                    : programEditor.getLoadedFormat();
+            final String cflags = options.cflags().isEmpty()
+                    ? System.getenv().getOrDefault("CFLAGS", "")
+                    : options.cflags();
+            final Program program = new ProgramParser().parse(sourceCode, format, cflags);
             program.setName("dat3mUI");
             try {
-                final Wmm targetModel = new ParserCat().parse(editorsPane.getEditor(EditorCode.TARGET_MM).getEditorPane().getText());
+                final String wmmCode = editorsPane.getEditor(EditorCode.TARGET_MM).getEditorPane().getText();
+                final Wmm targetModel = new ParserCat().parse(wmmCode);
                 testResult = new ReachabilityResult(program, targetModel, options);
             } catch (Exception e) {
                 final String msg = e.getMessage() == null ? "Memory model cannot be parsed" : e.getMessage();

--- a/ui/src/main/java/com/dat3m/ui/Dat3M.java
+++ b/ui/src/main/java/com/dat3m/ui/Dat3M.java
@@ -91,7 +91,7 @@ public class Dat3M extends JFrame implements ActionListener {
     }
 
     private void showViolation(ReachabilityResult testResult) {
-        final String filePath = testResult.getWitnessFile().getAbsolutePath();
+        final String filePath = testResult.getWitnessFile().toAbsolutePath().toString();
 
         // Generate scroll pane with image of violation
         final ImageIcon imageIcon = new ImageIcon(filePath);

--- a/ui/src/main/java/com/dat3m/ui/Dat3M.java
+++ b/ui/src/main/java/com/dat3m/ui/Dat3M.java
@@ -139,10 +139,11 @@ public class Dat3M extends JFrame implements ActionListener {
             final Editor programEditor = editorsPane.getEditor(EditorCode.PROGRAM);
             // We default to "c" code, if we do not know
             final String format = programEditor.getLoadedFormat().isEmpty() ? ProgramParser.EXTENSION_C : programEditor.getLoadedFormat();
+            final String cflags = options.cflags().isEmpty() ? System.getenv().getOrDefault("CFLAGS", "") : options.cflags();
             final Program program = new ProgramParser().parse(programEditor.getEditorPane().getText(),
-                    programEditor.getLoadedPath(),
                     format,
-                    options.cflags());
+                    cflags
+            );
             program.setName("dat3mUI");
             try {
                 final Wmm targetModel = new ParserCat().parse(editorsPane.getEditor(EditorCode.TARGET_MM).getEditorPane().getText());

--- a/ui/src/main/java/com/dat3m/ui/editor/Editor.java
+++ b/ui/src/main/java/com/dat3m/ui/editor/Editor.java
@@ -34,7 +34,7 @@ public class Editor extends RTextScrollPane implements ActionListener {
 
     private final ImmutableSet<String> allowedFormats;
     private String loadedFormat = "";
-    private String loadedPath = "";
+    private String loadedDir = "";
 
     private final Set<ActionListener> actionListeners = new HashSet<>();
 
@@ -90,8 +90,8 @@ public class Editor extends RTextScrollPane implements ActionListener {
         return loadedFormat;
     }
 
-    public String getLoadedPath() {
-        return loadedPath;
+    public String getLoadedDir() {
+        return loadedDir;
     }
 
     @Override
@@ -112,7 +112,7 @@ public class Editor extends RTextScrollPane implements ActionListener {
             return;
         }
         final File selectedFile = chooser.getSelectedFile();
-        loadedPath = Objects.requireNonNullElse(selectedFile.getParent(), "");
+        loadedDir = Objects.requireNonNullElse(selectedFile.getParent(), "");
         loadedFormat = allowedFormats.stream().filter(selectedFile.getName()::endsWith).findAny().orElse("");
         if (loadedFormat.isEmpty()) {
             showError("Please select a *" + String.join(", *", allowedFormats) + " file", "Invalid file format");

--- a/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
+++ b/ui/src/main/java/com/dat3m/ui/result/ReachabilityResult.java
@@ -12,7 +12,7 @@ import com.dat3m.ui.utils.UiOptions;
 import com.dat3m.ui.utils.Utils;
 import org.sosy_lab.common.configuration.Configuration;
 
-import java.io.File;
+import java.nio.file.Path;
 
 public class ReachabilityResult {
 
@@ -21,7 +21,7 @@ public class ReachabilityResult {
     private final UiOptions options;
 
     private String verdict;
-    private File witnessFile;
+    private Path witnessFile;
 
 
     public ReachabilityResult(Program program, Wmm wmm, UiOptions options) {
@@ -39,7 +39,7 @@ public class ReachabilityResult {
         return witnessFile != null;
     }
 
-    public File getWitnessFile() {
+    public Path getWitnessFile() {
         return witnessFile;
     }
 


### PR DESCRIPTION
- I have replaced most usages of `File` in the Dartagnan core part by `Path`. The remaining usages of `File` are all in the unit tests and the UI code.
- The `ProgramParser` and the backend `Compilation` classes have been simplified a bit. The latter now always constructs a temporary .c file in a temp directory when compiling raw input. In particular, the UI does not create a `dat3m.c` in the directory of a loaded .c file anymore (this was ugly!).

