### PR TITLE
Fix `--method=lazy` option

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolverBase.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/TaskSolverBase.java
@@ -59,7 +59,7 @@ abstract sealed class TaskSolverBase<TSolver, TTask extends Task, TResult extend
     protected TaskSolverBase(TTask task, Configuration config) throws InvalidConfigurationException {
         this.task = task;
 
-        config.recursiveInject(this);
+        config.inject(this, TaskSolverBase.class);
     }
 
     protected TaskSolverBase(TTask task) throws InvalidConfigurationException {

--- a/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTaskSolver.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/verification/VerificationTaskSolver.java
@@ -31,6 +31,8 @@ public final class VerificationTaskSolver extends TaskSolverBase<VerificationTas
 
     private VerificationTaskSolver(VerificationTask task) throws InvalidConfigurationException {
         super(task);
+
+        task.getConfig().inject(this);
     }
 
     public static VerificationTaskSolver create(VerificationTask task) throws InvalidConfigurationException {


### PR DESCRIPTION
I don't know how nobody noticed, but `--method=lazy` is broken since #1074 : we always used the default value `eager` instead.
The problem was that the `TaskSolverBase` injected the option correctly, but only then the field initializers of `VerificationTaskSolver` ran, resetting the injected value back to `Method.getDefault()`.
It seems there are only two valid ways to inject configuration in an inheritance chain:
- each subclass injects its own options (`inject`)
- the final subclass in the chain injects all options (`recursiveInject`)