### PR TITLE
Add script and CI job to compare performance of PRs

### DIFF
--- a/.github/performance-benchmarks.yml
+++ b/.github/performance-benchmarks.yml
@@ -1,5 +1,5 @@
 # Each entry is one deliberately selected performance measurement. Paths are relative to the repository root.
-# Configurations may add command-line options, for example: options: ["--bound=2"].
+# Options on an entry apply to every configuration; configurations can add their own options.
 benchmarks:
   - program: benchmarks/locks/cna.c
     runs: 3
@@ -9,11 +9,60 @@ benchmarks:
       - cat: cat/vmm.cat
         target: c11
 
+  - program: benchmarks/locks/linuxrwlock.c
+    runs: 3
+    options: ["--bound=2"]
+    configurations:
+      - cat: cat/aarch64.cat
+        target: arm8
+      - cat: cat/power.cat
+        target: power
+
+  - program: benchmarks/locks/mutex_musl.c
+    runs: 3
+    configurations:
+      - cat: cat/aarch64.cat
+        target: arm8
+        options: ["--bound=5"]
+      - cat: cat/power.cat
+        target: power
+        options: ["--bound=4"]
+      - cat: cat/vmm.cat
+        target: c11
+        options: ["--bound=3"]
+
   - program: benchmarks/lfds/dglm.c
+    runs: 3
+    configurations:
+      - cat: cat/aarch64.cat
+        target: arm8
+        options: ["--bound=3"]
+      - cat: cat/power.cat
+        target: power
+      - cat: cat/vmm.cat
+        target: c11
+        options: ["--bound=2"]
+
+  - program: benchmarks/lfds/ms.c
+    runs: 3
+    options: ["--bound=2"]
+    configurations:
+      - cat: cat/aarch64.cat
+        target: arm8
+      - cat: cat/power.cat
+        target: power
+      - cat: cat/vmm.cat
+        target: c11
+
+  - program: benchmarks/lfds/treiber.c
     runs: 3
     configurations:
       - cat: cat/power.cat
         target: power
+        options: ["--bound=4"]
+      - cat: cat/vmm.cat
+        target: c11
+        options: ["--bound=3"]
 
   - program: benchmarks/lfds/safe_stack.c
     runs: 3
@@ -24,6 +73,9 @@ benchmarks:
   - program: benchmarks/challenging/cna.c
     runs: 3
     configurations:
+      - cat: cat/aarch64.cat
+        target: arm8
+        options: ["--bound=2"]
       - cat: cat/vmm.cat
         target: c11
 
@@ -32,5 +84,3 @@ benchmarks:
     configurations:
       - cat: cat/aarch64.cat
         target: arm8
-      - cat: cat/vmm.cat
-        target: c11

--- a/.github/performance-benchmarks.yml
+++ b/.github/performance-benchmarks.yml
@@ -1,37 +1,36 @@
-# Each entry selects matching source files below its directory. Paths are relative to the repository root.
-# A folder exclude skips files for every configuration; a configuration exclude skips files only for itself.
+# Each entry is one deliberately selected performance measurement. Paths are relative to the repository root.
+# Configurations may add command-line options, for example: options: ["--bound=2"].
 benchmarks:
-  - directory: benchmarks/locks
-    include: ["*.c"]
+  - program: benchmarks/locks/cna.c
     runs: 3
     configurations:
-      - cat: cat/aarch64.cat
-        target: arm8
       - cat: cat/power.cat
         target: power
       - cat: cat/vmm.cat
         target: c11
 
-  - directory: benchmarks/lfds
-    include: ["*.c"]
+  - program: benchmarks/lfds/dglm.c
     runs: 3
     configurations:
-      - cat: cat/aarch64.cat
-        target: arm8
       - cat: cat/power.cat
         target: power
-        exclude: ["safe_stack.c"]
+
+  - program: benchmarks/lfds/safe_stack.c
+    runs: 3
+    configurations:
       - cat: cat/vmm.cat
         target: c11
 
-  - directory: benchmarks/challenging
-    include: ["*.c"]
+  - program: benchmarks/challenging/cna.c
+    runs: 3
+    configurations:
+      - cat: cat/vmm.cat
+        target: c11
+
+  - program: benchmarks/challenging/wsq.c
     runs: 3
     configurations:
       - cat: cat/aarch64.cat
         target: arm8
-      - cat: cat/power.cat
-        target: power
-        exclude: ["cna.c", "wsq.c"]
       - cat: cat/vmm.cat
         target: c11

--- a/.github/performance-benchmarks.yml
+++ b/.github/performance-benchmarks.yml
@@ -4,8 +4,6 @@ benchmarks:
   - program: benchmarks/locks/cna.c
     runs: 3
     configurations:
-      - cat: cat/power.cat
-        target: power
       - cat: cat/vmm.cat
         target: c11
 

--- a/.github/performance-benchmarks.yml
+++ b/.github/performance-benchmarks.yml
@@ -1,0 +1,37 @@
+# Each entry selects matching source files below its directory. Paths are relative to the repository root.
+# A folder exclude skips files for every configuration; a configuration exclude skips files only for itself.
+benchmarks:
+  - directory: benchmarks/locks
+    include: ["*.c"]
+    runs: 3
+    configurations:
+      - cat: cat/aarch64.cat
+        target: arm8
+      - cat: cat/power.cat
+        target: power
+      - cat: cat/vmm.cat
+        target: c11
+
+  - directory: benchmarks/lfds
+    include: ["*.c"]
+    runs: 3
+    configurations:
+      - cat: cat/aarch64.cat
+        target: arm8
+      - cat: cat/power.cat
+        target: power
+        exclude: ["safe_stack.c"]
+      - cat: cat/vmm.cat
+        target: c11
+
+  - directory: benchmarks/challenging
+    include: ["*.c"]
+    runs: 3
+    configurations:
+      - cat: cat/aarch64.cat
+        target: arm8
+      - cat: cat/power.cat
+        target: power
+        exclude: ["cna.c", "wsq.c"]
+      - cat: cat/vmm.cat
+        target: c11

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -64,7 +64,7 @@ jobs:
             --base-checkout "$GITHUB_WORKSPACE/base" \
             --head-checkout "$GITHUB_WORKSPACE/head" \
             --timeout 180 \
-            --jobs 1 \
+            --jobs 3 \
             --min-average-seconds 5 \
             --markdown performance/report.md \
             --json performance/results.json

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -64,7 +64,7 @@ jobs:
             --base-checkout "$GITHUB_WORKSPACE/base" \
             --head-checkout "$GITHUB_WORKSPACE/head" \
             --timeout 300 \
-            --jobs 3 \
+            --jobs 1 \
             --min-average-seconds 5 \
             --markdown performance/report.md \
             --json performance/results.json

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -14,8 +14,18 @@ concurrency:
 
 jobs:
   compare:
