### PR TITLE
[DRAFT] Fix CAS dep arm8

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/encoding/WmmEncoder.java
@@ -336,6 +336,7 @@ public class WmmEncoder {
 
         // ASSUMPTION: The active set of a static relation is a subset of the most precise may-set.
         //             This holds true as long as our RA computes the most precise may-set for static relations.
+        // FIXME: This assumption is violated by CourseRelationAnalysis: we will produce wrong results!
         private void visitStatic(Definition def) {
             final Relation rel = def.getDefinedRelation();
             final EncodingContext.EdgeEncoder edge = context.edge(rel);
@@ -590,6 +591,9 @@ public class WmmEncoder {
                     .get(ReachingDefinitionsAnalysis.class);
             final EncodingContext.EdgeEncoder edge = context.edge(dep.getDefinedRelation());
             getActiveSet(dep).apply((writer, reader) -> {
+                // FIXME: We cannot simply set edges between NO_CARRY_DEPS-annotated events
+                //  to false, because we use the idd-edges also to encode the data flow, not just
+                //  the dependencies.
                 if (!(writer instanceof RegWriter wr) || !(reader instanceof RegReader rr)) {
                     enc.add(bmgr.not(edge.encode(writer, reader)));
                 } else {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -70,15 +70,19 @@ class VisitorArm8 extends VisitorBase {
         final Store store = newRMWStoreWithMo(load, address, cas.getStoreValue(), storeMo);
         final Expression cmp = expressions.makeEQ(dummy, cas.getExpectedValue());
         final Label casEnd = newLabel("CAS_end");
-        final CondJump checkCond = newJumpUnless(cmp, casEnd);
+        final Label casFailure = newLabel("CAS_failure");
+        final CondJump checkCond = newJumpUnless(cmp, casFailure);
         checkCond.addTags(Tag.NO_CARRY_DEPS); // CAS does not carry ctrl-deps!
 
         return eventSequence(
                 load,
                 checkCond,
                 store,
-                casEnd,
-                newLocal(resultRegister, dummy)
+                newLocal(resultRegister, cas.getExpectedValue()),
+                newGoto(casEnd),
+                casFailure,
+                newLocal(resultRegister, dummy),
+                casEnd
         );
     }
 

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/processing/compilation/VisitorArm8.java
@@ -70,10 +70,12 @@ class VisitorArm8 extends VisitorBase {
         final Store store = newRMWStoreWithMo(load, address, cas.getStoreValue(), storeMo);
         final Expression cmp = expressions.makeEQ(dummy, cas.getExpectedValue());
         final Label casEnd = newLabel("CAS_end");
+        final CondJump checkCond = newJumpUnless(cmp, casEnd);
+        checkCond.addTags(Tag.NO_CARRY_DEPS); // CAS does not carry ctrl-deps!
 
         return eventSequence(
                 load,
-                newJumpUnless(cmp, casEnd),
+                checkCond,
                 store,
                 casEnd,
                 newLocal(resultRegister, dummy)

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/wmm/analysis/NativeRelationAnalysis.java
@@ -569,8 +569,8 @@ public class NativeRelationAnalysis implements RelationAnalysis {
             final IndexedEventGraph must = newGraphForDefinition(ctrlDep);
             for (Thread thread : program.getThreads()) {
                 for (CondJump jump : thread.getEvents(CondJump.class)) {
-                    if (jump.isGoto() || jump.isDead()) {
-                        continue; // There is no point in ctrl-edges from unconditional jumps.
+                    if (jump.isGoto() || jump.isDead() || jump.hasTag(NO_CARRY_DEPS)) {
+                        continue;
                     }
 
                     final List<Event> ctrlDependentEvents;
@@ -598,7 +598,7 @@ public class NativeRelationAnalysis implements RelationAnalysis {
 
         @Override
         public MutableKnowledge visitInternalDataDependency(DirectDataDependency idd) {
-            // FIXME: Our "internal data dependency" relation is quite odd an contains all but address dependencies.
+            // FIXME: Our "internal data dependency" relation is quite odd and contains all but address dependencies.
             return computeInternalDependencies(EnumSet.of(DATA, CTRL, OTHER));
         }
 
@@ -964,6 +964,9 @@ public class NativeRelationAnalysis implements RelationAnalysis {
                     if (!usageTypes.contains(regRead.usageType())) {
                         continue;
                     }
+                    // FIXME: We cannot simply skip NO_CARRY_DEPS annotated events
+                    //  because we use the idd-edges also to encode the data flow, not just
+                    //  the dependencies.
                     final var reachDef = state.ofRegister(regRead.register());
                     for (Event regWriter : reachDef.getMayWriters()) {
                         may.add(regWriter, regReader);


### PR DESCRIPTION
See #1078 for details.

In short:
- CAS does not produce ctrl-deps unlike LX/SX.
  EDIT: I think the CAS should still produce a ctrl-dep to the CAS store but not beyond. This would be similar to language-level ctrl-deps. I guess we need better support from structured control-flow in the core (`IfAsJump` feels kinda hacky ATM).
- CAS does not (necessarily) produce a data dep on successful CAS. This seems surprising, but the idea is that a successful CAS can funnel through the expected value rather than the freshly loaded value (since they are equal anyhow). I assume that in this case, if the expected value is loaded from memory, the CAS may extend the dependency from that load instead of producing a new dependency!
EDIT: This behavior is actually non-deterministic and depends on whether the hardware can predict the success of the CAS. A faithful implementation would need to guess here (the current one always assumes correct prediction).

TODO: 
- Add all tests mentioned in #1078
- Fix the problems mentioned in the EDITs above
