### PR TITLE
Fix indexed event graph

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/graph/mutable/IndexedEventGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/graph/mutable/IndexedEventGraph.java
@@ -154,7 +154,7 @@ public final class IndexedEventGraph extends AbstractEventGraph implements Mutab
 
     @Override
     public IndexedSet<Event> getRange(Event e) {
-        final IndexedSet<Event> range = outSetAt(rangeEvents().indexOf(e));
+        final IndexedSet<Event> range = outSetAt(domainEvents().indexOf(e));
         return range == null ? emptyRange : range.toUnmodifiableCopy();
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/graph/mutable/IndexedEventGraph.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/utils/graph/mutable/IndexedEventGraph.java
@@ -54,8 +54,8 @@ public final class IndexedEventGraph extends AbstractEventGraph implements Mutab
 
     public IndexedDomain<Event> eventDomain(Dimension dimension) {
         return switch (dimension) {
-            case DOMAIN -> domain.domain();
-            case RANGE -> emptyRange.domain();
+            case DOMAIN -> domainEvents();
+            case RANGE -> rangeEvents();
         };
     }
 
@@ -71,7 +71,7 @@ public final class IndexedEventGraph extends AbstractEventGraph implements Mutab
 
     @Override
     public boolean contains(Event e1, Event e2) {
-        final IndexedSet<Event> set = outSetAt(domain.domain().indexOf(e1));
+        final IndexedSet<Event> set = outSetAt(domainEvents().indexOf(e1));
         return set != null && set.contains(e2);
     }
 
@@ -163,7 +163,7 @@ public final class IndexedEventGraph extends AbstractEventGraph implements Mutab
         for (int i = 0; i < map.length; i++) {
             final IndexedSet<Event> range = outSetAt(i);
             if (range != null) {
-                final Event e1 = domain.domain().element(i);
+                final Event e1 = domainEvents().element(i);
                 for (Event e2 : range) {
                     f.accept(e1, e2);
                 }
@@ -200,14 +200,14 @@ public final class IndexedEventGraph extends AbstractEventGraph implements Mutab
     @Override
     public boolean addAll(EventGraph other) {
         if (other instanceof IndexedEventGraph indexedOther
-                && domain.domain().isCompatibleWith(indexedOther.domain.domain())
-                && emptyRange.domain().isCompatibleWith(indexedOther.emptyRange.domain())) {
+                && domainEvents().isCompatibleWith(indexedOther.domainEvents())
+                && rangeEvents().isCompatibleWith(indexedOther.rangeEvents())) {
             int diff = 0;
             for (int index = 0; index < map.length; index++) {
                 final IndexedSet<Event> otherOutSet = indexedOther.outSetAt(index);
                 if (otherOutSet != null) {
                     final IndexedSet<Event> foundOutSet = outSetAt(index);
-                    final IndexedSet<Event> outSet = foundOutSet != null ? foundOutSet : emptyRange.domain().newSet();
+                    final IndexedSet<Event> outSet = foundOutSet != null ? foundOutSet : rangeEvents().newSet();
                     diff -= foundOutSet == null ? 0 : outSet.size();
                     outSet.addAll(otherOutSet);
                     diff += outSet.size();

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/wmm/utils/graph/mutable/MutableEventGraphTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/wmm/utils/graph/mutable/MutableEventGraphTest.java
@@ -2,6 +2,8 @@ package com.dat3m.dartagnan.others.wmm.utils.graph.mutable;
 
 import com.dat3m.dartagnan.program.event.Event;
 import com.dat3m.dartagnan.program.event.core.Skip;
+import com.dat3m.dartagnan.utils.collections.IndexedDomain;
+import com.dat3m.dartagnan.wmm.utils.graph.mutable.IndexedEventGraph;
 import com.dat3m.dartagnan.wmm.utils.graph.mutable.MapEventGraph;
 import com.dat3m.dartagnan.wmm.utils.graph.mutable.MutableEventGraph;
 import org.junit.Test;
@@ -9,7 +11,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -746,6 +750,26 @@ public class MutableEventGraphTest {
 
         // then
         assertTrue(eventGraph.isEmpty());
+    }
+
+    @Test
+    public void indexedEventGraphIntoSmallerRange() {
+        // given
+        final List<Event> events = new ArrayList<>();
+        for (int i = 0; i < 129; i++) {
+            events.add(new Skip());
+        }
+        final IndexedDomain<Event> larger = new IndexedDomain<>(events);
+        final IndexedDomain<Event> smaller = new IndexedDomain<>(events.subList(0, 65));
+        final IndexedEventGraph eventGraph = new IndexedEventGraph(larger, smaller);
+
+        // when
+        eventGraph.add(events.get(65), events.get(0));
+
+        // then
+        assertTrue(eventGraph.contains(events.get(65), events.get(0)));
+        assertEquals(eventGraph.getRange(events.get(65)), Set.of(events.get(0)));
+        assertEquals(eventGraph.getRange(), Set.of(events.get(0)));
     }
 
     private MutableEventGraph makeEventGraph(Class<?> cls, Map<Event, Set<Event>> data) {


### PR DESCRIPTION
Fixes a bug in `IndexedEventGraph.getRange(Event)` where the wrong `IndexedDomain` was used to check the domain-sided event.  This leads to graphs with different domains appearing smaller than they actually are.  (

Let `dom` and `rng` be of type `IndexedDomain<Event>`.  Let `a` and `b` be events.
```java
assume(dom.fullSet().contains(a));
assume(rng.fullSet().contains(b));
assume(!rng.fullSet().contains(a));
var g = new IndexedEventGraph(dom, rng);
g.add(a, b);
g.contains(a, b); // before: true, now: true
g.size(); // before: 1, now: 1
g.getRange(); // before: [b], now [b]
g.getRange(a) // before: [], now: [b]
g.toString(); // before: "[]", now: "[(a,b)]"
```

This bug affects `NativeRelationAnalysis` on relations with different domains, like `__iddTrans ; __addrDirect`.  All of them are only joined over visible events (in the smaller domain).  So the missing edges are inactive.  No verification result is affected.