### PR TITLE
Fix transitivity of ExecutionAnalysis.isImplied

### DIFF
--- a/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/ExecutionAnalysis.java
+++ b/dartagnan/src/main/java/com/dat3m/dartagnan/program/analysis/ExecutionAnalysis.java
@@ -5,6 +5,7 @@ import com.dat3m.dartagnan.program.IRHelper;
 import com.dat3m.dartagnan.program.Program;
 import com.dat3m.dartagnan.program.Thread;
 import com.dat3m.dartagnan.program.event.Event;
+import com.dat3m.dartagnan.program.event.core.threading.ThreadCreate;
 import com.dat3m.dartagnan.program.event.core.threading.ThreadStart;
 import com.dat3m.dartagnan.utils.collections.IndexedDomain;
 import com.dat3m.dartagnan.utils.collections.IndexedSet;
@@ -92,20 +93,25 @@ class DefaultExecutionAnalysis implements ExecutionAnalysis {
                 eventsByImpliedEvent.put(e1, implying);
             }
         }
-        // (=> & ext) = (=> & int) ; (((=> & ext); [ThreadCreate|ThreadStart]) \ id); (=> & int)
-        for (Thread t1 : program.getThreads()) {
-            final List<Event> e1List = t1.getEvents();
-            for (Thread t2 : program.getThreads()) {
-                if (t1 == t2) {
-                    continue;
+        // (=> & ext) = ((=> & int) ; [Create|Start]; (=> & ext); [Create|Start]; (=> & int)) \ id
+        final List<Event> intermediates = program.getThreadEvents().stream()
+                .filter(e -> e instanceof ThreadCreate || e instanceof ThreadStart)
+                .toList();
+        for (Event e2 : intermediates) {
+            final Set<Event> implying2 = eventsByImpliedEvent.get(e2);
+            boolean modified = false;
+            for (Event e1 : intermediates) {
+                if (e1 != e2 && implied(e1, e2)) {
+                    // e0 => e1 => e2  ->  e0 => e2
+                    modified |= implying2.addAll(eventsByImpliedEvent.get(e1));
                 }
-                final ThreadStart s = t2.getEntry();
-                final List<Event> e2List = s.isSpawned() ? List.of(s, s.getCreator()) : List.of(s);
-                for (Event e1 : e1List) {
-                    for (Event e2 : e2List) {
-                        if (implied(e1, e2)) {
-                            eventsByImpliedEvent.get(e2).addAll(eventsByImpliedEvent.get(e1));
-                        }
+            }
+            if (modified) {
+                for (Event e3 : e2.getThread().getEvents()) {
+                    final Set<Event> implying3 = eventsByImpliedEvent.get(e3);
+                    if (implying3.contains(e2)) {
+                        // e0 => e2 => e3  ->  e0 => e3
+                        implying3.addAll(implying2);
                     }
                 }
             }

--- a/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/AnalysisTest.java
+++ b/dartagnan/src/test/java/com/dat3m/dartagnan/others/miscellaneous/AnalysisTest.java
@@ -104,6 +104,33 @@ public class AnalysisTest {
     }
 
     @Test
+    public void impliedInits() throws InvalidConfigurationException {
+        final ProgressModel.Hierarchy progressModel = ProgressModel.uniform(ProgressModel.FAIR);
+        final ProgramBuilder b = ProgramBuilder.forLanguage(Program.SourceLanguage.LITMUS);
+        final MemoryObject x = b.newMemoryObject("x", 1);
+        x.setInitialValue(0, expressions.makeZero(types.getByteType()));
+
+        b.newThread(0);
+        final Event store = newStore(x, expressions.makeOne(types.getByteType()));
+        b.addChildWithoutSourceLoc(0, store);
+
+        final Configuration config = Configuration.defaultConfiguration();
+        final Program program = b.build();
+        MemoryAllocation.newInstance().run(program);
+        final Event init = program.getThreadEvents(Init.class).get(0);
+        // Required by BranchEquivalence.
+        LoopUnrolling.fromConfig(config).run(program);
+
+        final Context analyses = Context.create();
+        final EventDomainRepository edr = EventDomainRepository.forProgram(program);
+        analyses.register(EventDomainRepository.class, edr);
+        final BranchEquivalence be = BranchEquivalence.fromConfig(program, config);
+        analyses.register(BranchEquivalence.class, be);
+        final ExecutionAnalysis exec = ExecutionAnalysis.fromConfig(program, progressModel, analyses, config);
+        assertTrue(exec.isImplied(store, init));
+    }
+
+    @Test
     public void reachingDefinitionMustOverride() throws InvalidConfigurationException {
         reachingDefinitionMustOverride(ReachingDefinitionsAnalysis.Method.BACKWARD);
         reachingDefinitionMustOverride(ReachingDefinitionsAnalysis.Method.FORWARD);


### PR DESCRIPTION
Fixes an imprecision in `ExecutionAnalysis` introduced in #1044:  The cached `implyingEvents` were not closed transitively and thus **the sets were substantially smaller than expected**.  Precisely, if `e2` was implied by a `ThreadCreate` or `ThreadStart` `e1`, then `implyingEvents(e2).addAll(implyingEvents(e1))` was missing.  There were `e0` with `isImplied(e0, e1) && isImplied(e1, e2) && ! isImplied(e0, e2)`.

This pull has the following concrete effects:
- Events now imply `Init` events again (see the new test `AnalysisTest.impliedInits()`)
- Events in a spawned thread can now imply many events in the creator thread again.

As a consequence, the precision of `RelationAnalysis` and `ActiveSetAnalysis` should increase, as well.  I expect a small positive effect on the eager solver's performance.

Thanks to @JnsGlnr for pointing this out.