### PR TITLE
Fix performance comparison job to be also run on PRs from forks

### DIFF
--- a/.github/workflows/performance-comparison.yml
+++ b/.github/workflows/performance-comparison.yml
@@ -1,4 +1,4 @@
-name: Performance regression
+name: Generate performance report
 
 on:
   pull_request:
@@ -6,15 +6,33 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # This artifact identifies which pull request should receive the generated report.
+  context:
+    name: Save pull request context
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save pull request number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/performance-context"
+          printf '%s\n' "$PR_NUMBER" > "$RUNNER_TEMP/performance-context/pr-number.txt"
+
+      - name: Publish pull request context
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-pr-context
+          path: ${{ runner.temp }}/performance-context/
+
   compare:
-    name: Check for performance regressions (${{ matrix.platform }})
+    name: Generate performance report (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -84,49 +102,3 @@ jobs:
         with:
           name: performance-comparison-${{ matrix.artifact }}
           path: performance/
-
-  publish-report:
-    name: Publish performance report
-    needs: compare
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Linux report
-        uses: actions/download-artifact@v4
-        with:
-          name: performance-comparison-linux-x64
-          path: performance/linux-x64
-
-      - name: Download macOS report
-        uses: actions/download-artifact@v4
-        with:
-          name: performance-comparison-macos-arm64
-          path: performance/macos-arm64
-
-      - name: Update pull request comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- dat3m-performance-report -->';
-            const reports = [
-              ['Linux x64', 'performance/linux-x64/report.md'],
-              ['macOS ARM64', 'performance/macos-arm64/report.md'],
-            ];
-            const body = marker + '\n# Performance comparison\n' + reports.map(([platform, path]) => {
-              const report = fs.readFileSync(path, 'utf8').replace(
-                /^<!-- dat3m-performance-report -->\n## Performance comparison\n?/, '',
-              );
-              return `\n## ${platform}\n${report}`;
-            }).join('');
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number,
-            });
-            const previous = comments.find(comment => comment.user.type === 'Bot' && comment.body.includes(marker));
-            if (previous) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: previous.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }

--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -1,0 +1,113 @@
+name: Publish performance report
+
+on:
+  workflow_run:
+    workflows: [Generate performance report]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: performance-report-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  publish-report:
+    name: Publish performance report
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download pull request context
+        uses: actions/download-artifact@v4
+        with:
+          name: performance-pr-context
+          path: ${{ runner.temp }}/performance/context
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Linux report
+        uses: actions/download-artifact@v4
+        with:
+          name: performance-comparison-linux-x64
+          path: ${{ runner.temp }}/performance/linux-x64
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download macOS report
+        uses: actions/download-artifact@v4
+        with:
+          name: performance-comparison-macos-arm64
+          path: ${{ runner.temp }}/performance/macos-arm64
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update pull request comment
+        uses: actions/github-script@v7
+        env:
+          REPORT_ROOT: ${{ runner.temp }}/performance
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const marker = '<!-- dat3m-performance-report -->';
+            const root = process.env.REPORT_ROOT;
+
+            const issueNumberText = fs.readFileSync(
+              path.join(root, 'context', 'pr-number.txt'),
+              'utf8',
+            ).trim();
+            const issue_number = Number(issueNumberText);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              throw new Error(`Invalid pull request number: "${issueNumberText}"`);
+            }
+
+            const { owner, repo } = context.repo;
+            let associatedPullRequests = context.payload.workflow_run.pull_requests || [];
+            if (associatedPullRequests.length === 0) {
+              const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: context.payload.workflow_run.head_sha,
+              });
+              associatedPullRequests = response.data;
+            }
+            if (!associatedPullRequests.some(pullRequest => pullRequest.number === issue_number)) {
+              throw new Error(`Pull request #${issue_number} is not associated with the triggering workflow run`);
+            }
+
+            const reports = [
+              ['Linux x64', path.join(root, 'linux-x64', 'report.md')],
+              ['macOS ARM64', path.join(root, 'macos-arm64', 'report.md')],
+            ];
+            const sections = reports.map(([platform, reportPath]) => {
+              const size = fs.statSync(reportPath).size;
+              if (size > 25000) {
+                throw new Error(`${platform} report is unexpectedly large: ${size} bytes`);
+              }
+              const report = fs.readFileSync(reportPath, 'utf8')
+                .replace(/^<!-- dat3m-performance-report -->\n## Performance comparison\n?/, '')
+                .replaceAll('@', '@\u200b');
+              return `\n## ${platform}\n${report}`;
+            });
+            const body = marker + '\n# Performance comparison\n' + sections.join('');
+            if (Buffer.byteLength(body, 'utf8') > 60000) {
+              throw new Error('Combined performance report is too large for a pull request comment');
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const previous = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+            if (previous) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: previous.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }


### PR DESCRIPTION
This is exaclty as #1091. I removed that one from the history because I thought it was wrong (i.e., no table was generated), but apparently those changes will only work once they land in the master branch.

We shouuld merge this one to development, then I will merge the whole development into master and then we can rebase all opened PRs.