-    name: Check for performance regressions
-    runs-on: ubuntu-latest
+    name: Check for performance regressions (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: Linux x64
+            runner: ubuntu-latest
+            artifact: linux-x64
+          - platform: macOS ARM64
+            runner: macos-14
+            artifact: macos-arm64
     steps:
       - name: Check out base revision
         uses: actions/checkout@v4
@@ -72,17 +82,43 @@ jobs:
       - name: Publish performance artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: performance-comparison
+          name: performance-comparison-${{ matrix.artifact }}
           path: performance/
 
+  publish-report:
+    name: Publish performance report
+    needs: compare
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Linux report
+        uses: actions/download-artifact@v4
+        with:
+          name: performance-comparison-linux-x64
+          path: performance/linux-x64
+
+      - name: Download macOS report
+        uses: actions/download-artifact@v4
+        with:
+          name: performance-comparison-macos-arm64
+          path: performance/macos-arm64
+
       - name: Update pull request comment
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const marker = '<!-- dat3m-performance-report -->';
-            const body = fs.readFileSync('performance/report.md', 'utf8');
+            const reports = [
+              ['Linux x64', 'performance/linux-x64/report.md'],
+              ['macOS ARM64', 'performance/macos-arm64/report.md'],
+            ];
+            const body = marker + '\n# Performance comparison\n' + reports.map(([platform, path]) => {
+              const report = fs.readFileSync(path, 'utf8').replace(
+                /^<!-- dat3m-performance-report -->\n## Performance comparison\n?/, '',
+              );
+              return `\n## ${platform}\n${report}`;
+            }).join('');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,96 @@
+name: Performance regression
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Check for performance regressions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out base revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Check out PR revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: head
+          persist-credentials: false
+
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          distribution: graalvm
+          components: native-image
+          cache: maven
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install performance-script dependencies
+        run: python -m pip install PyYAML
+
+      - name: Build base native executable
+        working-directory: base
+        run: mvn --batch-mode -Pnative package -DskipTests -pl dartagnan
+
+      - name: Build PR native executable
+        working-directory: head
+        run: mvn --batch-mode -Pnative package -DskipTests -pl dartagnan
+
+      - name: Compare performance
+        run: |
+          mkdir -p performance
+          python head/scripts/compare_performance.py \
+            --benchmarks head/.github/performance-benchmarks.yml \
+            --base-checkout "$GITHUB_WORKSPACE/base" \
+            --head-checkout "$GITHUB_WORKSPACE/head" \
+            --timeout 300 \
+            --jobs 3 \
+            --min-average-seconds 5 \
+            --markdown performance/report.md \
+            --json performance/results.json
+
+      - name: Publish performance artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-comparison
+          path: performance/
+
+      - name: Update pull request comment
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- dat3m-performance-report -->';
+            const body = fs.readFileSync('performance/report.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const previous = comments.find(comment => comment.user.type === 'Bot' && comment.body.includes(marker));
+            if (previous) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: previous.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -63,7 +63,7 @@ jobs:
             --benchmarks head/.github/performance-benchmarks.yml \
             --base-checkout "$GITHUB_WORKSPACE/base" \
             --head-checkout "$GITHUB_WORKSPACE/head" \
-            --timeout 300 \
+            --timeout 180 \
             --jobs 1 \
             --min-average-seconds 5 \
             --markdown performance/report.md \

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -64,7 +64,7 @@ jobs:
             --base-checkout "$GITHUB_WORKSPACE/base" \
             --head-checkout "$GITHUB_WORKSPACE/head" \
             --timeout 180 \
-            --jobs 3 \
+            --jobs 1 \
             --min-average-seconds 5 \
             --markdown performance/report.md \
             --json performance/results.json

--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Compare Dartagnan execution times for two repository revisions."""
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import fnmatch
+import json
+import math
+import os
+from pathlib import Path
+import re
+import statistics
+import subprocess
+import sys
+
+import yaml
+
+
+MAX_TIMEOUT_ATTEMPTS = 3
+
+
+TIME_PATTERN = re.compile(r"^Time:\s+(?:(?P<minutes>\d+):)?(?P<seconds>\d+(?:\.\d+)?)\s+(?:secs|mins)\s*$", re.MULTILINE)
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmarks", type=Path, required=True)
+    parser.add_argument("--base-checkout", type=Path, required=True)
+    parser.add_argument("--head-checkout", type=Path, required=True)
+    parser.add_argument("--timeout", type=float, required=True, help="timeout for one verification run in seconds")
+    parser.add_argument("--jobs", type=int, required=True, help="number of benchmark runs to execute in parallel")
+    parser.add_argument("--min-average-seconds", type=float, required=True)
+    parser.add_argument("--markdown", type=Path, required=True)
+    parser.add_argument("--json", type=Path, required=True)
+    arguments = parser.parse_args()
+    if arguments.min_average_seconds < 0:
+        parser.error("--min-average-seconds must not be negative")
+    if arguments.timeout <= 0:
+        parser.error("--timeout must be positive")
+    if arguments.jobs < 1:
+        parser.error("--jobs must be positive")
+    return arguments
+
+
+def load_benchmarks(benchmark_path):
+    with benchmark_path.open(encoding="utf-8") as benchmark_file:
+        benchmark_selection = yaml.safe_load(benchmark_file)
+    if not isinstance(benchmark_selection, dict) or not isinstance(benchmark_selection.get("benchmarks"), list):
+        raise ValueError("Benchmark file must contain a 'benchmarks' list")
+
+    benchmarks = []
+    for entry in benchmark_selection["benchmarks"]:
+        if not isinstance(entry, dict):
+            raise ValueError("Each performance benchmark entry must be a mapping")
+        required_keys = {"directory", "include", "runs", "configurations"}
+        missing_keys = required_keys - entry.keys()
+        if missing_keys:
+            raise ValueError("Benchmark entry is missing: " + ", ".join(sorted(missing_keys)))
+        if not isinstance(entry["directory"], str):
+            raise ValueError("Benchmark directory must be a string")
+        if not isinstance(entry["runs"], int) or isinstance(entry["runs"], bool) or entry["runs"] < 1:
+            raise ValueError("Benchmark runs must be a positive integer")
+        if not isinstance(entry["include"], list) or not entry["include"] or not all(isinstance(pattern, str) for pattern in entry["include"]):
+            raise ValueError("Benchmark include must be a non-empty list of strings")
+        folder_excludes = entry.get("exclude", [])
+        if not isinstance(folder_excludes, list) or not all(isinstance(pattern, str) for pattern in folder_excludes):
+            raise ValueError("Benchmark exclude must be a list of strings")
+
+        directory = Path(entry["directory"])
+        if directory.is_absolute() or ".." in directory.parts:
+            raise ValueError(f"Benchmark directory must be a repository-relative path: {directory}")
+        includes = entry["include"]
+        configurations = entry["configurations"]
+        if not isinstance(configurations, list) or not configurations:
+            raise ValueError("Benchmark configurations must be a non-empty list")
+        for configuration in configurations:
+            if not isinstance(configuration, dict) or not {"cat", "target"} <= configuration.keys() \
+                    or configuration.keys() - {"cat", "target", "exclude"}:
+                raise ValueError("Each benchmark configuration must contain a cat file and target")
+            if not isinstance(configuration["cat"], str) or not isinstance(configuration["target"], str):
+                raise ValueError("Benchmark configuration cat and target must be strings")
+            configuration_excludes = configuration.get("exclude", [])
+            if not isinstance(configuration_excludes, list) or not all(isinstance(pattern, str) for pattern in configuration_excludes):
+                raise ValueError("Benchmark configuration exclude must be a list of strings")
+
+        root = benchmark_path.parent.parent / directory
+        if not root.is_dir():
+            raise ValueError(f"Benchmark directory does not exist: {directory}")
+        for source in sorted(path for path in root.rglob("*") if path.is_file()):
+            relative_path = source.relative_to(benchmark_path.parent.parent)
+            relative_to_directory = source.relative_to(root)
+            if not any(fnmatch.fnmatch(relative_to_directory.as_posix(), pattern) for pattern in includes):
+                continue
+            if any(fnmatch.fnmatch(relative_to_directory.as_posix(), pattern) for pattern in folder_excludes):
+                continue
+            for configuration in configurations:
+                if any(fnmatch.fnmatch(relative_to_directory.as_posix(), pattern)
+                       for pattern in configuration.get("exclude", [])):
+                    continue
+                benchmarks.append({
+                    "name": relative_path.as_posix(),
+                    "program": relative_path.as_posix(),
+                    "runs": entry["runs"],
+                    "cat": configuration["cat"],
+                    "target": configuration["target"],
+                })
+    if not benchmarks:
+        raise ValueError("Benchmark file selects no benchmarks")
+    validate_benchmarks(benchmarks)
+    return benchmarks
+
+
+def validate_benchmarks(benchmarks):
+    seen_benchmarks = set()
+    for benchmark in benchmarks:
+        benchmark_key = (benchmark["program"], benchmark["cat"], benchmark["target"])
+        if benchmark_key in seen_benchmarks:
+            raise ValueError(
+                f"Benchmark is selected more than once: {benchmark['program']} ({benchmark['target']})"
+            )
+        seen_benchmarks.add(benchmark_key)
+
+
+def parse_time(output):
+    match = TIME_PATTERN.search(output)
+    if not match:
+        raise ValueError("Dartagnan did not report a verification time")
+    return int(match.group("minutes") or 0) * 60 + float(match.group("seconds"))
+
+
+def run_benchmark(revision_dir, benchmark, run, timeout):
+    executable = revision_dir / "dartagnan" / "target" / "dartagnan"
+    command = [
+        str(executable),
+        benchmark["cat"],
+        f"--target={benchmark['target']}",
+        benchmark["program"],
+    ]
+    environment = os.environ | {
+        "DAT3M_HOME": str(revision_dir),
+    }
+    library_path_variable = "DYLD_LIBRARY_PATH" if sys.platform == "darwin" else "LD_LIBRARY_PATH"
+    library_directory = str(revision_dir / "dartagnan" / "target" / "libs")
+    environment[library_path_variable] = library_directory + os.pathsep + environment.get(library_path_variable, "")
+    for attempt in range(MAX_TIMEOUT_ATTEMPTS):
+        output_directory = (
+            revision_dir / "output" / "performance" / Path(benchmark["cat"]).stem / benchmark["program"]
+            / f"run-{run}" / f"attempt-{attempt + 1}"
+        )
+        environment["DAT3M_OUTPUT"] = str(output_directory)
+        output_directory.mkdir(parents=True, exist_ok=True)
+        try:
+            completed = subprocess.run(command, cwd=revision_dir, env=environment, text=True, capture_output=True, timeout=timeout)
+            break
+        except subprocess.TimeoutExpired:
+            if attempt == MAX_TIMEOUT_ATTEMPTS - 1:
+                print(
+                    f"Benchmark timed out {MAX_TIMEOUT_ATTEMPTS} times; recording {timeout:g} seconds: "
+                    + " ".join(command),
+                    file=sys.stderr,
+                )
+                return timeout
+    return parse_time(completed.stdout + completed.stderr)
+
+
+def summarize(values):
+    return {
+        "average": statistics.mean(values),
+        "standard_deviation": statistics.stdev(values) if len(values) > 1 else 0.0,
+    }
+
+
+def percent_change(base, head):
+    return (head - base) / base * 100 if base else math.inf
+
+
+def measure_benchmark(benchmark, base_checkout, head_checkout, timeout):
+    measurements = []
+    base_times = []
+    head_times = []
+    for run in range(benchmark["runs"]):
+        revisions = (("base", base_checkout, base_times), ("head", head_checkout, head_times))
+        # Alternate the measurement order to avoid consistently favoring the revision that runs first.
+        for revision, directory, times in (revisions if run % 2 == 0 else reversed(revisions)):
+            time = run_benchmark(directory, benchmark, run + 1, timeout)
+            times.append(time)
+            measurements.append({"benchmark": benchmark["name"], "revision": revision, "run": run + 1, "seconds": time})
+    base = summarize(base_times)
+    head = summarize(head_times)
+    return {
+        "benchmark": benchmark["name"],
+        "memory_model": Path(benchmark["cat"]).stem,
+        "runs": benchmark["runs"],
+        "base": base,
+        "head": head,
+        "change": percent_change(base["average"], head["average"]),
+    }, measurements
+
+
+def render_markdown(rows, minimum):
+    visible_rows = [row for row in rows if max(row["base"]["average"], row["head"]["average"]) >= minimum]
+    lines = [
+        "<!-- dat3m-performance-report -->",
+        "## Performance comparison",
+    ]
+    memory_models = {}
+    for row in visible_rows:
+        memory_models.setdefault(row["memory_model"], []).append(row)
+    for memory_model, memory_model_rows in memory_models.items():
+        lines.extend([
+            "",
+            f"### Memory model: {memory_model}",
+            "",
+            "| Benchmark | Base branch | PR branch | Change |",
+            "|---|---:|---:|---:|",
+        ])
+        for row in memory_model_rows:
+            change = row["change"]
+            marker = "❌" if change > 0 else "✅" if change < 0 else "➖"
+            lines.append(
+                f"| `{row['benchmark']}` | {row['base']['average']:.3f} ± {row['base']['standard_deviation']:.3f} s "
+                f"| {row['head']['average']:.3f} ± {row['head']['standard_deviation']:.3f} s | {marker} {abs(change):.1f}% |"
+            )
+    if not visible_rows:
+        lines.append("| _No benchmark met the reporting threshold_ | — | — | — |")
+    filtered = len(rows) - len(visible_rows)
+    if filtered:
+        lines.extend(["", f"_{filtered} benchmark(s) omitted because both averages were below {minimum:g} seconds._"])
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    arguments = parse_arguments()
+    for output_path in (arguments.markdown, arguments.json):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+    benchmarks = load_benchmarks(arguments.benchmarks)
+    rows = []
+    measurements = []
+    with ThreadPoolExecutor(max_workers=arguments.jobs) as executor:
+        futures = [
+            executor.submit(
+                measure_benchmark, benchmark, arguments.base_checkout, arguments.head_checkout, arguments.timeout
+            )
+            for benchmark in benchmarks
+        ]
+        for future in futures:
+            row, benchmark_measurements = future.result()
+            rows.append(row)
+            measurements.extend(benchmark_measurements)
+    arguments.markdown.write_text(render_markdown(rows, arguments.min_average_seconds), encoding="utf-8")
+    arguments.json.write_text(json.dumps({"measurements": measurements, "summary": rows}, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, RuntimeError, ValueError, yaml.YAMLError) as error:
+        print(f"Performance comparison failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -3,7 +3,6 @@
 
 import argparse
 from concurrent.futures import ThreadPoolExecutor
-import fnmatch
 import json
 import math
 import os
@@ -52,58 +51,41 @@ def load_benchmarks(benchmark_path):
     for entry in benchmark_selection["benchmarks"]:
         if not isinstance(entry, dict):
             raise ValueError("Each performance benchmark entry must be a mapping")
-        required_keys = {"directory", "include", "runs", "configurations"}
+        required_keys = {"program", "runs", "configurations"}
         missing_keys = required_keys - entry.keys()
         if missing_keys:
             raise ValueError("Benchmark entry is missing: " + ", ".join(sorted(missing_keys)))
-        if not isinstance(entry["directory"], str):
-            raise ValueError("Benchmark directory must be a string")
+        if entry.keys() - {"program", "runs", "configurations"}:
+            raise ValueError("Benchmark entry contains unsupported keys")
+        if not isinstance(entry["program"], str):
+            raise ValueError("Benchmark program must be a string")
         if not isinstance(entry["runs"], int) or isinstance(entry["runs"], bool) or entry["runs"] < 1:
             raise ValueError("Benchmark runs must be a positive integer")
-        if not isinstance(entry["include"], list) or not entry["include"] or not all(isinstance(pattern, str) for pattern in entry["include"]):
-            raise ValueError("Benchmark include must be a non-empty list of strings")
-        folder_excludes = entry.get("exclude", [])
-        if not isinstance(folder_excludes, list) or not all(isinstance(pattern, str) for pattern in folder_excludes):
-            raise ValueError("Benchmark exclude must be a list of strings")
-
-        directory = Path(entry["directory"])
-        if directory.is_absolute() or ".." in directory.parts:
-            raise ValueError(f"Benchmark directory must be a repository-relative path: {directory}")
-        includes = entry["include"]
+        program = Path(entry["program"])
+        if program.is_absolute() or ".." in program.parts:
+            raise ValueError(f"Benchmark program must be a repository-relative path: {program}")
+        if not (benchmark_path.parent.parent / program).is_file():
+            raise ValueError(f"Benchmark program does not exist: {program}")
         configurations = entry["configurations"]
         if not isinstance(configurations, list) or not configurations:
             raise ValueError("Benchmark configurations must be a non-empty list")
         for configuration in configurations:
             if not isinstance(configuration, dict) or not {"cat", "target"} <= configuration.keys() \
-                    or configuration.keys() - {"cat", "target", "exclude"}:
+                    or configuration.keys() - {"cat", "target", "options"}:
                 raise ValueError("Each benchmark configuration must contain a cat file and target")
             if not isinstance(configuration["cat"], str) or not isinstance(configuration["target"], str):
                 raise ValueError("Benchmark configuration cat and target must be strings")
-            configuration_excludes = configuration.get("exclude", [])
-            if not isinstance(configuration_excludes, list) or not all(isinstance(pattern, str) for pattern in configuration_excludes):
-                raise ValueError("Benchmark configuration exclude must be a list of strings")
-
-        root = benchmark_path.parent.parent / directory
-        if not root.is_dir():
-            raise ValueError(f"Benchmark directory does not exist: {directory}")
-        for source in sorted(path for path in root.rglob("*") if path.is_file()):
-            relative_path = source.relative_to(benchmark_path.parent.parent)
-            relative_to_directory = source.relative_to(root)
-            if not any(fnmatch.fnmatch(relative_to_directory.as_posix(), pattern) for pattern in includes):
-                continue
-            if any(fnmatch.fnmatch(relative_to_directory.as_posix(), pattern) for pattern in folder_excludes):
-                continue
-            for configuration in configurations:
-                if any(fnmatch.fnmatch(relative_to_directory.as_posix(), pattern)
-                       for pattern in configuration.get("exclude", [])):
-                    continue
-                benchmarks.append({
-                    "name": relative_path.as_posix(),
-                    "program": relative_path.as_posix(),
-                    "runs": entry["runs"],
-                    "cat": configuration["cat"],
-                    "target": configuration["target"],
-                })
+            options = configuration.get("options", [])
+            if not isinstance(options, list) or not all(isinstance(option, str) for option in options):
+                raise ValueError("Benchmark configuration options must be a list of strings")
+            benchmarks.append({
+                "name": program.as_posix(),
+                "program": program.as_posix(),
+                "runs": entry["runs"],
+                "cat": configuration["cat"],
+                "target": configuration["target"],
+                "options": options,
+            })
     if not benchmarks:
         raise ValueError("Benchmark file selects no benchmarks")
     validate_benchmarks(benchmarks)
@@ -113,7 +95,7 @@ def load_benchmarks(benchmark_path):
 def validate_benchmarks(benchmarks):
     seen_benchmarks = set()
     for benchmark in benchmarks:
-        benchmark_key = (benchmark["program"], benchmark["cat"], benchmark["target"])
+        benchmark_key = (benchmark["program"], benchmark["cat"], benchmark["target"], tuple(benchmark["options"]))
         if benchmark_key in seen_benchmarks:
             raise ValueError(
                 f"Benchmark is selected more than once: {benchmark['program']} ({benchmark['target']})"
@@ -134,6 +116,7 @@ def run_benchmark(revision_dir, benchmark, run, timeout):
         str(executable),
         benchmark["cat"],
         f"--target={benchmark['target']}",
+        *benchmark["options"],
         benchmark["program"],
     ]
     environment = os.environ | {

--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -302,7 +302,7 @@ def summarize_total(rows):
     }
 
 
-def render_markdown(rows, minimum):
+def render_markdown(rows, minimum, timeout):
     visible_rows = [row for row in rows if max(row["base"]["average"], row["head"]["average"]) >= minimum]
     lines = [
         "<!-- dat3m-performance-report -->",
@@ -342,6 +342,19 @@ def render_markdown(rows, minimum):
     filtered = len(rows) - len(visible_rows)
     if filtered:
         lines.extend(["", f"_{filtered} benchmark(s) omitted because both averages were below {minimum:g} seconds._"])
+    base_timeouts = sum(row["results"]["base"].get("TIMEOUT", 0) for row in rows)
+    head_timeouts = sum(row["results"]["head"].get("TIMEOUT", 0) for row in rows)
+    if base_timeouts or head_timeouts:
+        timed_out_revisions = []
+        if base_timeouts:
+            timed_out_revisions.append(f"{base_timeouts} base-branch run(s)")
+        if head_timeouts:
+            timed_out_revisions.append(f"{head_timeouts} PR-branch run(s)")
+        lines.extend([
+            "",
+            f"_{' and '.join(timed_out_revisions)} timed out after {timeout:g} seconds "
+            f"({MAX_TIMEOUT_ATTEMPTS} attempts each) and were recorded as {timeout:g} seconds._",
+        ])
     return "\n".join(lines) + "\n"
 
 
@@ -363,7 +376,9 @@ def main():
             row, benchmark_measurements = future.result()
             rows.append(row)
             measurements.extend(benchmark_measurements)
-    arguments.markdown.write_text(render_markdown(rows, arguments.min_average_seconds), encoding="utf-8")
+    arguments.markdown.write_text(
+        render_markdown(rows, arguments.min_average_seconds, arguments.timeout), encoding="utf-8"
+    )
     arguments.json.write_text(json.dumps({"measurements": measurements, "summary": rows}, indent=2) + "\n", encoding="utf-8")
 
 

--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -2,6 +2,7 @@
 """Compare Dartagnan execution times for two repository revisions."""
 
 import argparse
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 import json
 import math
@@ -19,6 +20,7 @@ MAX_TIMEOUT_ATTEMPTS = 3
 
 
 TIME_PATTERN = re.compile(r"^Time:\s+(?:(?P<minutes>\d+):)?(?P<seconds>\d+(?:\.\d+)?)\s+(?:secs|mins)\s*$", re.MULTILINE)
+RESULT_PATTERN = re.compile(r"^Result:\s+(?P<result>\S+)\s*$", re.MULTILINE)
 
 
 def parse_arguments():
@@ -114,6 +116,13 @@ def parse_time(output):
     return int(match.group("minutes") or 0) * 60 + float(match.group("seconds"))
 
 
+def parse_result(output):
+    match = RESULT_PATTERN.search(output)
+    if not match:
+        raise ValueError("Dartagnan did not report a verification result")
+    return match.group("result")
+
+
 def run_benchmark(revision_dir, benchmark, run, timeout):
     executable = revision_dir / "dartagnan" / "target" / "dartagnan"
     command = [
@@ -146,8 +155,9 @@ def run_benchmark(revision_dir, benchmark, run, timeout):
                     + " ".join(command),
                     file=sys.stderr,
                 )
-                return timeout
-    return parse_time(completed.stdout + completed.stderr)
+                return timeout, "TIMEOUT"
+    output = completed.stdout + completed.stderr
+    return parse_time(output), parse_result(output)
 
 
 def summarize(values):
@@ -155,6 +165,10 @@ def summarize(values):
         "average": statistics.mean(values),
         "standard_deviation": statistics.stdev(values) if len(values) > 1 else 0.0,
     }
+
+
+def summarize_results(results):
+    return dict(sorted(Counter(results).items()))
 
 
 # Two-sided 95% Student-t critical values, indexed by degrees of freedom. Performance
@@ -217,13 +231,22 @@ def measure_benchmark(benchmark, base_checkout, head_checkout, timeout):
     measurements = []
     base_times = []
     head_times = []
+    base_results = []
+    head_results = []
     for run in range(benchmark["runs"]):
-        revisions = (("base", base_checkout, base_times), ("head", head_checkout, head_times))
+        revisions = (
+            ("base", base_checkout, base_times, base_results),
+            ("head", head_checkout, head_times, head_results),
+        )
         # Alternate the measurement order to avoid consistently favoring the revision that runs first.
-        for revision, directory, times in (revisions if run % 2 == 0 else reversed(revisions)):
-            time = run_benchmark(directory, benchmark, run + 1, timeout)
+        for revision, directory, times, results in (revisions if run % 2 == 0 else reversed(revisions)):
+            time, result = run_benchmark(directory, benchmark, run + 1, timeout)
             times.append(time)
-            measurements.append({"benchmark": benchmark["name"], "revision": revision, "run": run + 1, "seconds": time})
+            results.append(result)
+            measurements.append({
+                "benchmark": benchmark["name"], "revision": revision, "run": run + 1,
+                "seconds": time, "result": result,
+            })
     base = summarize(base_times)
     head = summarize(head_times)
     return {
@@ -234,6 +257,7 @@ def measure_benchmark(benchmark, base_checkout, head_checkout, timeout):
         "head": head,
         "base_times": base_times,
         "head_times": head_times,
+        "results": {"base": summarize_results(base_results), "head": summarize_results(head_results)},
         "improvement": paired_improvement(base_times, head_times),
     }, measurements
 
@@ -251,13 +275,33 @@ def format_improvement(improvement):
     return f"➖ {formatted_interval}"
 
 
+def common_result(results):
+    all_results = set(results["base"]) | set(results["head"])
+    return all_results.pop() if len(all_results) == 1 else None
+
+
+def format_result_counts(result_counts):
+    return ", ".join(f"{result} × {count}" for result, count in result_counts.items())
+
+
+def format_results(results):
+    result = common_result(results)
+    if result is not None:
+        return result
+    return f"Base: {format_result_counts(results['base'])}<br>PR: {format_result_counts(results['head'])}"
+
+
 def summarize_total(rows):
     """Summarize the total verification time of all rows for every paired run."""
     base_times = [sum(times) for times in zip(*(row["base_times"] for row in rows))]
     head_times = [sum(times) for times in zip(*(row["head_times"] for row in rows))]
+    result_counts = Counter()
+    for row in rows:
+        result_counts[common_result(row["results"]) or "MIXED"] += 1
     return {
         "base": summarize(base_times),
         "head": summarize(head_times),
+        "result_counts": dict(sorted(result_counts.items())),
         "improvement": paired_improvement(base_times, head_times),
     }
 
@@ -276,13 +320,14 @@ def render_markdown(rows, minimum):
             "",
             f"### Memory model: {memory_model}",
             "",
-            "| Benchmark | Base branch | PR branch | Improvement (95% CI) |",
-            "|---|---:|---:|---:|",
+            "| Benchmark | Base branch | PR branch | Result | Improvement (95% CI) |",
+            "|---|---:|---:|---|---:|",
         ])
         for row in memory_model_rows:
             lines.append(
                 f"| `{row['benchmark']}` | {row['base']['average']:.3f} ± {row['base']['standard_deviation']:.3f} s "
                 f"| {row['head']['average']:.3f} ± {row['head']['standard_deviation']:.3f} s "
+                f"| {format_results(row['results'])} "
                 f"| {format_improvement(row['improvement'])} |"
             )
     if visible_rows:
@@ -291,14 +336,15 @@ def render_markdown(rows, minimum):
             "",
             "### Total",
             "",
-            "| Benchmarks | Base branch | PR branch | Improvement (95% CI) |",
-            "|---|---:|---:|---:|",
+            "| Benchmarks | Base branch | PR branch | Result | Improvement (95% CI) |",
+            "|---|---:|---:|---|---:|",
             f"| All reported benchmarks | {total['base']['average']:.3f} ± {total['base']['standard_deviation']:.3f} s "
             f"| {total['head']['average']:.3f} ± {total['head']['standard_deviation']:.3f} s "
+            f"| {format_result_counts(total['result_counts'])} "
             f"| {format_improvement(total['improvement'])} |",
         ])
     if not visible_rows:
-        lines.append("| _No benchmark met the reporting threshold_ | — | — | — |")
+        lines.append("| _No benchmark met the reporting threshold_ | — | — | — | — |")
     filtered = len(rows) - len(visible_rows)
     if filtered:
         lines.extend(["", f"_{filtered} benchmark(s) omitted because both averages were below {minimum:g} seconds._"])

--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -295,13 +295,9 @@ def summarize_total(rows):
     """Summarize the total verification time of all rows for every paired run."""
     base_times = [sum(times) for times in zip(*(row["base_times"] for row in rows))]
     head_times = [sum(times) for times in zip(*(row["head_times"] for row in rows))]
-    result_counts = Counter()
-    for row in rows:
-        result_counts[common_result(row["results"]) or "MIXED"] += 1
     return {
         "base": summarize(base_times),
         "head": summarize(head_times),
-        "result_counts": dict(sorted(result_counts.items())),
         "improvement": paired_improvement(base_times, head_times),
     }
 
@@ -320,15 +316,14 @@ def render_markdown(rows, minimum):
             "",
             f"### Memory model: {memory_model}",
             "",
-            "| Benchmark | Base branch | PR branch | Result | Improvement (95% CI) |",
-            "|---|---:|---:|---|---:|",
+            "| Benchmark | Base branch | PR branch | Improvement (95% CI) | Result |",
+            "|---|---:|---:|---:|---|",
         ])
         for row in memory_model_rows:
             lines.append(
                 f"| `{row['benchmark']}` | {row['base']['average']:.3f} ± {row['base']['standard_deviation']:.3f} s "
                 f"| {row['head']['average']:.3f} ± {row['head']['standard_deviation']:.3f} s "
-                f"| {format_results(row['results'])} "
-                f"| {format_improvement(row['improvement'])} |"
+                f"| {format_improvement(row['improvement'])} | {format_results(row['results'])} |"
             )
     if visible_rows:
         total = summarize_total(visible_rows)
@@ -336,11 +331,10 @@ def render_markdown(rows, minimum):
             "",
             "### Total",
             "",
-            "| Benchmarks | Base branch | PR branch | Result | Improvement (95% CI) |",
-            "|---|---:|---:|---|---:|",
+            "| Benchmarks | Base branch | PR branch | Improvement (95% CI) |",
+            "|---|---:|---:|---:|",
             f"| All reported benchmarks | {total['base']['average']:.3f} ± {total['base']['standard_deviation']:.3f} s "
             f"| {total['head']['average']:.3f} ± {total['head']['standard_deviation']:.3f} s "
-            f"| {format_result_counts(total['result_counts'])} "
             f"| {format_improvement(total['improvement'])} |",
         ])
     if not visible_rows:

--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -157,8 +157,60 @@ def summarize(values):
     }
 
 
-def percent_change(base, head):
-    return (head - base) / base * 100 if base else math.inf
+# Two-sided 95% Student-t critical values, indexed by degrees of freedom. Performance
+# measurements normally have only a few runs, so the normal-distribution value (1.96)
+# would underestimate the confidence interval. For more than 31 runs, 1.96 is a close
+# enough approximation.
+T_CRITICAL_95 = {
+    1: 12.706,
+    2: 4.303,
+    3: 3.182,
+    4: 2.776,
+    5: 2.571,
+    6: 2.447,
+    7: 2.365,
+    8: 2.306,
+    9: 2.262,
+    10: 2.228,
+    11: 2.201,
+    12: 2.179,
+    13: 2.160,
+    14: 2.145,
+    15: 2.131,
+    16: 2.120,
+    17: 2.110,
+    18: 2.101,
+    19: 2.093,
+    20: 2.086,
+    21: 2.080,
+    22: 2.074,
+    23: 2.069,
+    24: 2.064,
+    25: 2.060,
+    26: 2.056,
+    27: 2.052,
+    28: 2.048,
+    29: 2.045,
+    30: 2.042,
+}
+
+
+def paired_improvement(base_times, head_times):
+    """Return the paired relative improvement and its two-sided 95% confidence interval.
+
+    Each base/head pair belongs to the same run and therefore shares much of the
+    machine noise. A positive value means that the head revision is faster. The
+    interval is used by the report to label a result as an improvement or regression
+    only when it does not contain zero.
+    """
+    improvements = [(base - head) / base * 100 for base, head in zip(base_times, head_times)]
+    average = statistics.mean(improvements)
+    if len(improvements) < 2:
+        return {"average": average, "lower": None, "upper": None}
+    standard_error = statistics.stdev(improvements) / math.sqrt(len(improvements))
+    critical_value = T_CRITICAL_95.get(len(improvements) - 1, 1.96)
+    margin = critical_value * standard_error
+    return {"average": average, "lower": average - margin, "upper": average + margin}
 
 
 def measure_benchmark(benchmark, base_checkout, head_checkout, timeout):
@@ -180,7 +232,7 @@ def measure_benchmark(benchmark, base_checkout, head_checkout, timeout):
         "runs": benchmark["runs"],
         "base": base,
         "head": head,
-        "change": percent_change(base["average"], head["average"]),
+        "improvement": paired_improvement(base_times, head_times),
     }, measurements
 
 
@@ -198,15 +250,32 @@ def render_markdown(rows, minimum):
             "",
             f"### Memory model: {memory_model}",
             "",
-            "| Benchmark | Base branch | PR branch | Change |",
+            "| Benchmark | Base branch | PR branch | Improvement (95% CI) |",
             "|---|---:|---:|---:|",
         ])
         for row in memory_model_rows:
-            change = row["change"]
-            marker = "❌" if change > 0 else "✅" if change < 0 else "➖"
+            improvement = row["improvement"]
+            if improvement["lower"] is None:
+                marker = "➖"
+                confidence_interval = "insufficient data"
+            elif improvement["lower"] > 0:
+                marker = "✅"
+                confidence_interval = (
+                    f"{improvement['average']:+.1f}% [{improvement['lower']:+.1f}%, {improvement['upper']:+.1f}%]"
+                )
+            elif improvement["upper"] < 0:
+                marker = "❌"
+                confidence_interval = (
+                    f"{improvement['average']:+.1f}% [{improvement['lower']:+.1f}%, {improvement['upper']:+.1f}%]"
+                )
+            else:
+                marker = "➖"
+                confidence_interval = (
+                    f"{improvement['average']:+.1f}% [{improvement['lower']:+.1f}%, {improvement['upper']:+.1f}%]"
+                )
             lines.append(
                 f"| `{row['benchmark']}` | {row['base']['average']:.3f} ± {row['base']['standard_deviation']:.3f} s "
-                f"| {row['head']['average']:.3f} ± {row['head']['standard_deviation']:.3f} s | {marker} {abs(change):.1f}% |"
+                f"| {row['head']['average']:.3f} ± {row['head']['standard_deviation']:.3f} s | {marker} {confidence_interval} |"
             )
     if not visible_rows:
         lines.append("| _No benchmark met the reporting threshold_ | — | — | — |")

--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -55,12 +55,15 @@ def load_benchmarks(benchmark_path):
         missing_keys = required_keys - entry.keys()
         if missing_keys:
             raise ValueError("Benchmark entry is missing: " + ", ".join(sorted(missing_keys)))
-        if entry.keys() - {"program", "runs", "configurations"}:
+        if entry.keys() - {"program", "runs", "options", "configurations"}:
             raise ValueError("Benchmark entry contains unsupported keys")
         if not isinstance(entry["program"], str):
             raise ValueError("Benchmark program must be a string")
         if not isinstance(entry["runs"], int) or isinstance(entry["runs"], bool) or entry["runs"] < 1:
             raise ValueError("Benchmark runs must be a positive integer")
+        shared_options = entry.get("options", [])
+        if not isinstance(shared_options, list) or not all(isinstance(option, str) for option in shared_options):
+            raise ValueError("Benchmark options must be a list of strings")
         program = Path(entry["program"])
         if program.is_absolute() or ".." in program.parts:
             raise ValueError(f"Benchmark program must be a repository-relative path: {program}")
@@ -75,8 +78,9 @@ def load_benchmarks(benchmark_path):
                 raise ValueError("Each benchmark configuration must contain a cat file and target")
             if not isinstance(configuration["cat"], str) or not isinstance(configuration["target"], str):
                 raise ValueError("Benchmark configuration cat and target must be strings")
-            options = configuration.get("options", [])
-            if not isinstance(options, list) or not all(isinstance(option, str) for option in options):
+            configuration_options = configuration.get("options", [])
+            if not isinstance(configuration_options, list) \
+                    or not all(isinstance(option, str) for option in configuration_options):
                 raise ValueError("Benchmark configuration options must be a list of strings")
             benchmarks.append({
                 "name": program.as_posix(),
@@ -84,7 +88,7 @@ def load_benchmarks(benchmark_path):
                 "runs": entry["runs"],
                 "cat": configuration["cat"],
                 "target": configuration["target"],
-                "options": options,
+                "options": [*shared_options, *configuration_options],
             })
     if not benchmarks:
         raise ValueError("Benchmark file selects no benchmarks")

--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -232,8 +232,34 @@ def measure_benchmark(benchmark, base_checkout, head_checkout, timeout):
         "runs": benchmark["runs"],
         "base": base,
         "head": head,
+        "base_times": base_times,
+        "head_times": head_times,
         "improvement": paired_improvement(base_times, head_times),
     }, measurements
+
+
+def format_improvement(improvement):
+    if improvement["lower"] is None:
+        return "➖ insufficient data"
+    formatted_interval = (
+        f"{improvement['average']:+.1f}% [{improvement['lower']:+.1f}%, {improvement['upper']:+.1f}%]"
+    )
+    if improvement["lower"] > 0:
+        return f"✅ {formatted_interval}"
+    if improvement["upper"] < 0:
+        return f"❌ {formatted_interval}"
+    return f"➖ {formatted_interval}"
+
+
+def summarize_total(rows):
+    """Summarize the total verification time of all rows for every paired run."""
+    base_times = [sum(times) for times in zip(*(row["base_times"] for row in rows))]
+    head_times = [sum(times) for times in zip(*(row["head_times"] for row in rows))]
+    return {
+        "base": summarize(base_times),
+        "head": summarize(head_times),
+        "improvement": paired_improvement(base_times, head_times),
+    }
 
 
 def render_markdown(rows, minimum):
@@ -254,29 +280,23 @@ def render_markdown(rows, minimum):
             "|---|---:|---:|---:|",
         ])
         for row in memory_model_rows:
-            improvement = row["improvement"]
-            if improvement["lower"] is None:
-                marker = "➖"
-                confidence_interval = "insufficient data"
-            elif improvement["lower"] > 0:
-                marker = "✅"
-                confidence_interval = (
-                    f"{improvement['average']:+.1f}% [{improvement['lower']:+.1f}%, {improvement['upper']:+.1f}%]"
-                )
-            elif improvement["upper"] < 0:
-                marker = "❌"
-                confidence_interval = (
-                    f"{improvement['average']:+.1f}% [{improvement['lower']:+.1f}%, {improvement['upper']:+.1f}%]"
-                )
-            else:
-                marker = "➖"
-                confidence_interval = (
-                    f"{improvement['average']:+.1f}% [{improvement['lower']:+.1f}%, {improvement['upper']:+.1f}%]"
-                )
             lines.append(
                 f"| `{row['benchmark']}` | {row['base']['average']:.3f} ± {row['base']['standard_deviation']:.3f} s "
-                f"| {row['head']['average']:.3f} ± {row['head']['standard_deviation']:.3f} s | {marker} {confidence_interval} |"
+                f"| {row['head']['average']:.3f} ± {row['head']['standard_deviation']:.3f} s "
+                f"| {format_improvement(row['improvement'])} |"
             )
+    if visible_rows:
+        total = summarize_total(visible_rows)
+        lines.extend([
+            "",
+            "### Total",
+            "",
+            "| Benchmarks | Base branch | PR branch | Improvement (95% CI) |",
+            "|---|---:|---:|---:|",
+            f"| All reported benchmarks | {total['base']['average']:.3f} ± {total['base']['standard_deviation']:.3f} s "
+            f"| {total['head']['average']:.3f} ± {total['head']['standard_deviation']:.3f} s "
+            f"| {format_improvement(total['improvement'])} |",
+        ])
     if not visible_rows:
         lines.append("| _No benchmark met the reporting threshold_ | — | — | — |")
     filtered = len(rows) - len(visible_rows)

--- a/scripts/compare_performance.py
+++ b/scripts/compare_performance.py
@@ -171,46 +171,46 @@ def summarize_results(results):
     return dict(sorted(Counter(results).items()))
 
 
-# Two-sided 95% Student-t critical values, indexed by degrees of freedom. Performance
-# measurements normally have only a few runs, so the normal-distribution value (1.96)
-# would underestimate the confidence interval. For more than 31 runs, 1.96 is a close
-# enough approximation.
-T_CRITICAL_95 = {
-    1: 12.706,
-    2: 4.303,
-    3: 3.182,
-    4: 2.776,
-    5: 2.571,
-    6: 2.447,
-    7: 2.365,
-    8: 2.306,
-    9: 2.262,
-    10: 2.228,
-    11: 2.201,
-    12: 2.179,
-    13: 2.160,
-    14: 2.145,
-    15: 2.131,
-    16: 2.120,
-    17: 2.110,
-    18: 2.101,
-    19: 2.093,
-    20: 2.086,
-    21: 2.080,
-    22: 2.074,
-    23: 2.069,
-    24: 2.064,
-    25: 2.060,
-    26: 2.056,
-    27: 2.052,
-    28: 2.048,
-    29: 2.045,
-    30: 2.042,
+# Values used to calculate a two-sided 99% confidence interval. The key is one less
+# than the number of repetitions: for example, five repetitions use the value for key
+# four. With more than 31 repetitions, the value 2.576 is close enough, so no larger
+# table is needed.
+T_CRITICAL_99 = {
+    1: 63.657,
+    2: 9.925,
+    3: 5.841,
+    4: 4.604,
+    5: 4.032,
+    6: 3.707,
+    7: 3.499,
+    8: 3.355,
+    9: 3.250,
+    10: 3.169,
+    11: 3.106,
+    12: 3.055,
+    13: 3.012,
+    14: 2.977,
+    15: 2.947,
+    16: 2.921,
+    17: 2.898,
+    18: 2.878,
+    19: 2.861,
+    20: 2.845,
+    21: 2.831,
+    22: 2.819,
+    23: 2.807,
+    24: 2.797,
+    25: 2.787,
+    26: 2.779,
+    27: 2.771,
+    28: 2.763,
+    29: 2.756,
+    30: 2.750,
 }
 
 
 def paired_improvement(base_times, head_times):
-    """Return the paired relative improvement and its two-sided 95% confidence interval.
+    """Return the paired relative improvement and its two-sided 99% confidence interval.
 
     Each base/head pair belongs to the same run and therefore shares much of the
     machine noise. A positive value means that the head revision is faster. The
@@ -222,7 +222,7 @@ def paired_improvement(base_times, head_times):
     if len(improvements) < 2:
         return {"average": average, "lower": None, "upper": None}
     standard_error = statistics.stdev(improvements) / math.sqrt(len(improvements))
-    critical_value = T_CRITICAL_95.get(len(improvements) - 1, 1.96)
+    critical_value = T_CRITICAL_99.get(len(improvements) - 1, 2.576)
     margin = critical_value * standard_error
     return {"average": average, "lower": average - margin, "upper": average + margin}
 
@@ -316,7 +316,7 @@ def render_markdown(rows, minimum):
             "",
             f"### Memory model: {memory_model}",
             "",
-            "| Benchmark | Base branch | PR branch | Improvement (95% CI) | Result |",
+            "| Benchmark | Base branch | PR branch | Improvement (99% CI) | Result |",
             "|---|---:|---:|---:|---|",
         ])
         for row in memory_model_rows:
@@ -331,7 +331,7 @@ def render_markdown(rows, minimum):
             "",
             "### Total",
             "",
-            "| Benchmarks | Base branch | PR branch | Improvement (95% CI) |",
+            "| Benchmarks | Base branch | PR branch | Improvement (99% CI) |",
             "|---|---:|---:|---:|",
             f"| All reported benchmarks | {total['base']['average']:.3f} ± {total['base']['standard_deviation']:.3f} s "
             f"| {total['head']['average']:.3f} ± {total['head']['standard_deviation']:.3f} s "


### PR DESCRIPTION
As an example, I ran the script locally comparing `development` with #1060 and this is what it generated (we might want to let the real CI run for that PR once the action is in place).

## Performance comparison

### Memory model: power

| Benchmark | Base branch | PR branch | Change |
| :--- | :--- | :--- | :--- |
| benchmarks/locks/cna.c | 68.667 ± 2.517 s | 66.667 ± 0.577 s | ✅ 2.9% |
| benchmarks/lfds/dglm.c | 6.199 ± 0.092 s | 5.906 ± 0.008 s | ✅ 4.7% |
| benchmarks/challenging/harris-3.c | 128.333 ± 11.240 s | 150.667 ± 13.429 s | ❌ 17.4% |

### Memory model: vmm

| Benchmark | Base branch | PR branch | Change |
| :--- | :--- | :--- | :--- |
| benchmarks/locks/cna.c | 8.353 ± 0.591 s | 8.977 ± 0.596 s | ❌ 7.5% |
| benchmarks/lfds/safe_stack.c | 8.117 ± 0.302 s | 6.197 ± 0.922 s | ✅ 23.7% |
| benchmarks/challenging/cna.c | 30.961 ± 0.965 s | 30.857 ± 1.985 s | ✅ 0.3% |
| benchmarks/challenging/harris-3.c | 5.372 ± 0.351 s | 5.521 ± 0.276 s | ❌ 2.8% |
| benchmarks/challenging/wsq.c | 133.667 ± 14.154 s | 145.000 ± 17.349 s | ❌ 8.5% |

### Memory model: aarch64

| Benchmark | Base branch | PR branch | Change |
| :--- | :--- | :--- | :--- |
| benchmarks/challenging/wsq.c | 10.177 ± 0.347 s | 11.175 ± 1.488 s | ❌ 9.8% |

*51 benchmark(s) omitted because both averages were below 5 seconds.*