### PR TITLE
Fix branch equivalence

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
@@ -229,6 +229,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
                 final Branch creatorBranch = decomposition.event2BranchMap.get(start.getCreator());
                 threadInitialBranch.mustPred.add(creatorBranch);
                 threadInitialBranch.exclusiveBranches.addAll(creatorBranch.exclusiveBranches);
+                creatorBranch.exclusiveBranches.forEach(b -> b.exclusiveBranches.add(threadInitialBranch));
                 creatorBranch.mustSucc.add(threadInitialBranch);
             } else {
                 unconditionalThreadInitialBranches.add(threadInitialBranch);

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
@@ -340,6 +340,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
 
             unreachableClass.impliedClasses.addAll(this.getAllTypedEqClasses());
             unreachableClass.exclusiveClasses.addAll(this.getAllTypedEqClasses());
+            unreachableClass.exclusiveClasses.remove(unreachableClass);
             this.<BranchClass>getAllTypedEqClasses().forEach(c -> c.exclusiveClasses.add(unreachableClass));
         }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/BranchEquivalence.java
@@ -339,6 +339,7 @@ public class BranchEquivalence extends AbstractEquivalence<Event> {
                     .get();
 
             unreachableClass.impliedClasses.addAll(this.getAllTypedEqClasses());
+            unreachableClass.exclusiveClasses.addAll(this.getAllTypedEqClasses());
             this.<BranchClass>getAllTypedEqClasses().forEach(c -> c.exclusiveClasses.add(unreachableClass));
         }
 

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/AnalysisTest.java
@@ -28,6 +28,7 @@ import com.dat3m.dartagnan.program.memory.MemoryObject;
 import com.dat3m.dartagnan.program.processing.LoopUnrolling;
 import com.dat3m.dartagnan.program.processing.MemoryAllocation;
 import com.dat3m.dartagnan.program.processing.ProcessingManager;
+import com.dat3m.dartagnan.program.processing.ThreadCreation;
 import com.dat3m.dartagnan.program.processing.compilation.Compilation;
 import com.dat3m.dartagnan.verification.Context;
 import com.dat3m.dartagnan.verification.VerificationTask;
@@ -38,6 +39,7 @@ import com.dat3m.dartagnan.wmm.analysis.RelationAnalysis;
 import com.dat3m.dartagnan.wmm.axiom.Emptiness;
 import com.dat3m.dartagnan.wmm.definition.Composition;
 import com.dat3m.dartagnan.wmm.definition.Intersection;
+import com.dat3m.dartagnan.wmm.utils.Tuple;
 import org.junit.Test;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
@@ -68,6 +70,38 @@ public class AnalysisTest {
 
     private static final TypeFactory types = TypeFactory.getInstance();
     private static final ExpressionFactory expressions = ExpressionFactory.getInstance();
+
+    @Test
+    public void branchEquivalenceIsSymmetricOnUnreachableCode() throws InvalidConfigurationException {
+        final ProgramBuilder b = ProgramBuilder.forLanguage(SourceLanguage.LITMUS);
+        b.newThread(0);
+        final Label skip = b.getOrCreateLabel(0, "skip");
+        b.addChildWithoutSourceLoc(0, newGoto(skip));
+        b.addChildWithoutSourceLoc(0, newGoto(skip)); // unreachable
+        b.addChildWithoutSourceLoc(0, skip);
+
+        final Configuration config = Configuration.defaultConfiguration();
+        final Program program = b.build();
+        Compilation.newInstance().run(program);
+        LoopUnrolling.newInstance().run(program);
+        ThreadCreation.fromConfig(config).run(program);
+        final BranchEquivalence branchEquivalence = BranchEquivalence.fromConfig(program, config);
+        checkExclusiveSymmetry(branchEquivalence, program.getThreadEvents());
+    }
+
+    private void checkExclusiveSymmetry(BranchEquivalence be, List<Event> events) {
+        final var mismatch = new ArrayList<Tuple>();
+        for (int i0 = 0; i0 < events.size(); i0++) {
+            final Event e0 = events.get(i0);
+            for (int i1 = i0; i1 < events.size(); i1++) {
+                final Event e1 = events.get(i1);
+                if (be.areMutuallyExclusive(e0, e1) != be.areMutuallyExclusive(e1, e0)) {
+                    mismatch.add(new Tuple(e0, e1));
+                }
+            }
+        }
+        assertTrue(mismatch.isEmpty());
+    }
 
     @Test
     public void reachingDefinitionMustOverride() throws InvalidConfigurationException {


### PR DESCRIPTION
Fixes a bug where uneliminated dead code leads to asymmetric results in `BranchEquivalence.areMutuallyExclusive(Event,Event)`.

Let `a` and `b` be unreachable events and `c` be reachable.  
```java
be.areMutuallyExclusive(a, a) // false -> true
be.areMutuallyExclusive(a, b) // false -> true
be.areMutuallyExclusive(a, c) // false -> true
be.areMutuallyExclusive(c, a) // true  -> true
```

Solves a problem in #1060.  A failing test showed different results between `LazyRelationAnalysis` and `NativeRelationAnalysis` (without XRA) on some programs.  The only affected relation was `loc`.  While LRA relied on the symmetry assumption of `loc`, NRA did not.  So at least one of the subroutines `AliasAnalysis.mayAlias` or `ExcutionAnalysis.areMutualExclusive` had to be asymmetric for some event pairs.  That MR exposed this bug because it reorders the branches and alters the results of LRA.